### PR TITLE
feat(mcp): agent combinator tools — replicate, wire_chain, wire_zip, fan_out, fan_in, feedback

### DIFF
--- a/compiler/expr.ts
+++ b/compiler/expr.ts
@@ -621,8 +621,69 @@ export function validateExpr(node: ExprNode, path = 'expr'): void {
     return
   }
 
-  // broadcast_to, matrix, function, etc. — pass through
-  if (op === 'broadcast_to' || op === 'matrix' || op === 'function') return
+  // ── Array construction ops ────────────────────────────────────────────────
+
+  if (op === 'zeros' || op === 'ones') {
+    if (!Array.isArray(obj.shape))
+      throw new Error(`${path}: '${op}' requires shape: number[]`)
+    return
+  }
+  if (op === 'fill') {
+    if (!Array.isArray(obj.shape))
+      throw new Error(`${path}: 'fill' requires shape: number[]`)
+    if (obj.value === undefined)
+      throw new Error(`${path}: 'fill' requires value: ExprNode`)
+    validateExpr(obj.value as ExprNode, `${path}.value`)
+    return
+  }
+  if (op === 'array_literal') {
+    if (!Array.isArray(obj.values))
+      throw new Error(`${path}: 'array_literal' requires values: ExprNode[]`)
+    for (let i = 0; i < (obj.values as unknown[]).length; i++)
+      validateExpr((obj.values as ExprNode[])[i], `${path}.values[${i}]`)
+    return
+  }
+
+  // ── Array manipulation ops ────────────────────────────────────────────────
+
+  if (op === 'reshape' || op === 'transpose') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length < 1)
+      throw new Error(`${path}: '${op}' requires args: [arr]`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    return
+  }
+  if (op === 'slice') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length < 1)
+      throw new Error(`${path}: 'slice' requires args: [arr]`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    if (typeof obj.start !== 'number') throw new Error(`${path}: 'slice' requires start: number`)
+    if (typeof obj.end   !== 'number') throw new Error(`${path}: 'slice' requires end: number`)
+    return
+  }
+  if (op === 'reduce') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length < 1)
+      throw new Error(`${path}: 'reduce' requires args: [arr]`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    if (typeof obj.reduce_op !== 'string')
+      throw new Error(`${path}: 'reduce' requires reduce_op: string`)
+    return
+  }
+  if (op === 'broadcast_to') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length < 1)
+      throw new Error(`${path}: 'broadcast_to' requires args: [arr]`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    return
+  }
+  if (op === 'map') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length < 1)
+      throw new Error(`${path}: 'map' requires args: [arr]`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    if (obj.callee !== undefined) validateExpr(obj.callee as ExprNode, `${path}.callee`)
+    return
+  }
+
+  // matrix, function — structural pass-through
+  if (op === 'matrix' || op === 'function') return
 
   // Unknown op
   throw new Error(`${path}: unknown op '${op}'`)

--- a/compiler/expr.ts
+++ b/compiler/expr.ts
@@ -609,6 +609,18 @@ export function validateExpr(node: ExprNode, path = 'expr'): void {
     return
   }
 
+  // delay: args[0] is the expression to delay; init is a number; id is an optional string name
+  if (op === 'delay') {
+    if (!Array.isArray(obj.args) || (obj.args as unknown[]).length !== 1)
+      throw new Error(`${path}: 'delay' requires args: [expr] — the expression whose value will be read next sample`)
+    validateExpr((obj.args as ExprNode[])[0], `${path}.args[0]`)
+    if (obj.init !== undefined && typeof obj.init !== 'number')
+      throw new Error(`${path}: 'delay' init must be a number, got ${typeof obj.init}`)
+    if (obj.id !== undefined && typeof obj.id !== 'string')
+      throw new Error(`${path}: 'delay' id must be a string, got ${typeof obj.id}`)
+    return
+  }
+
   // broadcast_to, matrix, function, etc. — pass through
   if (op === 'broadcast_to' || op === 'matrix' || op === 'function') return
 

--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -795,6 +795,76 @@ function resolveRefs(
  * 4. Compile expression trees → FlatProgram via emitNumericProgram
  * 5. Emit tropical_plan_4 JSON
  */
+// ─────────────────────────────────────────────────────────────
+// Session-level delay extraction
+// ─────────────────────────────────────────────────────────────
+
+interface SessionDelayRecord {
+  regIdx:         number    // pre-allocated flat register index
+  rawUpdateExpr:  ExprNode  // the expression to store each sample (already delay-free)
+  init:           number    // initial register value
+  regName:        string    // stable name for hot-swap state matching
+}
+
+/**
+ * Walk a wiring ExprNode tree, replacing every {op:"delay", args:[expr], init?, id?}
+ * node with {op:"reg", id:N} where N is the index into `out`.
+ *
+ * The replacement register reads from the *previous* sample's value, breaking any
+ * algebraic cycle without requiring a named breaks_cycles instance. Nested delays
+ * are extracted depth-first so inner delays get lower indices than outer ones.
+ */
+function extractSessionDelays(node: ExprNode, out: SessionDelayRecord[]): ExprNode {
+  if (typeof node === 'number' || typeof node === 'boolean') return node
+  if (Array.isArray(node)) return (node as ExprNode[]).map(n => extractSessionDelays(n, out))
+  if (typeof node !== 'object' || node === null) return node
+
+  const obj = node as Record<string, unknown>
+  if (typeof obj.op !== 'string') return node
+
+  if (obj.op === 'delay') {
+    const regIdx = out.length
+    const init   = (obj.init as number | undefined) ?? 0
+    const id     = obj.id   as string | undefined
+    // Recurse into the update expression first so inner delays get lower indices
+    const rawUpdate = extractSessionDelays((obj.args as ExprNode[])[0], out)
+    out.push({ regIdx, rawUpdateExpr: rawUpdate, init, regName: id ?? `wiring_delay_${regIdx}` })
+    return { op: 'reg' as const, id: regIdx }
+  }
+
+  // Generic recursion — mirrors the pattern used by resolveRefs / inlineCalls
+  let changed = false
+  const result: Record<string, unknown> = { op: obj.op }
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === 'op') continue
+    if (Array.isArray(v)) {
+      const arr = v as ExprNode[]
+      const newArr = arr.map(n => extractSessionDelays(n, out))
+      if (newArr.some((n, i) => n !== arr[i])) changed = true
+      result[k] = newArr
+    } else if (typeof v === 'object' && v !== null && 'op' in v) {
+      const newV = extractSessionDelays(v as ExprNode, out)
+      if (newV !== v) changed = true
+      result[k] = newV
+    } else if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+      // Record<string, ExprNode> fields (e.g. 'bind' in let nodes)
+      const rec = v as Record<string, ExprNode>
+      const newRec: Record<string, ExprNode> = {}
+      let recChanged = false
+      for (const [rk, rv] of Object.entries(rec)) {
+        const newRv = extractSessionDelays(rv, out)
+        if (newRv !== rv) recChanged = true
+        newRec[rk] = newRv
+      }
+      if (recChanged) changed = true
+      result[k] = recChanged ? newRec : rec
+    } else {
+      result[k] = v
+    }
+  }
+  return changed ? result as ExprNode : node
+}
+
 /**
  * Flatten a session into pre-emission ExprNode trees.
  * Returns the flattened output/register expressions, state init, and metadata
@@ -813,7 +883,20 @@ export function flattenExpressions(session: SessionState): FlatExpressions {
 
   // Validate and normalize wiring types (throws FlattenError on incompatible connections,
   // inserts broadcast_to wrappers for shape mismatches from patch-file or direct wiring)
-  const inputExprNodes = normalizeWiringTypes(instanceInfos, session.inputExprNodes)
+  let inputExprNodes = normalizeWiringTypes(instanceInfos, session.inputExprNodes)
+
+  // ── Phase 0: Extract session-level {op:"delay"} nodes from wiring expressions ──
+  // Each delay node is replaced with a {op:"reg", id:N} read from a pre-allocated register.
+  // The delay's update expression (args[0]) is recorded for deferred resolution after all
+  // instances are processed. This lets delay nodes appear anywhere in a wiring expression —
+  // including in cycles — without requiring a named breaks_cycles instance.
+  const sessionDelays: SessionDelayRecord[] = []
+  {
+    const transformed = new Map<string, ExprNode>()
+    for (const [key, expr] of inputExprNodes)
+      transformed.set(key, extractSessionDelays(expr, sessionDelays))
+    inputExprNodes = transformed
+  }
 
   // Identify cycle-breaking instances (outputs depend only on registers, not current inputs).
   // These can break feedback cycles: their outputs are previous-sample state reads.
@@ -859,7 +942,15 @@ export function flattenExpressions(session: SessionState): FlatExpressions {
     regStartIdx: number
   }> = []
 
-  let registerBase = 0
+  // Pre-allocate session-level delay registers at the front of the register array
+  // (indices 0..N-1). Instance registers follow, so registerBase starts at N.
+  for (const d of sessionDelays) {
+    flatRegisterExprs.push({ op: 'reg' as const, id: d.regIdx })  // placeholder — Phase 4 fills in
+    flatRegisterNames.push(d.regName)
+    flatRegisterTypes.push('float')
+    flatStateInit.push(d.init)
+  }
+  let registerBase = sessionDelays.length
   for (const name of cycleBreakerList) {
     const inst = instances.get(name)!
     const def = inst._def
@@ -1210,6 +1301,17 @@ export function flattenExpressions(session: SessionState): FlatExpressions {
         regIdx++
       }
     }
+  }
+
+  // ── Phase 4: Resolve session-level delay update expressions ──
+  // Now that all instance outputs are in resolvedOutputs, resolve the raw update
+  // expressions (which may ref any instance) and overwrite the placeholder entries.
+  for (const d of sessionDelays) {
+    const refsMemo  = new WeakMap<object, ExprNode>()
+    let expr = resolveRefs(d.rawUpdateExpr, resolvedOutputs, resolvedOutputNames, refsMemo)
+    const lowerMemo = new WeakMap<object, ExprNode>()
+    expr = lowerArrayOps(expr, lowerMemo)
+    flatRegisterExprs[d.regIdx] = expr
   }
 
   // Build output indices: map graphOutputs → flat output indices

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -211,14 +211,12 @@ const TOOLS = [
   },
   {
     name: 'fan_out',
-    description: 'Wire one source output to many target inputs. One recompile.',
+    description: 'Wire one source to many target inputs. Source can be an instance output ({instance, output}) or any ExprNode (literal, param, arithmetic expression, etc.). One recompile.',
     inputSchema: {
       type: 'object',
       properties: {
         source: {
-          type: 'object',
-          properties: { instance: { type: 'string' }, output: { description: 'Output port name or index' } },
-          required: ['instance', 'output'],
+          description: 'Either {instance, output} for an instance output, or any ExprNode (number, {op:"param",...}, {op:"mul",...}, etc.)',
         },
         targets: {
           type: 'array',
@@ -230,6 +228,58 @@ const TOOLS = [
         },
       },
       required: ['source', 'targets'],
+    },
+  },
+  {
+    name: 'fan_in',
+    description: 'Sum N instance outputs and wire the result to one input. Optional per-source gain. One recompile.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sources: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              instance: { type: 'string' },
+              output:   { description: 'Output port name or index' },
+              gain:     { type: 'number', description: 'Optional scale factor for this source' },
+            },
+            required: ['instance', 'output'],
+          },
+        },
+        target: {
+          type: 'object',
+          properties: {
+            instance: { type: 'string' },
+            input:    { description: 'Input port name or index' },
+          },
+          required: ['instance', 'input'],
+        },
+      },
+      required: ['sources', 'target'],
+    },
+  },
+  {
+    name: 'feedback',
+    description: 'Route a signal back through a cycle-breaking delay instance, creating a feedback loop. Auto-creates a Delay1 (1-sample) by default; use delay_type to choose a longer delay (Delay8, Delay16, Delay512, Delay4410, Delay44100). One recompile.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        from: {
+          type: 'object',
+          properties: { instance: { type: 'string' }, output: { description: 'Output port name or index' } },
+          required: ['instance', 'output'],
+        },
+        to: {
+          type: 'object',
+          properties: { instance: { type: 'string' }, input: { description: 'Input port name or index' } },
+          required: ['instance', 'input'],
+        },
+        delay_type: { type: 'string', description: 'Delay program type to use (default: Delay1)' },
+        delay_name: { type: 'string', description: 'Name for the auto-created delay instance (default: auto-generated)' },
+      },
+      required: ['from', 'to'],
     },
   },
   {
@@ -522,25 +572,123 @@ function handleWireZip(args: Record<string, unknown>) {
 
 function handleFanOut(args: Record<string, unknown>) {
   return wrap(() => {
-    const source  = args.source  as { instance: string; output: string | number }
-    const targets = args.targets as Array<{ instance: string; input: string | number }>
+    const rawSource = args.source as { instance?: string; output?: string | number } | ExprNode
+    const targets   = args.targets as Array<{ instance: string; input: string | number }>
 
-    const srcInst = session.instanceRegistry.get(source.instance)
-    if (!srcInst) throw new Error(`No instance named '${source.instance}'`)
-    const outName = resolveOutputName(srcInst, source.output)
-    const refExpr = { op: 'ref' as const, instance: source.instance, output: outName }
+    // Resolve source to a canonical ExprNode plus a display label
+    let sourceExpr: ExprNode
+    let sourceLabel: string
+    if (
+      rawSource !== null &&
+      typeof rawSource === 'object' &&
+      !Array.isArray(rawSource) &&
+      typeof (rawSource as Record<string, unknown>).instance === 'string' &&
+      (rawSource as Record<string, unknown>).output !== undefined
+    ) {
+      const s       = rawSource as { instance: string; output: string | number }
+      const srcInst = session.instanceRegistry.get(s.instance)
+      if (!srcInst) throw new Error(`No instance named '${s.instance}'`)
+      const outName = resolveOutputName(srcInst, s.output)
+      sourceExpr  = { op: 'ref' as const, instance: s.instance, output: outName }
+      sourceLabel = `${s.instance}.${outName}`
+    } else {
+      sourceExpr  = rawSource as ExprNode
+      sourceLabel = JSON.stringify(sourceExpr)
+    }
 
     const linked = []
     for (const dst of targets) {
       const dstInst = session.instanceRegistry.get(dst.instance)
       if (!dstInst) throw new Error(`No instance named '${dst.instance}'`)
       const inName   = resolveInputName(dstInst, dst.input)
-      const { expr } = adaptInputExpr(refExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), dst.instance, inName)
+      const { expr } = adaptInputExpr(sourceExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), dst.instance, inName)
       session.inputExprNodes.set(`${dst.instance}:${inName}`, expr)
-      linked.push(`${source.instance}.${outName} → ${dst.instance}.${inName}`)
+      linked.push(`${sourceLabel} → ${dst.instance}.${inName}`)
     }
 
     return { linked, ...wire() }
+  })
+}
+
+function handleFanIn(args: Record<string, unknown>) {
+  return wrap(() => {
+    const sources = args.sources as Array<{ instance: string; output: string | number; gain?: number }>
+    const target  = args.target  as { instance: string; input: string | number }
+
+    if (sources.length === 0) throw new Error('sources must be non-empty')
+
+    const dstInst = session.instanceRegistry.get(target.instance)
+    if (!dstInst) throw new Error(`No instance named '${target.instance}'`)
+
+    // Build one term per source: ref, optionally scaled
+    const terms: ExprNode[] = sources.map(src => {
+      const srcInst = session.instanceRegistry.get(src.instance)
+      if (!srcInst) throw new Error(`No instance named '${src.instance}'`)
+      const outName = resolveOutputName(srcInst, src.output)
+      const ref: ExprNode = { op: 'ref' as const, instance: src.instance, output: outName }
+      return src.gain !== undefined
+        ? { op: 'mul' as const, args: [ref, src.gain] }
+        : ref
+    })
+
+    // Left-fold into a binary add tree
+    const sumExpr = terms.slice(1).reduce<ExprNode>(
+      (acc, t) => ({ op: 'add' as const, args: [acc, t] }),
+      terms[0],
+    )
+
+    const inName   = resolveInputName(dstInst, target.input)
+    const { expr } = adaptInputExpr(sumExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), target.instance, inName)
+    session.inputExprNodes.set(`${target.instance}:${inName}`, expr)
+
+    return { mixed: sources.length, target: `${target.instance}.${inName}`, ...wire() }
+  })
+}
+
+function handleFeedback(args: Record<string, unknown>) {
+  return wrap(() => {
+    const from      = args.from       as { instance: string; output: string | number }
+    const to        = args.to         as { instance: string; input:  string | number }
+    const delayType = (args.delay_type as string | undefined) ?? 'Delay1'
+    const delayName = (args.delay_name as string | undefined) ?? nextName(session, delayType.toLowerCase())
+
+    if (session.instanceRegistry.has(delayName))
+      throw new Error(`Instance '${delayName}' already exists — provide a different delay_name`)
+
+    const type = session.typeRegistry.get(delayType)
+    if (!type)
+      throw new Error(`Delay type '${delayType}' not found. Available: ${[...session.typeRegistry.keys()].join(', ')}`)
+
+    const srcInst = session.instanceRegistry.get(from.instance)
+    if (!srcInst) throw new Error(`No instance named '${from.instance}'`)
+    const dstInst = session.instanceRegistry.get(to.instance)
+    if (!dstInst) throw new Error(`No instance named '${to.instance}'`)
+
+    const outName      = resolveOutputName(srcInst, from.output)
+    const inName       = resolveInputName(dstInst, to.input)
+    const delayInInst  = type._def.inputNames[0]
+    const delayOutInst = type._def.outputNames[0]
+    if (!delayInInst || !delayOutInst)
+      throw new Error(`'${delayType}' must have at least one input and one output`)
+
+    // Create the delay instance
+    const delayInst = type.instantiateAs(delayName)
+    session.instanceRegistry.set(delayName, delayInst)
+
+    // from → delay.in
+    const refToSrc: ExprNode = { op: 'ref' as const, instance: from.instance, output: outName }
+    session.inputExprNodes.set(`${delayName}:${delayInInst}`, refToSrc)
+
+    // delay.out → to
+    const refFromDelay: ExprNode = { op: 'ref' as const, instance: delayName, output: delayOutInst }
+    const { expr } = adaptInputExpr(refFromDelay, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), to.instance, inName)
+    session.inputExprNodes.set(`${to.instance}:${inName}`, expr)
+
+    return {
+      feedback: `${from.instance}.${outName} → ${delayName}(${delayType}) → ${to.instance}.${inName}`,
+      delay_instance: delayName,
+      ...wire(),
+    }
   })
 }
 
@@ -759,6 +907,12 @@ function handleTool(name: string, args: Record<string, unknown>) {
 
     case 'fan_out':
       return handleFanOut(args)
+
+    case 'fan_in':
+      return handleFanIn(args)
+
+    case 'feedback':
+      return handleFeedback(args)
 
     case 'list_programs':
       return handleListPrograms()

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -262,7 +262,7 @@ const TOOLS = [
   },
   {
     name: 'feedback',
-    description: 'Route a signal back through a cycle-breaking delay instance, creating a feedback loop. Auto-creates a Delay1 (1-sample) by default; use delay_type to choose a longer delay (Delay8, Delay16, Delay512, Delay4410, Delay44100). One recompile.',
+    description: 'Wire an instance output back to an input through a 1-sample delay, creating a feedback loop. The delay is inserted inline — no extra instance is created. One recompile.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -276,8 +276,8 @@ const TOOLS = [
           properties: { instance: { type: 'string' }, input: { description: 'Input port name or index' } },
           required: ['instance', 'input'],
         },
-        delay_type: { type: 'string', description: 'Delay program type to use (default: Delay1)' },
-        delay_name: { type: 'string', description: 'Name for the auto-created delay instance (default: auto-generated)' },
+        init:     { type: 'number', description: 'Initial delay register value (default 0)' },
+        delay_id: { type: 'string', description: 'Stable name for this delay register — preserves its state across hot-swaps' },
       },
       required: ['from', 'to'],
     },
@@ -647,46 +647,30 @@ function handleFanIn(args: Record<string, unknown>) {
 
 function handleFeedback(args: Record<string, unknown>) {
   return wrap(() => {
-    const from      = args.from       as { instance: string; output: string | number }
-    const to        = args.to         as { instance: string; input:  string | number }
-    const delayType = (args.delay_type as string | undefined) ?? 'Delay1'
-    const delayName = (args.delay_name as string | undefined) ?? nextName(session, delayType.toLowerCase())
-
-    if (session.instanceRegistry.has(delayName))
-      throw new Error(`Instance '${delayName}' already exists — provide a different delay_name`)
-
-    const type = session.typeRegistry.get(delayType)
-    if (!type)
-      throw new Error(`Delay type '${delayType}' not found. Available: ${[...session.typeRegistry.keys()].join(', ')}`)
+    const from    = args.from     as { instance: string; output: string | number }
+    const to      = args.to       as { instance: string; input:  string | number }
+    const init    = (args.init    as number | undefined) ?? 0
+    const delayId = args.delay_id as string | undefined
 
     const srcInst = session.instanceRegistry.get(from.instance)
     if (!srcInst) throw new Error(`No instance named '${from.instance}'`)
     const dstInst = session.instanceRegistry.get(to.instance)
     if (!dstInst) throw new Error(`No instance named '${to.instance}'`)
 
-    const outName      = resolveOutputName(srcInst, from.output)
-    const inName       = resolveInputName(dstInst, to.input)
-    const delayInInst  = type._def.inputNames[0]
-    const delayOutInst = type._def.outputNames[0]
-    if (!delayInInst || !delayOutInst)
-      throw new Error(`'${delayType}' must have at least one input and one output`)
+    const outName = resolveOutputName(srcInst, from.output)
+    const inName  = resolveInputName(dstInst, to.input)
 
-    // Create the delay instance
-    const delayInst = type.instantiateAs(delayName)
-    session.instanceRegistry.set(delayName, delayInst)
+    const refExpr: ExprNode = { op: 'ref' as const, instance: from.instance, output: outName }
+    const delayExpr: ExprNode = delayId !== undefined
+      ? { op: 'delay' as const, args: [refExpr], init, id: delayId }
+      : { op: 'delay' as const, args: [refExpr], init }
 
-    // from → delay.in
-    const refToSrc: ExprNode = { op: 'ref' as const, instance: from.instance, output: outName }
-    session.inputExprNodes.set(`${delayName}:${delayInInst}`, refToSrc)
-
-    // delay.out → to
-    const refFromDelay: ExprNode = { op: 'ref' as const, instance: delayName, output: delayOutInst }
-    const { expr } = adaptInputExpr(refFromDelay, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), to.instance, inName)
+    validateExpr(delayExpr, `${to.instance}.${inName}`)
+    const { expr } = adaptInputExpr(delayExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), to.instance, inName)
     session.inputExprNodes.set(`${to.instance}:${inName}`, expr)
 
     return {
-      feedback: `${from.instance}.${outName} → ${delayName}(${delayType}) → ${to.instance}.${inName}`,
-      delay_instance: delayName,
+      feedback: `${from.instance}.${outName} →[delay init=${init}]→ ${to.instance}.${inName}`,
       ...wire(),
     }
   })

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -157,6 +157,82 @@ const TOOLS = [
     },
   },
   {
+    name: 'replicate',
+    description: 'Create N instances of a program type in one call. Returns the list of created instance names and their ports. Does NOT trigger recompilation — follow up with wire and/or set_output.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        program:     { type: 'string', description: 'Registered program type name' },
+        count:       { type: 'number', description: 'Number of instances to create' },
+        name_prefix: { type: 'string', description: 'Name prefix for instances (default: lowercase program name). Instances are named prefix1, prefix2, …' },
+      },
+      required: ['program', 'count'],
+    },
+  },
+  {
+    name: 'wire_chain',
+    description: 'Wire N instances in series: instances[i].output → instances[i+1].input. Optionally set the first instance\'s input from an expression. One recompile.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        instances:    { type: 'array', items: { type: 'string' }, description: 'Ordered list of instance names to chain' },
+        output:       { description: 'Output port name or index to read from each instance' },
+        input:        { description: 'Input port name or index to feed on each instance' },
+        initial_expr: { description: 'Optional ExprNode to wire into the first instance\'s input' },
+      },
+      required: ['instances', 'output', 'input'],
+    },
+  },
+  {
+    name: 'wire_zip',
+    description: 'Wire two equal-length lists of ports pairwise: sources[i].output → targets[i].input. One recompile.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sources: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { instance: { type: 'string' }, output: { description: 'Output port name or index' } },
+            required: ['instance', 'output'],
+          },
+        },
+        targets: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { instance: { type: 'string' }, input: { description: 'Input port name or index' } },
+            required: ['instance', 'input'],
+          },
+        },
+      },
+      required: ['sources', 'targets'],
+    },
+  },
+  {
+    name: 'fan_out',
+    description: 'Wire one source output to many target inputs. One recompile.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source: {
+          type: 'object',
+          properties: { instance: { type: 'string' }, output: { description: 'Output port name or index' } },
+          required: ['instance', 'output'],
+        },
+        targets: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { instance: { type: 'string' }, input: { description: 'Input port name or index' } },
+            required: ['instance', 'input'],
+          },
+        },
+      },
+      required: ['source', 'targets'],
+    },
+  },
+  {
     name: 'list_programs',
     description: 'List all registered program types (builtins + user-defined) with their input/output port names and input defaults. Call this before building a program to discover what is available.',
     inputSchema: { type: 'object', properties: {} },
@@ -333,6 +409,138 @@ function handleAddInstance(programName: string, instanceName: string) {
     const inst = type.instantiateAs(instanceName)
     session.instanceRegistry.set(instanceName, inst)
     return instanceSummary(instanceName)
+  })
+}
+
+function handleReplicate(programName: string, count: number, namePrefix?: string) {
+  return wrap(() => {
+    const type = session.typeRegistry.get(programName)
+    if (!type)
+      throw new Error(`Unknown program '${programName}'. Known: ${[...session.typeRegistry.keys()].join(', ')}`)
+    if (!Number.isInteger(count) || count < 1)
+      throw new Error(`count must be a positive integer, got ${count}`)
+
+    const prefix = namePrefix ?? programName.toLowerCase()
+    const created = []
+    for (let i = 0; i < count; i++) {
+      const name = nextName(session, prefix)
+      if (session.instanceRegistry.has(name))
+        throw new Error(`Instance '${name}' already exists — pick a different name_prefix`)
+      const inst = type.instantiateAs(name)
+      session.instanceRegistry.set(name, inst)
+      created.push(instanceSummary(name))
+    }
+    return { created }
+  })
+}
+
+/** Resolve an output name/index on an instance and return the canonical name string. */
+function resolveOutputName(inst: { outputNames: string[] }, nameOrIdx: string | number): string {
+  const idx = resolveOutputIdx(inst, nameOrIdx)
+  return inst.outputNames[idx]
+}
+
+/** Resolve an input name/index on an instance and return the canonical name string. */
+function resolveInputName(inst: { inputNames: string[] }, nameOrIdx: string | number): string {
+  const idx = resolveInputIdx(inst, nameOrIdx)
+  return inst.inputNames[idx]
+}
+
+function handleWireChain(args: Record<string, unknown>) {
+  return wrap(() => {
+    const instanceNames = args.instances as string[]
+    const outputPort    = args.output as string | number
+    const inputPort     = args.input  as string | number
+    const initialExpr   = args.initial_expr as import('../compiler/expr.js').ExprNode | undefined
+
+    if (instanceNames.length < 2 && initialExpr === undefined)
+      throw new Error('wire_chain needs at least 2 instances, or 1 instance with initial_expr')
+
+    // Validate all instances upfront
+    const insts = instanceNames.map(n => {
+      const inst = session.instanceRegistry.get(n)
+      if (!inst) throw new Error(`No instance named '${n}'`)
+      return inst
+    })
+
+    // Optionally set first instance's input
+    if (initialExpr !== undefined) {
+      const firstName  = instanceNames[0]
+      const firstInst  = insts[0]
+      const inputName  = resolveInputName(firstInst, inputPort)
+      const { expr }   = adaptInputExpr(initialExpr, firstInst.inputPortType(firstInst.inputNames.indexOf(inputName)), firstName, inputName)
+      session.inputExprNodes.set(`${firstName}:${inputName}`, expr)
+    }
+
+    // Wire instances[i].output → instances[i+1].input
+    const linked = []
+    for (let i = 0; i < instanceNames.length - 1; i++) {
+      const srcInst  = insts[i]
+      const dstInst  = insts[i + 1]
+      const srcName  = instanceNames[i]
+      const dstName  = instanceNames[i + 1]
+      const outName  = resolveOutputName(srcInst, outputPort)
+      const inName   = resolveInputName(dstInst, inputPort)
+      const refExpr  = { op: 'ref' as const, instance: srcName, output: outName }
+      const { expr } = adaptInputExpr(refExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), dstName, inName)
+      session.inputExprNodes.set(`${dstName}:${inName}`, expr)
+      linked.push(`${srcName}.${outName} → ${dstName}.${inName}`)
+    }
+
+    return { linked, ...wire() }
+  })
+}
+
+function handleWireZip(args: Record<string, unknown>) {
+  return wrap(() => {
+    const sources = args.sources as Array<{ instance: string; output: string | number }>
+    const targets = args.targets as Array<{ instance: string; input:  string | number }>
+
+    if (sources.length !== targets.length)
+      throw new Error(`sources and targets must be the same length (got ${sources.length} vs ${targets.length})`)
+
+    const linked = []
+    for (let i = 0; i < sources.length; i++) {
+      const src     = sources[i]
+      const dst     = targets[i]
+      const srcInst = session.instanceRegistry.get(src.instance)
+      if (!srcInst) throw new Error(`No instance named '${src.instance}'`)
+      const dstInst = session.instanceRegistry.get(dst.instance)
+      if (!dstInst) throw new Error(`No instance named '${dst.instance}'`)
+
+      const outName  = resolveOutputName(srcInst, src.output)
+      const inName   = resolveInputName(dstInst, dst.input)
+      const refExpr  = { op: 'ref' as const, instance: src.instance, output: outName }
+      const { expr } = adaptInputExpr(refExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), dst.instance, inName)
+      session.inputExprNodes.set(`${dst.instance}:${inName}`, expr)
+      linked.push(`${src.instance}.${outName} → ${dst.instance}.${inName}`)
+    }
+
+    return { linked, ...wire() }
+  })
+}
+
+function handleFanOut(args: Record<string, unknown>) {
+  return wrap(() => {
+    const source  = args.source  as { instance: string; output: string | number }
+    const targets = args.targets as Array<{ instance: string; input: string | number }>
+
+    const srcInst = session.instanceRegistry.get(source.instance)
+    if (!srcInst) throw new Error(`No instance named '${source.instance}'`)
+    const outName = resolveOutputName(srcInst, source.output)
+    const refExpr = { op: 'ref' as const, instance: source.instance, output: outName }
+
+    const linked = []
+    for (const dst of targets) {
+      const dstInst = session.instanceRegistry.get(dst.instance)
+      if (!dstInst) throw new Error(`No instance named '${dst.instance}'`)
+      const inName   = resolveInputName(dstInst, dst.input)
+      const { expr } = adaptInputExpr(refExpr, dstInst.inputPortType(dstInst.inputNames.indexOf(inName)), dst.instance, inName)
+      session.inputExprNodes.set(`${dst.instance}:${inName}`, expr)
+      linked.push(`${source.instance}.${outName} → ${dst.instance}.${inName}`)
+    }
+
+    return { linked, ...wire() }
   })
 }
 
@@ -535,6 +743,22 @@ function handleTool(name: string, args: Record<string, unknown>) {
 
     case 'remove_instance':
       return handleRemoveInstance(args.instance_name as string)
+
+    case 'replicate':
+      return handleReplicate(
+        args.program as string,
+        args.count as number,
+        args.name_prefix as string | undefined,
+      )
+
+    case 'wire_chain':
+      return handleWireChain(args)
+
+    case 'wire_zip':
+      return handleWireZip(args)
+
+    case 'fan_out':
+      return handleFanOut(args)
 
     case 'list_programs':
       return handleListPrograms()

--- a/stdlib/Delay1.json
+++ b/stdlib/Delay1.json
@@ -1,0 +1,17 @@
+{
+  "schema": "tropical_program_1",
+  "name": "Delay1",
+  "inputs": ["x"],
+  "outputs": ["y"],
+  "regs": { "prev": 0 },
+  "input_defaults": { "x": 0 },
+  "breaks_cycles": true,
+  "process": {
+    "outputs": {
+      "y": { "op": "reg", "name": "prev" }
+    },
+    "next_regs": {
+      "prev": { "op": "input", "name": "x" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **`replicate(program, count, name_prefix?)`** — create N instances in one call, no recompile; follow up with `wire`/`set_output` for a single recompile
- **`wire_chain(connections)`** — wire a serial signal path (A→B→C→…) in one call
- **`wire_zip(sources, targets)`** — pairwise wire two lists of instances (1:1 zip)
- **`fan_out(source, targets)`** — broadcast one output to many inputs; source can be an instance output or any raw ExprNode
- **`fan_in(sources, target)`** — sum N sources into one input with optional per-source gain, as a left-fold add tree
- **`feedback(from, to, init?, delay_id?)`** — wire a feedback path using an inline session-level `{op:"delay"}` node (no named instance required)

## Compiler changes

- **`compiler/flatten.ts`** — Phase 0 pre-scans session wiring for `{op:"delay"}` nodes, replaces them with `{op:"reg", id:N}`, and defers update-expression resolution to Phase 4 after all instances are processed. Enables feedback loops without requiring a `breaks_cycles: true` instance.
- **`compiler/expr.ts`** — `validateExpr` now handles `delay`, `zeros`, `ones`, `fill`, `array_literal`, `reshape`, `transpose`, `slice`, `reduce`, `broadcast_to` (with recursion into args), and `map`. Previously these all threw `unknown op`, blocking their use in agent wiring.
- **`stdlib/Delay1.json`** — new stdlib type: explicit 1-sample delay instance (useful when you want a named, state-preserving delay rather than an inline one)

## Test plan

- [ ] `bun test` — 248 compiler tests pass
- [ ] `replicate("VCO", 4, "vco")` → 4 instances, no recompile
- [ ] `wire_chain` with 3+ instances → correct serial wiring
- [ ] `fan_out` with instance source → all targets wired
- [ ] `fan_out` with raw ExprNode source → same
- [ ] `fan_in` with gain per source → scaled add tree
- [ ] `feedback` round-trip: wire a VCO output back to its own freq with 1-sample delay, verify no cycle error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)