### PR TITLE
docs: testing philosophy with algebraic coverage framework

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "ink": "^5.0.0",
         "koffi": "^2.0.0",
         "react": "^18.0.0",
+        "tropical": "^0.10.0",
         "yaml": "^2.0.0",
         "zod": "^4.3.6",
       },
@@ -334,6 +335,8 @@
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tropical": ["tropical@0.10.0", "", {}, "sha512-1EkWrfgHCZ1HeWEH1OyxKB+WSWVzOQndgZZZ8Go2sbyxUEyPVveonMFBs+Igw9kRj7+3h09hem9tUs8xY0Z1Vw=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 

--- a/compiler/emit_numeric.test.ts
+++ b/compiler/emit_numeric.test.ts
@@ -1,0 +1,280 @@
+/**
+ * emit_numeric.test.ts — Tests for instruction emission (pipeline stage 7).
+ *
+ * Exercises emitNumericProgram(): ExprNode trees → FlatProgram instruction stream.
+ * All tests are O4 (exact structural match) on instruction tags, operand kinds,
+ * types, loop_count, strides, and slot indices.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { emitNumericProgram, type FlatProgram, type NInstr, type NOperand } from './emit_numeric'
+import type { ExprNode } from './expr'
+
+/** Find the first instruction with the given tag. */
+function findInstr(prog: FlatProgram, tag: string): NInstr | undefined {
+  return prog.instructions.find(i => i.tag === tag)
+}
+
+/** Find all instructions with the given tag. */
+function findAll(prog: FlatProgram, tag: string): NInstr[] {
+  return prog.instructions.filter(i => i.tag === tag)
+}
+
+/** Get the output-copy instruction (the last one whose dst === output_targets[i]). */
+function outputInstr(prog: FlatProgram, i = 0): NInstr {
+  const dst = prog.output_targets[i]
+  return prog.instructions.findLast(instr => instr.dst === dst)!
+}
+
+describe('emitNumericProgram', () => {
+
+  // ── Terminals ──────────────────────────────────────────────
+
+  test('number and boolean literals produce const operands', () => {
+    const numProg = emitNumericProgram([42], [])
+    const numOut = outputInstr(numProg)
+    expect(numOut.tag).toBe('Add')  // output copy: Add(val, 0)
+    expect(numOut.args[0]).toEqual({ kind: 'const', val: 42, scalar_type: 'float' })
+
+    const boolProg = emitNumericProgram([true], [])
+    const boolOut = outputInstr(boolProg)
+    expect(boolOut.args[0]).toEqual({ kind: 'const', val: 1, scalar_type: 'bool' })
+  })
+
+  test('leaf node terminals: input, state_reg, sample_rate, sample_index, param', () => {
+    const cases: [ExprNode, Partial<NOperand>][] = [
+      [{ op: 'input', id: 0 },                              { kind: 'input', slot: 0, scalar_type: 'float' }],
+      [{ op: 'reg', id: 0 },                                { kind: 'state_reg', slot: 0, scalar_type: 'float' }],
+      [{ op: 'sample_rate' },                                { kind: 'rate', scalar_type: 'float' }],
+      [{ op: 'sample_index' },                               { kind: 'tick', scalar_type: 'int' }],
+      [{ op: 'smoothed_param', _ptr: true, _handle: 12345 }, { kind: 'param', ptr: '12345', scalar_type: 'float' }],
+    ]
+    for (const [expr, expected] of cases) {
+      const prog = emitNumericProgram([expr], [])
+      const out = outputInstr(prog)
+      expect(out.args[0]).toMatchObject(expected)
+    }
+  })
+
+  // ── Scalar ops ─────────────────────────────────────────────
+
+  test('scalar binary: add(3, 4)', () => {
+    const prog = emitNumericProgram([{ op: 'add', args: [3, 4] }], [])
+    const add = findInstr(prog, 'Add')!
+    expect(add).toBeDefined()
+    expect(add.loop_count).toBe(1)
+    expect(add.strides).toEqual([])
+    expect(add.args[0]).toMatchObject({ kind: 'const', val: 3 })
+    expect(add.args[1]).toMatchObject({ kind: 'const', val: 4 })
+    expect(add.result_type).toBe('float')
+    expect(prog.register_count).toBeGreaterThanOrEqual(2)
+  })
+
+  test('scalar unary: sin(1.0)', () => {
+    const prog = emitNumericProgram([{ op: 'sin', args: [1.0] }], [])
+    const sin = findInstr(prog, 'Sin')!
+    expect(sin).toBeDefined()
+    expect(sin.loop_count).toBe(1)
+    expect(sin.args[0]).toMatchObject({ kind: 'const', val: 1.0 })
+    expect(sin.result_type).toBe('float')
+  })
+
+  test('scalar ternary: select and clamp', () => {
+    const selProg = emitNumericProgram([{ op: 'select', args: [true, 1, 2] }], [])
+    const sel = findInstr(selProg, 'Select')!
+    expect(sel).toBeDefined()
+    expect(sel.args).toHaveLength(3)
+    expect(sel.loop_count).toBe(1)
+    expect(sel.args[0]).toMatchObject({ kind: 'const', val: 1, scalar_type: 'bool' })  // true → 1
+    expect(sel.args[1]).toMatchObject({ kind: 'const', val: 1, scalar_type: 'float' })
+    expect(sel.args[2]).toMatchObject({ kind: 'const', val: 2, scalar_type: 'float' })
+
+    const clProg = emitNumericProgram([{ op: 'clamp', args: [5, 0, 10] }], [])
+    const cl = findInstr(clProg, 'Clamp')!
+    expect(cl).toBeDefined()
+    expect(cl.args).toHaveLength(3)
+    expect(cl.loop_count).toBe(1)
+  })
+
+  // ── Type inference ─────────────────────────────────────────
+
+  test('type categories: bitwise→int, comparison→bool, transcendental→float', () => {
+    const bitProg = emitNumericProgram([{ op: 'bit_and', args: [1, 2] }], [])
+    expect(findInstr(bitProg, 'BitAnd')!.result_type).toBe('int')
+
+    const cmpProg = emitNumericProgram([{ op: 'lt', args: [1, 2] }], [])
+    expect(findInstr(cmpProg, 'Less')!.result_type).toBe('bool')
+
+    const sinProg = emitNumericProgram([{ op: 'sin', args: [1] }], [])
+    expect(findInstr(sinProg, 'Sin')!.result_type).toBe('float')
+  })
+
+  test('type promotion in arithmetic', () => {
+    // float (input) + int (sample_index) → float
+    const prog1 = emitNumericProgram(
+      [{ op: 'add', args: [{ op: 'input', id: 0 }, { op: 'sample_index' }] }],
+      [],
+    )
+    const add1 = findInstr(prog1, 'Add')!
+    expect(add1.result_type).toBe('float')
+
+    // int (reg 0) + bool (reg 1) → int
+    const prog2 = emitNumericProgram(
+      [{ op: 'add', args: [{ op: 'reg', id: 0 }, { op: 'reg', id: 1 }] }],
+      [],
+      [0, false],        // stateInit
+      ['int', 'bool'],   // stateRegTypes
+    )
+    const add2 = findInstr(prog2, 'Add')!
+    expect(add2.result_type).toBe('int')
+  })
+
+  // ── Array ops ──────────────────────────────────────────────
+
+  test('inline array → Pack instruction', () => {
+    // JS array literal
+    const prog1 = emitNumericProgram([[1, 2, 3] as ExprNode], [])
+    const pack1 = findInstr(prog1, 'Pack')!
+    expect(pack1).toBeDefined()
+    expect(pack1.args).toHaveLength(3)
+    expect(prog1.array_slot_sizes).toContain(3)
+
+    // {op:'array', items:[...]} JSON format
+    const prog2 = emitNumericProgram([{ op: 'array', items: [4, 5] }], [])
+    const pack2 = findInstr(prog2, 'Pack')!
+    expect(pack2).toBeDefined()
+    expect(pack2.args).toHaveLength(2)
+    expect(prog2.array_slot_sizes).toContain(2)
+  })
+
+  test('elementwise binary with stride patterns', () => {
+    // array + scalar → strides [1, 0]
+    const prog1 = emitNumericProgram([{ op: 'add', args: [[1, 2, 3], 10] }], [])
+    const add1 = findAll(prog1, 'Add').find(i => i.loop_count > 1)!
+    expect(add1.loop_count).toBe(3)
+    expect(add1.strides).toEqual([1, 0])
+
+    // scalar + array → strides [0, 1]
+    const prog2 = emitNumericProgram([{ op: 'add', args: [10, [1, 2, 3]] }], [])
+    const add2 = findAll(prog2, 'Add').find(i => i.loop_count > 1)!
+    expect(add2.loop_count).toBe(3)
+    expect(add2.strides).toEqual([0, 1])
+
+    // array + array → strides [1, 1]
+    const prog3 = emitNumericProgram([{ op: 'add', args: [[1, 2, 3], [4, 5, 6]] }], [])
+    const add3 = findAll(prog3, 'Add').find(i => i.loop_count > 1)!
+    expect(add3.loop_count).toBe(3)
+    expect(add3.strides).toEqual([1, 1])
+  })
+
+  test('size-1 array unboxing prevents JIT segfault', () => {
+    // add([42], 1) — the [42] must be unboxed via Index[0] before scalar Add
+    const prog = emitNumericProgram([{ op: 'add', args: [[42], 1] }], [])
+
+    // Should have: Pack(size=1), Index (unbox), Add (scalar), Add (output copy)
+    const pack = findInstr(prog, 'Pack')!
+    expect(pack).toBeDefined()
+    expect(prog.array_slot_sizes).toContain(1)
+
+    const indices = findAll(prog, 'Index')
+    expect(indices.length).toBeGreaterThanOrEqual(1)
+    // The unbox Index reads from the array slot at const index 0
+    const unbox = indices[0]
+    expect(unbox.args[1]).toMatchObject({ kind: 'const', val: 0 })
+
+    // The final Add that does the arithmetic should be scalar (loop_count=1)
+    const adds = findAll(prog, 'Add')
+    const scalarAdd = adds.find(a => a.loop_count === 1 && a.args.some(
+      op => op.kind === 'const' && op.val === 1,
+    ))
+    expect(scalarAdd).toBeDefined()
+    expect(scalarAdd!.loop_count).toBe(1)
+  })
+
+  test('index and array_set', () => {
+    // index([10, 20, 30], 1)
+    const idxProg = emitNumericProgram([{ op: 'index', args: [[10, 20, 30], 1] }], [])
+    const pack = findInstr(idxProg, 'Pack')!
+    expect(pack).toBeDefined()
+    const idx = findInstr(idxProg, 'Index')!
+    expect(idx).toBeDefined()
+    expect(idx.loop_count).toBe(1)  // result is scalar
+
+    // array_set([10, 20, 30], 1, 99)
+    const setProg = emitNumericProgram([{ op: 'array_set', args: [[10, 20, 30], 1, 99] }], [])
+    const setEl = findInstr(setProg, 'SetElement')!
+    expect(setEl).toBeDefined()
+    expect(setEl.loop_count).toBe(1)
+  })
+
+  // ── Output & register targets ──────────────────────────────
+
+  test('output_targets: scalar output gets copy, array output gets Index[0]', () => {
+    // Scalar output → last instr is Add(val, 0) copy
+    const scalarProg = emitNumericProgram([42], [])
+    const scalarOut = outputInstr(scalarProg)
+    expect(scalarOut.tag).toBe('Add')
+    expect(scalarOut.args[1]).toMatchObject({ kind: 'const', val: 0 })
+
+    // Array output → last instr is Index(array_reg, 0)
+    const arrProg = emitNumericProgram([[1, 2] as ExprNode], [])
+    const arrOut = outputInstr(arrProg)
+    expect(arrOut.tag).toBe('Index')
+    expect(arrOut.args[0]).toMatchObject({ kind: 'array_reg' })
+    expect(arrOut.args[1]).toMatchObject({ kind: 'const', val: 0 })
+  })
+
+  test('register_targets: null→-1, scalar update, array→-1', () => {
+    const prog = emitNumericProgram(
+      [42],
+      [null, { op: 'add', args: [1, 2] }, [1, 2, 3]],
+    )
+    expect(prog.register_targets[0]).toBe(-1)          // null → no update
+    expect(prog.register_targets[1]).toBeGreaterThan(-1) // scalar → valid temp
+    expect(prog.register_targets[2]).toBe(-1)           // array → unsupported
+  })
+
+  // ── State & memoization ────────────────────────────────────
+
+  test('typed state registers and array register init', () => {
+    // Int register reads with correct scalar_type
+    const intProg = emitNumericProgram(
+      [{ op: 'reg', id: 0 }],
+      [],
+      [0],
+      ['int'],
+    )
+    const intOut = outputInstr(intProg)
+    expect(intOut.args[0]).toMatchObject({ kind: 'state_reg', slot: 0, scalar_type: 'int' })
+
+    // Array register init: reg 1 backed by [1,2,3] → array_reg, not state_reg
+    const arrProg = emitNumericProgram(
+      [{ op: 'reg', id: 1 }],
+      [],
+      [0, [1, 2, 3]],
+    )
+    // The reg should compile as an array — output path extracts element 0
+    const arrOut = outputInstr(arrProg)
+    expect(arrOut.tag).toBe('Index')
+    expect(arrOut.args[0]).toMatchObject({ kind: 'array_reg' })
+    expect(arrProg.array_slot_sizes).toContain(3)
+  })
+
+  test('CSE: shared subexpression compiles once', () => {
+    const shared = { op: 'add', args: [1, 2] } as ExprNode
+    const prog = emitNumericProgram([{ op: 'mul', args: [shared, shared] }], [])
+
+    // Only 1 Add instruction — the shared node is compiled once via WeakMap memo
+    const adds = findAll(prog, 'Add').filter(i =>
+      // Exclude the output-copy Add(val, 0)
+      !(i.args.length === 2 && i.args[1]?.kind === 'const' && (i.args[1] as { val: number }).val === 0
+        && i.args[0]?.kind === 'reg'),
+    )
+    expect(adds).toHaveLength(1)
+
+    // Mul's two args reference the same reg slot
+    const mul = findInstr(prog, 'Mul')!
+    expect(mul).toBeDefined()
+    expect(mul.args[0]).toEqual(mul.args[1])
+  })
+})

--- a/design/TESTING.md
+++ b/design/TESTING.md
@@ -1,0 +1,270 @@
+# Testing Philosophy
+
+An algebra for reasoning about what tests do, where they apply, and what's missing.
+
+---
+
+## 1. The Algebra
+
+A test is a function `t : S -> {pass, fail}` where S is some subset of the system's state space. Everything else follows from how you compose and constrain that function.
+
+**Scope.** The scope of a test is a contiguous interval `[stage_i, stage_j]` in the pipeline. A test with scope `[ExprNode, ExprNode]` observes one stage; a test with scope `[ProgramJSON, Audio]` observes the whole pipeline. Scopes form a lattice under subset ordering on pipeline intervals. A test with smaller scope fails closer to the fault.
+
+**Oracle strength.** Every test's predicate falls on a spectrum:
+
+| Level | Name | Criterion |
+|-------|------|-----------|
+| O0 | Liveness | Does not crash, does not hang |
+| O1 | Range | Output is in some expected set (e.g. peak in (0, 100)) |
+| O2 | Relational | Output satisfies a structural invariant (type preservation, idempotence, categorical law) |
+| O3 | Differential | Output matches a reference implementation within epsilon |
+| O4 | Exact | Output matches a known-good value to machine precision |
+
+Most smoke tests are O0-O1. Most DSP correctness tests need O3-O4. The useful insight: you can have an O4 oracle for structure (exact instruction match) and only an O1 oracle for numerics (peak level) on the same test — oracle strength is per-assertion, not per-test.
+
+**Observability.** When `t(s) = fail`, how many bits does the failure message carry? Low: "test failed." High: "at stage Flatten, module VCO1, expression `{op:'ref', module:'VCO1', output:'saw'}`, expected type `float` but got `float[4]`." Observability is orthogonal to scope and oracle strength.
+
+**Covering.** A test suite covers a behavior region R if for every behavior b in R, there exists a test whose scope includes b and whose oracle is strong enough to distinguish correct from incorrect. Gaps in the covering are undertested behaviors. You can ask: is there a region covered by only O0? That's more honest than counting "unit tests."
+
+**Composition.** Tests compose vertically (extending scope across more pipeline stages) and horizontally (parameterizing over more inputs). Property-based testing is horizontal composition — same oracle, wider input domain. End-to-end testing is vertical composition — more stages, same input. The ideal suite has tests at every oracle level for every pipeline scope, composed with enough horizontal breadth to cover the input space.
+
+---
+
+## 2. The Pipeline Lattice
+
+Tropical's compilation pipeline is a linear chain. Each boundary between stages has a concrete type that serves as the testable observable.
+
+```
+Stage 0:  ProgramJSON            tropical_program_1 schema (stdlib or user-defined)
+Stage 1:  loadModuleFromJSON     JSON -> ProgramDef via slottifyExpr (name -> slot)
+Stage 2:  Session assembly       type/instance registries, wiring, input expressions
+Stage 3:  ExprNode trees         recursive JSON union -- the universal IR
+Stage 4:  Flattening             multi-module -> single expression set, ref resolution
+Stage 5:  Combinator expansion   generate/fold/chain/scan/iterate -> scalar trees
+Stage 6:  Array lowering         array ops -> scalar primitives (static unrolling)
+Stage 7:  Instruction emission   ExprNode -> FlatProgram NInstr stream
+Stage 8:  JSON serialization     tropical_plan_4 JSON string
+          --- C API boundary (koffi FFI) ---
+Stage 9:  Plan parsing           JSON -> FlatProgram C++ struct
+Stage 10: JIT compilation        FlatProgram -> LLVM IR -> native kernel
+Stage 11: FlatRuntime            kernel execution, double-buffered state management
+Stage 12: Audio output           RtAudio callback
+```
+
+The **Term IR** path is a parallel branch (`ExprNode -> Term -> optimized Term`) used for type-checking and structural reasoning. It does not feed the audio path directly.
+
+**Key property: stages 0-8 are all JSON-serializable.** This is what makes the interpreter strategy viable — an interpreter can consume any intermediate representation up through the plan and produce numerical output, bypassing the JIT entirely.
+
+### Boundary types
+
+| Boundary | Type | Serializable |
+|----------|------|:---:|
+| 0 -> 1 | `ProgramJSON` | yes |
+| 1 -> 2 | `ProgramDef` (slot-indexed IR) | yes |
+| 2 -> 3 | `ExprNode` trees per instance | yes |
+| 3 -> 4 | flattened `ExprNode` set | yes |
+| 4 -> 5 | `ExprNode` with combinators expanded | yes |
+| 5 -> 6 | `ExprNode` with arrays lowered | yes |
+| 6 -> 7 | `FlatProgram` (`NInstr[]`) | yes |
+| 7 -> 8 | `tropical_plan_4` JSON string | by definition |
+| 8 -> 9 | `FlatProgram` C++ struct | no |
+| 9 -> 10 | `NumericKernelFn` (function pointer) | no |
+| 10 -> 11 | `double[]` output buffer | yes |
+
+---
+
+## 3. Oracle Taxonomy per Stage
+
+What the strongest available oracle is for each stage, what exists today, and where the gaps are.
+
+| Stage | Transfer function | Strongest oracle | Current tests | Gap |
+|-------|-------------------|------------------|---------------|-----|
+| ProgramJSON schema | Zod parse + roundtrip | O4 | `program.test.ts` (14) | No fuzz of malformed JSON |
+| loadModuleFromJSON | slottifyExpr (name -> slot) | O4 (structural) | None dedicated | **No tests for slottifyExpr** |
+| ExprNode construction | expr.ts operations | O4 | `expr.test.ts` (14) | Only construction, no evaluation |
+| Term IR | Categorical laws | O4 + O2 (PBT) | `term.test.ts` (45+, 200-500 PBT runs) | Excellent |
+| Term optimization | Structural rewrites | O2 (PBT) | `optimizer.test.ts` (26, 300 PBT runs) | Excellent |
+| Flattening | Inline + resolve refs | O4 | `flatten_wiring.test.ts` (12) | No nested call resolution tests |
+| Combinator expansion | Unroll to scalars | O4 | `combinators.test.ts` (22) | Good |
+| Array lowering | Static unroll | O4 | `lower_arrays.test.ts` (25) | Good |
+| Instruction emission | emitNumericProgram() | O4 (structural) | **None** | **Critical: no emit_numeric.test.ts** |
+| Plan serialization | JSON.stringify | O4 | `plan.test.ts` (20, plan_1) | plan_4 not directly tested |
+| Plan parsing (C++) | JSON -> struct | O2 | `test_module_process.cpp` (implicit) | No dedicated parsing tests |
+| JIT compilation | LLVM codegen | O3 (differential) | **No interpreter exists** | **Critical: no reference oracle** |
+| FlatRuntime | Kernel execution | O3 (epsilon) | `test_module_process.cpp` (10), `apply_plan.test.ts` (11) | Only handwritten plans |
+| Audio output | RtAudio callback | O0 | `mcp/patch.test.ts` (range check) | Inherently limited |
+
+### Module type coverage
+
+19 built-in module types exist as `stdlib/*.json`. Integration tests exercise only **VCO, VCA, Clock** (3/19) through the full pipeline with numerical output. All 19 load and flatten successfully, but no test verifies that the remaining 16 produce numerically correct audio.
+
+Untested numerically: ADEnvelope, ADSREnvelope, Reverb, Phaser, Phaser16, Compressor, BassDrum, LadderFilter, BitCrusher, NoiseLFSR, TopoWaveguide, Delay8/16/512/4410/44100.
+
+---
+
+## 4. Coverage Map
+
+Current test suite as a covering of (scope interval) x (oracle strength). Each cell: `*` = well-covered, `~` = partial, `.` = no coverage.
+
+```
+Scope (interval)                     O0  O1  O2  O3  O4
+-------------------------------------------------------
+[ProgramJSON schema]                  .   .   *   .   *
+[loadModuleFromJSON / slottifyExpr]   ~   .   .   .   .
+[ExprNode construction]               .   .   *   .   *
+[Term IR + type checking]             .   .   *   .   *
+[Term optimization]                   .   .   *   .   *
+[Flattening]                          .   .   *   .   *
+[Combinator expansion]                .   .   .   .   *
+[Array lowering]                      .   .   .   .   *
+[Instruction emission]                .   .   .   .   .   <- EMPTY
+[Plan serialization]                  .   .   *   .   *
+[Plan parsing (C++)]                  *   .   .   .   .
+[JIT + Runtime]                       *   .   .   .   ~
+[ProgramJSON -> FlatRuntime]          *   *   .   .   ~
+[ProgramJSON -> Audio]                *   *   .   .   .
+```
+
+### Critical gaps, ranked
+
+**1. Instruction emission (stage 7).** No `emit_numeric.test.ts` exists. This stage translates ExprNode trees into `FlatProgram` instruction streams. If it has a bug, tests downstream either catch it at O1 (range check on audio output) or miss it entirely. A structural oracle (O4) here would dramatically improve fault localization.
+
+**2. No interpreter for differential testing.** No ExprNode interpreter exists. This would enable O3 testing across the entire pipeline: for any program, run the interpreter on the lowered ExprNode tree, run the JIT path, compare sample-by-sample. This single addition would convert every integration test from O1 to O3.
+
+**3. slottifyExpr / loadModuleFromJSON untested.** These are the new functions (from the stdlib-as-JSON migration) that convert named references in ProgramJSON to slot-indexed ProgramDef. They're exercised indirectly through integration tests, but a bug in name resolution would be hard to diagnose without isolated tests.
+
+**4. Only 3/19 modules tested numerically.** The stdlib JSON files are frozen artifacts. Their correctness was validated once during generation (against the now-deleted TypeScript factories). There is no ongoing regression oracle — if the flattener or emitter changes behavior, 16 modules could silently break.
+
+---
+
+## 5. The Interpreter Strategy
+
+The single highest-impact addition to the test suite. A reference evaluator for ExprNode trees that serves as a universal differential oracle.
+
+### What it is
+
+A function `evalExprNode(node: ExprNode, env: Environment) -> number | boolean | number[]` that recursively evaluates an ExprNode tree to a concrete value. The environment provides: sample rate, sample index, register values, parameter values, input values.
+
+### Why ExprNode is the right level
+
+ExprNode is the stage where all module boundaries have been erased (post-flatten), all combinators expanded (post-lower_arrays), but the representation is still JSON. An interpreter at this level serves as oracle for everything from stage 6 through stage 11.
+
+### Sketch
+
+```typescript
+function evalExprNode(node: ExprNode, env: Env): number | boolean | (number | boolean)[] {
+  if (typeof node === 'number') return node
+  if (typeof node === 'boolean') return node
+  if (Array.isArray(node)) return node.map(n => evalExprNode(n, env))
+  switch (node.op) {
+    case 'add':    return eval(node.args[0]) + eval(node.args[1])
+    case 'mul':    return eval(node.args[0]) * eval(node.args[1])
+    case 'sin':    return Math.sin(eval(node.args[0]))
+    case 'select': return eval(node.args[0]) ? eval(node.args[1]) : eval(node.args[2])
+    case 'sample_rate':  return env.sampleRate
+    case 'sample_index': return env.sampleIndex
+    case 'state_reg':    return env.registers[node.slot]
+    case 'input':        return env.inputs[node.slot]
+    case 'param':        return env.params[node.ptr]
+    // ... ~35 ops total, matching BINARY_TAG + UNARY_TAG in emit_numeric.ts
+  }
+}
+```
+
+The interpreter handles the post-lowering ExprNode dialect only — no `generate`, `fold`, `let`, `zeros`, `reshape`. Those are all expanded by `lowerArrayOps`. The ops it must support are exactly those in `BINARY_TAG`, `UNARY_TAG`, and the special cases in `emit_numeric.ts`: approximately 35 ops.
+
+### Stateful evaluation
+
+For modules with registers, the interpreter runs sample-by-sample: evaluate all output expressions, evaluate all register-target expressions, advance sample index, repeat. This mirrors `FlatRuntime::process()`.
+
+### Use `Math.*`, not JIT transcendentals
+
+The interpreter uses JavaScript's `Math.sin`, `Math.cos`, etc. The JIT uses inline minimax polynomial approximations. These diverge at ~1e-10. This is a feature: the O3 differential test with epsilon tolerance (1e-6) tests the algebraic structure of the computation while allowing implementation-level numerical variation. Disagreement beyond 1e-6 indicates a semantic bug.
+
+### Where it lives
+
+`compiler/interpret.ts`. Imports only `ExprNode` from `expr.ts`. No FFI, no C++ dependency. Pure TS, fully deterministic, runnable in `bun test`.
+
+### What it enables
+
+Every test in `apply_plan.test.ts` can be upgraded: instead of checking `peak(buf) > 0` (O1), check `|jit_output[i] - interp_output[i]| < 1e-6 for all i` (O3). Every stdlib module gets tested by loading the JSON, flattening, interpreting N samples, and comparing against JIT output. The interpreter is the ongoing regression oracle that replaces the deleted TypeScript module factories.
+
+---
+
+## 6. Concrete Next Steps
+
+Ranked by coverage impact — which regions of behavior space each addition covers.
+
+### Priority 1: Build the ExprNode interpreter
+
+`compiler/interpret.ts` — ~200 lines of TS (35 ops, each 1-3 lines).
+
+- **Scope**: enables O3 oracle for `[ExprNode, Audio]` — the widest interval
+- **Dependency**: none
+- **Impact**: converts every integration test from O1 to O3; makes module coverage trivial to expand; provides ongoing oracle for stdlib JSON correctness
+
+### Priority 2: Stdlib golden-output tests
+
+For each of the 19 `stdlib/*.json` files: load -> flatten -> JIT -> process N samples -> compare against interpreter output (O3) or snapshot as golden reference (O4).
+
+- **Scope**: `[ProgramJSON, FlatRuntime]` per module type
+- **Dependency**: interpreter (for O3), or standalone with snapshotted output (O4)
+- **Impact**: covers 16 currently untested module types; catches regressions in flattener/emitter/JIT
+
+### Priority 3: Create `emit_numeric.test.ts`
+
+Feed ExprNode trees in, assert on emitted `NInstr[]`. Same pattern as `lower_arrays.test.ts`.
+
+- **Scope**: `[ExprNode, FlatProgram]` — stage 7 only
+- **Oracle**: O4 (exact structural match)
+- **Start with**: arithmetic, register read/write, array pack/index, select, sample_rate/sample_index
+- **Impact**: fills the completely empty row in the coverage grid
+
+### Priority 4: `slottifyExpr` unit tests
+
+Exercise name-to-slot conversion edge cases: unknown names, nested calls, delay refs, array registers.
+
+- **Scope**: `[ProgramJSON, ProgramDef]` — stage 1 only
+- **Oracle**: O4 (exact structural match on output ExprNode)
+- **Impact**: tests the new code path from the stdlib-as-JSON migration
+
+### Priority 5: Property-based tests for instruction emission
+
+- **Scope**: `[ExprNode, FlatProgram]` — stage 7
+- **Oracle**: O2 (relational invariants)
+- **Properties**: output_targets.length matches expected output count; all register_targets are valid temp indices; instruction count bounded by ExprNode tree size
+- **Pairs with**: interpreter differential tests (O2 + O3 together)
+
+### Priority 6: Cross-boundary roundtrip tests
+
+Emit a `FlatProgram` in TS, serialize to `tropical_plan_4` JSON, parse in C++ via `NumericProgramParser`, verify field-by-field.
+
+- **Scope**: `[FlatProgram TS, FlatProgram C++]` — stages 7-9
+- **Oracle**: O4 (structural match after JSON roundtrip)
+- **Impact**: catches serialization/parsing mismatches at the FFI boundary
+
+---
+
+## 7. Determinism
+
+Stages 0-9 (all TS + C++ parsing) are **fully deterministic** — pure functions from input to output. Same ExprNode in, same FlatProgram out. O4 oracles apply freely.
+
+Stage 10 (JIT) is **functionally deterministic.** The kernel function is deterministic for a given FlatProgram. Inline transcendental approximations (sin, cos, exp, log, tanh) produce bit-identical results across runs on the same platform (no libm dependency). Cross-platform reproducibility is a non-goal (macOS/ARM64 only in practice).
+
+Stage 11 (FlatRuntime) with **hot-swap** introduces observable non-determinism: the output of buffer N+1 depends on whether a hot-swap occurred between N and N+1. Tests exercising hot-swap must account for this (and `test_module_process.cpp` test 3 already does).
+
+Stage 12 (Audio) is **inherently non-deterministic** — callback timing, device latency, buffer underruns. No O3/O4 oracle is possible. O0 (liveness) and O1 (range) are the strongest practical oracles.
+
+---
+
+## 8. Maintaining the Covering
+
+Rules for keeping the coverage map current as the codebase evolves.
+
+**New stdlib module.** Add JSON to `stdlib/`. Add golden-output test (load -> flatten -> process N samples). Verify interpreter match once interpreter exists.
+
+**New ExprNode op.** Four tests required: (a) construction test in `expr.test.ts`, (b) emission test in `emit_numeric.test.ts`, (c) interpreter case in `interpret.ts`, (d) C++ OpTag test in `test_module_process.cpp` with handwritten `tropical_plan_4` JSON.
+
+**Modifying flattener or emitter.** Run full stdlib golden-output suite. Any change to `flatten.ts`, `lower_arrays.ts`, or `emit_numeric.ts` can silently alter the behavior of all 19 modules.
+
+**New pipeline stage.** Add at least one O2+ test in isolation, plus verify existing end-to-end tests still pass. Update this document's lattice diagram.


### PR DESCRIPTION
## Summary

- Adds `design/TESTING.md` — a testing philosophy document that replaces "unit vs integration" with a formal algebra: tests as functions, scope as a lattice over pipeline stages, oracle strength spectrum (O0-O4), observability, and covering analysis
- Includes concrete coverage map of the current test suite (13 test files) against the pipeline lattice, identifying four critical gaps
- Designs an ExprNode interpreter (`compiler/interpret.ts`) as a universal differential oracle — the highest-impact single addition to the test suite
- Accounts for the stdlib-as-JSON migration (PR #79): the interpreter becomes the ongoing regression oracle replacing the deleted TS module factories

## Key gaps identified

1. **Instruction emission untested** — no `emit_numeric.test.ts` exists
2. **No reference interpreter** — no differential oracle for JIT correctness
3. **`slottifyExpr` / `loadModuleFromJSON` untested** — new code paths from #79
4. **Only 3/19 stdlib modules tested numerically** through the full pipeline

## Test plan

- [x] Document is internally consistent (terms defined before use)
- [ ] Review coverage map against actual test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)