### PR TITLE
Add TriggerParam: one-shot trigger param with per-frame snapshot

### DIFF
--- a/egress/__init__.py
+++ b/egress/__init__.py
@@ -56,7 +56,7 @@ from .module import (
     _InputPort,
 )
 from .audio import DAC
-from .param import Param
+from .param import Param, Trigger
 from .yaml_schema import load_module_from_yaml, load_patch_from_yaml, save_patch_to_yaml
 
 
@@ -109,6 +109,6 @@ __all__ = [
     "ModuleType", "PureFunction",
     "DAC",
     "connect", "disconnect", "add_output",
-    "Param",
+    "Param", "Trigger",
     "load_module_from_yaml", "load_patch_from_yaml", "save_patch_to_yaml",
 ]

--- a/egress/_bindings.py
+++ b/egress/_bindings.py
@@ -106,7 +106,9 @@ egress_param_new  = _fn("egress_param_new",  _c,   _d, _d)
 egress_param_free = _fn("egress_param_free", None, _c)
 egress_param_set  = _fn("egress_param_set",  None, _c, _d)
 egress_param_get  = _fn("egress_param_get",  _d,   _c)
-egress_expr_param = _fn("egress_expr_param", _c,   _c)
+egress_expr_param         = _fn("egress_expr_param",         _c, _c)
+egress_param_new_trigger  = _fn("egress_param_new_trigger",  _c)
+egress_expr_trigger_param = _fn("egress_expr_trigger_param", _c, _c)
 
 # ---------- Module spec builder API ----------
 egress_module_spec_new                = _fn("egress_module_spec_new",                _c, _u, _d)
@@ -221,6 +223,7 @@ EXPR_NEG            = 37
 EXPR_BIT_NOT        = 38
 EXPR_SMOOTHED_PARAM = 39
 EXPR_SELECT         = 40
+EXPR_TRIGGER_PARAM  = 41
 
 
 # ---------- Helpers ----------

--- a/egress/expr.py
+++ b/egress/expr.py
@@ -23,11 +23,11 @@ __all__ = [
 
 
 def _coerce(value):
-    """Convert a Python scalar, Param, or SignalExpr to a SignalExpr."""
+    """Convert a Python scalar, Param, Trigger, or SignalExpr to a SignalExpr."""
     if isinstance(value, SignalExpr):
         return value
-    # Avoid circular import: check by class name for Param
-    if type(value).__name__ == "Param" and hasattr(value, "_as_expr"):
+    # Avoid circular import: check by class name for Param/Trigger
+    if type(value).__name__ in ("Param", "Trigger") and hasattr(value, "_as_expr"):
         return value._as_expr()
     if isinstance(value, bool):
         return SignalExpr._from_handle(_b.check(

--- a/egress/param.py
+++ b/egress/param.py
@@ -18,7 +18,7 @@ Usage::
 
 from . import _bindings as _b
 
-__all__ = ["Param"]
+__all__ = ["Param", "Trigger"]
 
 
 class Param:
@@ -97,3 +97,48 @@ class Param:
 
     def __repr__(self):
         return f"Param(value={self.value!r})"
+
+
+class Trigger:
+    """
+    Lock-free one-shot trigger parameter.
+
+    Call ``fire()`` from the UI/control thread to arm the trigger. The Graph
+    snapshots the value once per frame (before any module processes), so every
+    module referencing this Trigger sees it fire exactly once — on the sample
+    immediately following the ``fire()`` call — then automatically resets to 0.0.
+
+    Triggers are not composable arithmetically; use them as gate/reset signals
+    rather than continuous values.
+    """
+
+    __slots__ = ("_h",)
+
+    def __init__(self):
+        self._h = _b.check(
+            _b.egress_param_new_trigger(), "param_new_trigger"
+        )
+
+    def __del__(self):
+        if self._h:
+            _b.egress_param_free(self._h)
+            self._h = None
+
+    def fire(self):
+        """Arm the trigger (atomic store of 1.0). Safe to call from any thread."""
+        _b.egress_param_set(self._h, 1.0)
+
+    @property
+    def value(self) -> float:
+        """Raw atomic read — for debugging. Not the consumed per-frame value."""
+        return _b.egress_param_get(self._h)
+
+    def _as_expr(self):
+        """Return a TriggerParam SignalExpr for use in module expressions."""
+        from .expr import SignalExpr
+        return SignalExpr._from_handle(
+            _b.check(_b.egress_expr_trigger_param(self._h), "expr_trigger_param")
+        )
+
+    def __repr__(self):
+        return "Trigger()"

--- a/egress/yaml_schema.py
+++ b/egress/yaml_schema.py
@@ -113,6 +113,10 @@ def _build_expr(node: dict, lctx: _LoadContext) -> SignalExpr:
         p = lctx.param_registry[node["name"]]
         return p._as_expr()
 
+    if op == "trigger_param":
+        p = lctx.param_registry[node["name"]]
+        return p._as_expr()
+
     if op == "sample_rate":
         return sample_rate_expr()
 

--- a/src/c_api/egress_c.cpp
+++ b/src/c_api/egress_c.cpp
@@ -252,6 +252,26 @@ egress_expr_t egress_expr_param(egress_param_t p)
   catch (const std::exception & e) { set_error(e.what()); return nullptr; }
 }
 
+egress_param_t egress_param_new_trigger(void)
+{
+  try { return new EgressParam(0.0, 0.0); }
+  catch (const std::exception & e) { set_error(e.what()); return nullptr; }
+}
+
+egress_expr_t egress_expr_trigger_param(egress_param_t p)
+{
+  try
+  {
+    if (!p)
+    {
+      set_error("egress_expr_trigger_param: null param handle");
+      return nullptr;
+    }
+    return new EgressExpr{expr::trigger_param_expr(static_cast<EgressParam *>(p)->param)};
+  }
+  catch (const std::exception & e) { set_error(e.what()); return nullptr; }
+}
+
 // ---------- Expression factory API ----------
 
 egress_expr_t egress_expr_literal_float(double v)

--- a/src/c_api/egress_c.h
+++ b/src/c_api/egress_c.h
@@ -59,6 +59,7 @@ typedef void* egress_param_t;
 #define EGRESS_EXPR_BIT_NOT       38
 #define EGRESS_EXPR_SMOOTHED_PARAM 39
 #define EGRESS_EXPR_SELECT        40
+#define EGRESS_EXPR_TRIGGER_PARAM 41
 
 /* Error handling — thread-local; valid until next call on this thread */
 const char* egress_last_error(void);
@@ -108,6 +109,12 @@ double         egress_param_get(egress_param_t);
 /* Create a SmoothedParam expression that can be used in module outputs/registers.
    The Param must outlive all modules that reference the returned expression. */
 egress_expr_t  egress_expr_param(egress_param_t);
+
+/* Create a trigger parameter. Fires once per frame: set value to 1.0 from the UI
+   thread; the DSP evaluator reads and atomically clears it each frame.
+   The Param must outlive all modules that reference the returned expression. */
+egress_param_t egress_param_new_trigger(void);
+egress_expr_t  egress_expr_trigger_param(egress_param_t);
 
 /* ---------- Module spec builder API ---------- */
 egress_module_spec_t egress_module_spec_new(unsigned int input_count, double sample_rate);

--- a/src/expr/Expr.hpp
+++ b/src/expr/Expr.hpp
@@ -15,10 +15,12 @@ namespace egress_expr
 // ControlParam: lock-free parameter for control-rate values.
 // Written from UI/control thread, read per-sample by the DSP evaluator.
 // One-pole lowpass smoothing (time_const in seconds) is applied automatically.
+// frame_value: written once per frame by the Graph before module processing (used by TriggerParam).
 struct ControlParam
 {
   std::atomic<double> value;
   double time_const;
+  double frame_value = 0.0;
 
   ControlParam(double init, double tc) : value(init), time_const(tc) {}
 
@@ -100,7 +102,8 @@ enum class ExprKind
   Neg,
   BitNot,
   SmoothedParam,
-  Select
+  Select,
+  TriggerParam
 };
 
 struct ExprSpec
@@ -738,6 +741,16 @@ inline ExprSpecPtr smoothed_param_expr(ControlParam * param)
 {
   auto expr = std::make_shared<ExprSpec>();
   expr->kind = ExprKind::SmoothedParam;
+  expr->control_param = param;
+  return expr;
+}
+
+// Creates a TriggerParam expression. The Graph snapshots frame_value once per frame
+// (via exchange) before module processing, so all modules see the same trigger state.
+inline ExprSpecPtr trigger_param_expr(ControlParam * param)
+{
+  auto expr = std::make_shared<ExprSpec>();
+  expr->kind = ExprKind::TriggerParam;
   expr->control_param = param;
   return expr;
 }

--- a/src/expr/ExprRewrite.cpp
+++ b/src/expr/ExprRewrite.cpp
@@ -69,6 +69,7 @@ ExprSpecPtr simplify_expr(const ExprSpecPtr & expr_spec)
     case ExprKind::SampleRate:
     case ExprKind::SampleIndex:
     case ExprKind::SmoothedParam:
+    case ExprKind::TriggerParam:
       return expr_spec;
     case ExprKind::ArrayPack:
     {
@@ -605,7 +606,9 @@ ExprSpecPtr replace_refs_with_zero(
       expr_spec->kind == ExprKind::NestedValue ||
       expr_spec->kind == ExprKind::DelayValue ||
       expr_spec->kind == ExprKind::SampleRate ||
-      expr_spec->kind == ExprKind::SampleIndex)
+      expr_spec->kind == ExprKind::SampleIndex ||
+      expr_spec->kind == ExprKind::SmoothedParam ||
+      expr_spec->kind == ExprKind::TriggerParam)
   {
     return expr_spec;
   }

--- a/src/expr/ExprStructural.cpp
+++ b/src/expr/ExprStructural.cpp
@@ -287,6 +287,7 @@ std::size_t structural_hash(
       }
       break;
     case ExprKind::SmoothedParam:
+    case ExprKind::TriggerParam:
       // Use the pointer address as the hash — each ControlParam is unique
       seed = hash_mix(seed, std::hash<const void *>{}(expr_spec->control_param));
       break;
@@ -405,7 +406,8 @@ bool structural_equal(const ExprSpecPtr & lhs, const ExprSpecPtr & rhs)
     case ExprKind::DelayValue:
       return lhs->slot_id == rhs->slot_id;
     case ExprKind::SmoothedParam:
-      // Two SmoothedParam nodes are equal only if they reference the same ControlParam
+    case ExprKind::TriggerParam:
+      // Two param nodes are equal only if they reference the same ControlParam
       return lhs->control_param == rhs->control_param;
     case ExprKind::Function:
       return lhs->param_count == rhs->param_count && structural_equal(lhs->lhs, rhs->lhs);
@@ -553,7 +555,8 @@ ExprSpecPtr inline_functions(const ExprSpecPtr & expr_spec, unsigned int inline_
       expr_spec->kind == ExprKind::DelayValue ||
       expr_spec->kind == ExprKind::SampleRate ||
       expr_spec->kind == ExprKind::SampleIndex ||
-      expr_spec->kind == ExprKind::SmoothedParam)
+      expr_spec->kind == ExprKind::SmoothedParam ||
+      expr_spec->kind == ExprKind::TriggerParam)
   {
     return expr_spec;
   }

--- a/src/graph/Graph.hpp
+++ b/src/graph/Graph.hpp
@@ -202,6 +202,12 @@ class Graph
         }
         if (!body_covers_all_modules)
         {
+          // Snapshot all TriggerParam values once per sample before any module processes.
+          // This ensures every module in the frame sees the same trigger state.
+          for (auto * p : runtime.trigger_params)
+          {
+            p->frame_value = p->value.exchange(0.0, std::memory_order_acq_rel);
+          }
           parallel_next_module_index_.store(0, std::memory_order_relaxed);
           if (worker_count_ > 1 && runtime.modules.size() > 1)
           {

--- a/src/graph/GraphRuntime.hpp
+++ b/src/graph/GraphRuntime.hpp
@@ -268,6 +268,9 @@ struct RuntimeState
   std::vector<MixExpr> mix_exprs;
   std::vector<OutputTap> taps;
   std::unique_ptr<FusedGraphState> fused_graph;
+  // All TriggerParam ControlParam pointers across all modules.
+  // The Graph snapshots these once per sample before module processing.
+  std::vector<egress_expr::ControlParam *> trigger_params;
 };
 
 #ifdef EGRESS_PROFILE

--- a/src/graph/GraphRuntimeMethods.hpp
+++ b/src/graph/GraphRuntimeMethods.hpp
@@ -93,6 +93,24 @@ Graph::RuntimeState Graph::build_runtime_locked() const
     slot.indexed_prev_output_values.assign(module.out_count, {});
   }
 
+  // Collect all TriggerParam ControlParam pointers across modules (deduped).
+  {
+    std::unordered_set<egress_expr::ControlParam *> seen;
+    for (const auto & slot : runtime.modules)
+    {
+      if (slot.module)
+      {
+        for (auto * p : slot.module->trigger_params())
+        {
+          if (seen.insert(p).second)
+          {
+            runtime.trigger_params.push_back(p);
+          }
+        }
+      }
+    }
+  }
+
   runtime.mix.reserve(control_mix_.size());
   for (const auto & tap : control_mix_)
   {

--- a/src/graph/Module.hpp
+++ b/src/graph/Module.hpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -126,6 +127,10 @@ class Module
         for (const auto & e : register_exprs) walk_expr_for_params(e, param_anon_reg_map_, next_anon_idx);
         for (const auto & ds : delay_state_specs) walk_expr_for_params(ds.update_expr, param_anon_reg_map_, next_anon_idx);
         has_smoothed_params_ = !param_anon_reg_map_.empty();
+        // Collect TriggerParam pointers separately so Graph can snapshot them per frame.
+        for (const auto & e : output_exprs) collect_trigger_params(e, trigger_params_);
+        for (const auto & e : register_exprs) collect_trigger_params(e, trigger_params_);
+        for (const auto & ds : delay_state_specs) collect_trigger_params(ds.update_expr, trigger_params_);
         if (has_smoothed_params_)
         {
           // Build sorted list so register slots are assigned deterministically
@@ -221,6 +226,13 @@ class Module
 
     unsigned int register_count() const;
 
+    // Returns the set of TriggerParam ControlParam pointers used by this module.
+    // The Graph uses this to snapshot trigger values once per frame before processing.
+    const std::unordered_set<egress_expr::ControlParam *> & trigger_params() const
+    {
+      return trigger_params_;
+    }
+
   #ifdef EGRESS_PROFILE
     CompileStats compile_stats() const;
 
@@ -280,13 +292,28 @@ class Module
 
     // Walk an expression tree and collect unique ControlParam pointers.
     // Assigns each a sequential anonymous register index (0-based) in map.
+    static void collect_trigger_params(
+      const ExprSpecPtr & expr,
+      std::unordered_set<egress_expr::ControlParam *> & out)
+    {
+      if (!expr) return;
+      if (expr->kind == ExprKind::TriggerParam)
+      {
+        if (expr->control_param) out.insert(expr->control_param);
+        return;
+      }
+      collect_trigger_params(expr->lhs, out);
+      collect_trigger_params(expr->rhs, out);
+      for (const auto & arg : expr->args) collect_trigger_params(arg, out);
+    }
+
     static void walk_expr_for_params(
       const ExprSpecPtr & expr,
       std::unordered_map<egress_expr::ControlParam *, uint32_t> & map,
       uint32_t & next_idx)
     {
       if (!expr) return;
-      if (expr->kind == ExprKind::SmoothedParam)
+      if (expr->kind == ExprKind::SmoothedParam || expr->kind == ExprKind::TriggerParam)
       {
         if (expr->control_param && map.find(expr->control_param) == map.end())
         {
@@ -305,6 +332,7 @@ class Module
     unsigned int input_count_ = 0;
     uint32_t user_register_count_ = 0;
     std::unordered_map<egress_expr::ControlParam *, uint32_t> param_anon_reg_map_;
+    std::unordered_set<egress_expr::ControlParam *> trigger_params_;
     bool has_smoothed_params_ = false;
     CompiledProgram program_;
     CompiledProgram composite_output_program_;

--- a/src/graph/ModuleMethods.hpp
+++ b/src/graph/ModuleMethods.hpp
@@ -751,6 +751,7 @@ uint32_t Module::compile_expr_node(
       }
       break;
     case ExprKind::SmoothedParam:
+    case ExprKind::TriggerParam:
     {
       // Assign the anonymous register slot (user_register_count_ + anon_index)
       const auto it = param_anon_reg_map_.find(expr->control_param);
@@ -1021,6 +1022,20 @@ void Module::eval_program(const CompiledProgram & expr, std::vector<Value> & tem
           {
             next_registers_[instr.slot_id] = egress_expr::float_value(new_val);
           }
+        }
+        else
+        {
+          temps[instr.dst] = egress_expr::float_value(0.0);
+        }
+        break;
+      }
+      case ExprKind::TriggerParam:
+      {
+        // Read the per-frame snapshot written by Graph before the processing loop.
+        // The Graph does a single exchange(0.0) per frame so all modules see the same value.
+        if (instr.control_param)
+        {
+          temps[instr.dst] = egress_expr::float_value(instr.control_param->frame_value);
         }
         else
         {


### PR DESCRIPTION
Closes #7

## Summary

- Adds `Trigger`, a runtime-mutable one-shot trigger parameter for firing events (note gates, resets, etc.) from the UI/control thread into the DSP graph
- The Graph snapshots all trigger params once per sample (single `exchange(0.0, acq_rel)`) before any module processes, so every module in the same frame sees the same trigger state — no "first module wins" race
- Module eval reads the plain `frame_value` double, no per-sample atomic op
- `Param(time_const=0.0)` is the recommended approach for gate/binary signals; `Trigger` is for one-shot fire-and-forget events only

## Changes

- `src/expr/Expr.hpp` — `frame_value` on `ControlParam`, `ExprKind::TriggerParam`, `trigger_param_expr()` factory
- `src/expr/ExprStructural.cpp` / `ExprRewrite.cpp` — leaf handling for new kind
- `src/graph/Module.hpp` / `ModuleMethods.hpp` — compile + eval cases; `trigger_params()` accessor
- `src/graph/GraphRuntime.hpp` / `GraphRuntimeMethods.hpp` / `Graph.hpp` — per-frame snapshot loop
- `src/c_api/egress_c.h` / `.cpp` — `egress_param_new_trigger`, `egress_expr_trigger_param`
- `egress/_bindings.py`, `param.py`, `__init__.py`, `yaml_schema.py` — Python `Trigger` class + `trigger_param` YAML op

## Test plan

- [ ] All existing tests pass (`pytest test/` — 7 passed)
- [ ] Build clean with `EGRESS_LLVM_ORC_JIT=OFF`
- [ ] Manually verify `trigger.fire()` → module sees 1.0 on next sample, 0.0 thereafter
- [ ] Verify two modules referencing same `Trigger` both see the fire in the same frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)