### PR TITLE
feat(dac): add device enumeration and explicit device-switching APIs

### DIFF
--- a/egress/_bindings.py
+++ b/egress/_bindings.py
@@ -179,7 +179,28 @@ class EgressDacStats(ctypes.Structure):
 
 egress_dac_get_stats      = _fn("egress_dac_get_stats",      None, _c, ctypes.POINTER(EgressDacStats))
 egress_dac_reset_stats    = _fn("egress_dac_reset_stats",    None, _c)
-egress_dac_is_reconnecting = _fn("egress_dac_is_reconnecting", _b,  _c)
+egress_dac_is_reconnecting   = _fn("egress_dac_is_reconnecting",   _b, _c)
+egress_dac_get_active_device = _fn("egress_dac_get_active_device", _u, _c)
+egress_dac_switch_device     = _fn("egress_dac_switch_device",     _b, _c, _u)
+
+# ---------- Device enumeration ----------
+
+class EgressDeviceInfo(ctypes.Structure):
+    _fields_ = [
+        ("id",                    ctypes.c_uint),
+        ("name",                  ctypes.c_char * 256),
+        ("output_channels",       ctypes.c_uint),
+        ("input_channels",        ctypes.c_uint),
+        ("is_default_output",     ctypes.c_bool),
+        ("preferred_sample_rate", ctypes.c_uint),
+        ("sample_rate_count",     ctypes.c_uint),
+        ("sample_rates",          ctypes.c_uint * 32),
+    ]
+
+egress_audio_device_count          = _fn("egress_audio_device_count",          _u,   )
+egress_audio_get_device_ids        = _fn("egress_audio_get_device_ids",        None, ctypes.POINTER(ctypes.c_uint), _u)
+egress_audio_get_device_info       = _fn("egress_audio_get_device_info",       _b,   _u, ctypes.POINTER(EgressDeviceInfo))
+egress_audio_default_output_device = _fn("egress_audio_default_output_device", _u,   )
 
 # ---------- ExprKind constants ----------
 EXPR_LITERAL        = 0

--- a/egress/audio.py
+++ b/egress/audio.py
@@ -2,6 +2,8 @@
 DAC — Digital-to-Analog Converter.  Wraps egress_dac_t.
 """
 
+import ctypes
+
 from . import _bindings as _b
 
 __all__ = ["DAC"]
@@ -77,3 +79,58 @@ class DAC:
     def reset_stats(self) -> None:
         """Reset all callback diagnostic counters."""
         _b.egress_dac_reset_stats(self._h)
+
+    @property
+    def active_device(self) -> int:
+        """Device ID currently open for output (0 if not started)."""
+        return int(_b.egress_dac_get_active_device(self._h))
+
+    def switch_device(self, device_id: int) -> bool:
+        """
+        Switch output to the specified device while running.
+
+        Returns True on success, False if the DAC is not running or the
+        device ID is invalid / has no output channels.
+        """
+        return bool(_b.egress_dac_switch_device(self._h, device_id))
+
+    # ---------- Class-level device enumeration ----------
+
+    @staticmethod
+    def list_devices() -> list:
+        """
+        Return a list of dicts describing all available audio devices.
+
+        Each dict contains:
+          id                    -- RtAudio device ID
+          name                  -- human-readable device name
+          output_channels       -- maximum output channels
+          input_channels        -- maximum input channels
+          is_default_output     -- True if this is the system default output
+          preferred_sample_rate -- driver-preferred sample rate in Hz
+          sample_rates          -- list of supported sample rates
+        """
+        count = _b.egress_audio_device_count()
+        if count == 0:
+            return []
+        id_arr = (ctypes.c_uint * count)()
+        _b.egress_audio_get_device_ids(id_arr, count)
+        devices = []
+        info = _b.EgressDeviceInfo()
+        for device_id in id_arr:
+            if _b.egress_audio_get_device_info(device_id, ctypes.byref(info)):
+                devices.append({
+                    "id":                    info.id,
+                    "name":                  info.name.decode("utf-8", errors="replace"),
+                    "output_channels":       info.output_channels,
+                    "input_channels":        info.input_channels,
+                    "is_default_output":     bool(info.is_default_output),
+                    "preferred_sample_rate": info.preferred_sample_rate,
+                    "sample_rates":          list(info.sample_rates[:info.sample_rate_count]),
+                })
+        return devices
+
+    @staticmethod
+    def default_device() -> int:
+        """Return the system default output device ID."""
+        return int(_b.egress_audio_default_output_device())

--- a/src/c_api/egress_c.cpp
+++ b/src/c_api/egress_c.cpp
@@ -5,6 +5,8 @@
 #include "graph/Module.hpp"
 #include "dac/EgressDAC.hpp"
 
+#include <algorithm>
+#include <cstring>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -853,6 +855,54 @@ unsigned int egress_graph_get_buffer_length(egress_graph_t g)
   return static_cast<Graph*>(g)->getBufferLength();
 }
 
+// ---------- Device enumeration ----------
+
+unsigned int egress_audio_device_count(void)
+{
+  RtAudio tmp;
+  return tmp.getDeviceCount();
+}
+
+void egress_audio_get_device_ids(unsigned int* out, unsigned int count)
+{
+  if (!out) return;
+  RtAudio tmp;
+  const auto ids = tmp.getDeviceIds();
+  const unsigned int n = std::min(static_cast<unsigned int>(ids.size()), count);
+  for (unsigned int i = 0; i < n; ++i)
+    out[i] = ids[i];
+}
+
+bool egress_audio_get_device_info(unsigned int device_id, egress_device_info_t* out)
+{
+  if (!out) return false;
+  try
+  {
+    RtAudio tmp;
+    const RtAudio::DeviceInfo info = tmp.getDeviceInfo(device_id);
+    out->id                  = info.ID;
+    std::strncpy(out->name, info.name.c_str(), sizeof(out->name) - 1);
+    out->name[sizeof(out->name) - 1] = '\0';
+    out->output_channels     = info.outputChannels;
+    out->input_channels      = info.inputChannels;
+    out->is_default_output   = info.isDefaultOutput;
+    out->preferred_sample_rate = info.preferredSampleRate;
+    const unsigned int n = std::min(static_cast<unsigned int>(info.sampleRates.size()),
+                                    static_cast<unsigned int>(32));
+    out->sample_rate_count = n;
+    for (unsigned int i = 0; i < n; ++i)
+      out->sample_rates[i] = info.sampleRates[i];
+    return true;
+  }
+  catch (...) { return false; }
+}
+
+unsigned int egress_audio_default_output_device(void)
+{
+  RtAudio tmp;
+  return tmp.getDefaultOutputDevice();
+}
+
 // ---------- DAC API ----------
 
 egress_dac_t egress_dac_new(egress_graph_t g, unsigned int sample_rate, unsigned int channels)
@@ -902,6 +952,18 @@ void egress_dac_reset_stats(egress_dac_t d)
 bool egress_dac_is_reconnecting(egress_dac_t d)
 {
   return d && static_cast<EgressDAC*>(d)->is_reconnecting();
+}
+
+unsigned int egress_dac_get_active_device(egress_dac_t d)
+{
+  return d ? static_cast<EgressDAC*>(d)->active_device() : 0;
+}
+
+bool egress_dac_switch_device(egress_dac_t d, unsigned int device_id)
+{
+  if (!d) return false;
+  try { return static_cast<EgressDAC*>(d)->switch_device(device_id); }
+  catch (const std::exception& e) { set_error(e.what()); return false; }
 }
 
 } // extern "C"

--- a/src/c_api/egress_c.h
+++ b/src/c_api/egress_c.h
@@ -171,6 +171,25 @@ void            egress_graph_set_fusion_enabled(egress_graph_t, bool);
 bool            egress_graph_get_fusion_enabled(egress_graph_t);
 unsigned int    egress_graph_get_buffer_length(egress_graph_t);
 
+/* ---------- Device enumeration (no DAC instance required) ---------- */
+
+typedef struct {
+  unsigned int id;
+  char         name[256];
+  unsigned int output_channels;
+  unsigned int input_channels;
+  bool         is_default_output;
+  unsigned int preferred_sample_rate;
+  unsigned int sample_rate_count;        /* number of valid entries in sample_rates */
+  unsigned int sample_rates[32];
+} egress_device_info_t;
+
+unsigned int egress_audio_device_count(void);
+/* Fills `out[0..count-1]` with device IDs.  Call egress_audio_device_count() first. */
+void         egress_audio_get_device_ids(unsigned int* out, unsigned int count);
+bool         egress_audio_get_device_info(unsigned int device_id, egress_device_info_t* out);
+unsigned int egress_audio_default_output_device(void);
+
 /* ---------- DAC API ---------- */
 egress_dac_t egress_dac_new(egress_graph_t, unsigned int sample_rate, unsigned int channels);
 void         egress_dac_free(egress_dac_t);
@@ -190,6 +209,11 @@ void egress_dac_get_stats(egress_dac_t, egress_dac_stats_t* out);
 void egress_dac_reset_stats(egress_dac_t);
 /* True while a device-disconnect has been detected and reconnection is in progress */
 bool egress_dac_is_reconnecting(egress_dac_t);
+
+/* Returns the device ID currently open for output (0 if not started) */
+unsigned int egress_dac_get_active_device(egress_dac_t);
+/* Switch the running DAC to a different output device.  Returns false on failure. */
+bool         egress_dac_switch_device(egress_dac_t, unsigned int device_id);
 
 #ifdef __cplusplus
 }

--- a/src/dac/EgressDAC.hpp
+++ b/src/dac/EgressDAC.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 static constexpr int kPrimeCycles = 4;
 
@@ -119,6 +120,71 @@ struct EgressDAC
     overrun_count_.store(0, std::memory_order_relaxed);
   }
 
+  // ---------- Device query ----------
+
+  unsigned int active_device() const noexcept { return active_device_id_; }
+
+  std::vector<unsigned int> device_ids() { return audio.getDeviceIds(); }
+
+  RtAudio::DeviceInfo device_info(unsigned int id)
+  {
+    return audio.getDeviceInfo(id);
+  }
+
+  unsigned int default_output_device()
+  {
+    return audio.getDefaultOutputDevice();
+  }
+
+  // ---------- Device switching ----------
+
+  // Switch the active output to `device_id`.  Returns false if the stream is
+  // not running or if `device_id` is not a valid output device.
+  bool switch_device(unsigned int device_id)
+  {
+    if (!running)
+      return false;
+
+    // Validate: device must exist and have at least one output channel.
+    const auto info = audio.getDeviceInfo(device_id);
+    if (info.outputChannels == 0)
+      return false;
+
+    // Stop the watcher so it doesn't race with our stream swap.
+    watcher_shutdown_.store(true, std::memory_order_relaxed);
+    if (watcher_thread_.joinable())
+      watcher_thread_.join();
+
+    // Close the current stream quickly (no fade — user-initiated switch).
+    try
+    {
+      if (audio.isStreamRunning())
+        audio.abortStream();
+      if (audio.isStreamOpen())
+        audio.closeStream();
+    }
+    catch (...) {}
+
+    // Open on the requested device.
+    bool ok = true;
+    try
+    {
+      graph->begin_fade_in();
+      open_stream(device_id);
+    }
+    catch (...)
+    {
+      ok = false;
+    }
+
+    // Restart the watcher regardless of success so auto-reconnect keeps working.
+    device_disconnected_.store(false, std::memory_order_relaxed);
+    watcher_shutdown_.store(false, std::memory_order_relaxed);
+    watcher_thread_ = std::thread(&EgressDAC::watcher_loop, this);
+
+    return ok;
+  }
+
   static int fill_buffer(
     void*               output_buffer,
     void*,
@@ -164,11 +230,16 @@ struct EgressDAC
 private:
   void open_stream()
   {
+    open_stream(audio.getDefaultOutputDevice());
+  }
+
+  void open_stream(unsigned int device_id)
+  {
     if (audio.getDeviceCount() < 1)
       throw std::runtime_error("No audio output devices found.");
 
     RtAudio::StreamParameters out_params;
-    active_device_id_       = audio.getDefaultOutputDevice();
+    active_device_id_       = device_id;
     out_params.deviceId     = active_device_id_;
     out_params.nChannels    = channels;
     out_params.firstChannel = 0;


### PR DESCRIPTION
## Summary

- `EgressDAC`: new `active_device()`, `device_ids()`, `device_info()`, `default_output_device()`, and `switch_device()` methods; private `open_stream(device_id)` overload
- C API: `egress_device_info_t` struct + `egress_audio_{device_count,get_device_ids,get_device_info,default_output_device}` (no DAC instance needed) + `egress_dac_{get_active_device,switch_device}`
- Python: `DAC.list_devices()`, `DAC.default_device()`, `dac.active_device`, `dac.switch_device()`; `EgressDeviceInfo` ctypes struct + bindings

## Test plan

- [ ] `cmake --build build` succeeds
- [ ] `DAC.list_devices()` returns non-empty list
- [ ] `dac.active_device` matches `DAC.default_device()` after `start()`
- [ ] `dac.switch_device(id)` returns `True` for a valid output device and audio continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)