### PR TITLE
feat(jit): add SmoothedParam support to numeric JIT path

### DIFF
--- a/src/graph/Module.hpp
+++ b/src/graph/Module.hpp
@@ -203,13 +203,9 @@ class Module
       temps_.assign(temp_register_count, expr::float_value(0.0));
 
 #ifdef EGRESS_LLVM_ORC_JIT
-      if (!has_dynamic_registers_ && !has_smoothed_params_)
+      if (!has_dynamic_registers_)
       {
         initialize_numeric_jit(inputs);
-      }
-      else if (has_smoothed_params_)
-      {
-        jit_status_ = "numeric JIT disabled for SmoothedParam (one-pole smoother)";
       }
       else
       {

--- a/src/graph/ModuleMethods.hpp
+++ b/src/graph/ModuleMethods.hpp
@@ -108,6 +108,14 @@ void Module::process(const std::vector<bool> * output_materialize_mask)
         }
       }
 
+      // Preserve anonymous registers (e.g., SmoothedParam state) written in-kernel
+      for (unsigned int register_id = static_cast<unsigned int>(program_.register_targets.size());
+           register_id < numeric_registers_.size();
+           ++register_id)
+      {
+        numeric_next_registers_[register_id] = numeric_registers_[register_id];
+      }
+
       numeric_registers_.swap(numeric_next_registers_);
 
       for (unsigned int register_id = 0; register_id < array_register_targets_.size(); ++register_id)

--- a/src/graph/ModuleNumericJitMethods.hpp
+++ b/src/graph/ModuleNumericJitMethods.hpp
@@ -107,6 +107,7 @@ bool Module::supports_numeric_jit_expr_kind(ExprKind kind) const
     case ExprKind::Neg:
     case ExprKind::BitNot:
     case ExprKind::ArrayPack:
+    case ExprKind::SmoothedParam:
       return true;
     default:
       return false;
@@ -1724,6 +1725,23 @@ bool Module::build_numeric_program(const std::vector<Value> & current_inputs, eg
         jit_instr.op = egress_jit::NumericOp::BitNot;
         reg_info[instr.dst].kind = NumericValueKind::Scalar;
         break;
+      case ExprKind::SmoothedParam:
+      {
+        if (!instr.control_param)
+        {
+          return false;
+        }
+        const double tc = instr.control_param->time_const;
+        const double coeff = (tc > 0.0)
+          ? 1.0 - std::exp(-1.0 / (tc * sample_rate_))
+          : 1.0;
+        jit_instr.op = egress_jit::NumericOp::SmoothedParam;
+        jit_instr.literal = coeff;
+        jit_instr.param_ptr = reinterpret_cast<uint64_t>(&instr.control_param->value);
+        jit_instr.slot_id = instr.slot_id;
+        reg_info[instr.dst].kind = NumericValueKind::Scalar;
+        break;
+      }
       default:
         return false;
     }
@@ -1741,6 +1759,7 @@ bool Module::build_numeric_program(const std::vector<Value> & current_inputs, eg
           instr.kind != ExprKind::RegisterValue &&
           instr.kind != ExprKind::SampleRate &&
           instr.kind != ExprKind::SampleIndex &&
+          instr.kind != ExprKind::SmoothedParam &&
           instr.kind != ExprKind::Index &&
           instr.kind != ExprKind::ArraySet)
       {
@@ -2360,6 +2379,14 @@ void Module::apply_numeric_register_targets(
     {
       numeric_next_registers_[register_id] = numeric_registers_[register_id];
     }
+  }
+
+  // Preserve anonymous registers (e.g., SmoothedParam state) written in-kernel
+  for (unsigned int register_id = static_cast<unsigned int>(compiled_program.register_targets.size());
+       register_id < numeric_registers_.size();
+       ++register_id)
+  {
+    numeric_next_registers_[register_id] = numeric_registers_[register_id];
   }
 
   numeric_registers_.swap(numeric_next_registers_);

--- a/src/jit/OrcJitEngine.cpp
+++ b/src/jit/OrcJitEngine.cpp
@@ -768,7 +768,7 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_numeric_program(
         llvm::Value * cond     = load_temp(instr.src_a);
         llvm::Value * then_val = load_temp(instr.src_b);
         llvm::Value * else_val = load_temp(instr.src_c);
-        llvm::Value * cond_bool = builder.CreateFCmpUNE(cond, llvm::ConstantFP::get(double_type, 0.0));
+        llvm::Value * cond_bool = builder.CreateFCmpUNE(cond, llvm::ConstantFP::get(f64_ty, 0.0));
         result = builder.CreateSelect(cond_bool, then_val, else_val);
         break;
       }
@@ -825,6 +825,29 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_numeric_program(
       {
         llvm::Value * value = builder.CreateFPToSI(load_temp(instr.src_a), i64_ty);
         result = builder.CreateSIToFP(builder.CreateNot(value), f64_ty);
+        break;
+      }
+      case NumericOp::SmoothedParam:
+      {
+        // Load current smoother state from registers[slot_id]
+        llvm::Value * reg_ptr = gep_f64(regs_arg, instr.slot_id);
+        llvm::Value * current = builder.CreateLoad(f64_ty, reg_ptr, "smooth_current");
+
+        // Atomic monotonic load of target value from ControlParam::value
+        llvm::Value * param_addr = builder.CreateIntToPtr(
+          builder.getInt64(instr.param_ptr), f64_ptr_ty, "smooth_param_ptr");
+        llvm::LoadInst * target_load = builder.CreateAlignedLoad(
+          f64_ty, param_addr, llvm::Align(sizeof(double)), "smooth_target");
+        target_load->setAtomic(llvm::AtomicOrdering::Monotonic);
+
+        // new_val = current + coeff * (target - current)
+        llvm::Value * coeff = llvm::ConstantFP::get(f64_ty, instr.literal);
+        llvm::Value * diff = builder.CreateFSub(target_load, current, "smooth_diff");
+        llvm::Value * step = builder.CreateFMul(coeff, diff, "smooth_step");
+        result = builder.CreateFAdd(current, step, "smooth_new");
+
+        // Write back smoother state for next sample
+        builder.CreateStore(result, reg_ptr);
         break;
       }
     }

--- a/src/jit/OrcJitEngine.hpp
+++ b/src/jit/OrcJitEngine.hpp
@@ -64,7 +64,8 @@ enum class NumericOp : uint8_t
   SetArrayElement,
   Sin,
   Neg,
-  BitNot
+  BitNot,
+  SmoothedParam
 };
 
 struct NumericInstr
@@ -76,6 +77,7 @@ struct NumericInstr
   uint32_t src_c = 0;
   uint32_t slot_id = 0;
   double literal = 0.0;
+  uint64_t param_ptr = 0;
   std::vector<uint32_t> args;
 };
 
@@ -87,7 +89,7 @@ struct NumericProgram
 
 using NumericKernelFn = void (*)(
   const double * inputs,
-  const double * registers,
+  double * registers,
   double * const * arrays,
   const uint64_t * array_sizes,
   double * temps,


### PR DESCRIPTION
Closes #1.

## Summary

- `SmoothedParam` nodes no longer disqualify a module from JIT compilation
- The one-pole smoother runs entirely inside the JIT kernel — no per-sample `exp()`, coefficient is baked at compile time
- Smoother state is persisted across samples via in-kernel write-back to the `registers` buffer

## Changes

| What | Where |
|---|---|
| `SmoothedParam` added to `NumericOp` enum; `param_ptr` field added to `NumericInstr` | `OrcJitEngine.hpp` |
| `registers` parameter changed `const double *` → `double *` in `NumericKernelFn` | `OrcJitEngine.hpp` |
| LLVM IR emission for `SmoothedParam`: atomic monotonic load → one-pole update → register write-back | `OrcJitEngine.cpp` |
| Pre-existing `double_type` typo fixed in `Select` IR emission | `OrcJitEngine.cpp` |
| `SmoothedParam` added to `supports_numeric_jit_expr_kind()` and builder switch | `ModuleNumericJitMethods.hpp` |
| Anonymous registers (SmoothedParam state) copied to `next_registers` before swap, in both the simple and composite JIT paths | `ModuleNumericJitMethods.hpp`, `ModuleMethods.hpp` |
| `has_smoothed_params_` removed from JIT gate | `Module.hpp` |

## Test plan

- [x] Full build passes (`egress_core`)
- [x] All 22 existing tests pass (`pytest test/ --ignore=test/manual`)
- [x] Manual smoke test: smoother output matches reference one-pole computation exactly (sample-by-sample, `|err| < 1e-12`) and converges to target after sufficient samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)