### PR TITLE
feat: bounded types with automatic clamp enforcement

### DIFF
--- a/compiler/bounds.test.ts
+++ b/compiler/bounds.test.ts
@@ -218,7 +218,7 @@ describe('flattenSession output bounds', () => {
     expect(hasClamp).toBe(true)
   })
 
-  test('unbounded output has no clamp injection', () => {
+  test('unbounded output still gets audio safety clamp when routed to graph output', () => {
     const session = mockSession()
 
     const type = loadProgramDef(leafProgram(), session)
@@ -239,13 +239,14 @@ describe('flattenSession output bounds', () => {
     }
 
     const plan = flattenSession(fullSession)
+    // Audio safety clamp injects Clamp even with no declared bounds
     const hasClamp = plan.instructions.some(
       (instr: any) => instr.tag === 'Clamp'
     )
-    expect(hasClamp).toBe(false)
+    expect(hasClamp).toBe(true)
   })
 
-  test('one-sided lower bound produces Select (max pattern)', () => {
+  test('one-sided lower bound produces Select (max) plus audio safety Clamp', () => {
     const session = mockSession()
 
     const type = loadProgramDef(leafProgram({
@@ -268,11 +269,11 @@ describe('flattenSession output bounds', () => {
     }
 
     const plan = flattenSession(fullSession)
-    // Should have a Select instruction (for max) but no Clamp
+    // Select from output bounds [0, null] (max pattern), plus safety Clamp [-1, 1]
     const hasSelect = plan.instructions.some((instr: any) => instr.tag === 'Select')
     const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
     expect(hasSelect).toBe(true)
-    expect(hasClamp).toBe(false)
+    expect(hasClamp).toBe(true)
   })
 })
 
@@ -363,8 +364,104 @@ describe('flattenSession cross-instance bounded output', () => {
     }
 
     const plan = flattenSession(fullSession)
-    // Source's bounded output should produce exactly one Clamp (shared via DAG)
+    // Source's bounded output: 1 Clamp (shared via DAG).
+    // d1 and d2 are unbounded graph outputs: each gets 1 audio safety Clamp.
+    // Total: 3 Clamps.
+    const clampCount = plan.instructions.filter((instr: any) => instr.tag === 'Clamp').length
+    expect(clampCount).toBe(3)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Audio output safety clamp
+// ─────────────────────────────────────────────────────────────
+
+describe('audio output safety clamp', () => {
+  function makeFullSession(session: ReturnType<typeof mockSession>, graphOutputs: Array<{ instance: string; output: string }>) {
+    return {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs,
+      inputExprNodes: new Map<string, ExprNode>(),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+  }
+
+  test('unbounded audio output gets safety clamp to [-1, 1]', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      process: { outputs: { out: 999 } },
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+    session.instanceRegistry.set('a', type.instantiateAs('a'))
+
+    const plan = flattenSession(makeFullSession(session, [{ instance: 'a', output: 'out' }]))
+    const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
+    expect(hasClamp).toBe(true)
+  })
+
+  test('output bounded [-1, 1] gets no extra safety clamp', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [-1, 1] }],
+      process: { outputs: { out: { op: 'input', name: 'x' } } },
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+    session.instanceRegistry.set('a', type.instantiateAs('a'))
+
+    const plan = flattenSession(makeFullSession(session, [{ instance: 'a', output: 'out' }]))
+    // One Clamp from the output bounds, no extra from safety
     const clampCount = plan.instructions.filter((instr: any) => instr.tag === 'Clamp').length
     expect(clampCount).toBe(1)
+  })
+
+  test('output bounded [0, 1] (tighter) gets no extra safety clamp', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [0, 1] }],
+      process: { outputs: { out: { op: 'input', name: 'x' } } },
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+    session.instanceRegistry.set('a', type.instantiateAs('a'))
+
+    const plan = flattenSession(makeFullSession(session, [{ instance: 'a', output: 'out' }]))
+    // One Clamp from the output bounds, no extra from safety
+    const clampCount = plan.instructions.filter((instr: any) => instr.tag === 'Clamp').length
+    expect(clampCount).toBe(1)
+  })
+
+  test('output bounded [-5, 5] (wider) gets additional safety clamp', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [-5, 5] }],
+      process: { outputs: { out: { op: 'input', name: 'x' } } },
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+    session.instanceRegistry.set('a', type.instantiateAs('a'))
+
+    const plan = flattenSession(makeFullSession(session, [{ instance: 'a', output: 'out' }]))
+    // Two Clamps: one from output bounds [-5, 5], one from safety [-1, 1]
+    const clampCount = plan.instructions.filter((instr: any) => instr.tag === 'Clamp').length
+    expect(clampCount).toBe(2)
+  })
+
+  test('one-sided output bounds [0, null] gets safety clamp', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [0, null] }],
+      process: { outputs: { out: { op: 'input', name: 'x' } } },
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+    session.instanceRegistry.set('a', type.instantiateAs('a'))
+
+    const plan = flattenSession(makeFullSession(session, [{ instance: 'a', output: 'out' }]))
+    // Select from output bounds (max), plus Clamp from safety [-1, 1]
+    const hasSelect = plan.instructions.some((instr: any) => instr.tag === 'Select')
+    const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
+    expect(hasSelect).toBe(true)
+    expect(hasClamp).toBe(true)
   })
 })

--- a/compiler/bounds.test.ts
+++ b/compiler/bounds.test.ts
@@ -1,0 +1,370 @@
+/**
+ * bounds.test.ts — Tests for bounded types and automatic clamp enforcement.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { applyBounds, flattenSession } from './flatten'
+import { loadProgramDef, resolveBounds, resolveBaseType, BOUNDED_TYPE_ALIASES } from './session'
+import type { ExprNode } from './expr'
+import type { ProgramJSON } from './program'
+import type { ProgramType, ProgramInstance, Bounds } from './program_types'
+import { Param, Trigger } from './runtime/param'
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ────────���────────────────────────────────────────────────────
+
+/** Minimal session for loadProgramDef (no FFI). */
+function mockSession() {
+  return {
+    typeRegistry: new Map<string, ProgramType>(),
+    instanceRegistry: new Map<string, ProgramInstance>(),
+    paramRegistry: new Map<string, Param>(),
+    triggerRegistry: new Map<string, Trigger>(),
+  }
+}
+
+/** Leaf program that computes output = input * 2. */
+function leafProgram(overrides: Partial<ProgramJSON> = {}): ProgramJSON {
+  return {
+    schema: 'tropical_program_1',
+    name: 'TestLeaf',
+    inputs: [{ name: 'x', type: 'float' }],
+    outputs: [{ name: 'out', type: 'float' }],
+    input_defaults: { x: 0 },
+    process: {
+      outputs: { out: { op: 'mul', args: [{ op: 'input', name: 'x' }, 2] } },
+    },
+    ...overrides,
+  }
+}
+
+/** Check whether an expression tree contains a node with the given op. */
+function containsOp(node: ExprNode, op: string): boolean {
+  if (typeof node === 'number' || typeof node === 'boolean') return false
+  if (Array.isArray(node)) return node.some(n => containsOp(n, op))
+  if (typeof node !== 'object' || node === null) return false
+  const obj = node as { op: string; [k: string]: unknown }
+  if (obj.op === op) return true
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === 'op') continue
+    if (Array.isArray(v)) { if (v.some(n => containsOp(n as ExprNode, op))) return true }
+    else if (typeof v === 'object' && v !== null) { if (containsOp(v as ExprNode, op)) return true }
+  }
+  return false
+}
+
+// ──────���────────────────────────────────────���─────────────────
+// applyBounds (unit)
+// ────────────────────────────────���────────────────────────────
+
+describe('applyBounds', () => {
+  const x: ExprNode = { op: 'input', id: 0 }
+
+  test('two-sided bounds produce clamp', () => {
+    const result = applyBounds(x, [-1, 1])
+    expect(result).toEqual({ op: 'clamp', args: [x, -1, 1] })
+  })
+
+  test('lower bound only produces select+gt (max)', () => {
+    const result = applyBounds(x, [0, null])
+    expect(result).toEqual({ op: 'select', args: [{ op: 'gt', args: [x, 0] }, x, 0] })
+  })
+
+  test('upper bound only produces select+lt (min)', () => {
+    const result = applyBounds(x, [null, 10])
+    expect(result).toEqual({ op: 'select', args: [{ op: 'lt', args: [x, 10] }, x, 10] })
+  })
+
+  test('both null returns expression unchanged', () => {
+    const result = applyBounds(x, [null, null])
+    expect(result).toBe(x)
+  })
+})
+
+// ───────���─────────────────────────────────────────────────────
+// resolveBounds / resolveBaseType
+// ───────────��───────────────────────────────��─────────────────
+
+describe('resolveBounds', () => {
+  test('string spec returns null', () => {
+    expect(resolveBounds('x')).toBeNull()
+  })
+
+  test('explicit bounds are returned', () => {
+    expect(resolveBounds({ name: 'out', bounds: [-2, 2] })).toEqual([-2, 2])
+  })
+
+  test('named alias extracts bounds', () => {
+    expect(resolveBounds({ name: 'out', type: 'signal' })).toEqual([-1, 1])
+    expect(resolveBounds({ name: 'out', type: 'unipolar' })).toEqual([0, 1])
+    expect(resolveBounds({ name: 'out', type: 'freq' })).toEqual([0, null])
+    expect(resolveBounds({ name: 'out', type: 'phase' })).toEqual([0, 1])
+  })
+
+  test('explicit bounds override alias', () => {
+    expect(resolveBounds({ name: 'out', type: 'signal', bounds: [-2, 2] })).toEqual([-2, 2])
+  })
+
+  test('unknown type returns null', () => {
+    expect(resolveBounds({ name: 'out', type: 'float' })).toBeNull()
+  })
+
+  test('no type no bounds returns null', () => {
+    expect(resolveBounds({ name: 'out' })).toBeNull()
+  })
+})
+
+describe('resolveBaseType', () => {
+  test('alias resolves to base type', () => {
+    expect(resolveBaseType('signal')).toBe('float')
+    expect(resolveBaseType('freq')).toBe('float')
+    expect(resolveBaseType('phase')).toBe('float')
+  })
+
+  test('non-alias passes through', () => {
+    expect(resolveBaseType('float')).toBe('float')
+    expect(resolveBaseType('int')).toBe('int')
+    expect(resolveBaseType('float[4]')).toBe('float[4]')
+  })
+
+  test('undefined passes through', () => {
+    expect(resolveBaseType(undefined)).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// loadProgramDef bounds extraction
+// ────────────────────────────────────────────────────────────���
+
+describe('loadProgramDef bounds', () => {
+  test('extracts explicit output bounds', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [-1, 1] }],
+    }), session)
+    expect(type._def.outputBounds).toEqual([[-1, 1]])
+  })
+
+  test('extracts bounds from named type alias', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'signal' }],
+    }), session)
+    expect(type._def.outputBounds).toEqual([[-1, 1]])
+    // Base type resolved to float
+    expect(type._def.outputPortTypes).toEqual(['float'])
+  })
+
+  test('extracts explicit input bounds', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      inputs: [{ name: 'x', type: 'float', bounds: [0, null] }],
+    }), session)
+    expect(type._def.inputBounds).toEqual([[0, null]])
+  })
+
+  test('no bounds yields null entries', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram(), session)
+    expect(type._def.outputBounds).toEqual([null])
+    expect(type._def.inputBounds).toEqual([null])
+  })
+
+  test('string-shorthand input has null bounds', () => {
+    const session = mockSession()
+    const type = loadProgramDef(leafProgram({
+      inputs: ['x'],
+    }), session)
+    expect(type._def.inputBounds).toEqual([null])
+  })
+})
+
+// ───────���──────────────���─────────────────────────��────────────
+// flattenSession with bounds
+// ───────────────────���─────────────────────────────────────────
+
+describe('flattenSession output bounds', () => {
+  test('output bounds inject clamp into flattened expression', () => {
+    const session = mockSession()
+
+    // Register a leaf type with bounded output
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [-1, 1] }],
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+
+    // Create instance
+    const inst = type.instantiateAs('a')
+    session.instanceRegistry.set('a', inst)
+
+    // Build a minimal full session for flattenSession
+    const fullSession = {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs: [{ instance: 'a', output: 'out' }],
+      inputExprNodes: new Map<string, ExprNode>(),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+
+    const plan = flattenSession(fullSession)
+    // The plan should contain a Clamp instruction
+    const hasClamp = plan.instructions.some(
+      (instr: any) => instr.tag === 'Clamp'
+    )
+    expect(hasClamp).toBe(true)
+  })
+
+  test('unbounded output has no clamp injection', () => {
+    const session = mockSession()
+
+    const type = loadProgramDef(leafProgram(), session)
+    session.typeRegistry.set('TestLeaf', type)
+
+    const inst = type.instantiateAs('a')
+    session.instanceRegistry.set('a', inst)
+
+    const fullSession = {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs: [{ instance: 'a', output: 'out' }],
+      inputExprNodes: new Map<string, ExprNode>(),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+
+    const plan = flattenSession(fullSession)
+    const hasClamp = plan.instructions.some(
+      (instr: any) => instr.tag === 'Clamp'
+    )
+    expect(hasClamp).toBe(false)
+  })
+
+  test('one-sided lower bound produces Select (max pattern)', () => {
+    const session = mockSession()
+
+    const type = loadProgramDef(leafProgram({
+      outputs: [{ name: 'out', type: 'float', bounds: [0, null] }],
+    }), session)
+    session.typeRegistry.set('TestLeaf', type)
+
+    const inst = type.instantiateAs('a')
+    session.instanceRegistry.set('a', inst)
+
+    const fullSession = {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs: [{ instance: 'a', output: 'out' }],
+      inputExprNodes: new Map<string, ExprNode>(),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+
+    const plan = flattenSession(fullSession)
+    // Should have a Select instruction (for max) but no Clamp
+    const hasSelect = plan.instructions.some((instr: any) => instr.tag === 'Select')
+    const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
+    expect(hasSelect).toBe(true)
+    expect(hasClamp).toBe(false)
+  })
+})
+
+describe('flattenSession input bounds', () => {
+  test('input bounds clamp wiring expression', () => {
+    const session = mockSession()
+
+    // Source: unbounded output
+    const srcType = loadProgramDef(leafProgram({
+      name: 'Source',
+      inputs: [],
+      input_defaults: {},
+      process: { outputs: { out: 999 } },
+    }), session)
+    session.typeRegistry.set('Source', srcType)
+
+    // Dest: bounded input [0, 1]
+    const dstType = loadProgramDef(leafProgram({
+      name: 'Dest',
+      inputs: [{ name: 'x', type: 'float', bounds: [0, 1] }],
+    }), session)
+    session.typeRegistry.set('Dest', dstType)
+
+    const srcInst = srcType.instantiateAs('src')
+    const dstInst = dstType.instantiateAs('dst')
+    session.instanceRegistry.set('src', srcInst)
+    session.instanceRegistry.set('dst', dstInst)
+
+    const fullSession = {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs: [{ instance: 'dst', output: 'out' }],
+      inputExprNodes: new Map<string, ExprNode>([
+        ['dst:x', { op: 'ref', instance: 'src', output: 'out' }],
+      ]),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+
+    const plan = flattenSession(fullSession)
+    // The input wiring should be clamped
+    const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
+    expect(hasClamp).toBe(true)
+  })
+})
+
+describe('flattenSession cross-instance bounded output', () => {
+  test('bounded output shared across consumers', () => {
+    const session = mockSession()
+
+    // Source with bounded output
+    const srcType = loadProgramDef(leafProgram({
+      name: 'Source',
+      inputs: [],
+      input_defaults: {},
+      outputs: [{ name: 'out', type: 'float', bounds: [-1, 1] }],
+      process: { outputs: { out: 999 } },
+    }), session)
+    session.typeRegistry.set('Source', srcType)
+
+    // Two consumers
+    const dstType = loadProgramDef(leafProgram({
+      name: 'Dest',
+    }), session)
+    session.typeRegistry.set('Dest', dstType)
+
+    session.instanceRegistry.set('src', srcType.instantiateAs('src'))
+    session.instanceRegistry.set('d1', dstType.instantiateAs('d1'))
+    session.instanceRegistry.set('d2', dstType.instantiateAs('d2'))
+
+    const fullSession = {
+      ...session,
+      bufferLength: 1,
+      dac: null,
+      graphOutputs: [
+        { instance: 'd1', output: 'out' },
+        { instance: 'd2', output: 'out' },
+      ],
+      inputExprNodes: new Map<string, ExprNode>([
+        ['d1:x', { op: 'ref', instance: 'src', output: 'out' }],
+        ['d2:x', { op: 'ref', instance: 'src', output: 'out' }],
+      ]),
+      runtime: null as any,
+      graph: null as any,
+      _nameCounters: new Map<string, number>(),
+    }
+
+    const plan = flattenSession(fullSession)
+    // Source's bounded output should produce exactly one Clamp (shared via DAG)
+    const clampCount = plan.instructions.filter((instr: any) => instr.tag === 'Clamp').length
+    expect(clampCount).toBe(1)
+  })
+})

--- a/compiler/bounds.test.ts
+++ b/compiler/bounds.test.ts
@@ -18,6 +18,7 @@ import { Param, Trigger } from './runtime/param'
 function mockSession() {
   return {
     typeRegistry: new Map<string, ProgramType>(),
+    typeAliasRegistry: new Map<string, { base: string; bounds: Bounds }>(),
     instanceRegistry: new Map<string, ProgramInstance>(),
     paramRegistry: new Map<string, Param>(),
     triggerRegistry: new Map<string, Trigger>(),
@@ -463,5 +464,74 @@ describe('audio output safety clamp', () => {
     const hasClamp = plan.instructions.some((instr: any) => instr.tag === 'Clamp')
     expect(hasSelect).toBe(true)
     expect(hasClamp).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// User-definable type aliases
+// ─────────────────────────────────────────────────────────────
+
+describe('user-definable type aliases', () => {
+  test('user alias resolved via resolveBounds', () => {
+    const aliases = new Map<string, { base: string; bounds: Bounds }>()
+    aliases.set('cv', { base: 'float', bounds: [0, 10] })
+    expect(resolveBounds({ name: 'out', type: 'cv' }, aliases)).toEqual([0, 10])
+  })
+
+  test('user alias resolved via resolveBaseType', () => {
+    const aliases = new Map<string, { base: string; bounds: Bounds }>()
+    aliases.set('cv', { base: 'float', bounds: [0, 10] })
+    expect(resolveBaseType('cv', aliases)).toBe('float')
+  })
+
+  test('explicit bounds override user alias', () => {
+    const aliases = new Map<string, { base: string; bounds: Bounds }>()
+    aliases.set('cv', { base: 'float', bounds: [0, 10] })
+    expect(resolveBounds({ name: 'out', type: 'cv', bounds: [-5, 5] }, aliases)).toEqual([-5, 5])
+  })
+
+  test('user alias takes precedence over built-in', () => {
+    const aliases = new Map<string, { base: string; bounds: Bounds }>()
+    aliases.set('signal', { base: 'float', bounds: [-2, 2] })
+    expect(resolveBounds({ name: 'out', type: 'signal' }, aliases)).toEqual([-2, 2])
+    expect(resolveBaseType('signal', aliases)).toBe('float')
+  })
+
+  test('loadProgramDef uses session typeAliasRegistry', () => {
+    const session = mockSession()
+    session.typeAliasRegistry.set('audio_level', { base: 'float', bounds: [-0.5, 0.5] })
+
+    const type = loadProgramDef(leafProgram({
+      inputs: [{ name: 'x', type: 'audio_level' }],
+      outputs: [{ name: 'out', type: 'audio_level' }],
+    }), session)
+    expect(type._def.inputBounds).toEqual([[-0.5, 0.5]])
+    expect(type._def.outputBounds).toEqual([[-0.5, 0.5]])
+    expect(type._def.inputPortTypes).toEqual(['float'])
+    expect(type._def.outputPortTypes).toEqual(['float'])
+  })
+
+  test('Zod schema accepts alias type_def', () => {
+    const { parseProgram } = require('./schema')
+    const prog = parseProgram({
+      schema: 'tropical_program_1',
+      name: 'Test',
+      type_defs: [{ kind: 'alias', name: 'cv', base: 'float', bounds: [0, 10] }],
+      inputs: [{ name: 'x', type: 'cv' }],
+      outputs: [{ name: 'out', type: 'cv' }],
+      process: { outputs: { out: 0 } },
+    })
+    expect(prog.type_defs).toHaveLength(1)
+    expect(prog.type_defs[0].kind).toBe('alias')
+  })
+
+  test('Zod schema rejects alias with invalid bounds', () => {
+    const { parseProgram } = require('./schema')
+    expect(() => parseProgram({
+      schema: 'tropical_program_1',
+      name: 'Test',
+      type_defs: [{ kind: 'alias', name: 'cv', base: 'float', bounds: 'wrong' }],
+      process: { outputs: {} },
+    })).toThrow()
   })
 })

--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -1216,6 +1216,17 @@ export function flattenSession(session: SessionState): FlatPlan {
     const outputIdx = inst._def.outputNames.indexOf(output)
     if (outputIdx === -1) continue
     const flatIdx = (outputStart.get(instance) ?? 0) + outputIdx
+
+    // Safety clamp: ensure audio outputs stay within [-1, 1].
+    // Skip if the output already has bounds that are within [-1, 1].
+    const bounds = inst._def.outputBounds[outputIdx]
+    const withinSafe = bounds
+      && bounds[0] !== null && bounds[0] >= -1
+      && bounds[1] !== null && bounds[1] <= 1
+    if (!withinSafe) {
+      flatOutputExprs[flatIdx] = applyBounds(flatOutputExprs[flatIdx], [-1, 1])
+    }
+
     outputIndices.push(flatIdx)
   }
 

--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -10,7 +10,7 @@
 
 import type { ExprNode } from './expr.js'
 import type { SessionState } from './session.js'
-import type { ProgramInstance, NestedCall } from './program_types.js'
+import type { ProgramInstance, NestedCall, Bounds } from './program_types.js'
 import {
   type CompilerInput, type InstanceInfo,
   compilerInputFromSession, extractInstanceInfo,
@@ -105,6 +105,24 @@ export function normalizeWiringTypes(
   }
 
   return result
+}
+
+// ─────────────────────────────────────────────────────────────
+// Bounds enforcement
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Wrap an expression with bounds enforcement.
+ * [lo, hi]   → clamp(expr, lo, hi)
+ * [lo, null] → max(expr, lo) via select
+ * [null, hi] → min(expr, hi) via select
+ */
+export function applyBounds(expr: ExprNode, bounds: Bounds): ExprNode {
+  const [lo, hi] = bounds
+  if (lo !== null && hi !== null) return { op: 'clamp', args: [expr, lo, hi] }
+  if (lo !== null) return { op: 'select', args: [{ op: 'gt', args: [expr, lo] }, expr, lo] }
+  if (hi !== null) return { op: 'select', args: [{ op: 'lt', args: [expr, hi] }, expr, hi] }
+  return expr
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -838,9 +856,9 @@ export function flattenSession(session: SessionState): FlatPlan {
     // Process output expressions — no input substitution or ref resolution needed
     // (cycle-breaking instance outputs are purely register-derived)
     const cbOutputExprs: ExprNode[] = []
-    for (const outputNode of def.outputExprNodes) {
+    for (let i = 0; i < def.outputExprNodes.length; i++) {
       const cloneMemo = new WeakMap<object, ExprNode>()
-      let expr = cloneExpr(outputNode, cloneMemo)
+      let expr = cloneExpr(def.outputExprNodes[i], cloneMemo)
       expr = resolveNestedOutputs(expr, def.nestedCalls, nestedRegStart)
       const inlineMemo = new WeakMap<object, ExprNode>()
       expr = inlineCalls(expr, inlineMemo)
@@ -850,6 +868,8 @@ export function flattenSession(session: SessionState): FlatPlan {
       expr = resolveDelayValues(expr, delayBase, delayMemo)
       const lowerMemo = new WeakMap<object, ExprNode>()
       expr = lowerArrayOps(expr, lowerMemo)
+      const bounds = def.outputBounds[i]
+      if (bounds) expr = applyBounds(expr, bounds)
       flatOutputExprs.push(expr)
       cbOutputExprs.push(expr)
     }
@@ -905,15 +925,19 @@ export function flattenSession(session: SessionState): FlatPlan {
     for (let i = 0; i < def.inputNames.length; i++) {
       const key = `${name}:${def.inputNames[i]}`
       const wiringExpr = inputExprNodes.get(key)
+      let resolved: ExprNode
       if (wiringExpr !== undefined) {
         // Resolve refs in the wiring expression (they reference earlier instances)
-        inputMap.set(i, resolveRefs(wiringExpr, resolvedOutputs, resolvedOutputNames))
+        resolved = resolveRefs(wiringExpr, resolvedOutputs, resolvedOutputNames)
       } else {
         // Use default value or 0
         const defaultExpr = def.inputDefaults[i]
         const node = defaultExpr?._node ?? 0
-        inputMap.set(i, inlineCalls(typeof node === 'object' ? cloneExpr(node) : node))
+        resolved = inlineCalls(typeof node === 'object' ? cloneExpr(node) : node)
       }
+      const inBounds = def.inputBounds[i]
+      if (inBounds) resolved = applyBounds(resolved, inBounds)
+      inputMap.set(i, resolved)
     }
 
     // Helper: full expression pipeline for a local module expression.
@@ -947,7 +971,9 @@ export function flattenSession(session: SessionState): FlatPlan {
     // because wiring expressions already have globally-correct register IDs.
     const instOutputExprs: ExprNode[] = []
     for (let i = 0; i < def.outputExprNodes.length; i++) {
-      const expr = processExpr(def.outputExprNodes[i])
+      let expr = processExpr(def.outputExprNodes[i])
+      const bounds = def.outputBounds[i]
+      if (bounds) expr = applyBounds(expr, bounds)
       flatOutputExprs.push(expr)
       instOutputExprs.push(expr)
     }
@@ -1067,13 +1093,17 @@ export function flattenSession(session: SessionState): FlatPlan {
     for (let i = 0; i < def.inputNames.length; i++) {
       const key = `${name}:${def.inputNames[i]}`
       const wiringExpr = inputExprNodes.get(key)
+      let resolved: ExprNode
       if (wiringExpr !== undefined) {
-        inputMap.set(i, resolveRefs(wiringExpr, resolvedOutputs, resolvedOutputNames))
+        resolved = resolveRefs(wiringExpr, resolvedOutputs, resolvedOutputNames)
       } else {
         const defaultExpr = def.inputDefaults[i]
         const node = defaultExpr?._node ?? 0
-        inputMap.set(i, inlineCalls(typeof node === 'object' ? cloneExpr(node) : node))
+        resolved = inlineCalls(typeof node === 'object' ? cloneExpr(node) : node)
       }
+      const inBounds = def.inputBounds[i]
+      if (inBounds) resolved = applyBounds(resolved, inBounds)
+      inputMap.set(i, resolved)
     }
 
     const processExpr = (rawNode: ExprNode): ExprNode => {

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -90,6 +90,14 @@ export function loadProgramAsSession(
   session.triggerRegistry.clear()
   session.inputExprNodes.clear()
   session._nameCounters.clear()
+  session.typeAliasRegistry.clear()
+
+  // Register type aliases from type_defs before anything else
+  for (const td of prog.type_defs ?? []) {
+    if (td.kind === 'alias') {
+      session.typeAliasRegistry.set(td.name, { base: td.base, bounds: td.bounds })
+    }
+  }
 
   // Register inline program definitions
   if (prog.programs) {
@@ -155,8 +163,17 @@ export function loadProgramAsSession(
  */
 export function loadProgramAsType(
   prog: ProgramJSON,
-  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'triggerRegistry'>,
+  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'triggerRegistry'> & Partial<Pick<SessionState, 'typeAliasRegistry'>>,
 ): ProgramType {
+  // Register type aliases from type_defs before processing subprograms
+  if (session.typeAliasRegistry) {
+    for (const td of prog.type_defs ?? []) {
+      if (td.kind === 'alias') {
+        session.typeAliasRegistry.set(td.name, { base: td.base, bounds: td.bounds })
+      }
+    }
+  }
+
   // Register inline subprograms first
   if (prog.programs) {
     for (const [name, subProg] of Object.entries(prog.programs)) {
@@ -183,6 +200,13 @@ export function mergeProgramIntoSession(
   for (const p of prog.params ?? []) {
     if (session.paramRegistry.has(p.name) || session.triggerRegistry.has(p.name))
       throw new Error(`merge collision: param/trigger '${p.name}' already exists.`)
+  }
+
+  // Register type aliases from type_defs (additive)
+  for (const td of prog.type_defs ?? []) {
+    if (td.kind === 'alias') {
+      session.typeAliasRegistry.set(td.name, { base: td.base, bounds: td.bounds })
+    }
   }
 
   // Register inline program definitions

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -24,9 +24,9 @@ export interface ProgramJSON {
   name: string
 
   /** Inputs to this program. Empty or absent = top-level (no external inputs). */
-  inputs?: Array<string | { name: string; type?: string; default?: ExprNode }>
+  inputs?: Array<string | { name: string; type?: string; default?: ExprNode; bounds?: [number | null, number | null] }>
   /** Output declarations — names for leaf programs, expressions for composites. */
-  outputs?: Array<string | { name: string; type?: string }>
+  outputs?: Array<string | { name: string; type?: string; bounds?: [number | null, number | null] }>
 
   /** Scalar/array state registers. */
   regs?: Record<string, number | boolean | number[] | number[][] | { init: number | boolean | number[] | number[][]; type: string }>

--- a/compiler/program_types.ts
+++ b/compiler/program_types.ts
@@ -14,6 +14,11 @@ export type ValueCoercible = boolean | number | number[] | number[][]
 /** A register initialiser: either a bare value or { init, type }. */
 export type RegInit = ValueCoercible | { init: ValueCoercible; type: string }
 
+// ---------- Bounded types ----------
+
+/** Value bounds for a port: [lo, hi]. null on either side = unbounded. */
+export type Bounds = [number | null, number | null]
+
 // ---------- ProgramDef ----------
 
 /**
@@ -39,6 +44,8 @@ export interface ProgramDef {
   delayUpdateNodes: ExprNode[]
   nestedCalls: NestedCall[]
   breaksCycles: boolean
+  inputBounds: (Bounds | null)[]
+  outputBounds: (Bounds | null)[]
 }
 
 // ---------- NestedCall ----------

--- a/compiler/schema.ts
+++ b/compiler/schema.ts
@@ -88,17 +88,23 @@ const TypeDefSchema = z.union([StructTypeDefSchema, SumTypeDefSchema])
 
 
 // ─────────────────────────────────────────────────────────────
+// Bounds — [lo, hi], null on either side = unbounded
+// ─────────────────────────────────────────────────────────────
+
+const BoundsSchema = z.tuple([z.number().nullable(), z.number().nullable()])
+
+// ─────────────────────────────────────────────────────────────
 // ProgramJSON
 // ─────────────────────────────────────────────────────────────
 
 const ProgramInputSchema = z.union([
   z.string(),
-  z.object({ name: z.string(), type: z.string().optional(), default: ExprNodeSchema.optional() }),
+  z.object({ name: z.string(), type: z.string().optional(), default: ExprNodeSchema.optional(), bounds: BoundsSchema.optional() }),
 ])
 
 const ProgramOutputSchema = z.union([
   z.string(),
-  z.object({ name: z.string(), type: z.string().optional() }),
+  z.object({ name: z.string(), type: z.string().optional(), bounds: BoundsSchema.optional() }),
 ])
 
 const ProgramInstanceSchema = z.object({

--- a/compiler/schema.ts
+++ b/compiler/schema.ts
@@ -84,14 +84,20 @@ const SumTypeDefSchema = z.object({
   variants: z.array(SumVariantSchema),
 })
 
-const TypeDefSchema = z.union([StructTypeDefSchema, SumTypeDefSchema])
-
-
 // ─────────────────────────────────────────────────────────────
 // Bounds — [lo, hi], null on either side = unbounded
 // ─────────────────────────────────────────────────────────────
 
 const BoundsSchema = z.tuple([z.number().nullable(), z.number().nullable()])
+
+const AliasTypeDefSchema = z.object({
+  kind: z.literal('alias'),
+  name: z.string(),
+  base: z.string(),
+  bounds: BoundsSchema,
+})
+
+const TypeDefSchema = z.union([StructTypeDefSchema, SumTypeDefSchema, AliasTypeDefSchema])
 
 // ─────────────────────────────────────────────────────────────
 // ProgramJSON

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -44,7 +44,14 @@ export interface SumTypeDefJSON {
   variants: SumVariantJSON[]
 }
 
-export type TypeDefJSON = StructTypeDefJSON | SumTypeDefJSON
+export interface AliasTypeDefJSON {
+  kind: 'alias'
+  name: string
+  base: string
+  bounds: [number | null, number | null]
+}
+
+export type TypeDefJSON = StructTypeDefJSON | SumTypeDefJSON | AliasTypeDefJSON
 
 
 // ─────────────────────────────────────────────────────────────
@@ -55,6 +62,7 @@ export interface SessionState {
   bufferLength: number
   dac: import('./runtime/audio.js').DAC | null  // lazy type import to avoid circular dep
   typeRegistry: Map<string, ProgramType>
+  typeAliasRegistry: Map<string, { base: string; bounds: Bounds }>
   instanceRegistry: Map<string, ProgramInstance>
   graphOutputs: Array<{ instance: string; output: string }>
   paramRegistry: Map<string, Param>
@@ -75,6 +83,7 @@ export function makeSession(bufferLength = 512): SessionState {
     bufferLength,
     dac: null,
     typeRegistry: new Map(),
+    typeAliasRegistry: new Map(),
     instanceRegistry: new Map(),
     graphOutputs: [],
     paramRegistry: new Map(),
@@ -244,19 +253,28 @@ export const BOUNDED_TYPE_ALIASES: Record<string, { base: string; bounds: Bounds
   freq:     { base: 'float', bounds: [0, null] },
 }
 
-/** Resolve a type string to its base type (stripping alias). */
-export function resolveBaseType(typeStr: string | undefined): string | undefined {
-  if (typeStr && typeStr in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[typeStr].base
+type AliasMap = Map<string, { base: string; bounds: Bounds }>
+
+/** Resolve a type string to its base type (stripping alias). Checks user aliases first. */
+export function resolveBaseType(typeStr: string | undefined, userAliases?: AliasMap): string | undefined {
+  if (!typeStr) return typeStr
+  const user = userAliases?.get(typeStr)
+  if (user) return user.base
+  if (typeStr in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[typeStr].base
   return typeStr
 }
 
-/** Extract bounds from a port spec. Explicit bounds override alias bounds. */
+/** Extract bounds from a port spec. Explicit bounds override alias bounds. Checks user aliases first. */
 export function resolveBounds(
   spec: string | { name: string; type?: string; bounds?: [number | null, number | null] },
+  userAliases?: AliasMap,
 ): Bounds | null {
   if (typeof spec === 'string') return null
   if (spec.bounds) return spec.bounds
-  if (spec.type && spec.type in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[spec.type].bounds
+  if (!spec.type) return null
+  const user = userAliases?.get(spec.type)
+  if (user) return user.bounds
+  if (spec.type in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[spec.type].bounds
   return null
 }
 
@@ -266,16 +284,17 @@ export function resolveBounds(
 
 export function loadProgramDef(
   def: ProgramJSON,
-  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'triggerRegistry'>,
+  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'triggerRegistry'> & Partial<Pick<SessionState, 'typeAliasRegistry'>>,
 ): ProgramType {
+  const aliases = session.typeAliasRegistry
   const inputSpecs  = def.inputs ?? []
   const outputSpecs = def.outputs ?? []
   const inputNames  = inputSpecs.map(i => typeof i === 'string' ? i : i.name)
   const outputNames = outputSpecs.map(o => typeof o === 'string' ? o : o.name)
-  const inputPortTypes  = inputSpecs.map(i => resolveBaseType(typeof i === 'string' ? undefined : i.type))
-  const outputPortTypes = outputSpecs.map(o => resolveBaseType(typeof o === 'string' ? undefined : o.type))
-  const inputBounds     = inputSpecs.map(resolveBounds)
-  const outputBounds    = outputSpecs.map(resolveBounds)
+  const inputPortTypes  = inputSpecs.map(i => resolveBaseType(typeof i === 'string' ? undefined : i.type, aliases))
+  const outputPortTypes = outputSpecs.map(o => resolveBaseType(typeof o === 'string' ? undefined : o.type, aliases))
+  const inputBounds     = inputSpecs.map(s => resolveBounds(s, aliases))
+  const outputBounds    = outputSpecs.map(s => resolveBounds(s, aliases))
   const regsRaw     = def.regs ?? {}
   const delaysRaw   = def.delays ?? {}
   const nestedRaw   = def.instances ?? {}

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -7,7 +7,7 @@ import {
 } from './expr.js'
 import {
   ProgramType, ProgramInstance,
-  type ProgramDef, type NestedCall, type ValueCoercible,
+  type ProgramDef, type NestedCall, type ValueCoercible, type Bounds,
 } from './program_types.js'
 import { Runtime } from './runtime/runtime.js'
 import { loadProgramAsSession, type ProgramJSON } from './program.js'
@@ -231,6 +231,39 @@ function slottifyExpr(
   return node
 }
 
+// ─────────────────────────────────────────────────────────────
+// Bounded type aliases
+// ─────────────────────────────────────────────────────────────
+
+/** Built-in type aliases that map semantic names to a base type + bounds. */
+export const BOUNDED_TYPE_ALIASES: Record<string, { base: string; bounds: Bounds }> = {
+  signal:   { base: 'float', bounds: [-1, 1] },
+  bipolar:  { base: 'float', bounds: [-1, 1] },
+  unipolar: { base: 'float', bounds: [0, 1] },
+  phase:    { base: 'float', bounds: [0, 1] },
+  freq:     { base: 'float', bounds: [0, null] },
+}
+
+/** Resolve a type string to its base type (stripping alias). */
+export function resolveBaseType(typeStr: string | undefined): string | undefined {
+  if (typeStr && typeStr in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[typeStr].base
+  return typeStr
+}
+
+/** Extract bounds from a port spec. Explicit bounds override alias bounds. */
+export function resolveBounds(
+  spec: string | { name: string; type?: string; bounds?: [number | null, number | null] },
+): Bounds | null {
+  if (typeof spec === 'string') return null
+  if (spec.bounds) return spec.bounds
+  if (spec.type && spec.type in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[spec.type].bounds
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────
+// ProgramJSON → ProgramDef
+// ─────────────────────────────────────────────────────────────
+
 export function loadProgramDef(
   def: ProgramJSON,
   session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'triggerRegistry'>,
@@ -239,8 +272,10 @@ export function loadProgramDef(
   const outputSpecs = def.outputs ?? []
   const inputNames  = inputSpecs.map(i => typeof i === 'string' ? i : i.name)
   const outputNames = outputSpecs.map(o => typeof o === 'string' ? o : o.name)
-  const inputPortTypes  = inputSpecs.map(i => typeof i === 'string' ? undefined : i.type)
-  const outputPortTypes = outputSpecs.map(o => typeof o === 'string' ? undefined : o.type)
+  const inputPortTypes  = inputSpecs.map(i => resolveBaseType(typeof i === 'string' ? undefined : i.type))
+  const outputPortTypes = outputSpecs.map(o => resolveBaseType(typeof o === 'string' ? undefined : o.type))
+  const inputBounds     = inputSpecs.map(resolveBounds)
+  const outputBounds    = outputSpecs.map(resolveBounds)
   const regsRaw     = def.regs ?? {}
   const delaysRaw   = def.delays ?? {}
   const nestedRaw   = def.instances ?? {}
@@ -345,6 +380,8 @@ export function loadProgramDef(
     delayUpdateNodes,
     nestedCalls,
     breaksCycles: def.breaks_cycles ?? false,
+    inputBounds,
+    outputBounds,
   }
 
   return new ProgramType(programDef)

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -359,8 +359,17 @@ function handleListPrograms() {
       const defaultsMap = (d.rawInputDefaults ?? {}) as Record<string, unknown>
       return {
         program_name: typeName,
-        inputs:    d.inputNames.map(n => ({ name: n, default: defaultsMap[n] ?? null })),
-        outputs: d.outputNames,
+        inputs:    d.inputNames.map((n, i) => ({
+          name: n,
+          type: d.inputPortTypes[i] ?? null,
+          bounds: d.inputBounds[i] ?? null,
+          default: defaultsMap[n] ?? null,
+        })),
+        outputs: d.outputNames.map((n, i) => ({
+          name: n,
+          type: d.outputPortTypes[i] ?? null,
+          bounds: d.outputBounds[i] ?? null,
+        })),
         registers: d.registerNames.map((n, i) => ({ name: n, type: d.registerPortTypes[i] ?? null })),
       }
     }),
@@ -382,12 +391,18 @@ function handleGetInfo(instanceName: string) {
       program: inst.typeName,
       inputs:  inst.inputNames.map((n, i) => ({
         name: n, index: i,
+        type: inst._def.inputPortTypes[i] ?? null,
+        bounds: inst._def.inputBounds[i] ?? null,
         expr: session.inputExprNodes.get(`${instanceName}:${n}`) ?? null,
         pretty: session.inputExprNodes.has(`${instanceName}:${n}`)
           ? prettyExpr(session.inputExprNodes.get(`${instanceName}:${n}`)!, session.instanceRegistry)
           : null,
       })),
-      outputs: inst.outputNames.map((n, i) => ({ name: n, index: i })),
+      outputs: inst.outputNames.map((n, i) => ({
+        name: n, index: i,
+        type: inst._def.outputPortTypes[i] ?? null,
+        bounds: inst._def.outputBounds[i] ?? null,
+      })),
       registers: inst.registerNames.map((n, i) => ({
         name: n, index: i, type: inst.registerPortType(i) ?? null,
       })),

--- a/stdlib/ADEnvelope.json
+++ b/stdlib/ADEnvelope.json
@@ -2,12 +2,12 @@
   "schema": "tropical_program_1",
   "name": "ADEnvelope",
   "inputs": [
-    "gate",
-    "attack",
-    "decay"
+    { "name": "gate", "type": "unipolar" },
+    { "name": "attack", "type": "float", "bounds": [0, null] },
+    { "name": "decay", "type": "float", "bounds": [0, null] }
   ],
   "outputs": [
-    "env"
+    { "name": "env", "type": "unipolar" }
   ],
   "regs": {
     "stage": 0,

--- a/stdlib/ADSREnvelope.json
+++ b/stdlib/ADSREnvelope.json
@@ -2,14 +2,14 @@
   "schema": "tropical_program_1",
   "name": "ADSREnvelope",
   "inputs": [
-    "gate",
-    "attack",
-    "decay",
-    "sustain",
-    "release"
+    { "name": "gate", "type": "unipolar" },
+    { "name": "attack", "type": "float", "bounds": [0, null] },
+    { "name": "decay", "type": "float", "bounds": [0, null] },
+    { "name": "sustain", "type": "unipolar" },
+    { "name": "release", "type": "float", "bounds": [0, null] }
   ],
   "outputs": [
-    "env"
+    { "name": "env", "type": "unipolar" }
   ],
   "regs": {
     "stage": 0,

--- a/stdlib/BassDrum.json
+++ b/stdlib/BassDrum.json
@@ -9,7 +9,7 @@
     "tone"
   ],
   "outputs": [
-    "output"
+    { "name": "output", "type": "signal" }
   ],
   "regs": {
     "amp_env": 0,

--- a/stdlib/Clock.json
+++ b/stdlib/Clock.json
@@ -2,11 +2,11 @@
   "schema": "tropical_program_1",
   "name": "Clock",
   "inputs": [
-    "freq",
+    { "name": "freq", "type": "freq" },
     { "name": "ratios_in", "type": "float[1]" }
   ],
   "outputs": [
-    "output",
+    { "name": "output", "type": "unipolar" },
     { "name": "ratios_out", "type": "float[1]" }
   ],
   "input_defaults": { "freq": 1, "ratios_in": [1] },

--- a/stdlib/Compressor.json
+++ b/stdlib/Compressor.json
@@ -12,7 +12,7 @@
   ],
   "outputs": [
     "output",
-    "gr"
+    { "name": "gr", "type": "unipolar" }
   ],
   "regs": {
     "env": 0,

--- a/stdlib/LadderFilter.json
+++ b/stdlib/LadderFilter.json
@@ -3,8 +3,8 @@
   "name": "LadderFilter",
   "inputs": [
     "input",
-    "cutoff",
-    "resonance",
+    { "name": "cutoff", "type": "freq" },
+    { "name": "resonance", "type": "unipolar" },
     "drive"
   ],
   "outputs": [

--- a/stdlib/NoiseLFSR.json
+++ b/stdlib/NoiseLFSR.json
@@ -2,7 +2,7 @@
   "schema": "tropical_program_1",
   "name": "NoiseLFSR",
   "inputs": ["clock"],
-  "outputs": ["out"],
+  "outputs": [{ "name": "out", "type": "signal" }],
   "regs": { "state": { "init": 44257, "type": "int" }, "value": 0 },
   "delays": {
     "prev_clock": { "update": { "op": "input", "name": "clock" }, "init": 0 }

--- a/stdlib/VCO.json
+++ b/stdlib/VCO.json
@@ -2,15 +2,15 @@
   "schema": "tropical_program_1",
   "name": "VCO",
   "inputs": [
-    { "name": "freq", "type": "float" },
+    { "name": "freq", "type": "freq" },
     { "name": "fm", "type": "float" },
     { "name": "fm_index", "type": "float" }
   ],
   "outputs": [
-    { "name": "saw", "type": "float" },
-    { "name": "tri", "type": "float" },
-    { "name": "sin", "type": "float" },
-    { "name": "sqr", "type": "float" }
+    { "name": "saw", "type": "signal" },
+    { "name": "tri", "type": "signal" },
+    { "name": "sin", "type": "signal" },
+    { "name": "sqr", "type": "signal" }
   ],
   "regs": { "phase": 0, "tri_state": 0 },
   "input_defaults": { "freq": 100, "fm": 0, "fm_index": 5 },


### PR DESCRIPTION
## Summary

- **Bounded types**: inputs and outputs can declare value bounds (`"bounds": [-1, 1]`) that are automatically enforced via clamp injection during flattening
- **Named type aliases**: built-in (`signal`, `unipolar`, `bipolar`, `phase`, `freq`) and user-definable via `type_defs: [{ kind: "alias", name: "cv", base: "float", bounds: [0, 10] }]`
- **Audio safety clamp**: graph outputs auto-clamped to [-1, 1] unless the source already has tighter bounds
- **MCP visibility**: `list_programs` and `get_info` now return type and bounds on all ports
- **Stdlib annotations**: VCO, envelopes, Clock, NoiseLFSR, BassDrum, Compressor, LadderFilter annotated with bounds

## Test plan

- [x] 35 new tests in `compiler/bounds.test.ts` (applyBounds unit, resolution functions, loadProgramDef extraction, flattenSession integration, audio safety clamp, user aliases, Zod validation)
- [x] All 299 compiler tests pass (`bun test compiler/`)
- [x] Zod schema round-trip verified for explicit bounds, named aliases, and user-defined aliases
- [x] MCP smoke test: define bounded program, wire, load, start_audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)