### PR TITLE
feat(profiling): expose graph profile stats via C API and MCP

### DIFF
--- a/src/c_api/egress_c.cpp
+++ b/src/c_api/egress_c.cpp
@@ -867,6 +867,80 @@ unsigned int egress_graph_get_buffer_length(egress_graph_t g)
   return static_cast<Graph*>(g)->getBufferLength();
 }
 
+// ---------- Profile stats ----------
+
+static thread_local std::string tls_profile_stats_json;
+
+static std::string profile_escape_json(const std::string & s)
+{
+  std::string out;
+  out.reserve(s.size() + 2);
+  out += '"';
+  for (unsigned char c : s)
+  {
+    if      (c == '"')  out += "\\\"";
+    else if (c == '\\') out += "\\\\";
+    else if (c == '\n') out += "\\n";
+    else if (c == '\r') out += "\\r";
+    else if (c == '\t') out += "\\t";
+    else                out += static_cast<char>(c);
+  }
+  out += '"';
+  return out;
+}
+
+const char* egress_graph_get_profile_stats_json(egress_graph_t g)
+{
+  const auto s = static_cast<Graph*>(g)->profile_stats();
+  std::string j;
+  j.reserve(512);
+  j += "{\"enabled\":";         j += s.enabled ? "true" : "false";
+  j += ",\"callback_count\":";  j += std::to_string(s.callback_count);
+  j += ",\"avg_callback_ms\":"; j += std::to_string(s.avg_callback_ms);
+  j += ",\"max_callback_ms\":"; j += std::to_string(s.max_callback_ms);
+  j += ",\"primitive_body_available\":";          j += s.primitive_body_available ? "true" : "false";
+  j += ",\"primitive_body_covers_all_modules\":"; j += s.primitive_body_covers_all_modules ? "true" : "false";
+  j += ",\"input_kernel_available\":";            j += s.input_kernel_available ? "true" : "false";
+  j += ",\"fused_input_use_count\":";  j += std::to_string(s.fused_input_use_count);
+  j += ",\"fused_body_use_count\":";   j += std::to_string(s.fused_body_use_count);
+  j += ",\"fusion_candidate_reason\":"; j += profile_escape_json(s.fusion_candidate_reason);
+  j += ",\"primitive_body_status\":";   j += profile_escape_json(s.primitive_body_status);
+  j += ",\"input_kernel_status\":";     j += profile_escape_json(s.input_kernel_status);
+  j += ",\"modules\":[";
+  for (size_t i = 0; i < s.modules.size(); ++i)
+  {
+    const auto & m = s.modules[i];
+    if (i > 0) j += ",";
+    j += "{\"name\":";        j += profile_escape_json(m.module_name);
+    j += ",\"call_count\":";  j += std::to_string(m.call_count);
+    j += ",\"avg_call_ms\":"; j += std::to_string(m.avg_call_ms);
+    j += ",\"max_call_ms\":"; j += std::to_string(m.max_call_ms);
+    j += "}";
+  }
+  j += "]";
+#ifdef EGRESS_PROFILE
+  auto fused_sync_json = [](const Graph::ProfileStats::FusedSyncStats & fs) {
+    std::string r;
+    r += "{\"call_count\":";       r += std::to_string(fs.call_count);
+    r += ",\"total_ms\":";         r += std::to_string(fs.total_ms);
+    r += ",\"max_ms\":";           r += std::to_string(fs.max_ms);
+    r += ",\"output_copy_count\":";r += std::to_string(fs.output_copy_count);
+    r += "}";
+    return r;
+  };
+  j += ",\"fused_current_output_sync\":"; j += fused_sync_json(s.fused_current_output_sync);
+  j += ",\"fused_prev_output_sync\":";    j += fused_sync_json(s.fused_prev_output_sync);
+#endif
+  j += "}";
+  tls_profile_stats_json = std::move(j);
+  return tls_profile_stats_json.c_str();
+}
+
+void egress_graph_reset_profile_stats(egress_graph_t g)
+{
+  static_cast<Graph*>(g)->reset_profile_stats();
+}
+
 // ---------- Device enumeration ----------
 
 unsigned int egress_audio_device_count(void)

--- a/src/c_api/egress_c.h
+++ b/src/c_api/egress_c.h
@@ -172,6 +172,9 @@ unsigned int    egress_graph_get_worker_count(egress_graph_t);
 void            egress_graph_set_fusion_enabled(egress_graph_t, bool);
 bool            egress_graph_get_fusion_enabled(egress_graph_t);
 unsigned int    egress_graph_get_buffer_length(egress_graph_t);
+/* Returns JSON-serialized ProfileStats. Pointer valid until next call on this thread. */
+const char*     egress_graph_get_profile_stats_json(egress_graph_t);
+void            egress_graph_reset_profile_stats(egress_graph_t);
 
 /* ---------- Device enumeration (no DAC instance required) ---------- */
 

--- a/tui/src/bindings.ts
+++ b/tui/src/bindings.ts
@@ -171,7 +171,9 @@ export const egress_graph_set_worker_count  = lib.func('egress_graph_set_worker_
 export const egress_graph_get_worker_count  = lib.func('egress_graph_get_worker_count',  'uint32', ['void *'])
 export const egress_graph_set_fusion_enabled = lib.func('egress_graph_set_fusion_enabled', 'void', ['void *', 'bool'])
 export const egress_graph_get_fusion_enabled = lib.func('egress_graph_get_fusion_enabled', 'bool', ['void *'])
-export const egress_graph_get_buffer_length  = lib.func('egress_graph_get_buffer_length',  'uint32', ['void *'])
+export const egress_graph_get_buffer_length          = lib.func('egress_graph_get_buffer_length',          'uint32', ['void *'])
+export const egress_graph_get_profile_stats_json     = lib.func('egress_graph_get_profile_stats_json',     'string', ['void *'])
+export const egress_graph_reset_profile_stats        = lib.func('egress_graph_reset_profile_stats',        'void',   ['void *'])
 
 // ---------- DAC API ----------
 

--- a/tui/src/graph.ts
+++ b/tui/src/graph.ts
@@ -128,6 +128,17 @@ export class Graph {
     b.egress_graph_set_fusion_enabled(this._h, v)
   }
 
+  // ---- Profiling ----
+
+  profileStats(): unknown {
+    const json = b.egress_graph_get_profile_stats_json(this._h) as string
+    return JSON.parse(json)
+  }
+
+  resetProfileStats(): void {
+    b.egress_graph_reset_profile_stats(this._h)
+  }
+
   // ---- Name generation (used by module builder) ----
 
   nextName(prefix: string): string {

--- a/tui/src/server.ts
+++ b/tui/src/server.ts
@@ -257,6 +257,16 @@ const TOOLS = [
     inputSchema: { type: 'object', properties: {} },
   },
   {
+    name: 'get_profile_stats',
+    description: 'Return graph profiling statistics: per-callback timing, JIT fusion usage, and per-module call timing. Module-level timing and fused-sync detail are only populated when built with -DEGRESS_PROFILE=ON (make profile); JIT fusion flags are always available.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'reset_profile_stats',
+    description: 'Reset all accumulated graph profile statistics to zero.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
     name: 'set_param',
     description: 'Set the value of a named Param (thread-safe, smoothed).',
     inputSchema: {
@@ -585,6 +595,15 @@ function handleTool(name: string, args: Record<string, unknown>) {
         is_reconnecting: session.dac.isReconnecting,
         stats:           session.dac.callbackStats(),
       }
+    })
+
+    // ── get_profile_stats ──────────────────────────────────────────────────
+    case 'get_profile_stats': return wrap(() => session.graph.profileStats())
+
+    // ── reset_profile_stats ────────────────────────────────────────────────
+    case 'reset_profile_stats': return wrap(() => {
+      session.graph.resetProfileStats()
+      return { reset: true }
     })
 
     // ── set_param ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `egress_graph_get_profile_stats_json` and `egress_graph_reset_profile_stats` to the C ABI, wiring up the existing `Graph::profile_stats()` / `reset_profile_stats()` that were previously C++ only
- Serializes `ProfileStats` to JSON via a thread-local buffer (same pattern as `egress_last_error`)
- Adds koffi bindings + `Graph.profileStats()` / `resetProfileStats()` methods in TypeScript
- Adds two MCP tools: `get_profile_stats` and `reset_profile_stats`

## What the stats include

| Field | Always | Profile build only |
|---|---|---|
| `callback_count`, `avg/max_callback_ms` | ✓ | |
| `primitive_body_available`, `input_kernel_available` | ✓ | |
| `fused_input_use_count`, `fused_body_use_count` | ✓ | |
| `fusion_candidate_reason`, `*_status` strings | ✓ | |
| Per-module `avg/max_call_ms` | | ✓ (`make profile`) |
| `fused_current/prev_output_sync` detail | | ✓ (`make profile`) |

Both `make build` and `make profile` verified clean.

## Test plan

- [ ] Call `get_profile_stats` after starting audio — verify JIT fusion fields are present
- [ ] Call `reset_profile_stats`, then `get_profile_stats` — verify counts reset to zero
- [ ] Build with `make profile`, run same patch — verify per-module `avg/max_call_ms` are non-zero
- [ ] Call `get_profile_stats` before starting audio — verify it returns without error (callback_count = 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)