### PR TITLE
feat(compiler): ExprNode interpreter for differential testing

### DIFF
--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -146,6 +146,17 @@ export interface FlatPlan {
   register_targets: number[]
 }
 
+/** Pre-emission representation: flattened ExprNode trees before instruction emission. */
+export interface FlatExpressions {
+  outputExprs: ExprNode[]
+  registerExprs: ExprNode[]
+  stateInit: (number | boolean | number[])[]
+  registerTypes: ScalarType[]
+  registerNames: string[]
+  outputIndices: number[]
+  sampleRate: number
+}
+
 // ─────────────────────────────────────────────────────────────
 // Expression tree manipulation
 // ─────────────────────────────────────────────────────────────
@@ -784,7 +795,12 @@ function resolveRefs(
  * 4. Compile expression trees → FlatProgram via emitNumericProgram
  * 5. Emit tropical_plan_4 JSON
  */
-export function flattenSession(session: SessionState): FlatPlan {
+/**
+ * Flatten a session into pre-emission ExprNode trees.
+ * Returns the flattened output/register expressions, state init, and metadata
+ * without compiling to instructions. Used by the interpreter for differential testing.
+ */
+export function flattenExpressions(session: SessionState): FlatExpressions {
   const { instanceRegistry, graphOutputs } = session
 
   // Build instance info map
@@ -1230,27 +1246,39 @@ export function flattenSession(session: SessionState): FlatPlan {
     outputIndices.push(flatIdx)
   }
 
-  // Compile expression trees → flat instruction stream
-  const program = emitNumericProgram(flatOutputExprs, flatRegisterExprs, flatStateInit, flatRegisterTypes)
+  return {
+    outputExprs: flatOutputExprs,
+    registerExprs: flatRegisterExprs,
+    stateInit: flatStateInit,
+    registerTypes: flatRegisterTypes,
+    registerNames: flatRegisterNames,
+    outputIndices,
+    sampleRate: 44100,
+  }
+}
+
+/** Flatten a session and compile to a tropical_plan_4 instruction stream. */
+export function flattenSession(session: SessionState): FlatPlan {
+  const flat = flattenExpressions(session)
+
+  const program = emitNumericProgram(flat.outputExprs, flat.registerExprs, flat.stateInit, flat.registerTypes)
 
   // Compute array slot names for state transfer on hot-swap.
-  // Array slots are allocated in the order array entries appear in flatStateInit,
-  // matching the order of program.array_slot_sizes.
   const arraySlotNames: string[] = []
-  for (let i = 0; i < flatStateInit.length; i++) {
-    if (Array.isArray(flatStateInit[i])) {
-      arraySlotNames.push(flatRegisterNames[i])
+  for (let i = 0; i < flat.stateInit.length; i++) {
+    if (Array.isArray(flat.stateInit[i])) {
+      arraySlotNames.push(flat.registerNames[i])
     }
   }
 
   return {
     schema: 'tropical_plan_4',
-    config: { sample_rate: 44100 },
-    state_init: flatStateInit as (number | boolean)[],
-    register_names: flatRegisterNames,
-    register_types: flatRegisterTypes,
+    config: { sample_rate: flat.sampleRate },
+    state_init: flat.stateInit as (number | boolean)[],
+    register_names: flat.registerNames,
+    register_types: flat.registerTypes,
     array_slot_names: arraySlotNames,
-    outputs: outputIndices,
+    outputs: flat.outputIndices,
     instructions:     program.instructions,
     register_count:   program.register_count,
     array_slot_count: program.array_slot_count,

--- a/compiler/interpret.test.ts
+++ b/compiler/interpret.test.ts
@@ -1,0 +1,467 @@
+/**
+ * interpret.test.ts — Tests for the ExprNode tree interpreter.
+ *
+ * Tests evalExpr on individual ops (O4 exact match), then tests
+ * interpretSamples on small programs with register state.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { evalExpr, interpretSamples, type InterpretEnv } from './interpret'
+import type { ExprNode } from './expr'
+import type { FlatExpressions } from './flatten'
+
+// ─── helpers ─────────────────────────────────────────────────
+
+function env(overrides: Partial<InterpretEnv> = {}): InterpretEnv {
+  return {
+    sampleRate: 44100,
+    sampleIndex: 0,
+    registers: [],
+    inputs: [],
+    params: new Map(),
+    ...overrides,
+  }
+}
+
+// ─── literals ────────────────────────────────────────────────
+
+describe('evalExpr literals', () => {
+  test('number', () => {
+    expect(evalExpr(42, env())).toBe(42)
+    expect(evalExpr(0, env())).toBe(0)
+    expect(evalExpr(-3.14, env())).toBe(-3.14)
+  })
+
+  test('boolean', () => {
+    expect(evalExpr(true, env())).toBe(true)
+    expect(evalExpr(false, env())).toBe(false)
+  })
+
+  test('inline array', () => {
+    expect(evalExpr([1, 2, 3], env())).toEqual([1, 2, 3])
+  })
+
+  test('nested array expressions', () => {
+    const node: ExprNode = [{ op: 'add', args: [1, 2] }, 10]
+    expect(evalExpr(node, env())).toEqual([3, 10])
+  })
+})
+
+// ─── terminals ───────────────────────────────────────────────
+
+describe('evalExpr terminals', () => {
+  test('input', () => {
+    expect(evalExpr({ op: 'input', id: 0 }, env({ inputs: [440] }))).toBe(440)
+    expect(evalExpr({ op: 'input', id: 1 }, env({ inputs: [440, 880] }))).toBe(880)
+    expect(evalExpr({ op: 'input', id: 5 }, env())).toBe(0) // missing → 0
+  })
+
+  test('reg', () => {
+    expect(evalExpr({ op: 'reg', id: 0 }, env({ registers: [0.5] }))).toBe(0.5)
+    expect(evalExpr({ op: 'reg', id: 1 }, env({ registers: [0, [1, 2, 3]] }))).toEqual([1, 2, 3])
+  })
+
+  test('sample_rate', () => {
+    expect(evalExpr({ op: 'sample_rate' }, env())).toBe(44100)
+    expect(evalExpr({ op: 'sample_rate' }, env({ sampleRate: 48000 }))).toBe(48000)
+  })
+
+  test('sample_index', () => {
+    expect(evalExpr({ op: 'sample_index' }, env({ sampleIndex: 100 }))).toBe(100)
+  })
+
+  test('smoothed_param', () => {
+    const params = new Map([[12345, 0.75]])
+    expect(evalExpr({ op: 'smoothed_param', _ptr: true, _handle: 12345 }, env({ params }))).toBe(0.75)
+  })
+
+  test('trigger_param', () => {
+    const params = new Map([[99, 1]])
+    expect(evalExpr({ op: 'trigger_param', _ptr: true, _handle: 99 }, env({ params }))).toBe(1)
+  })
+
+  test('missing param returns 0', () => {
+    expect(evalExpr({ op: 'smoothed_param', _ptr: true, _handle: 999 }, env())).toBe(0)
+  })
+})
+
+// ─── binary arithmetic ──────────────────────────────────────
+
+describe('evalExpr binary arithmetic', () => {
+  test('add', () => {
+    expect(evalExpr({ op: 'add', args: [3, 4] }, env())).toBe(7)
+  })
+
+  test('sub', () => {
+    expect(evalExpr({ op: 'sub', args: [10, 3] }, env())).toBe(7)
+  })
+
+  test('mul', () => {
+    expect(evalExpr({ op: 'mul', args: [3, 4] }, env())).toBe(12)
+  })
+
+  test('div', () => {
+    expect(evalExpr({ op: 'div', args: [10, 4] }, env())).toBe(2.5)
+    expect(evalExpr({ op: 'div', args: [1, 0] }, env())).toBe(0) // div by zero
+  })
+
+  test('mod', () => {
+    expect(evalExpr({ op: 'mod', args: [7, 3] }, env())).toBe(1)
+    expect(evalExpr({ op: 'mod', args: [1, 0] }, env())).toBe(0) // mod by zero
+  })
+
+  test('pow', () => {
+    expect(evalExpr({ op: 'pow', args: [2, 10] }, env())).toBe(1024)
+  })
+
+  test('floor_div', () => {
+    expect(evalExpr({ op: 'floor_div', args: [7, 2] }, env())).toBe(3)
+    expect(evalExpr({ op: 'floorDiv', args: [7, 2] }, env())).toBe(3)
+  })
+})
+
+// ─── binary comparison ──────────────────────────────────────
+
+describe('evalExpr comparison', () => {
+  test('lt / lte / gt / gte', () => {
+    expect(evalExpr({ op: 'lt', args: [1, 2] }, env())).toBe(true)
+    expect(evalExpr({ op: 'lt', args: [2, 2] }, env())).toBe(false)
+    expect(evalExpr({ op: 'lte', args: [2, 2] }, env())).toBe(true)
+    expect(evalExpr({ op: 'gt', args: [3, 2] }, env())).toBe(true)
+    expect(evalExpr({ op: 'gte', args: [2, 2] }, env())).toBe(true)
+  })
+
+  test('eq / neq', () => {
+    expect(evalExpr({ op: 'eq', args: [5, 5] }, env())).toBe(true)
+    expect(evalExpr({ op: 'eq', args: [5, 6] }, env())).toBe(false)
+    expect(evalExpr({ op: 'neq', args: [5, 6] }, env())).toBe(true)
+  })
+})
+
+// ─── binary bitwise ─────────────────────────────────────────
+
+describe('evalExpr bitwise', () => {
+  test('bit_and / bit_or / bit_xor', () => {
+    expect(evalExpr({ op: 'bit_and', args: [0xFF, 0x0F] }, env())).toBe(0x0F)
+    expect(evalExpr({ op: 'bit_or', args: [0xF0, 0x0F] }, env())).toBe(0xFF)
+    expect(evalExpr({ op: 'bit_xor', args: [0xFF, 0x0F] }, env())).toBe(0xF0)
+  })
+
+  test('lshift / rshift', () => {
+    expect(evalExpr({ op: 'lshift', args: [1, 4] }, env())).toBe(16)
+    expect(evalExpr({ op: 'rshift', args: [16, 4] }, env())).toBe(1)
+  })
+
+  test('camelCase aliases', () => {
+    expect(evalExpr({ op: 'bitAnd', args: [0xFF, 0x0F] }, env())).toBe(0x0F)
+    expect(evalExpr({ op: 'bitOr', args: [0xF0, 0x0F] }, env())).toBe(0xFF)
+    expect(evalExpr({ op: 'bitXor', args: [0xFF, 0x0F] }, env())).toBe(0xF0)
+  })
+})
+
+// ─── binary logical ─────────────────────────────────────────
+
+describe('evalExpr logical', () => {
+  test('and / or', () => {
+    expect(evalExpr({ op: 'and', args: [true, true] }, env())).toBe(true)
+    expect(evalExpr({ op: 'and', args: [true, false] }, env())).toBe(false)
+    expect(evalExpr({ op: 'or', args: [false, true] }, env())).toBe(true)
+    expect(evalExpr({ op: 'or', args: [false, false] }, env())).toBe(false)
+  })
+
+  test('numeric truthiness', () => {
+    expect(evalExpr({ op: 'and', args: [1, 1] }, env())).toBe(true)
+    expect(evalExpr({ op: 'and', args: [1, 0] }, env())).toBe(false)
+  })
+})
+
+// ─── unary math ─────────────────────────────────────────────
+
+describe('evalExpr unary', () => {
+  test('neg / abs', () => {
+    expect(evalExpr({ op: 'neg', args: [5] }, env())).toBe(-5)
+    expect(evalExpr({ op: 'abs', args: [-3] }, env())).toBe(3)
+  })
+
+  test('transcendentals', () => {
+    expect(evalExpr({ op: 'sin', args: [0] }, env())).toBeCloseTo(0, 10)
+    expect(evalExpr({ op: 'cos', args: [0] }, env())).toBeCloseTo(1, 10)
+    expect(evalExpr({ op: 'tanh', args: [0] }, env())).toBeCloseTo(0, 10)
+    expect(evalExpr({ op: 'exp', args: [0] }, env())).toBeCloseTo(1, 10)
+    expect(evalExpr({ op: 'log', args: [1] }, env())).toBeCloseTo(0, 10)
+    expect(evalExpr({ op: 'sqrt', args: [9] }, env())).toBeCloseTo(3, 10)
+  })
+
+  test('rounding', () => {
+    expect(evalExpr({ op: 'floor', args: [2.7] }, env())).toBe(2)
+    expect(evalExpr({ op: 'ceil', args: [2.1] }, env())).toBe(3)
+    expect(evalExpr({ op: 'round', args: [2.5] }, env())).toBe(3)
+  })
+
+  test('not / bit_not', () => {
+    expect(evalExpr({ op: 'not', args: [true] }, env())).toBe(false)
+    expect(evalExpr({ op: 'not', args: [0] }, env())).toBe(true)
+    expect(evalExpr({ op: 'bit_not', args: [0] }, env())).toBe(-1) // ~0 === -1
+  })
+})
+
+// ─── ternary ────────────────────────────────────────────────
+
+describe('evalExpr ternary', () => {
+  test('select: true branch', () => {
+    expect(evalExpr({ op: 'select', args: [true, 10, 20] }, env())).toBe(10)
+  })
+
+  test('select: false branch', () => {
+    expect(evalExpr({ op: 'select', args: [false, 10, 20] }, env())).toBe(20)
+  })
+
+  test('select: numeric condition', () => {
+    expect(evalExpr({ op: 'select', args: [1, 10, 20] }, env())).toBe(10)
+    expect(evalExpr({ op: 'select', args: [0, 10, 20] }, env())).toBe(20)
+  })
+
+  test('clamp', () => {
+    expect(evalExpr({ op: 'clamp', args: [5, 0, 10] }, env())).toBe(5)
+    expect(evalExpr({ op: 'clamp', args: [-1, 0, 10] }, env())).toBe(0)
+    expect(evalExpr({ op: 'clamp', args: [15, 0, 10] }, env())).toBe(10)
+  })
+})
+
+// ─── array ops ──────────────────────────────────────────────
+
+describe('evalExpr array ops', () => {
+  test('array construction', () => {
+    expect(evalExpr({ op: 'array', items: [1, 2, 3] }, env())).toEqual([1, 2, 3])
+  })
+
+  test('array with computed items', () => {
+    expect(evalExpr({ op: 'array', items: [{ op: 'add', args: [1, 2] }, 10] }, env())).toEqual([3, 10])
+  })
+
+  test('index', () => {
+    expect(evalExpr({ op: 'index', args: [[10, 20, 30], 1] }, env())).toBe(20)
+  })
+
+  test('index out of bounds returns 0', () => {
+    expect(evalExpr({ op: 'index', args: [[10, 20], 5] }, env())).toBe(0)
+  })
+
+  test('array_set', () => {
+    expect(evalExpr({ op: 'array_set', args: [[10, 20, 30], 1, 99] }, env())).toEqual([10, 99, 30])
+  })
+
+  test('broadcast_to scalar', () => {
+    expect(evalExpr({ op: 'broadcast_to', args: [5], shape: [3] }, env())).toEqual([5, 5, 5])
+  })
+
+  test('broadcast_to array', () => {
+    expect(evalExpr({ op: 'broadcast_to', args: [[1, 2]], shape: [4] }, env())).toEqual([1, 2, 1, 2])
+  })
+
+  test('matrix', () => {
+    expect(evalExpr({ op: 'matrix', rows: [[1, 2], [3, 4]] }, env())).toEqual([1, 2, 3, 4])
+  })
+})
+
+// ─── elementwise broadcasting ───────────────────────────────
+
+describe('evalExpr elementwise', () => {
+  test('array + scalar', () => {
+    expect(evalExpr({ op: 'add', args: [[1, 2, 3], 10] }, env())).toEqual([11, 12, 13])
+  })
+
+  test('scalar + array', () => {
+    expect(evalExpr({ op: 'add', args: [10, [1, 2, 3]] }, env())).toEqual([11, 12, 13])
+  })
+
+  test('array + array', () => {
+    expect(evalExpr({ op: 'add', args: [[1, 2, 3], [10, 20, 30]] }, env())).toEqual([11, 22, 33])
+  })
+
+  test('unary on array', () => {
+    expect(evalExpr({ op: 'neg', args: [[1, -2, 3]] }, env())).toEqual([-1, 2, -3])
+  })
+})
+
+// ─── unsupported op ─────────────────────────────────────────
+
+describe('evalExpr error handling', () => {
+  test('throws on unsupported op', () => {
+    expect(() => evalExpr({ op: 'nonexistent', args: [] }, env())).toThrow('unsupported op')
+  })
+})
+
+// ─── interpretSamples ───────────────────────────────────────
+
+describe('interpretSamples', () => {
+  test('constant output', () => {
+    const flat: FlatExpressions = {
+      outputExprs: [5],
+      registerExprs: [],
+      stateInit: [],
+      registerTypes: [],
+      registerNames: [],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+    const buf = interpretSamples(flat, 4)
+    // 5 / 20.0 = 0.25
+    for (let i = 0; i < 4; i++) {
+      expect(buf[i]).toBeCloseTo(0.25, 10)
+    }
+  })
+
+  test('two outputs mixed', () => {
+    const flat: FlatExpressions = {
+      outputExprs: [3, 7],
+      registerExprs: [],
+      stateInit: [],
+      registerTypes: [],
+      registerNames: [],
+      outputIndices: [0, 1],
+      sampleRate: 44100,
+    }
+    const buf = interpretSamples(flat, 4)
+    // (3 + 7) / 20.0 = 0.5
+    for (let i = 0; i < 4; i++) {
+      expect(buf[i]).toBeCloseTo(0.5, 10)
+    }
+  })
+
+  test('phase accumulator (sample-delay semantics)', () => {
+    // Register 0: phase, init = 0
+    // Register update: mod(add(reg(0), div(440, sample_rate)), 1.0)
+    // Output 0: mul(sub(mul(reg(0), 2), 1), 10)
+    //   maps phase [0,1) → [-10, 10)
+    // Audio = output / 20.0 → [-0.5, 0.5)
+    const flat: FlatExpressions = {
+      outputExprs: [
+        { op: 'mul', args: [
+          { op: 'sub', args: [
+            { op: 'mul', args: [{ op: 'reg', id: 0 }, 2] },
+            1,
+          ]},
+          10,
+        ]},
+      ],
+      registerExprs: [
+        { op: 'mod', args: [
+          { op: 'add', args: [
+            { op: 'reg', id: 0 },
+            { op: 'div', args: [440, { op: 'sample_rate' }] },
+          ]},
+          1.0,
+        ]},
+      ],
+      stateInit: [0],
+      registerTypes: ['float'],
+      registerNames: ['phase'],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+
+    const buf = interpretSamples(flat, 4)
+
+    // Sample 0: phase=0, output = (0*2 - 1)*10 = -10, audio = -10/20 = -0.5
+    expect(buf[0]).toBeCloseTo(-0.5, 10)
+
+    // Sample 1: phase = 440/44100, output = (phase*2 - 1)*10, audio = that/20
+    const phase1 = 440 / 44100
+    const expected1 = (phase1 * 2 - 1) * 10 / 20
+    expect(buf[1]).toBeCloseTo(expected1, 10)
+
+    // Samples should be monotonically increasing (before wrap)
+    expect(buf[1]).toBeGreaterThan(buf[0])
+    expect(buf[2]).toBeGreaterThan(buf[1])
+    expect(buf[3]).toBeGreaterThan(buf[2])
+  })
+
+  test('integer counter with modular wrap', () => {
+    // Register 0: counter, init = 0
+    // Register update: mod(add(reg(0), 1), 8)
+    // Output: reg(0)
+    const flat: FlatExpressions = {
+      outputExprs: [{ op: 'reg', id: 0 }],
+      registerExprs: [
+        { op: 'mod', args: [{ op: 'add', args: [{ op: 'reg', id: 0 }, 1] }, 8] },
+      ],
+      stateInit: [0],
+      registerTypes: ['float'],
+      registerNames: ['counter'],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+
+    const buf = interpretSamples(flat, 10)
+    const expected = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]
+    for (let i = 0; i < 10; i++) {
+      expect(buf[i]).toBeCloseTo(expected[i] / 20.0, 10)
+    }
+  })
+
+  test('select gate: high when counter > 4', () => {
+    // Register 0: phase, init = 0, update = add(reg(0), 1)
+    // Output: select(gt(reg(0), 4), 1, 0)
+    const flat: FlatExpressions = {
+      outputExprs: [
+        { op: 'select', args: [
+          { op: 'gt', args: [{ op: 'reg', id: 0 }, 4] },
+          1, 0,
+        ]},
+      ],
+      registerExprs: [
+        { op: 'add', args: [{ op: 'reg', id: 0 }, 1] },
+      ],
+      stateInit: [0],
+      registerTypes: ['float'],
+      registerNames: ['phase'],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+
+    const buf = interpretSamples(flat, 8)
+    // phase: 0,1,2,3,4,5,6,7 → gate: 0,0,0,0,0,1,1,1
+    const expected = [0, 0, 0, 0, 0, 1, 1, 1]
+    for (let i = 0; i < 8; i++) {
+      expect(buf[i]).toBeCloseTo(expected[i] / 20.0, 10)
+    }
+  })
+
+  test('sample_index increments', () => {
+    const flat: FlatExpressions = {
+      outputExprs: [{ op: 'sample_index' }],
+      registerExprs: [],
+      stateInit: [],
+      registerTypes: [],
+      registerNames: [],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+
+    const buf = interpretSamples(flat, 4)
+    expect(buf[0]).toBeCloseTo(0 / 20.0, 10)
+    expect(buf[1]).toBeCloseTo(1 / 20.0, 10)
+    expect(buf[2]).toBeCloseTo(2 / 20.0, 10)
+    expect(buf[3]).toBeCloseTo(3 / 20.0, 10)
+  })
+
+  test('array register state preserved across samples', () => {
+    // Register 0: array [1, 2, 3], update = identity (reg(0))
+    // Output: index(reg(0), 1)  → should always be 2
+    const flat: FlatExpressions = {
+      outputExprs: [{ op: 'index', args: [{ op: 'reg', id: 0 }, 1] }],
+      registerExprs: [{ op: 'reg', id: 0 }],
+      stateInit: [[1, 2, 3]],
+      registerTypes: ['float'],
+      registerNames: ['arr'],
+      outputIndices: [0],
+      sampleRate: 44100,
+    }
+
+    const buf = interpretSamples(flat, 4)
+    for (let i = 0; i < 4; i++) {
+      expect(buf[i]).toBeCloseTo(2 / 20.0, 10)
+    }
+  })
+})

--- a/compiler/interpret.ts
+++ b/compiler/interpret.ts
@@ -1,0 +1,290 @@
+/**
+ * interpret.ts — ExprNode tree interpreter for differential testing.
+ *
+ * Recursively evaluates post-flatten, post-lower ExprNode trees using
+ * JavaScript Math.* for transcendentals. Serves as a reference oracle
+ * against the LLVM JIT path.
+ *
+ * The interpreter handles the ~40 ops that survive array lowering and
+ * combinator expansion. It does NOT handle higher-level ops like
+ * generate, fold, let, zeros, reshape — those are expanded by
+ * lowerArrayOps before the interpreter sees them.
+ *
+ * No FFI, no C++ dependency. Pure TS, fully deterministic.
+ */
+
+import type { ExprNode } from './expr.js'
+import type { FlatExpressions } from './flatten.js'
+
+// ─────────────────────────────────────────────────────────────
+// Environment
+// ─────────────────────────────────────────────────────────────
+
+export interface InterpretEnv {
+  sampleRate: number
+  sampleIndex: number
+  registers: (number | boolean | number[])[]
+  inputs: number[]
+  params: Map<number, number>
+}
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+/** Coerce a value to a JS number (booleans → 0/1). */
+function toNum(v: number | boolean): number {
+  return typeof v === 'boolean' ? (v ? 1 : 0) : v
+}
+
+/** Coerce a value to an integer for bitwise ops. */
+function toInt(v: number | boolean): number {
+  return Math.trunc(toNum(v))
+}
+
+/** Coerce a value to boolean (0 → false, nonzero → true). */
+function toBool(v: number | boolean): boolean {
+  return typeof v === 'boolean' ? v : v !== 0
+}
+
+type Value = number | boolean | number[]
+
+/** Apply a scalar binary op elementwise, broadcasting scalar args. */
+function binOp(a: Value, b: Value, fn: (x: number, y: number) => number | boolean): Value {
+  const aArr = Array.isArray(a)
+  const bArr = Array.isArray(b)
+  if (!aArr && !bArr) return fn(toNum(a as number | boolean), toNum(b as number | boolean))
+  if (aArr && bArr) {
+    const aa = a as number[], bb = b as number[]
+    const len = Math.max(aa.length, bb.length)
+    const out = new Array<number>(len)
+    for (let i = 0; i < len; i++) out[i] = toNum(fn(aa[i % aa.length], bb[i % bb.length]))
+    return out
+  }
+  if (aArr) {
+    const aa = a as number[], bv = toNum(b as number | boolean)
+    return aa.map(x => toNum(fn(x, bv)))
+  }
+  const bb = b as number[], av = toNum(a as number | boolean)
+  return bb.map(y => toNum(fn(av, y)))
+}
+
+/** Apply a scalar unary op elementwise. */
+function unOp(a: Value, fn: (x: number) => number | boolean): Value {
+  if (Array.isArray(a)) return (a as number[]).map(x => toNum(fn(x)))
+  return fn(toNum(a as number | boolean))
+}
+
+// ─────────────────────────────────────────────────────────────
+// Core evaluator
+// ─────────────────────────────────────────────────────────────
+
+export function evalExpr(node: ExprNode, env: InterpretEnv): Value {
+  if (typeof node === 'number') return node
+  if (typeof node === 'boolean') return node
+  if (Array.isArray(node)) return (node as ExprNode[]).map(n => toNum(evalExpr(n, env) as number | boolean))
+
+  const obj = node as Record<string, unknown>
+  const op = obj.op as string
+  const args = obj.args as ExprNode[] | undefined
+
+  switch (op) {
+    // ── Terminals ──────────────────────────────────────────
+    case 'input':
+      return env.inputs[(obj.id ?? obj.slot) as number] ?? 0
+    case 'reg':
+      return env.registers[(obj.id ?? obj.slot) as number] ?? 0
+    case 'sample_rate':
+      return env.sampleRate
+    case 'sample_index':
+      return env.sampleIndex
+    case 'smoothed_param':
+    case 'trigger_param': {
+      const handle = (obj._handle ?? obj.ptr) as number
+      return env.params.get(handle) ?? 0
+    }
+
+    // ── Binary arithmetic ─────────────────────────────────
+    case 'add':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a + b)
+    case 'sub':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a - b)
+    case 'mul':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a * b)
+    case 'div':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => b !== 0 ? a / b : 0)
+    case 'mod':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => b !== 0 ? a % b : 0)
+    case 'pow':       return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => Math.pow(a, b))
+    case 'floor_div':
+    case 'floorDiv':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => b !== 0 ? Math.floor(a / b) : 0)
+
+    // ── Binary comparison ─────────────────────────────────
+    case 'lt':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a < b)
+    case 'lte': return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a <= b)
+    case 'gt':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a > b)
+    case 'gte': return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a >= b)
+    case 'eq':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a === b)
+    case 'neq': return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => a !== b)
+
+    // ── Binary bitwise ────────────────────────────────────
+    case 'bit_and':
+    case 'bitAnd':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toInt(a) & toInt(b))
+    case 'bit_or':
+    case 'bitOr':   return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toInt(a) | toInt(b))
+    case 'bit_xor':
+    case 'bitXor':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toInt(a) ^ toInt(b))
+    case 'lshift':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toInt(a) << toInt(b))
+    case 'rshift':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toInt(a) >> toInt(b))
+
+    // ── Binary logical ────────────────────────────────────
+    case 'and': return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toBool(a) && toBool(b))
+    case 'or':  return binOp(evalExpr(args![0], env), evalExpr(args![1], env), (a, b) => toBool(a) || toBool(b))
+
+    // ── Unary math ────────────────────────────────────────
+    case 'neg':   return unOp(evalExpr(args![0], env), x => -x)
+    case 'abs':   return unOp(evalExpr(args![0], env), x => Math.abs(x))
+    case 'sin':   return unOp(evalExpr(args![0], env), x => Math.sin(x))
+    case 'cos':   return unOp(evalExpr(args![0], env), x => Math.cos(x))
+    case 'tanh':  return unOp(evalExpr(args![0], env), x => Math.tanh(x))
+    case 'log':   return unOp(evalExpr(args![0], env), x => Math.log(x))
+    case 'exp':   return unOp(evalExpr(args![0], env), x => Math.exp(x))
+    case 'sqrt':  return unOp(evalExpr(args![0], env), x => Math.sqrt(x))
+    case 'floor': return unOp(evalExpr(args![0], env), x => Math.floor(x))
+    case 'ceil':  return unOp(evalExpr(args![0], env), x => Math.ceil(x))
+    case 'round': return unOp(evalExpr(args![0], env), x => Math.round(x))
+
+    // ── Unary logical/bitwise ─────────────────────────────
+    case 'not':     return unOp(evalExpr(args![0], env), x => !toBool(x))
+    case 'bit_not': return unOp(evalExpr(args![0], env), x => ~toInt(x))
+
+    // ── Ternary ───────────────────────────────────────────
+    case 'select': {
+      const cond = evalExpr(args![0], env)
+      const then_ = evalExpr(args![1], env)
+      const else_ = evalExpr(args![2], env)
+      if (Array.isArray(cond)) {
+        const c = cond as number[], t = then_ as number[] | number, e = else_ as number[] | number
+        return c.map((cv, i) => toBool(cv)
+          ? toNum(Array.isArray(t) ? t[i] : t as number | boolean)
+          : toNum(Array.isArray(e) ? e[i] : e as number | boolean))
+      }
+      return toBool(cond as number | boolean) ? then_ : else_
+    }
+    case 'clamp': {
+      const v = evalExpr(args![0], env)
+      const lo = evalExpr(args![1], env)
+      const hi = evalExpr(args![2], env)
+      if (Array.isArray(v)) {
+        return (v as number[]).map((x, i) => {
+          const l = toNum(Array.isArray(lo) ? lo[i] : lo as number | boolean)
+          const h = toNum(Array.isArray(hi) ? hi[i] : hi as number | boolean)
+          return Math.min(Math.max(x, l), h)
+        })
+      }
+      return Math.min(Math.max(toNum(v as number | boolean), toNum(lo as number | boolean)), toNum(hi as number | boolean))
+    }
+
+    // ── Array ops ─────────────────────────────────────────
+    case 'array': {
+      const items = obj.items as ExprNode[]
+      return items.map(item => toNum(evalExpr(item, env) as number | boolean))
+    }
+    case 'index': {
+      const arr = evalExpr(args![0], env)
+      const idx = toInt(evalExpr(args![1], env) as number | boolean)
+      if (Array.isArray(arr)) return (arr as number[])[idx] ?? 0
+      return arr // scalar indexing returns the scalar
+    }
+    case 'array_set': {
+      const arr = evalExpr(args![0], env)
+      const idx = toInt(evalExpr(args![1], env) as number | boolean)
+      const val = toNum(evalExpr(args![2], env) as number | boolean)
+      if (Array.isArray(arr)) {
+        const copy = [...arr as number[]]
+        if (idx >= 0 && idx < copy.length) copy[idx] = val
+        return copy
+      }
+      return val // scalar case
+    }
+    case 'broadcast_to': {
+      const src = evalExpr(args![0], env)
+      const shape = obj.shape as number[]
+      const len = shape.reduce((a, b) => a * b, 1)
+      if (Array.isArray(src)) {
+        const s = src as number[]
+        const out = new Array<number>(len)
+        for (let i = 0; i < len; i++) out[i] = s[i % s.length]
+        return out
+      }
+      return new Array<number>(len).fill(toNum(src as number | boolean))
+    }
+    case 'matrix': {
+      const rows = obj.rows as ExprNode[][]
+      const flat: number[] = []
+      for (const row of rows) {
+        for (const cell of row) flat.push(toNum(evalExpr(cell, env) as number | boolean))
+      }
+      return flat
+    }
+
+    default:
+      throw new Error(`interpret: unsupported op '${op}'`)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sample runner
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Interpret a flattened program for nSamples, returning the audio output buffer.
+ *
+ * Mirrors FlatRuntime execution order:
+ * 1. Evaluate output expressions → accumulate sum
+ * 2. Evaluate register update expressions → store in new values
+ * 3. Write back all registers atomically (sample-delay semantics)
+ * 4. Write sum(selected outputs) / 20.0 to output buffer
+ * 5. Advance sampleIndex
+ */
+export function interpretSamples(
+  flat: FlatExpressions,
+  nSamples: number,
+  params?: Map<number, number>,
+): Float64Array {
+  const output = new Float64Array(nSamples)
+  const registers: (number | boolean | number[])[] = flat.stateInit.map(
+    v => Array.isArray(v) ? [...v] : v,
+  )
+
+  const env: InterpretEnv = {
+    sampleRate: flat.sampleRate,
+    sampleIndex: 0,
+    registers,
+    inputs: [],
+    params: params ?? new Map(),
+  }
+
+  for (let s = 0; s < nSamples; s++) {
+    env.sampleIndex = s
+
+    // Evaluate all output expressions
+    const outputValues: Value[] = flat.outputExprs.map(expr => evalExpr(expr, env))
+
+    // Evaluate all register update expressions
+    const newRegisters: (number | boolean | number[])[] = flat.registerExprs.map(
+      expr => evalExpr(expr, env) as number | boolean | number[],
+    )
+
+    // Atomic writeback (sample-delay semantics)
+    for (let i = 0; i < newRegisters.length; i++) {
+      const v = newRegisters[i]
+      env.registers[i] = Array.isArray(v) ? [...v] : v
+    }
+
+    // Mix selected outputs and scale
+    let mixed = 0
+    for (const idx of flat.outputIndices) {
+      const v = outputValues[idx]
+      mixed += toNum(Array.isArray(v) ? v[0] : v as number | boolean)
+    }
+    output[s] = mixed / 20.0
+  }
+
+  return output
+}

--- a/compiler/render.test.ts
+++ b/compiler/render.test.ts
@@ -19,6 +19,8 @@ import { join } from 'node:path'
 import { makeSession, loadJSON } from './session'
 import { loadStdlib as loadBuiltins, type ProgramJSON } from './program'
 import { applySessionWiring } from './apply_plan'
+import { flattenExpressions } from './flatten'
+import { interpretSamples } from './interpret'
 import {
   renderFrames,
   peak,
@@ -147,5 +149,118 @@ describe('renderFrames / buffer backend', () => {
 
     s32.graph.dispose()
     s512.graph.dispose()
+  })
+})
+
+// ─── differential tests: interpreter vs JIT ──────────────────────────────────
+
+/** Max absolute difference between two buffers. */
+function maxDiff(a: Float64Array, b: Float64Array): number {
+  let d = 0
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    d = Math.max(d, Math.abs(a[i] - b[i]))
+  }
+  return d
+}
+
+describe('interpreter vs JIT differential', () => {
+  test('VCO sawtooth matches within epsilon', () => {
+    const session = vcoSession(440, 'saw')
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256  // 4096
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(interp.length).toBe(nSamples)
+    expect(jit.length).toBe(nSamples)
+    expect(maxDiff(interp, jit)).toBeLessThan(1e-6)
+
+    session.graph.dispose()
+  })
+
+  test('VCO sine matches within epsilon', () => {
+    // Wider tolerance: JIT uses 7th-order minimax sin approximation that
+    // diverges from Math.sin by up to ~0.004 in the output range.
+    const session = vcoSession(440, 'sin')
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(maxDiff(interp, jit)).toBeLessThan(0.005)
+
+    session.graph.dispose()
+  })
+
+  test('VCO triangle matches within epsilon', () => {
+    const session = vcoSession(440, 'tri')
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(maxDiff(interp, jit)).toBeLessThan(1e-6)
+
+    session.graph.dispose()
+  })
+
+  test('VCO square matches within epsilon', () => {
+    const session = vcoSession(440, 'sqr')
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(maxDiff(interp, jit)).toBeLessThan(1e-6)
+
+    session.graph.dispose()
+  })
+
+  test('VCO+VCA chain matches within epsilon', () => {
+    const session = makeSession(256)
+    loadBuiltins(session.typeRegistry)
+    loadJSON({
+      schema: 'tropical_program_1',
+      name: 'test',
+      instances: {
+        osc: { program: 'VCO', inputs: { freq: 440 } },
+        amp: { program: 'VCA', inputs: {
+          audio: { op: 'ref', instance: 'osc', output: 'saw' },
+          cv: 1.0,
+        }},
+      },
+      audio_outputs: [{ instance: 'amp', output: 'out' }],
+    } as ProgramJSON, session)
+
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(maxDiff(interp, jit)).toBeLessThan(1e-6)
+
+    session.graph.dispose()
+  })
+
+  test('Clock module matches within epsilon', () => {
+    const session = makeSession(256)
+    loadBuiltins(session.typeRegistry)
+    loadJSON({
+      schema: 'tropical_program_1',
+      name: 'test',
+      instances: {
+        clk: { program: 'Clock', inputs: { freq: 1.0, ratios_in: [1.0] } },
+      },
+      audio_outputs: [{ instance: 'clk', output: 'output' }],
+    } as ProgramJSON, session)
+
+    const flat = flattenExpressions(session)
+    const nSamples = 16 * 256
+    const interp = interpretSamples(flat, nSamples)
+    const jit = renderFrames(session.runtime, 16)
+
+    expect(maxDiff(interp, jit)).toBeLessThan(1e-6)
+
+    session.graph.dispose()
   })
 })

--- a/compiler/render.test.ts
+++ b/compiler/render.test.ts
@@ -1,0 +1,151 @@
+/**
+ * render.test.ts — End-to-end integration tests using the buffer backend.
+ *
+ * These tests exercise the full TS compiler pipeline:
+ *   makeSession + loadStdlib
+ *   → loadJSON (tropical_program_1 schema)
+ *   → applyFlatPlan (flatten + emit + JIT compile)
+ *   → renderFrames (synchronous audio rendering, no audio device)
+ *   → peak / rms / dominantFrequency (signal-level assertions)
+ *
+ * Requires build/libtropical.dylib — run `make build` first.
+ * Like apply_plan.test.ts, run with: bun test compiler/render.test.ts
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test'
+import { statSync, existsSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { makeSession, loadJSON } from './session'
+import { loadStdlib as loadBuiltins, type ProgramJSON } from './program'
+import { applySessionWiring } from './apply_plan'
+import {
+  renderFrames,
+  peak,
+  rms,
+  dominantFrequency,
+  writeWav,
+} from './test_utils/audio'
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** Build and compile a single-VCO session outputting the named waveform. */
+function vcoSession(freq: number, output: 'saw' | 'sin' | 'tri' | 'sqr', bufferLength = 256) {
+  const session = makeSession(bufferLength)
+  loadBuiltins(session.typeRegistry)
+  loadJSON({
+    schema: 'tropical_program_1',
+    name: 'test',
+    instances: { osc: { program: 'VCO', inputs: { freq } } },
+    audio_outputs: [{ instance: 'osc', output }],
+  } as ProgramJSON, session)
+  return session
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('renderFrames / buffer backend', () => {
+  test('sawtooth peak and RMS are in expected range', () => {
+    // VCO sawtooth maps phase [0,1) → [-1,1).  The JIT kernel divides all
+    // outputs by 20.0 (OrcJitEngine.cpp), so the output buffer is in [-0.05, 0.05].
+    // After ~40 full cycles (440 Hz × 4096/44100 s ≈ 40.8) peak should be near 1/20.
+    const session = vcoSession(440, 'saw')
+    const samples = renderFrames(session.runtime, 16)  // 16 × 256 = 4096 samples
+
+    // Expect peak ≈ 1.0/20 = 0.05 (PolyBLEP smoothing may trim it slightly)
+    expect(peak(samples)).toBeGreaterThan(0.03)
+    expect(peak(samples)).toBeLessThan(0.07)
+    // Theoretical RMS of sawtooth ≈ 0.577/20 ≈ 0.029
+    expect(rms(samples)).toBeGreaterThan(0.015)
+
+    session.graph.dispose()
+  })
+
+  test('sine dominant frequency matches configured VCO frequency', () => {
+    // Use the sin output — no harmonics, so the peak FFT bin maps cleanly to
+    // the fundamental.  174 × 256 = 44544 samples ≈ 1 second at 44100 Hz,
+    // giving sub-Hz resolution after zero-pad to 65536.
+    const session = vcoSession(440, 'sin')
+    const samples = renderFrames(session.runtime, 174)  // ~1 s
+
+    const freq = dominantFrequency(samples, 44100)
+    expect(Math.abs(freq - 440)).toBeLessThan(15)  // ±15 Hz tolerance
+
+    session.graph.dispose()
+  })
+
+  test('hot-swap updates frequency while preserving phase state', () => {
+    // Start at 220 Hz, advance state, hot-swap to 440 Hz, then verify the
+    // output frequency changed.  Phase register persistence means no reset to 0.
+    const session = makeSession(256)
+    loadBuiltins(session.typeRegistry)
+    loadJSON({
+      schema: 'tropical_program_1',
+      name: 'test',
+      instances: { osc: { program: 'VCO', inputs: { freq: 220 } } },
+      audio_outputs: [{ instance: 'osc', output: 'sin' }],
+    } as ProgramJSON, session)
+
+    // Advance phase state (8 buffer frames worth of 220 Hz oscillation)
+    renderFrames(session.runtime, 8)
+
+    // Hot-swap to 440 Hz — applySessionWiring recompiles and atomically swaps
+    session.inputExprNodes.set('osc:freq', 440)
+    applySessionWiring(session)
+
+    // Render ~1 second and verify dominant frequency is now 440, not 220
+    const samples = renderFrames(session.runtime, 174)
+    const freq = dominantFrequency(samples, 44100)
+    expect(Math.abs(freq - 440)).toBeLessThan(15)
+    expect(Math.abs(freq - 220)).toBeGreaterThan(15)
+
+    session.graph.dispose()
+  })
+
+  test('WAV file is written with correct byte size', async () => {
+    // 16 × 256 = 4096 samples → file = 46-byte header + 4096 × 4 bytes = 16430 bytes
+    const session = vcoSession(440, 'saw')
+    const samples = renderFrames(session.runtime, 16)
+
+    const path = join(tmpdir(), 'tropical_render_test.wav')
+    await writeWav(path, samples, 44100)
+
+    expect(existsSync(path)).toBe(true)
+    const expectedBytes = 46 + samples.length * 4  // header + float32 data
+    expect(statSync(path).size).toBe(expectedBytes)
+
+    unlinkSync(path)
+    session.graph.dispose()
+  })
+
+  test('sample count equals nCalls * bufferLength regardless of buffer size', () => {
+    // Two sessions with different buffer sizes but the same program and initial
+    // state should produce identical output — the JIT kernel is per-sample and
+    // cannot be vectorized across samples due to state register updates.
+    const prog: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'test',
+      instances: { osc: { program: 'VCO', inputs: { freq: 440 } } },
+      audio_outputs: [{ instance: 'osc', output: 'sin' }],
+    }
+
+    const s32 = makeSession(32)
+    loadBuiltins(s32.typeRegistry)
+    loadJSON(prog, s32)
+    const a = renderFrames(s32.runtime, 16)  // 16 × 32 = 512
+
+    const s512 = makeSession(512)
+    loadBuiltins(s512.typeRegistry)
+    loadJSON(prog, s512)
+    const b = renderFrames(s512.runtime, 1)  // 1 × 512 = 512
+
+    expect(a.length).toBe(512)
+    expect(b.length).toBe(512)
+    for (let i = 0; i < 512; i++) {
+      expect(a[i]).toBeCloseTo(b[i], 10)
+    }
+
+    s32.graph.dispose()
+    s512.graph.dispose()
+  })
+})

--- a/compiler/test_utils/audio.ts
+++ b/compiler/test_utils/audio.ts
@@ -12,6 +12,7 @@
  *   await writeWav('/tmp/out.wav', samples, 44100)
  */
 
+import { writeFile } from 'node:fs/promises'
 import type { Runtime } from '../runtime/runtime'
 
 // ─── Buffer backend ───────────────────────────────────────────────────────────
@@ -189,5 +190,5 @@ export async function writeWav(
   cc('data'); u32(dataBytes)
   for (let i = 0; i < samples.length; i++) { v.setFloat32(off, samples[i], true); off += 4 }
 
-  await Bun.write(path, buf)
+  await writeFile(path, new Uint8Array(buf))
 }

--- a/compiler/test_utils/audio.ts
+++ b/compiler/test_utils/audio.ts
@@ -1,0 +1,193 @@
+/**
+ * test_utils/audio.ts — Buffer renderer and signal analysis utilities for integration testing.
+ *
+ * The buffer backend is the testing analogue of `runtime.createDAC().start()`:
+ * instead of letting RtAudio drive process() asynchronously, renderFrames() drives
+ * it synchronously and captures the output for assertion or file output.
+ *
+ * Usage:
+ *   const samples = renderFrames(session.runtime, 174)   // ~1 second at 44100 Hz
+ *   expect(peak(samples)).toBeGreaterThan(0.9)
+ *   expect(dominantFrequency(samples, 44100)).toBeCloseTo(440, -1)
+ *   await writeWav('/tmp/out.wav', samples, 44100)
+ */
+
+import type { Runtime } from '../runtime/runtime'
+
+// ─── Buffer backend ───────────────────────────────────────────────────────────
+
+/**
+ * Drive runtime.process() for nCalls iterations and return all collected samples.
+ * Total samples = nCalls * runtime.bufferLength.
+ *
+ * This is the synchronous "buffer backend" — use instead of createDAC().start()
+ * when you want deterministic, device-free audio rendering for tests.
+ */
+export function renderFrames(runtime: Runtime, nCalls: number): Float64Array {
+  const bufLen = runtime.bufferLength
+  const result = new Float64Array(nCalls * bufLen)
+  for (let i = 0; i < nCalls; i++) {
+    runtime.process()
+    result.set(runtime.outputBuffer, i * bufLen)
+  }
+  return result
+}
+
+// ─── Signal analysis ──────────────────────────────────────────────────────────
+
+/** Maximum absolute sample value. */
+export function peak(samples: Float64Array): number {
+  let p = 0
+  for (let i = 0; i < samples.length; i++) {
+    const a = Math.abs(samples[i])
+    if (a > p) p = a
+  }
+  return p
+}
+
+/** Root-mean-square amplitude. */
+export function rms(samples: Float64Array): number {
+  let sum = 0
+  for (let i = 0; i < samples.length; i++) sum += samples[i] * samples[i]
+  return Math.sqrt(sum / samples.length)
+}
+
+// ─── Spectrum analysis ────────────────────────────────────────────────────────
+
+function nextPow2(n: number): number {
+  let p = 1
+  while (p < n) p <<= 1
+  return p
+}
+
+/**
+ * In-place Cooley-Tukey radix-2 DIT FFT.
+ * buf is interleaved [re0, im0, re1, im1, ...], length must be 2 * (power of 2).
+ */
+function fftInPlace(buf: Float64Array): void {
+  const n = buf.length >> 1
+  // Bit-reversal permutation
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1
+    for (; j & bit; bit >>= 1) j ^= bit
+    j ^= bit
+    if (i < j) {
+      let t = buf[2 * i]; buf[2 * i] = buf[2 * j]; buf[2 * j] = t
+      t = buf[2 * i + 1]; buf[2 * i + 1] = buf[2 * j + 1]; buf[2 * j + 1] = t
+    }
+  }
+  // Butterfly stages
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = -2 * Math.PI / len
+    const wr = Math.cos(ang)
+    const wi = Math.sin(ang)
+    for (let i = 0; i < n; i += len) {
+      let cr = 1, ci = 0
+      for (let j = 0; j < len >> 1; j++) {
+        const ur = buf[2 * (i + j)]
+        const ui = buf[2 * (i + j) + 1]
+        const vr = buf[2 * (i + j + (len >> 1))] * cr - buf[2 * (i + j + (len >> 1)) + 1] * ci
+        const vi = buf[2 * (i + j + (len >> 1))] * ci + buf[2 * (i + j + (len >> 1)) + 1] * cr
+        buf[2 * (i + j)] = ur + vr
+        buf[2 * (i + j) + 1] = ui + vi
+        buf[2 * (i + j + (len >> 1))] = ur - vr
+        buf[2 * (i + j + (len >> 1)) + 1] = ui - vi
+        const newCr = cr * wr - ci * wi
+        ci = cr * wi + ci * wr
+        cr = newCr
+      }
+    }
+  }
+}
+
+/**
+ * Compute the magnitude spectrum of a real-valued signal.
+ * Zero-pads the input to the next power of 2.
+ * Returns bins [0 .. n/2], length = n/2 + 1, where n is the padded size.
+ */
+export function magnitudeSpectrum(samples: Float64Array): Float64Array {
+  const n = nextPow2(samples.length)
+  const buf = new Float64Array(2 * n) // interleaved re/im, im = 0
+  for (let i = 0; i < samples.length; i++) buf[2 * i] = samples[i]
+  fftInPlace(buf)
+  const out = new Float64Array(n / 2 + 1)
+  for (let i = 0; i <= n / 2; i++) {
+    const re = buf[2 * i]
+    const im = buf[2 * i + 1]
+    out[i] = Math.sqrt(re * re + im * im)
+  }
+  return out
+}
+
+/**
+ * Index of the highest-magnitude bin, excluding DC (bin 0).
+ */
+export function dominantBin(spectrum: Float64Array): number {
+  let maxVal = -Infinity
+  let maxIdx = 1
+  for (let i = 1; i < spectrum.length; i++) {
+    if (spectrum[i] > maxVal) { maxVal = spectrum[i]; maxIdx = i }
+  }
+  return maxIdx
+}
+
+/**
+ * Convert a FFT bin index to Hz.
+ * nSamples is the original (pre-pad) sample count; sampleRate is in Hz.
+ */
+export function binToHz(bin: number, nSamples: number, sampleRate: number): number {
+  return (bin * sampleRate) / nextPow2(nSamples)
+}
+
+/**
+ * Find the dominant frequency (Hz) in a real-valued signal, excluding DC.
+ */
+export function dominantFrequency(samples: Float64Array, sampleRate: number): number {
+  const spectrum = magnitudeSpectrum(samples)
+  return binToHz(dominantBin(spectrum), samples.length, sampleRate)
+}
+
+// ─── WAV output ───────────────────────────────────────────────────────────────
+
+/**
+ * Write a mono 32-bit float PCM WAV file.
+ * Format: RIFF/WAVE, IEEE_FLOAT (0x0003), 1 channel, 18-byte fmt chunk.
+ * Uses Bun.write — only available in Bun runtime.
+ */
+export async function writeWav(
+  path: string,
+  samples: Float64Array,
+  sampleRate: number,
+): Promise<void> {
+  const dataBytes = samples.length * 4  // float32 per sample
+
+  // File layout:
+  //   RIFF header:  12 bytes ("RIFF" + size + "WAVE")
+  //   fmt chunk:    26 bytes ("fmt " + 18 + 18 bytes of data)
+  //   data chunk:   8 + dataBytes bytes ("data" + size + samples)
+  // Total:          46 + dataBytes
+  const totalBytes = 46 + dataBytes
+  const riffSize = totalBytes - 8  // everything after "RIFF" + size field
+
+  const buf = new ArrayBuffer(totalBytes)
+  const v = new DataView(buf)
+  let off = 0
+
+  const cc = (s: string) => { for (let i = 0; i < 4; i++) v.setUint8(off + i, s.charCodeAt(i)); off += 4 }
+  const u32 = (x: number) => { v.setUint32(off, x, true); off += 4 }
+  const u16 = (x: number) => { v.setUint16(off, x, true); off += 2 }
+
+  cc('RIFF'); u32(riffSize); cc('WAVE')
+  cc('fmt '); u32(18)           // fmt chunk: 18-byte body (IEEE_FLOAT requires cbSize)
+  u16(3)                        // AudioFormat: IEEE_FLOAT
+  u16(1)                        // NumChannels: mono
+  u32(sampleRate)               // SampleRate
+  u32(sampleRate * 4)           // ByteRate = SampleRate * BlockAlign
+  u16(4)                        // BlockAlign = channels * bytesPerSample
+  u16(32)                       // BitsPerSample
+  u16(0)                        // cbSize: no extra bytes
+  cc('data'); u32(dataBytes)
+  for (let i = 0; i < samples.length; i++) { v.setFloat32(off, samples[i], true); off += 4 }
+
+  await Bun.write(path, buf)
+}

--- a/design/TESTING.md
+++ b/design/TESTING.md
@@ -16,13 +16,13 @@ A test is a function `t : S -> {pass, fail}` where S is some subset of the syste
 |-------|------|-----------|
 | O0 | Liveness | Does not crash, does not hang |
 | O1 | Range | Output is in some expected set (e.g. peak in (0, 100)) |
-| O2 | Relational | Output satisfies a structural invariant (type preservation, idempotence, categorical law) |
+| O2 | Relational | Output satisfies a structural invariant (type preservation, idempotence) |
 | O3 | Differential | Output matches a reference implementation within epsilon |
 | O4 | Exact | Output matches a known-good value to machine precision |
 
 Most smoke tests are O0-O1. Most DSP correctness tests need O3-O4. The useful insight: you can have an O4 oracle for structure (exact instruction match) and only an O1 oracle for numerics (peak level) on the same test — oracle strength is per-assertion, not per-test.
 
-**Observability.** When `t(s) = fail`, how many bits does the failure message carry? Low: "test failed." High: "at stage Flatten, module VCO1, expression `{op:'ref', module:'VCO1', output:'saw'}`, expected type `float` but got `float[4]`." Observability is orthogonal to scope and oracle strength.
+**Observability.** When `t(s) = fail`, how many bits does the failure message carry? Low: "test failed." High: "at stage Flatten, instance VCO1, expression `{op:'ref', instance:'VCO1', output:'saw'}`, expected type `float` but got `float[4]`." Observability is orthogonal to scope and oracle strength.
 
 **Covering.** A test suite covers a behavior region R if for every behavior b in R, there exists a test whose scope includes b and whose oracle is strong enough to distinguish correct from incorrect. Gaps in the covering are undertested behaviors. You can ask: is there a region covered by only O0? That's more honest than counting "unit tests."
 
@@ -36,10 +36,10 @@ Tropical's compilation pipeline is a linear chain. Each boundary between stages 
 
 ```
 Stage 0:  ProgramJSON            tropical_program_1 schema (stdlib or user-defined)
-Stage 1:  loadModuleFromJSON     JSON -> ProgramDef via slottifyExpr (name -> slot)
+Stage 1:  loadProgramDef         JSON -> ProgramDef via slottifyExpr (name -> slot)
 Stage 2:  Session assembly       type/instance registries, wiring, input expressions
 Stage 3:  ExprNode trees         recursive JSON union -- the universal IR
-Stage 4:  Flattening             multi-module -> single expression set, ref resolution
+Stage 4:  Flattening             multi-instance -> single expression set, ref resolution
 Stage 5:  Combinator expansion   generate/fold/chain/scan/iterate -> scalar trees
 Stage 6:  Array lowering         array ops -> scalar primitives (static unrolling)
 Stage 7:  Instruction emission   ExprNode -> FlatProgram NInstr stream
@@ -51,9 +51,7 @@ Stage 11: FlatRuntime            kernel execution, double-buffered state managem
 Stage 12: Audio output           RtAudio callback
 ```
 
-The **Term IR** path is a parallel branch (`ExprNode -> Term -> optimized Term`) used for type-checking and structural reasoning. It does not feed the audio path directly.
-
-**Key property: stages 0-8 are all JSON-serializable.** This is what makes the interpreter strategy viable — an interpreter can consume any intermediate representation up through the plan and produce numerical output, bypassing the JIT entirely.
+**Key property: stages 0-8 are all JSON-serializable.** An interpreter at any of these stages could produce numerical output without the JIT.
 
 ### Boundary types
 
@@ -73,26 +71,32 @@ The **Term IR** path is a parallel branch (`ExprNode -> Term -> optimized Term`)
 
 ---
 
-## 3. Oracle Taxonomy per Stage
+## 3. Current Test Suite
 
-What the strongest available oracle is for each stage, what exists today, and where the gaps are.
+**199 tests total** — 189 TS tests across 11 files (1152 expect() calls), 10 C++ tests.
 
-| Stage | Transfer function | Strongest oracle | Current tests | Gap |
-|-------|-------------------|------------------|---------------|-----|
-| ProgramJSON schema | Zod parse + roundtrip | O4 | `program.test.ts` (14) | No fuzz of malformed JSON |
-| loadModuleFromJSON | slottifyExpr (name -> slot) | O4 (structural) | None dedicated | **No tests for slottifyExpr** |
-| ExprNode construction | expr.ts operations | O4 | `expr.test.ts` (14) | Only construction, no evaluation |
-| Term IR | Categorical laws | O4 + O2 (PBT) | `term.test.ts` (45+, 200-500 PBT runs) | Excellent |
-| Term optimization | Structural rewrites | O2 (PBT) | `optimizer.test.ts` (26, 300 PBT runs) | Excellent |
-| Flattening | Inline + resolve refs | O4 | `flatten_wiring.test.ts` (12) | No nested call resolution tests |
-| Combinator expansion | Unroll to scalars | O4 | `combinators.test.ts` (22) | Good |
-| Array lowering | Static unroll | O4 | `lower_arrays.test.ts` (25) | Good |
-| Instruction emission | emitNumericProgram() | O4 (structural) | **None** | **Critical: no emit_numeric.test.ts** |
-| Plan serialization | JSON.stringify | O4 | `plan.test.ts` (20, plan_1) | plan_4 not directly tested |
-| Plan parsing (C++) | JSON -> struct | O2 | `test_module_process.cpp` (implicit) | No dedicated parsing tests |
-| JIT compilation | LLVM codegen | O3 (differential) | **No interpreter exists** | **Critical: no reference oracle** |
-| FlatRuntime | Kernel execution | O3 (epsilon) | `test_module_process.cpp` (10), `apply_plan.test.ts` (11) | Only handwritten plans |
-| Audio output | RtAudio callback | O0 | `mcp/patch.test.ts` (range check) | Inherently limited |
+### Test inventory
+
+| File | Tests | Scope | Oracle | What it covers |
+|------|------:|-------|--------|----------------|
+| `program.test.ts` | 5 | [ProgramJSON] | O4 | Zod schema validation: minimal, graph, nested programs, rejects |
+| `expr.test.ts` | 20 | [ExprNode] | O4 | Array construction, shape inference, operations, matmul, broadcasting, coercion |
+| `compiler.test.ts` | 30 | [Session assembly] | O4 | portTypeFromString, exprDependencies, buildDependencyGraph, topologicalSort, tarjanSCC, extractInstanceInfo |
+| `flatten_wiring.test.ts` | 11 | [Flattening] | O4 | Wiring type validation: scalar/array compatibility, broadcast insertion, shape mismatches |
+| `array_wiring.test.ts` | 13 | [Wiring validation] | O4 | checkArrayConnection: scalar compat, auto-broadcast, struct types, 2D shapes |
+| `combinators.test.ts` | 22 | [Combinator expansion] | O4 | let, generate, iterate, fold, scan, map2, zip_with, chain, binding passthrough |
+| `lower_arrays.test.ts` | 22 | [Array lowering] | O4 | zeros, ones, fill, reshape, transpose, slice, reduce, broadcast_to, map, matmul, nested lowering |
+| `bounds.test.ts` | 35 | [Flattening + bounds] | O4 | applyBounds, resolveBounds, resolveBaseType, loadProgramDef bounds, flattenSession clamp injection, audio safety clamp, type aliases |
+| `emit_numeric.test.ts` | 15 | [Instruction emission] | O4 | Terminals, scalar binary/unary/ternary, type inference/promotion, arrays (Pack, stride patterns, size-1 unboxing, index, array_set), output/register targets, typed state registers, CSE memoization |
+| `apply_plan.test.ts` | 12 | [ProgramJSON → FlatRuntime] | O1-O4 | Session wiring (connect, disconnect, switch output, batch update, rewire, arithmetic expressions), FlatRuntime execution (VCO+VCA, Clock, continuous output, hot-swap state preservation) |
+| `render.test.ts` | 5 | [ProgramJSON → Audio samples] | O1-O3 | Sawtooth peak/RMS range, sine dominant frequency (FFT), hot-swap frequency change, WAV output, buffer-size determinism (bit-exact cross-config) |
+| `test_module_process.cpp` | 10 | [Plan JSON → FlatRuntime] | O4 | Sawtooth oscillator, two-output mix, hot-swap state transfer, array literals, integer counter with modular wrap, select/conditional, multi-register clock, multiple outputs summed, typed int bitwise (LFSR), typed bool comparison + select |
+
+### Test infrastructure
+
+**Buffer backend** (`compiler/test_utils/audio.ts`) — Device-free audio rendering for integration tests. `renderFrames(runtime, nCalls)` drives `process()` synchronously and returns collected samples. Signal analysis: `peak()`, `rms()`, `dominantFrequency()` (Cooley-Tukey FFT), `magnitudeSpectrum()`. WAV output via `writeWav()`.
+
+**C++ test harness** (`engine/tests/test_module_process.cpp`) — Custom `run_test()` / `ASSERT()` / `ASSERT_NEAR()` macros. Each test builds `tropical_plan_4` JSON by hand and exercises the C API directly.
 
 ### Module type coverage
 
@@ -102,7 +106,31 @@ Untested numerically: ADEnvelope, ADSREnvelope, Reverb, Phaser, Phaser16, Compre
 
 ---
 
-## 4. Coverage Map
+## 4. Oracle Taxonomy per Stage
+
+What the strongest available oracle is for each stage, what exists today, and where the gaps are.
+
+| Stage | Transfer function | Strongest oracle | Current tests | Gap |
+|-------|-------------------|------------------|---------------|-----|
+| ProgramJSON schema | Zod parse + roundtrip | O4 | `program.test.ts` (5) | No fuzz of malformed JSON |
+| loadProgramDef / slottifyExpr | Name -> slot conversion | O4 (structural) | Indirect via `bounds.test.ts` | **No isolated slottifyExpr tests** |
+| ExprNode construction | expr.ts operations | O4 | `expr.test.ts` (20) | Only construction, no evaluation |
+| Graph utilities | Dep graph, topo sort, SCC | O4 | `compiler.test.ts` (30) | Good |
+| Wiring validation | Type compat + broadcast | O4 | `array_wiring.test.ts` (13), `flatten_wiring.test.ts` (11) | Good |
+| Flattening | Inline + resolve refs | O4 | `flatten_wiring.test.ts` (11), `bounds.test.ts` (35) | No nested call resolution tests |
+| Combinator expansion | Unroll to scalars | O4 | `combinators.test.ts` (22) | Good |
+| Array lowering | Static unroll | O4 | `lower_arrays.test.ts` (22) | Good |
+| Bounds enforcement | Clamp insertion | O4 | `bounds.test.ts` (35) | Thorough |
+| Instruction emission | emitNumericProgram() | O4 (structural) | `emit_numeric.test.ts` (15) | Good structural coverage; no numerical oracle |
+| Plan serialization | JSON.stringify | O4 | Implicit via apply_plan | No dedicated tests |
+| Plan parsing (C++) | JSON -> struct | O2 | `test_module_process.cpp` (implicit) | No dedicated parsing tests |
+| JIT compilation | LLVM codegen | O4 (handwritten) | `test_module_process.cpp` (10) | Only handwritten plans; no cross-boundary roundtrip |
+| FlatRuntime | Kernel execution | O1-O4 | `apply_plan.test.ts` (12), `render.test.ts` (5), `test_module_process.cpp` (10) | Only 3/19 modules |
+| Audio output | RtAudio callback | O0 | None | No automated audio device test |
+
+---
+
+## 5. Coverage Map
 
 Current test suite as a covering of (scope interval) x (oracle strength). Each cell: `*` = well-covered, `~` = partial, `.` = no coverage.
 
@@ -110,34 +138,36 @@ Current test suite as a covering of (scope interval) x (oracle strength). Each c
 Scope (interval)                     O0  O1  O2  O3  O4
 -------------------------------------------------------
 [ProgramJSON schema]                  .   .   *   .   *
-[loadModuleFromJSON / slottifyExpr]   ~   .   .   .   .
+[loadProgramDef / slottifyExpr]       ~   .   .   .   .
 [ExprNode construction]               .   .   *   .   *
-[Term IR + type checking]             .   .   *   .   *
-[Term optimization]                   .   .   *   .   *
+[Graph utilities]                     .   .   *   .   *
+[Wiring validation]                   .   .   *   .   *
 [Flattening]                          .   .   *   .   *
 [Combinator expansion]                .   .   .   .   *
 [Array lowering]                      .   .   .   .   *
-[Instruction emission]                .   .   .   .   .   <- EMPTY
-[Plan serialization]                  .   .   *   .   *
+[Bounds enforcement]                  .   .   *   .   *
+[Instruction emission]                .   .   .   .   *
 [Plan parsing (C++)]                  *   .   .   .   .
-[JIT + Runtime]                       *   .   .   .   ~
+[JIT + Runtime (handwritten plans)]   .   .   .   .   *
 [ProgramJSON -> FlatRuntime]          *   *   .   .   ~
-[ProgramJSON -> Audio]                *   *   .   .   .
+[ProgramJSON -> Audio samples]        *   *   .   ~   ~
 ```
 
 ### Critical gaps, ranked
 
-**1. Instruction emission (stage 7).** No `emit_numeric.test.ts` exists. This stage translates ExprNode trees into `FlatProgram` instruction streams. If it has a bug, tests downstream either catch it at O1 (range check on audio output) or miss it entirely. A structural oracle (O4) here would dramatically improve fault localization.
+**1. No interpreter for differential testing.** No ExprNode interpreter exists. This would enable O3 testing across the entire pipeline: for any program, run the interpreter on the lowered ExprNode tree, run the JIT path, compare sample-by-sample. This single addition would convert every integration test from O1 to O3.
 
-**2. No interpreter for differential testing.** No ExprNode interpreter exists. This would enable O3 testing across the entire pipeline: for any program, run the interpreter on the lowered ExprNode tree, run the JIT path, compare sample-by-sample. This single addition would convert every integration test from O1 to O3.
+**2. Only 3/19 modules tested numerically.** The stdlib JSON files are frozen artifacts. Their correctness was validated once during generation. There is no ongoing regression oracle — if the flattener or emitter changes behavior, 16 modules could silently break.
 
-**3. slottifyExpr / loadModuleFromJSON untested.** These are the new functions (from the stdlib-as-JSON migration) that convert named references in ProgramJSON to slot-indexed ProgramDef. They're exercised indirectly through integration tests, but a bug in name resolution would be hard to diagnose without isolated tests.
+**3. slottifyExpr untested in isolation.** `loadProgramDef` is exercised indirectly through `bounds.test.ts` and integration tests, but `slottifyExpr` itself (the pure name→slot tree walk) has no dedicated tests. A bug in name resolution would be hard to diagnose.
 
-**4. Only 3/19 modules tested numerically.** The stdlib JSON files are frozen artifacts. Their correctness was validated once during generation (against the now-deleted TypeScript factories). There is no ongoing regression oracle — if the flattener or emitter changes behavior, 16 modules could silently break.
+**4. No cross-boundary roundtrip tests.** The TS emitter and C++ parser are tested independently but never against each other. A serialization mismatch would only surface as a mysterious audio bug in integration tests.
+
+**5. No plan serialization tests.** The `tropical_plan_4` JSON schema is implicit — defined by whatever `emit_numeric.ts` produces and `NumericProgramParser.hpp` accepts. No test verifies this contract directly.
 
 ---
 
-## 5. The Interpreter Strategy
+## 6. The Interpreter Strategy
 
 The single highest-impact addition to the test suite. A reference evaluator for ExprNode trees that serves as a universal differential oracle.
 
@@ -187,11 +217,11 @@ The interpreter uses JavaScript's `Math.sin`, `Math.cos`, etc. The JIT uses inli
 
 ### What it enables
 
-Every test in `apply_plan.test.ts` can be upgraded: instead of checking `peak(buf) > 0` (O1), check `|jit_output[i] - interp_output[i]| < 1e-6 for all i` (O3). Every stdlib module gets tested by loading the JSON, flattening, interpreting N samples, and comparing against JIT output. The interpreter is the ongoing regression oracle that replaces the deleted TypeScript module factories.
+Every test in `apply_plan.test.ts` and `render.test.ts` can be upgraded: instead of checking `peak(buf) > 0` (O1), check `|jit_output[i] - interp_output[i]| < 1e-6 for all i` (O3). Every stdlib module gets tested by loading the JSON, flattening, interpreting N samples, and comparing against JIT output. The interpreter is the ongoing regression oracle for all 19 stdlib modules.
 
 ---
 
-## 6. Concrete Next Steps
+## 7. Concrete Next Steps
 
 Ranked by coverage impact — which regions of behavior space each addition covers.
 
@@ -211,22 +241,21 @@ For each of the 19 `stdlib/*.json` files: load -> flatten -> JIT -> process N sa
 - **Dependency**: interpreter (for O3), or standalone with snapshotted output (O4)
 - **Impact**: covers 16 currently untested module types; catches regressions in flattener/emitter/JIT
 
-### Priority 3: Create `emit_numeric.test.ts`
-
-Feed ExprNode trees in, assert on emitted `NInstr[]`. Same pattern as `lower_arrays.test.ts`.
-
-- **Scope**: `[ExprNode, FlatProgram]` — stage 7 only
-- **Oracle**: O4 (exact structural match)
-- **Start with**: arithmetic, register read/write, array pack/index, select, sample_rate/sample_index
-- **Impact**: fills the completely empty row in the coverage grid
-
-### Priority 4: `slottifyExpr` unit tests
+### Priority 3: `slottifyExpr` unit tests
 
 Exercise name-to-slot conversion edge cases: unknown names, nested calls, delay refs, array registers.
 
 - **Scope**: `[ProgramJSON, ProgramDef]` — stage 1 only
 - **Oracle**: O4 (exact structural match on output ExprNode)
-- **Impact**: tests the new code path from the stdlib-as-JSON migration
+- **Impact**: tests a critical path in the stdlib-as-JSON migration
+
+### Priority 4: Cross-boundary roundtrip tests
+
+Emit a `FlatProgram` in TS, serialize to `tropical_plan_4` JSON, parse in C++ via `NumericProgramParser`, verify field-by-field.
+
+- **Scope**: `[FlatProgram TS, FlatProgram C++]` — stages 7-9
+- **Oracle**: O4 (structural match after JSON roundtrip)
+- **Impact**: catches serialization/parsing mismatches at the FFI boundary
 
 ### Priority 5: Property-based tests for instruction emission
 
@@ -235,36 +264,32 @@ Exercise name-to-slot conversion edge cases: unknown names, nested calls, delay 
 - **Properties**: output_targets.length matches expected output count; all register_targets are valid temp indices; instruction count bounded by ExprNode tree size
 - **Pairs with**: interpreter differential tests (O2 + O3 together)
 
-### Priority 6: Cross-boundary roundtrip tests
-
-Emit a `FlatProgram` in TS, serialize to `tropical_plan_4` JSON, parse in C++ via `NumericProgramParser`, verify field-by-field.
-
-- **Scope**: `[FlatProgram TS, FlatProgram C++]` — stages 7-9
-- **Oracle**: O4 (structural match after JSON roundtrip)
-- **Impact**: catches serialization/parsing mismatches at the FFI boundary
-
 ---
 
-## 7. Determinism
+## 8. Determinism
 
 Stages 0-9 (all TS + C++ parsing) are **fully deterministic** — pure functions from input to output. Same ExprNode in, same FlatProgram out. O4 oracles apply freely.
 
 Stage 10 (JIT) is **functionally deterministic.** The kernel function is deterministic for a given FlatProgram. Inline transcendental approximations (sin, cos, exp, log, tanh) produce bit-identical results across runs on the same platform (no libm dependency). Cross-platform reproducibility is a non-goal (macOS/ARM64 only in practice).
 
-Stage 11 (FlatRuntime) with **hot-swap** introduces observable non-determinism: the output of buffer N+1 depends on whether a hot-swap occurred between N and N+1. Tests exercising hot-swap must account for this (and `test_module_process.cpp` test 3 already does).
+Stage 11 (FlatRuntime) with **hot-swap** introduces observable non-determinism: the output of buffer N+1 depends on whether a hot-swap occurred between N and N+1. Tests exercising hot-swap must account for this (and both `test_module_process.cpp` test 3 and `render.test.ts` test 3 already do).
 
 Stage 12 (Audio) is **inherently non-deterministic** — callback timing, device latency, buffer underruns. No O3/O4 oracle is possible. O0 (liveness) and O1 (range) are the strongest practical oracles.
 
+**Buffer-size determinism**: `render.test.ts` verifies that the same program produces bit-identical output regardless of buffer size (32×16 vs 512×1). This holds because the JIT kernel is per-sample with state register updates between samples — no vectorization across samples.
+
 ---
 
-## 8. Maintaining the Covering
+## 9. Maintaining the Covering
 
 Rules for keeping the coverage map current as the codebase evolves.
 
 **New stdlib module.** Add JSON to `stdlib/`. Add golden-output test (load -> flatten -> process N samples). Verify interpreter match once interpreter exists.
 
-**New ExprNode op.** Four tests required: (a) construction test in `expr.test.ts`, (b) emission test in `emit_numeric.test.ts`, (c) interpreter case in `interpret.ts`, (d) C++ OpTag test in `test_module_process.cpp` with handwritten `tropical_plan_4` JSON.
+**New ExprNode op.** Three tests required: (a) construction test in `expr.test.ts`, (b) emission test in `emit_numeric.test.ts`, (c) C++ OpTag test in `test_module_process.cpp` with handwritten `tropical_plan_4` JSON. Plus: interpreter case in `interpret.ts` once it exists.
 
 **Modifying flattener or emitter.** Run full stdlib golden-output suite. Any change to `flatten.ts`, `lower_arrays.ts`, or `emit_numeric.ts` can silently alter the behavior of all 19 modules.
 
 **New pipeline stage.** Add at least one O2+ test in isolation, plus verify existing end-to-end tests still pass. Update this document's lattice diagram.
+
+**New bounded type or alias.** Add test cases in `bounds.test.ts` for both `resolveBounds` and `flattenSession` clamp injection paths.

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -13,8 +13,8 @@ Also configured in `.mcp.json` for Claude Code integration.
 ## Layout
 
 ```
-server.ts        MCP server: session management, tool definitions, request handlers
-program.test.ts  Program round-trip tests
+server.ts      MCP server: session management, tool definitions, request handlers
+test_patch.ts  Standalone CLI smoke-tester: bun run mcp/test_patch.ts <patch.json> [n_frames]
 ```
 
 ## How it works

--- a/mcp/test_patch.ts
+++ b/mcp/test_patch.ts
@@ -1,7 +1,7 @@
 /**
  * test_patch.ts — standalone patch smoke-test, no audio device required.
  *
- * Usage:  bun run src/test_patch.ts <patch.json> [n_frames]
+ * Usage:  bun run mcp/test_patch.ts <patch.json> [n_frames]
  *
  * Loads a patch, calls runtime.process() n_frames times,
  * and reports pass/fail. Exits non-zero on any thrown exception.
@@ -17,7 +17,7 @@ const patchArg = process.argv[2]
 const nFrames  = parseInt(process.argv[3] ?? '128', 10)
 
 if (!patchArg) {
-  console.error('Usage: bun run src/test_patch.ts <patch.json> [n_frames]')
+  console.error('Usage: bun run mcp/test_patch.ts <patch.json> [n_frames]')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary

- **Extract `flattenExpressions()`** from `flattenSession()` to expose pre-emission ExprNode trees without duplicating the flatten pipeline
- **Add `compiler/interpret.ts`** — pure TS recursive tree walker (~40 ops) that evaluates post-flatten, post-lower ExprNode trees using `Math.*` for transcendentals. No FFI dependency.
- **Add 6 differential tests** comparing interpreter vs JIT sample-by-sample for VCO (saw/sin/tri/sqr), VCO→VCA, and Clock — arithmetic paths match within 1e-6, transcendental paths within 0.005
- **Rewrite `design/TESTING.md`** to reflect current codebase state (excised Term IR, new test files, updated coverage map)

Test suite: 189 → 248 tests, all passing.

## Test plan

- [x] `bun test compiler/interpret.test.ts` — 53 unit tests for evalExpr + interpretSamples
- [x] `bun test compiler/render.test.ts` — 6 differential tests (interpreter ≈ JIT)
- [x] `bun test` — all 248 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)