### PR TITLE
Structured port types + Sequencer<N>

### DIFF
--- a/compiler/array_wiring.test.ts
+++ b/compiler/array_wiring.test.ts
@@ -4,36 +4,37 @@
 
 import { describe, test, expect } from 'bun:test'
 import { checkArrayConnection } from './array_wiring'
+import { Float, Bool, ArrayType, StructType } from './term'
 import type { ExprNode } from './expr'
 
 const ref: ExprNode = { op: 'ref', instance: 'VCO1', output: 'saw' }
 
 describe('checkArrayConnection', () => {
   test('identical scalar types are compatible', () => {
-    const check = checkArrayConnection('float', 'float', ref)
+    const check = checkArrayConnection(Float, Float, ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeUndefined()
   })
 
-  test('undefined types are compatible (backwards compat)', () => {
+  test('undefined types default to float and are compatible', () => {
     const check = checkArrayConnection(undefined, undefined, ref)
     expect(check.compatible).toBe(true)
   })
 
-  test('identical string types are compatible', () => {
-    const check = checkArrayConnection('float[4]', 'float[4]', ref)
+  test('identical array types are compatible', () => {
+    const check = checkArrayConnection(ArrayType(Float, [4]), ArrayType(Float, [4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeUndefined()
   })
 
   test('different scalar types are incompatible', () => {
-    const check = checkArrayConnection('float', 'bool', ref)
+    const check = checkArrayConnection(Float, Bool, ref)
     expect(check.compatible).toBe(false)
     expect(check.error).toBeDefined()
   })
 
   test('scalar to array auto-broadcasts', () => {
-    const check = checkArrayConnection('float', 'float[4]', ref)
+    const check = checkArrayConnection(Float, ArrayType(Float, [4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeDefined()
     const node = check.broadcastExpr as Record<string, unknown>
@@ -43,25 +44,25 @@ describe('checkArrayConnection', () => {
   })
 
   test('array to scalar is incompatible', () => {
-    const check = checkArrayConnection('float[4]', 'float', ref)
+    const check = checkArrayConnection(ArrayType(Float, [4]), Float, ref)
     expect(check.compatible).toBe(false)
     expect(check.error).toContain('reduce or index')
   })
 
   test('compatible array shapes pass through', () => {
-    const check = checkArrayConnection('float[4]', 'float[4]', ref)
+    const check = checkArrayConnection(ArrayType(Float, [4]), ArrayType(Float, [4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeUndefined()
   })
 
   test('incompatible array shapes fail', () => {
-    const check = checkArrayConnection('float[3]', 'float[4]', ref)
+    const check = checkArrayConnection(ArrayType(Float, [3]), ArrayType(Float, [4]), ref)
     expect(check.compatible).toBe(false)
     expect(check.error).toContain('not broadcast-compatible')
   })
 
   test('broadcastable array shapes insert broadcast_to', () => {
-    const check = checkArrayConnection('float[1]', 'float[4]', ref)
+    const check = checkArrayConnection(ArrayType(Float, [1]), ArrayType(Float, [4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeDefined()
     const node = check.broadcastExpr as Record<string, unknown>
@@ -70,24 +71,24 @@ describe('checkArrayConnection', () => {
   })
 
   test('2D array shape compatibility', () => {
-    const check = checkArrayConnection('float[4,4]', 'float[4,4]', ref)
+    const check = checkArrayConnection(ArrayType(Float, [4, 4]), ArrayType(Float, [4, 4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeUndefined()
   })
 
   test('2D array shape broadcast', () => {
-    const check = checkArrayConnection('float[1,4]', 'float[3,4]', ref)
+    const check = checkArrayConnection(ArrayType(Float, [1, 4]), ArrayType(Float, [3, 4]), ref)
     expect(check.compatible).toBe(true)
     expect(check.broadcastExpr).toBeDefined()
   })
 
   test('struct type mismatch', () => {
-    const check = checkArrayConnection('MyStruct', 'OtherStruct', ref)
+    const check = checkArrayConnection(StructType('MyStruct'), StructType('OtherStruct'), ref)
     expect(check.compatible).toBe(false)
   })
 
   test('same struct types are compatible', () => {
-    const check = checkArrayConnection('MyStruct', 'MyStruct', ref)
+    const check = checkArrayConnection(StructType('MyStruct'), StructType('MyStruct'), ref)
     expect(check.compatible).toBe(true)
   })
 })

--- a/compiler/array_wiring.ts
+++ b/compiler/array_wiring.ts
@@ -5,9 +5,9 @@
  * compatible and inserts broadcast_to nodes when needed.
  */
 
-import { portTypeFromString } from './compiler.js'
 import {
   type PortType,
+  Float,
   portTypeEqual,
   portTypeToString,
   broadcastShapes,
@@ -35,17 +35,12 @@ export interface ConnectionCheck {
  * - error: human-readable explanation if incompatible
  */
 export function checkArrayConnection(
-  srcTypeStr: string | undefined,
-  dstTypeStr: string | undefined,
+  srcTypeIn: PortType | undefined,
+  dstTypeIn: PortType | undefined,
   refExpr: ExprNode,
 ): ConnectionCheck {
-  const srcType = portTypeFromString(srcTypeStr)
-  const dstType = portTypeFromString(dstTypeStr)
-
-  // If both are undefined or identical strings, allow (backwards compat)
-  if (srcTypeStr === dstTypeStr) {
-    return { compatible: true }
-  }
+  const srcType = srcTypeIn ?? Float
+  const dstType = dstTypeIn ?? Float
 
   // If port types are structurally equal, pass through
   if (portTypeEqual(srcType, dstType)) {

--- a/compiler/bounds.test.ts
+++ b/compiler/bounds.test.ts
@@ -9,6 +9,7 @@ import type { ExprNode } from './expr'
 import type { ProgramJSON } from './program'
 import type { ProgramType, ProgramInstance, Bounds } from './program_types'
 import { Param, Trigger } from './runtime/param'
+import { Float } from './term'
 
 // ─────────────────────────────────────────────────────────────
 // Helpers
@@ -154,7 +155,7 @@ describe('loadProgramDef bounds', () => {
     }), session)
     expect(type._def.outputBounds).toEqual([[-1, 1]])
     // Base type resolved to float
-    expect(type._def.outputPortTypes).toEqual(['float'])
+    expect(type._def.outputPortTypes).toEqual([Float])
   })
 
   test('extracts explicit input bounds', () => {
@@ -507,8 +508,8 @@ describe('user-definable type aliases', () => {
     }), session)
     expect(type._def.inputBounds).toEqual([[-0.5, 0.5]])
     expect(type._def.outputBounds).toEqual([[-0.5, 0.5]])
-    expect(type._def.inputPortTypes).toEqual(['float'])
-    expect(type._def.outputPortTypes).toEqual(['float'])
+    expect(type._def.inputPortTypes).toEqual([Float])
+    expect(type._def.outputPortTypes).toEqual([Float])
   })
 
   test('Zod schema accepts alias type_def', () => {

--- a/compiler/compiler.test.ts
+++ b/compiler/compiler.test.ts
@@ -4,106 +4,14 @@
 
 import { describe, test, expect } from 'bun:test'
 import {
-  portTypeFromString,
   exprDependencies,
   buildDependencyGraph,
   topologicalSort,
   tarjanSCC,
   extractInstanceInfo,
-  CompilerError,
-  type InstanceInfo,
 } from './compiler'
-import {
-  Float, Int, Bool, Unit, StructType, ArrayType,
-  portTypeEqual,
-} from './term'
+import { Float, Int, Bool, portTypeEqual } from './term'
 import type { ExprNode } from './session'
-
-// ─────────────────────────────────────────────────────────────
-// Helpers
-// ─────────────────────────────────────────────────────────────
-
-/** Build a simple InstanceInfo for testing. */
-function modInfo(
-  name: string,
-  opts: {
-    typeName?: string
-    inputs?: string[]
-    outputs?: string[]
-    registers?: string[]
-    inputTypes?: string[]
-    outputTypes?: string[]
-    registerTypes?: string[]
-  } = {},
-): InstanceInfo {
-  const inputs = opts.inputs ?? ['in']
-  const outputs = opts.outputs ?? ['out']
-  const registers = opts.registers ?? []
-  return {
-    name,
-    typeName: opts.typeName ?? name,
-    inputNames: inputs,
-    outputNames: outputs,
-    registerNames: registers,
-    inputTypes: (opts.inputTypes ?? inputs.map(() => 'float')).map(s => portTypeFromString(s)),
-    outputTypes: (opts.outputTypes ?? outputs.map(() => 'float')).map(s => portTypeFromString(s)),
-    registerTypes: (opts.registerTypes ?? registers.map(() => 'float')).map(s => portTypeFromString(s)),
-  }
-}
-
-// ─────────────────────────────────────────────────────────────
-// portTypeFromString
-// ─────────────────────────────────────────────────────────────
-
-describe('portTypeFromString', () => {
-  test('scalar types', () => {
-    expect(portTypeEqual(portTypeFromString('float'), Float)).toBe(true)
-    expect(portTypeEqual(portTypeFromString('int'), Int)).toBe(true)
-    expect(portTypeEqual(portTypeFromString('bool'), Bool)).toBe(true)
-  })
-
-  test('unit type', () => {
-    expect(portTypeEqual(portTypeFromString('unit'), Unit)).toBe(true)
-  })
-
-  test('undefined defaults to float', () => {
-    expect(portTypeEqual(portTypeFromString(undefined), Float)).toBe(true)
-  })
-
-  test('unknown name becomes struct type', () => {
-    const t = portTypeFromString('MyStruct')
-    expect(t.tag).toBe('struct')
-    expect(portTypeEqual(t, StructType('MyStruct'))).toBe(true)
-  })
-
-  test('array type with shape', () => {
-    const t = portTypeFromString('float[4]')
-    expect(portTypeEqual(t, ArrayType(Float, [4]))).toBe(true)
-  })
-
-  test('array type multi-dimensional', () => {
-    const t = portTypeFromString('float[4,4]')
-    expect(portTypeEqual(t, ArrayType(Float, [4, 4]))).toBe(true)
-  })
-
-  test('array type with int element', () => {
-    const t = portTypeFromString('int[8]')
-    expect(portTypeEqual(t, ArrayType(Int, [8]))).toBe(true)
-  })
-
-  test('legacy array string', () => {
-    const t = portTypeFromString('array')
-    expect(t.tag).toBe('array')
-  })
-
-  test('legacy matrix string', () => {
-    const t = portTypeFromString('matrix')
-    expect(t.tag).toBe('array')
-    if (t.tag === 'array') {
-      expect(t.shape.length).toBe(2)
-    }
-  })
-})
 
 // ─────────────────────────────────────────────────────────────
 // exprDependencies

--- a/compiler/compiler.test.ts
+++ b/compiler/compiler.test.ts
@@ -335,15 +335,15 @@ describe('tarjanSCC', () => {
 // ─────────────────────────────────────────────────────────────
 
 describe('extractInstanceInfo', () => {
-  test('converts port type strings', () => {
+  test('forwards PortTypes, defaulting undefined to Float', () => {
     const def = {
       typeName: 'Test',
       inputNames: ['a', 'b'],
       outputNames: ['out'],
       registerNames: ['state'],
-      inputPortTypes: ['float', 'bool'] as (string | undefined)[],
-      outputPortTypes: ['int'] as (string | undefined)[],
-      registerPortTypes: [undefined] as (string | undefined)[],
+      inputPortTypes: [Float, Bool],
+      outputPortTypes: [Int],
+      registerPortTypes: [undefined],
     }
     const info = extractInstanceInfo('Test1', def)
     expect(info.name).toBe('Test1')

--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -2,15 +2,12 @@
  * compiler.ts — Graph utilities for the compilation pipeline.
  *
  * Provides dependency graph construction, topological sorting (Kahn's with
- * level grouping), cycle detection (Tarjan's SCC), and port type conversion.
+ * level grouping), and cycle detection (Tarjan's SCC).
  * Used by flatten.ts to determine execution order.
  */
 
 import type { ExprNode } from './session'
-import {
-  type PortType,
-  Float, Int, Bool, Unit, StructType, ArrayType,
-} from './term'
+import { type PortType, Float } from './term'
 
 // ─────────────────────────────────────────────────────────────
 // Errors
@@ -20,46 +17,6 @@ export class CompilerError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'CompilerError'
-  }
-}
-
-// ─────────────────────────────────────────────────────────────
-// Port type conversion
-// ─────────────────────────────────────────────────────────────
-
-/**
- * Convert a string type annotation (from ProgramDef) to a PortType.
- *
- * Supports:
- *   'float', 'int', 'bool', 'unit'       — scalars
- *   'float[4]', 'float[4,4]'             — arrays with static shapes
- *   'array'                                — float[1] (legacy compat)
- *   'matrix'                               — float[1,1] (legacy compat)
- *   anything else                          — struct type
- */
-export function portTypeFromString(s: string | undefined): PortType {
-  if (s === undefined) return Float
-
-  // Check for array syntax: type[d1,d2,...] e.g. float[8], int[4,4]
-  const arrayMatch = s.match(/^(\w+)\[([^\]]+)\]$/)
-  if (arrayMatch) {
-    const elementType = portTypeFromString(arrayMatch[1])
-    const shape = arrayMatch[2].split(',').map(d => {
-      const n = parseInt(d.trim(), 10)
-      if (isNaN(n) || n <= 0) throw new Error(`Invalid array dimension '${d.trim()}' in type '${s}'`)
-      return n
-    })
-    return ArrayType(elementType, shape)
-  }
-
-  switch (s) {
-    case 'float': return Float
-    case 'int':   return Int
-    case 'bool':  return Bool
-    case 'unit':  return Unit
-    case 'array': return ArrayType(Float, [1])  // legacy: bare 'array' — shape from init value
-    case 'matrix': return ArrayType(Float, [1, 1])  // legacy: bare 'matrix'
-    default:      return StructType(s)
   }
 }
 

--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -85,22 +85,23 @@ interface ProgramDefLike {
   inputNames: string[]
   outputNames: string[]
   registerNames: string[]
-  inputPortTypes: (string | undefined)[]
-  outputPortTypes: (string | undefined)[]
-  registerPortTypes: (string | undefined)[]
+  inputPortTypes: (PortType | undefined)[]
+  outputPortTypes: (PortType | undefined)[]
+  registerPortTypes: (PortType | undefined)[]
 }
 
-/** Extract InstanceInfo from a program definition. */
+/** Extract InstanceInfo from a program definition. Undeclared ports default to Float. */
 export function extractInstanceInfo(name: string, def: ProgramDefLike): InstanceInfo {
+  const fillFloat = (t: PortType | undefined): PortType => t ?? Float
   return {
     name,
     typeName: def.typeName,
     inputNames: [...def.inputNames],
     outputNames: [...def.outputNames],
     registerNames: [...def.registerNames],
-    inputTypes: def.inputPortTypes.map(portTypeFromString),
-    outputTypes: def.outputPortTypes.map(portTypeFromString),
-    registerTypes: def.registerPortTypes.map(portTypeFromString),
+    inputTypes: def.inputPortTypes.map(fillFloat),
+    outputTypes: def.outputPortTypes.map(fillFloat),
+    registerTypes: def.registerPortTypes.map(fillFloat),
   }
 }
 

--- a/compiler/delay_generic.test.ts
+++ b/compiler/delay_generic.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, loadJSON, resolveProgramType } from './session'
 import { loadStdlib } from './program'
 import { flattenSession } from './flatten'
+import { Float, ArrayType } from './term'
 
 describe('stdlib Delay<N>', () => {
   test('Delay with N=8 resolves to a distinct type from Delay with N=44100', () => {
@@ -10,8 +11,8 @@ describe('stdlib Delay<N>', () => {
     const a = resolveProgramType(session, 'Delay', { N: 8 }, undefined)
     const b = resolveProgramType(session, 'Delay', { N: 44100 }, undefined)
     expect(a.type).not.toBe(b.type)
-    expect(a.type._def.registerPortTypes[0]).toBe('float[8]')
-    expect(b.type._def.registerPortTypes[0]).toBe('float[44100]')
+    expect(a.type._def.registerPortTypes[0]).toEqual(ArrayType(Float, [8]))
+    expect(b.type._def.registerPortTypes[0]).toEqual(ArrayType(Float, [44100]))
   })
 
   test('Delay with default N=44100 matches explicit N=44100', () => {

--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -17,7 +17,7 @@ import {
   buildDependencyGraph, topologicalSort, tarjanSCC,
 } from './compiler.js'
 import { lowerArrayOps } from './lower_arrays.js'
-import { portTypeToString } from './term.js'
+import { type PortType, Float, Bool, ArrayType } from './term.js'
 import { checkArrayConnection } from './array_wiring.js'
 import { emitNumericProgram, type NInstr, type ScalarType } from './emit_numeric.js'
 
@@ -33,16 +33,16 @@ export class FlattenError extends Error {
 }
 
 /**
- * Infer the output type string of an ExprNode, given the instance type context.
+ * Infer the output PortType of an ExprNode, given the instance type context.
  * Returns undefined when the type cannot be statically determined.
  */
 function inferExprOutputType(
   expr: ExprNode,
   instanceInfos: Map<string, InstanceInfo>,
-): string | undefined {
-  if (typeof expr === 'number') return 'float'
-  if (typeof expr === 'boolean') return 'bool'
-  if (Array.isArray(expr)) return `float[${(expr as unknown[]).length}]`
+): PortType | undefined {
+  if (typeof expr === 'number') return Float
+  if (typeof expr === 'boolean') return Bool
+  if (Array.isArray(expr)) return ArrayType(Float, [(expr as unknown[]).length])
   if (typeof expr !== 'object' || expr === null) return undefined
   const obj = expr as Record<string, unknown>
   switch (obj.op as string) {
@@ -52,15 +52,15 @@ function inferExprOutputType(
       const outName = obj.output as string | number
       const outIdx = typeof outName === 'number' ? outName : modInfo.outputNames.indexOf(outName)
       if (outIdx === -1 || outIdx >= modInfo.outputTypes.length) return undefined
-      return portTypeToString(modInfo.outputTypes[outIdx])
+      return modInfo.outputTypes[outIdx]
     }
     case 'broadcast_to':
-      return `float[${(obj.shape as number[]).join(',')}]`
+      return ArrayType(Float, obj.shape as number[])
     case 'zeros':
     case 'ones':
     case 'fill':
     case 'array_literal':
-      return `float[${(obj.shape as number[]).join(',')}]`
+      return ArrayType(Float, obj.shape as number[])
     default:
       return undefined
   }
@@ -89,11 +89,11 @@ export function normalizeWiringTypes(
     const inputIdx = modInfo.inputNames.indexOf(inputName)
     if (inputIdx === -1) continue
 
-    const dstTypeStr = portTypeToString(modInfo.inputTypes[inputIdx])
-    const srcTypeStr = inferExprOutputType(expr, instanceInfos)
-    if (srcTypeStr === undefined) continue
+    const dstType = modInfo.inputTypes[inputIdx]
+    const srcType = inferExprOutputType(expr, instanceInfos)
+    if (srcType === undefined) continue
 
-    const check = checkArrayConnection(srcTypeStr, dstTypeStr, expr)
+    const check = checkArrayConnection(srcType, dstType, expr)
     if (!check.compatible) {
       throw new FlattenError(
         `Wiring type mismatch on '${instanceName}'.${inputName}: ${check.error}`
@@ -105,6 +105,12 @@ export function normalizeWiringTypes(
   }
 
   return result
+}
+
+/** Map a register's PortType to the scalar tag carried in FlatRegister metadata. */
+function registerScalarTag(t: PortType | undefined): ScalarType {
+  const scalar = t?.tag === 'scalar' ? t.scalar : t?.tag === 'array' && t.element.tag === 'scalar' ? t.element.scalar : 'float'
+  return scalar === 'int' ? 'int' : scalar === 'bool' ? 'bool' : 'float'
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -1218,10 +1224,7 @@ export function flattenExpressions(session: SessionState): FlatExpressions {
     for (let i = 0; i < def.registerNames.length; i++) {
       flatRegisterExprs.push({ op: 'reg', id: registerBase + i })
       flatRegisterNames.push(`${name}_${def.registerNames[i]}`)
-      const portType = def.registerPortTypes[i]
-      flatRegisterTypes.push(
-        portType === 'int' ? 'int' : portType === 'bool' ? 'bool' : 'float',
-      )
+      flatRegisterTypes.push(registerScalarTag(def.registerPortTypes[i]))
       const initVal = def.registerInitValues[i]
       if (typeof initVal === 'number' || typeof initVal === 'boolean') {
         flatStateInit.push(initVal)
@@ -1329,10 +1332,7 @@ export function flattenExpressions(session: SessionState): FlatExpressions {
 
       // Register name, init value, and type
       flatRegisterNames.push(`${name}_${def.registerNames[i]}`)
-      const portType = def.registerPortTypes[i]
-      flatRegisterTypes.push(
-        portType === 'int' ? 'int' : portType === 'bool' ? 'bool' : 'float',
-      )
+      flatRegisterTypes.push(registerScalarTag(def.registerPortTypes[i]))
       const initVal = def.registerInitValues[i]
       if (typeof initVal === 'number' || typeof initVal === 'boolean') {
         flatStateInit.push(initVal)

--- a/compiler/program.test.ts
+++ b/compiler/program.test.ts
@@ -87,8 +87,8 @@ describe('exportSessionAsProgram — port type round-trip', () => {
     const typedLeaf: ProgramJSON = {
       schema: 'tropical_program_1',
       name: 'TypedLeaf',
-      inputs: [{ name: 'a', type: 'float[4]' }],
-      outputs: [{ name: 'out', type: 'float[4]' }],
+      inputs: [{ name: 'a', type: { kind: 'array', element: 'float', shape: [4] } }],
+      outputs: [{ name: 'out', type: { kind: 'array', element: 'float', shape: [4] } }],
       process: { outputs: { out: { op: 'input', name: 'a' } } },
     }
     loadProgramAsType(typedLeaf, session)
@@ -105,8 +105,8 @@ describe('exportSessionAsProgram — port type round-trip', () => {
     const reparsed = parseProgram(exported) as ProgramJSON
     const inputEntry = reparsed.inputs![0]
     const outputEntry = reparsed.outputs![0]
-    expect(typeof inputEntry === 'object' && inputEntry.type).toBe('float[4]')
-    expect(typeof outputEntry === 'object' && outputEntry.type).toBe('float[4]')
+    expect(typeof inputEntry === 'object' && inputEntry.type).toEqual({ kind: 'array', element: 'float', shape: [4] })
+    expect(typeof outputEntry === 'object' && outputEntry.type).toEqual({ kind: 'array', element: 'float', shape: [4] })
 
     // Load the exported program into a fresh session and check port types survive.
     // The nested TypedLeaf must be registered before the exported composite that uses it.

--- a/compiler/program.test.ts
+++ b/compiler/program.test.ts
@@ -80,6 +80,71 @@ function makeTestSession() {
   return session
 }
 
+describe('exportSessionAsProgram — port type round-trip', () => {
+  test('emits typed inputs/outputs matching source instance port types', () => {
+    const session = makeSession(256)
+    // Register a leaf type with typed inputs and outputs
+    const typedLeaf: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'TypedLeaf',
+      inputs: [{ name: 'a', type: 'float[4]' }],
+      outputs: [{ name: 'out', type: 'float[4]' }],
+      process: { outputs: { out: { op: 'input', name: 'a' } } },
+    }
+    loadProgramAsType(typedLeaf, session)
+    const { type } = resolveProgramType(session, 'TypedLeaf', undefined, undefined)
+    session.instanceRegistry.set('t1', type.instantiateAs('t1', { baseTypeName: 'TypedLeaf' }))
+
+    const exported = exportSessionAsProgram(session, {
+      name: 'Exported',
+      inputs: { a: 't1:a' },
+      outputs: { out: { instance: 't1', output: 'out' } },
+    })
+
+    // Re-parse through the schema to confirm it's well-formed
+    const reparsed = parseProgram(exported) as ProgramJSON
+    const inputEntry = reparsed.inputs![0]
+    const outputEntry = reparsed.outputs![0]
+    expect(typeof inputEntry === 'object' && inputEntry.type).toBe('float[4]')
+    expect(typeof outputEntry === 'object' && outputEntry.type).toBe('float[4]')
+
+    // Load the exported program into a fresh session and check port types survive.
+    // The nested TypedLeaf must be registered before the exported composite that uses it.
+    const session2 = makeSession(256)
+    loadProgramAsType(typedLeaf, session2)
+    loadProgramAsType(exported, session2)
+    const { type: exportedType } = resolveProgramType(session2, 'Exported', undefined, undefined)
+    const srcPt = exportedType._def.inputPortTypes[0]
+    const dstPt = exportedType._def.outputPortTypes[0]
+    expect(srcPt?.tag).toBe('array')
+    expect(dstPt?.tag).toBe('array')
+    if (srcPt?.tag === 'array') expect(srcPt.shape).toEqual([4])
+    if (dstPt?.tag === 'array') expect(dstPt.shape).toEqual([4])
+  })
+
+  test('emits bare string names when no type or bounds are declared', () => {
+    const session = makeSession(256)
+    const plain: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'Plain',
+      inputs: ['x'],
+      outputs: ['y'],
+      process: { outputs: { y: { op: 'input', name: 'x' } } },
+    }
+    loadProgramAsType(plain, session)
+    const { type } = resolveProgramType(session, 'Plain', undefined, undefined)
+    session.instanceRegistry.set('p1', type.instantiateAs('p1', { baseTypeName: 'Plain' }))
+
+    const exported = exportSessionAsProgram(session, {
+      name: 'Exported',
+      inputs: { x: 'p1:x' },
+      outputs: { y: { instance: 'p1', output: 'y' } },
+    })
+    expect(exported.inputs![0]).toBe('x')
+    expect(exported.outputs![0]).toBe('y')
+  })
+})
+
 describe('exportSessionAsProgram', () => {
   test('errors on unknown instance in outputs', () => {
     const session = makeTestSession()

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -16,24 +16,32 @@ import { Param, Trigger } from './runtime/param.js'
 import { ProgramType } from './program_types.js'
 import { exprDependencies, reachableInstances, buildDependencyGraph, topologicalSort } from './compiler.js'
 import type { RawTypeArgs } from './specialize.js'
-import { Float, portTypeEqual, portTypeToString, type PortType } from './term.js'
+import { Float, portTypeEqual, type PortType } from './term.js'
 import type { Bounds } from './program_types.js'
 
 // ─────────────────────────────────────────────────────────────
 // ProgramJSON schema
 // ─────────────────────────────────────────────────────────────
 
+/** Compile-time shape dimension: a concrete int or a reference to an
+ *  outer type parameter to be substituted during specialization. */
+export type ShapeDim = number | { op: 'type_param'; name: string }
+
+/** Structured port/reg type declaration. Scalars and aliases are bare strings;
+ *  arrays use the structured form so type_param refs can appear in shapes. */
+export type PortTypeDecl = string | { kind: 'array'; element: string; shape: ShapeDim[] }
+
 export interface ProgramJSON {
   schema: 'tropical_program_1'
   name: string
 
   /** Inputs to this program. Empty or absent = top-level (no external inputs). */
-  inputs?: Array<string | { name: string; type?: string; default?: ExprNode; bounds?: [number | null, number | null] }>
+  inputs?: Array<string | { name: string; type?: PortTypeDecl; default?: ExprNode; bounds?: [number | null, number | null] }>
   /** Output declarations — names for leaf programs, expressions for composites. */
-  outputs?: Array<string | { name: string; type?: string; bounds?: [number | null, number | null] }>
+  outputs?: Array<string | { name: string; type?: PortTypeDecl; bounds?: [number | null, number | null] }>
 
   /** Scalar/array state registers. */
-  regs?: Record<string, number | boolean | number[] | number[][] | { init: number | boolean | number[] | number[][]; type: string }>
+  regs?: Record<string, number | boolean | number[] | number[][] | { init: number | boolean | number[] | number[][]; type: PortTypeDecl }>
   /** Named delay nodes. */
   delays?: Record<string, { update: ExprNode; init?: number }>
   /** Sample rate override. */
@@ -519,6 +527,23 @@ export function exportSessionAsProgram(
   const boundsProvided = (b: Bounds | null | undefined): b is Bounds =>
     !!b && (b[0] !== null || b[1] !== null)
 
+  const portTypeToDecl = (t: PortType): PortTypeDecl => {
+    switch (t.tag) {
+      case 'scalar': return t.scalar
+      case 'array': {
+        if (t.element.tag !== 'scalar') {
+          throw new Error(`export: cannot serialize nested array element type (${t.element.tag})`)
+        }
+        return { kind: 'array', element: t.element.scalar, shape: t.shape }
+      }
+      case 'struct': return t.name
+      case 'sum': return t.name
+      case 'unit': return 'unit'
+      case 'product':
+        throw new Error(`export: product port types cannot be serialized (no ProgramJSON form)`)
+    }
+  }
+
   const inputEntries: NonNullable<ProgramJSON['inputs']> = inputNames.map(inputName => {
     const target = inputs[inputName]
     const [instName, portName] = target.split(':')
@@ -526,8 +551,8 @@ export function exportSessionAsProgram(
     const idx = inst.inputIndex(portName)
     const pt = inst.inputPortType(idx)
     const bnds = inst._def.inputBounds[idx]
-    const entry: { name: string; type?: string; bounds?: Bounds } = { name: inputName }
-    if (!isDefaultPortType(pt)) entry.type = portTypeToString(pt!)
+    const entry: { name: string; type?: PortTypeDecl; bounds?: Bounds } = { name: inputName }
+    if (!isDefaultPortType(pt)) entry.type = portTypeToDecl(pt!)
     if (boundsProvided(bnds)) entry.bounds = bnds
     return entry.type === undefined && entry.bounds === undefined ? inputName : entry
   })
@@ -538,8 +563,8 @@ export function exportSessionAsProgram(
     const idx = inst.outputIndex(ref.output)
     const pt = inst.outputPortType(idx)
     const bnds = inst._def.outputBounds[idx]
-    const entry: { name: string; type?: string; bounds?: Bounds } = { name: outName }
-    if (!isDefaultPortType(pt)) entry.type = portTypeToString(pt!)
+    const entry: { name: string; type?: PortTypeDecl; bounds?: Bounds } = { name: outName }
+    if (!isDefaultPortType(pt)) entry.type = portTypeToDecl(pt!)
     if (boundsProvided(bnds)) entry.bounds = bnds
     return entry.type === undefined && entry.bounds === undefined ? outName : entry
   })

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -16,6 +16,8 @@ import { Param, Trigger } from './runtime/param.js'
 import { ProgramType } from './program_types.js'
 import { exprDependencies, reachableInstances, buildDependencyGraph, topologicalSort } from './compiler.js'
 import type { RawTypeArgs } from './specialize.js'
+import { Float, portTypeEqual, portTypeToString, type PortType } from './term.js'
+import type { Bounds } from './program_types.js'
 
 // ─────────────────────────────────────────────────────────────
 // ProgramJSON schema
@@ -510,12 +512,44 @@ export function exportSessionAsProgram(
     return node
   }
 
+  // Gather port type + bounds metadata from the source instances so exported
+  // inputs/outputs round-trip through re-parse.
+  const isDefaultPortType = (t: PortType | undefined): boolean =>
+    t === undefined || portTypeEqual(t, Float)
+  const boundsProvided = (b: Bounds | null | undefined): b is Bounds =>
+    !!b && (b[0] !== null || b[1] !== null)
+
+  const inputEntries: NonNullable<ProgramJSON['inputs']> = inputNames.map(inputName => {
+    const target = inputs[inputName]
+    const [instName, portName] = target.split(':')
+    const inst = session.instanceRegistry.get(instName)!
+    const idx = inst.inputIndex(portName)
+    const pt = inst.inputPortType(idx)
+    const bnds = inst._def.inputBounds[idx]
+    const entry: { name: string; type?: string; bounds?: Bounds } = { name: inputName }
+    if (!isDefaultPortType(pt)) entry.type = portTypeToString(pt!)
+    if (boundsProvided(bnds)) entry.bounds = bnds
+    return entry.type === undefined && entry.bounds === undefined ? inputName : entry
+  })
+
+  const outputEntries: NonNullable<ProgramJSON['outputs']> = outputNames.map(outName => {
+    const ref = outputs[outName]
+    const inst = session.instanceRegistry.get(ref.instance)!
+    const idx = inst.outputIndex(ref.output)
+    const pt = inst.outputPortType(idx)
+    const bnds = inst._def.outputBounds[idx]
+    const entry: { name: string; type?: string; bounds?: Bounds } = { name: outName }
+    if (!isDefaultPortType(pt)) entry.type = portTypeToString(pt!)
+    if (boundsProvided(bnds)) entry.bounds = bnds
+    return entry.type === undefined && entry.bounds === undefined ? outName : entry
+  })
+
   // Build the exported ProgramJSON
   const prog: ProgramJSON = {
     schema: 'tropical_program_1',
     name,
-    inputs: inputNames,
-    outputs: outputNames,
+    inputs: inputEntries,
+    outputs: outputEntries,
   }
 
   // Topologically sort reachable instances so dependencies come first.

--- a/compiler/program_types.ts
+++ b/compiler/program_types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SignalExpr, ExprCoercible, ExprNode } from './expr.js'
+import type { PortType } from './term.js'
 
 // ---------- Value helpers ----------
 
@@ -30,10 +31,10 @@ export interface ProgramDef {
   typeName: string
   inputNames: string[]
   outputNames: string[]
-  inputPortTypes: (string | undefined)[]
-  outputPortTypes: (string | undefined)[]
+  inputPortTypes: (PortType | undefined)[]
+  outputPortTypes: (PortType | undefined)[]
   registerNames: string[]
-  registerPortTypes: (string | undefined)[]
+  registerPortTypes: (PortType | undefined)[]
   registerInitValues: ValueCoercible[]
   sampleRate: number
   rawInputDefaults: Record<string, ExprNode>
@@ -95,9 +96,9 @@ export class ProgramInstance {
   get registerNames(): string[] { return this._def.registerNames }
   get typeName(): string { return this.baseTypeName }
 
-  inputPortType(idx: number): string | undefined { return this._def.inputPortTypes[idx] }
-  outputPortType(idx: number): string | undefined { return this._def.outputPortTypes[idx] }
-  registerPortType(idx: number): string | undefined { return this._def.registerPortTypes[idx] }
+  inputPortType(idx: number): PortType | undefined { return this._def.inputPortTypes[idx] }
+  outputPortType(idx: number): PortType | undefined { return this._def.outputPortTypes[idx] }
+  registerPortType(idx: number): PortType | undefined { return this._def.registerPortTypes[idx] }
 
   inputIndex(name: string): number {
     const idx = this._def.inputNames.indexOf(name)

--- a/compiler/schema.ts
+++ b/compiler/schema.ts
@@ -23,6 +23,33 @@ export const ExprNodeSchema: z.ZodType = z.lazy(() =>
 )
 
 // ─────────────────────────────────────────────────────────────
+// Bounds + PortType declaration (used by regs and ports)
+// ─────────────────────────────────────────────────────────────
+
+const BoundsSchema = z.tuple([z.number().nullable(), z.number().nullable()])
+
+const ShapeDimSchema = z.union([
+  z.number().int().nonnegative(),
+  z.object({ op: z.literal('type_param'), name: z.string() }),
+])
+
+const ArrayTypeDeclSchema = z.object({
+  kind: z.literal('array'),
+  element: z.string(),
+  shape: z.array(ShapeDimSchema).min(1),
+})
+
+/** A port/reg type declaration. Scalar/alias names are bare strings; array
+ *  types must use the structured form. Old bracketed strings like "float[4]"
+ *  are rejected with a clear error. */
+const PortTypeDeclSchema = z.union([
+  z.string().refine(s => !s.includes('['), {
+    message: 'Bracketed array types like "float[4]" are not supported. Use {kind:"array", element:"float", shape:[4]}.',
+  }),
+  ArrayTypeDeclSchema,
+])
+
+// ─────────────────────────────────────────────────────────────
 // ArrayStateJSON
 // ─────────────────────────────────────────────────────────────
 
@@ -55,7 +82,7 @@ const RegValueSchema = z.union([
 /** Typed register entry: { init, type } */
 const TypedRegValueSchema = z.object({
   init: RegValueSchema,
-  type: z.string(),
+  type: PortTypeDeclSchema,
 })
 
 /** A register entry is either a bare value or a typed { init, type } object. */
@@ -93,12 +120,6 @@ const SumTypeDefSchema = z.object({
   variants: z.array(SumVariantSchema),
 })
 
-// ─────────────────────────────────────────────────────────────
-// Bounds — [lo, hi], null on either side = unbounded
-// ─────────────────────────────────────────────────────────────
-
-const BoundsSchema = z.tuple([z.number().nullable(), z.number().nullable()])
-
 const AliasTypeDefSchema = z.object({
   kind: z.literal('alias'),
   name: z.string(),
@@ -114,12 +135,12 @@ const TypeDefSchema = z.union([StructTypeDefSchema, SumTypeDefSchema, AliasTypeD
 
 const ProgramInputSchema = z.union([
   z.string(),
-  z.object({ name: z.string(), type: z.string().optional(), default: ExprNodeSchema.optional(), bounds: BoundsSchema.optional() }),
+  z.object({ name: z.string(), type: PortTypeDeclSchema.optional(), default: ExprNodeSchema.optional(), bounds: BoundsSchema.optional() }),
 ])
 
 const ProgramOutputSchema = z.union([
   z.string(),
-  z.object({ name: z.string(), type: z.string().optional(), bounds: BoundsSchema.optional() }),
+  z.object({ name: z.string(), type: PortTypeDeclSchema.optional(), bounds: BoundsSchema.optional() }),
 ])
 
 const ProgramInstanceSchema = z.object({

--- a/compiler/sequencer.test.ts
+++ b/compiler/sequencer.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, loadJSON, resolveProgramType } from './session'
+import { loadStdlib } from './program'
+import { flattenSession } from './flatten'
+import { Float, Int, ArrayType, portTypeEqual } from './term'
+
+describe('stdlib Sequencer<N>', () => {
+  test('Sequencer<N> monomorphizes values input shape to [N]', () => {
+    const session = makeSession()
+    loadStdlib(session)
+    const { type: t4 } = resolveProgramType(session, 'Sequencer', { N: 4 }, undefined)
+    const { type: t8 } = resolveProgramType(session, 'Sequencer', { N: 8 }, undefined)
+    // values is the second input
+    expect(t4._def.inputPortTypes[1]).toEqual(ArrayType(Float, [4]))
+    expect(t8._def.inputPortTypes[1]).toEqual(ArrayType(Float, [8]))
+    expect(t4).not.toBe(t8)
+  })
+
+  test('Sequencer uses declared default N=8 when no type_args provided', () => {
+    const session = makeSession()
+    loadStdlib(session)
+    const { type, typeArgs } = resolveProgramType(session, 'Sequencer', undefined, undefined)
+    expect(typeArgs).toEqual({ N: 8 })
+    expect(type._def.inputPortTypes[1]).toEqual(ArrayType(Float, [8]))
+  })
+
+  test('Sequencer<4> flattens end-to-end with an arrayPack input', () => {
+    const session = makeSession(64)
+    loadStdlib(session)
+    loadJSON({
+      schema: 'tropical_program_1',
+      name: 'test',
+      instances: {
+        clk: { program: 'Clock', inputs: { freq: 4, ratios_in: [1] } },
+        seq: {
+          program: 'Sequencer',
+          type_args: { N: 4 },
+          inputs: {
+            clock: { op: 'ref', instance: 'clk', output: 'output' },
+            values: [110, 220, 330, 440],
+          },
+        },
+      },
+      audio_outputs: [{ instance: 'seq', output: 'value' }],
+    }, session)
+    const plan = flattenSession(session)
+    expect(plan).toBeDefined()
+    const inst = session.instanceRegistry.get('seq')!
+    expect(inst.typeName).toBe('Sequencer')
+    expect(inst.typeArgs).toEqual({ N: 4 })
+  })
+})

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -10,14 +10,13 @@ import {
   type ProgramDef, type NestedCall, type ValueCoercible, type Bounds,
 } from './program_types.js'
 import { Runtime } from './runtime/runtime.js'
-import { loadProgramAsSession, type ProgramJSON } from './program.js'
+import { loadProgramAsSession, type ProgramJSON, type PortTypeDecl } from './program.js'
 import { Param, Trigger } from './runtime/param.js'
 import {
   specializeProgramJSON, specializationCacheKey, resolveTypeArgs,
   type RawTypeArgs, type ResolvedTypeArgs,
 } from './specialize.js'
-import { portTypeFromString } from './compiler.js'
-import { type PortType, Float, ArrayType } from './term.js'
+import { type PortType, Float, Int, Bool, Unit, ArrayType, StructType } from './term.js'
 
 // ─────────────────────────────────────────────────────────────
 // JSON schema types
@@ -279,14 +278,49 @@ export function resolveBaseType(typeStr: string | undefined, userAliases?: Alias
   return typeStr
 }
 
-/** Extract bounds from a port spec. Explicit bounds override alias bounds. Checks user aliases first. */
+/** Convert a scalar or alias name to a PortType. Unknown names become struct refs. */
+function scalarNameToPortType(name: string): PortType {
+  switch (name) {
+    case 'float': return Float
+    case 'int':   return Int
+    case 'bool':  return Bool
+    case 'unit':  return Unit
+    default:      return StructType(name)
+  }
+}
+
+/** Decode a structured port type declaration to a PortType, resolving aliases.
+ *  Throws if the shape still contains an unresolved type_param ref — callers that
+ *  use type_params must run `specializeProgramJSON` first. */
+export function decodePortTypeDecl(
+  t: PortTypeDecl,
+  aliases: AliasMap | undefined,
+  contextName: string,
+): PortType {
+  if (typeof t === 'string') {
+    return scalarNameToPortType(resolveBaseType(t, aliases) ?? t)
+  }
+  const elemName = resolveBaseType(t.element, aliases) ?? t.element
+  const elem = scalarNameToPortType(elemName)
+  const shape = t.shape.map(dim => {
+    if (typeof dim === 'number') return dim
+    throw new Error(
+      `${contextName}: array port type shape contains unresolved type_param '${dim.name}'. ` +
+      `This should have been substituted at specialization time.`,
+    )
+  })
+  return ArrayType(elem, shape)
+}
+
+/** Extract bounds from a port spec. Explicit bounds override alias bounds. Checks user aliases first.
+ *  Only string type names can carry alias-derived bounds; structured array types do not. */
 export function resolveBounds(
-  spec: string | { name: string; type?: string; bounds?: [number | null, number | null] },
+  spec: string | { name: string; type?: PortTypeDecl; bounds?: [number | null, number | null] },
   userAliases?: AliasMap,
 ): Bounds | null {
   if (typeof spec === 'string') return null
   if (spec.bounds) return spec.bounds
-  if (!spec.type) return null
+  if (!spec.type || typeof spec.type !== 'string') return null
   const user = userAliases?.get(spec.type)
   if (user) return user.bounds
   if (spec.type in BOUNDED_TYPE_ALIASES) return BOUNDED_TYPE_ALIASES[spec.type].bounds
@@ -351,10 +385,12 @@ export function loadProgramDef(
   const outputSpecs = def.outputs ?? []
   const inputNames  = inputSpecs.map(i => typeof i === 'string' ? i : i.name)
   const outputNames = outputSpecs.map(o => typeof o === 'string' ? o : o.name)
-  const declaredTypeToPortType = (t: string | undefined): PortType | undefined =>
-    t === undefined ? undefined : portTypeFromString(resolveBaseType(t, aliases))
-  const inputPortTypes  = inputSpecs.map(i => declaredTypeToPortType(typeof i === 'string' ? undefined : i.type))
-  const outputPortTypes = outputSpecs.map(o => declaredTypeToPortType(typeof o === 'string' ? undefined : o.type))
+  const decodeType = (t: PortTypeDecl | undefined): PortType | undefined => {
+    if (t === undefined) return undefined
+    return decodePortTypeDecl(t, aliases, def.name)
+  }
+  const inputPortTypes  = inputSpecs.map(i => decodeType(typeof i === 'string' ? undefined : i.type))
+  const outputPortTypes = outputSpecs.map(o => decodeType(typeof o === 'string' ? undefined : o.type))
   const inputBounds     = inputSpecs.map(s => resolveBounds(s, aliases))
   const outputBounds    = outputSpecs.map(s => resolveBounds(s, aliases))
   const regsRaw     = def.regs ?? {}
@@ -373,9 +409,9 @@ export function loadProgramDef(
       regInitValues.push(new Array(n).fill(0))
       regPortTypes.push(ArrayType(Float, [n]))
     } else if (typeof val === 'object' && val !== null && !Array.isArray(val) && 'init' in val) {
-      const typed = val as { init: ValueCoercible; type: string }
+      const typed = val as { init: ValueCoercible; type: PortTypeDecl }
       regInitValues.push(typed.init)
-      regPortTypes.push(portTypeFromString(typed.type))
+      regPortTypes.push(decodePortTypeDecl(typed.type, aliases, def.name))
     } else {
       regInitValues.push(val as ValueCoercible)
       regPortTypes.push(undefined)

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -16,6 +16,8 @@ import {
   specializeProgramJSON, specializationCacheKey, resolveTypeArgs,
   type RawTypeArgs, type ResolvedTypeArgs,
 } from './specialize.js'
+import { portTypeFromString } from './compiler.js'
+import { type PortType, Float, ArrayType } from './term.js'
 
 // ─────────────────────────────────────────────────────────────
 // JSON schema types
@@ -349,8 +351,10 @@ export function loadProgramDef(
   const outputSpecs = def.outputs ?? []
   const inputNames  = inputSpecs.map(i => typeof i === 'string' ? i : i.name)
   const outputNames = outputSpecs.map(o => typeof o === 'string' ? o : o.name)
-  const inputPortTypes  = inputSpecs.map(i => resolveBaseType(typeof i === 'string' ? undefined : i.type, aliases))
-  const outputPortTypes = outputSpecs.map(o => resolveBaseType(typeof o === 'string' ? undefined : o.type, aliases))
+  const declaredTypeToPortType = (t: string | undefined): PortType | undefined =>
+    t === undefined ? undefined : portTypeFromString(resolveBaseType(t, aliases))
+  const inputPortTypes  = inputSpecs.map(i => declaredTypeToPortType(typeof i === 'string' ? undefined : i.type))
+  const outputPortTypes = outputSpecs.map(o => declaredTypeToPortType(typeof o === 'string' ? undefined : o.type))
   const inputBounds     = inputSpecs.map(s => resolveBounds(s, aliases))
   const outputBounds    = outputSpecs.map(s => resolveBounds(s, aliases))
   const regsRaw     = def.regs ?? {}
@@ -360,18 +364,18 @@ export function loadProgramDef(
   // ── Parse registers ──
   const regNames: string[] = []
   const regInitValues: ValueCoercible[] = []
-  const regPortTypes: (string | undefined)[] = []
+  const regPortTypes: (PortType | undefined)[] = []
   for (const [name, val] of Object.entries(regsRaw)) {
     regNames.push(name)
     if (typeof val === 'object' && val !== null && !Array.isArray(val) && 'zeros' in val) {
-      // Compact form: {"zeros": N} → array of N zeros with inferred type
+      // Compact form: {"zeros": N} → array of N zeros, float element
       const n = (val as { zeros: number }).zeros
       regInitValues.push(new Array(n).fill(0))
-      regPortTypes.push(`float[${n}]`)
+      regPortTypes.push(ArrayType(Float, [n]))
     } else if (typeof val === 'object' && val !== null && !Array.isArray(val) && 'init' in val) {
       const typed = val as { init: ValueCoercible; type: string }
       regInitValues.push(typed.init)
-      regPortTypes.push(typed.type)
+      regPortTypes.push(portTypeFromString(typed.type))
     } else {
       regInitValues.push(val as ValueCoercible)
       regPortTypes.push(undefined)

--- a/compiler/specialize.test.ts
+++ b/compiler/specialize.test.ts
@@ -196,4 +196,49 @@ describe('specializeProgramJSON', () => {
     const y = spec.process!.outputs.y as any
     expect(y.n).toBe(4)
   })
+
+  test('substitutes type_param refs in input port type shapes', () => {
+    const prog: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'ArrIn',
+      type_params: { N: { type: 'int' } },
+      inputs: [
+        { name: 'values', type: { kind: 'array', element: 'float', shape: [{ op: 'type_param', name: 'N' }] } },
+      ],
+      outputs: ['y'],
+      process: { outputs: { y: 0 } },
+    }
+    const spec = specializeProgramJSON(prog, { N: 8 })
+    const input = spec.inputs![0] as { name: string; type: any }
+    expect(input.type).toEqual({ kind: 'array', element: 'float', shape: [8] })
+  })
+
+  test('substitutes type_param refs in output port type shapes', () => {
+    const prog: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'ArrOut',
+      type_params: { N: { type: 'int' } },
+      outputs: [
+        { name: 'out', type: { kind: 'array', element: 'float', shape: [{ op: 'type_param', name: 'N' }, 2] } },
+      ],
+      process: { outputs: { out: 0 } },
+    }
+    const spec = specializeProgramJSON(prog, { N: 3 })
+    const out = spec.outputs![0] as { name: string; type: any }
+    expect(out.type).toEqual({ kind: 'array', element: 'float', shape: [3, 2] })
+  })
+
+  test('rejects a port type shape referencing an undeclared type_param', () => {
+    const prog: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'BadArr',
+      type_params: { N: { type: 'int' } },
+      inputs: [
+        { name: 'values', type: { kind: 'array', element: 'float', shape: [{ op: 'type_param', name: 'M' }] } },
+      ],
+      outputs: ['y'],
+      process: { outputs: { y: 0 } },
+    }
+    expect(() => specializeProgramJSON(prog, { N: 4 })).toThrow(/undeclared type_param 'M'/)
+  })
 })

--- a/compiler/specialize.ts
+++ b/compiler/specialize.ts
@@ -110,7 +110,20 @@ export function specializeProgramJSON(
           ;(clone.regs as Record<string, unknown>)[name] = { zeros: args[paramName] }
         }
       }
+      // Typed reg: { init: ..., type: <structured-array> } — substitute shape.
+      if (val && typeof val === 'object' && !Array.isArray(val) && 'type' in val) {
+        const typed = val as { init: unknown; type: unknown }
+        typed.type = substituteTypeInDecl(typed.type, args, prog.name, `reg '${name}'`)
+      }
     }
+  }
+
+  // Port type declarations on inputs/outputs
+  if (clone.inputs) {
+    clone.inputs = clone.inputs.map(i => substituteTypeOnPortSpec(i, args, prog.name, 'input')) as typeof clone.inputs
+  }
+  if (clone.outputs) {
+    clone.outputs = clone.outputs.map(o => substituteTypeOnPortSpec(o, args, prog.name, 'output')) as typeof clone.outputs
   }
 
   // ExprNode-bearing fields
@@ -175,6 +188,53 @@ export function specializeProgramJSON(
   // when that nested instance is resolved.
 
   return clone
+}
+
+/** Substitute {op:'type_param',name} refs inside a port-type declaration's
+ *  shape array with their resolved integer values. Scalars pass through. */
+function substituteTypeInDecl(
+  t: unknown,
+  args: ResolvedTypeArgs,
+  progName: string,
+  context: string,
+): unknown {
+  if (t === undefined || typeof t === 'string') return t
+  if (t && typeof t === 'object' && !Array.isArray(t)) {
+    const o = t as { kind?: string; shape?: unknown[]; element?: string }
+    if (o.kind === 'array' && Array.isArray(o.shape)) {
+      const newShape = o.shape.map((dim, i) => {
+        if (typeof dim === 'number') return dim
+        if (dim && typeof dim === 'object' && (dim as { op?: string }).op === 'type_param') {
+          const name = (dim as { name: string }).name
+          if (!(name in args)) {
+            throw new Error(
+              `${progName}: ${context} type shape[${i}] references undeclared type_param '${name}'`,
+            )
+          }
+          return args[name]
+        }
+        return dim
+      })
+      return { ...o, shape: newShape }
+    }
+  }
+  return t
+}
+
+function substituteTypeOnPortSpec(
+  spec: unknown,
+  args: ResolvedTypeArgs,
+  progName: string,
+  kind: string,
+): unknown {
+  if (typeof spec === 'string') return spec
+  if (spec && typeof spec === 'object') {
+    const o = spec as { name: string; type?: unknown }
+    if (o.type !== undefined) {
+      return { ...o, type: substituteTypeInDecl(o.type, args, progName, `${kind} '${o.name}'`) }
+    }
+  }
+  return spec
 }
 
 function substituteTypeParams(

--- a/compiler/specialize_integration.test.ts
+++ b/compiler/specialize_integration.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, resolveProgramType } from './session.js'
 import { loadProgramAsType } from './program.js'
 import type { ProgramJSON } from './program.js'
+import { Float, ArrayType } from './term.js'
 
 function genericDelay(): ProgramJSON {
   return {
@@ -56,8 +57,8 @@ describe('resolveProgramType — generic instantiation', () => {
     expect(a3).toEqual({ N: 8 })
 
     // Specialized regs have concrete sizes
-    expect(t1._def.registerPortTypes[0]).toBe('float[8]')
-    expect(t2._def.registerPortTypes[0]).toBe('float[16]')
+    expect(t1._def.registerPortTypes[0]).toEqual(ArrayType(Float, [8]))
+    expect(t2._def.registerPortTypes[0]).toEqual(ArrayType(Float, [16]))
   })
 
   test('applies declared default when type_args absent', () => {
@@ -65,7 +66,7 @@ describe('resolveProgramType — generic instantiation', () => {
     loadProgramAsType(genericDelay(), session)
     const { type, typeArgs } = resolveProgramType(session, 'Delay', undefined, undefined)
     expect(typeArgs).toEqual({ N: 44100 })
-    expect(type._def.registerPortTypes[0]).toBe('float[44100]')
+    expect(type._def.registerPortTypes[0]).toEqual(ArrayType(Float, [44100]))
   })
 
   test('rejects type_args on non-generic programs', () => {

--- a/compiler/specialize_integration.test.ts
+++ b/compiler/specialize_integration.test.ts
@@ -101,4 +101,28 @@ describe('resolveProgramType — generic instantiation', () => {
     expect(type).toBeDefined()
     expect(typeArgs).toBeUndefined()
   })
+
+  test('type_param refs in array port shapes become concrete PortTypes after instantiation', () => {
+    const prog: ProgramJSON = {
+      schema: 'tropical_program_1',
+      name: 'Bus',
+      type_params: { N: { type: 'int', default: 4 } },
+      inputs: [
+        { name: 'values', type: { kind: 'array', element: 'float', shape: [{ op: 'type_param', name: 'N' }] } },
+      ],
+      outputs: [
+        { name: 'out', type: { kind: 'array', element: 'float', shape: [{ op: 'type_param', name: 'N' }] } },
+      ],
+      process: { outputs: { out: { op: 'input', name: 'values' } } },
+    }
+    const session = makeSession()
+    loadProgramAsType(prog, session)
+
+    const { type: t8 } = resolveProgramType(session, 'Bus', { N: 8 }, undefined)
+    expect(t8._def.inputPortTypes[0]).toEqual(ArrayType(Float, [8]))
+    expect(t8._def.outputPortTypes[0]).toEqual(ArrayType(Float, [8]))
+
+    const { type: tdef } = resolveProgramType(session, 'Bus', undefined, undefined)
+    expect(tdef._def.inputPortTypes[0]).toEqual(ArrayType(Float, [4]))
+  })
 })

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -32,6 +32,10 @@ import { applyFlatPlan }  from '../compiler/apply_plan.js'
 import { checkArrayConnection } from '../compiler/array_wiring.js'
 import { validateExpr }         from '../compiler/expr.js'
 import { exprDependencies }     from '../compiler/compiler.js'
+import { portTypeToString, type PortType } from '../compiler/term.js'
+
+const portTypeOrNull = (t: PortType | undefined): string | null =>
+  t === undefined ? null : portTypeToString(t)
 
 // ─── Session ──────────────────────────────────────────────────────────────────
 
@@ -48,18 +52,18 @@ loadBuiltins(session.typeRegistry)
  */
 function adaptInputExpr(
   node: ExprNode,
-  dstTypeStr: string | undefined,
+  dstType: PortType | undefined,
   instanceName: string,
   inputName: string,
 ): { expr: ExprNode; resultShape?: number[] } {
-  let srcTypeStr: string | undefined
+  let srcType: PortType | undefined
 
   if (typeof node === 'number') {
-    srcTypeStr = 'float'
+    srcType = { tag: 'scalar', scalar: 'float' }
   } else if (typeof node === 'boolean') {
-    srcTypeStr = 'bool'
+    srcType = { tag: 'scalar', scalar: 'bool' }
   } else if (Array.isArray(node)) {
-    srcTypeStr = `float[${(node as unknown[]).length}]`
+    srcType = { tag: 'array', element: { tag: 'scalar', scalar: 'float' }, shape: [(node as unknown[]).length] }
   } else if (typeof node === 'object' && node !== null) {
     const obj = node as Record<string, unknown>
     if (obj.op === 'ref') {
@@ -67,14 +71,14 @@ function adaptInputExpr(
       if (srcInst) {
         const outName = obj.output as string | number
         const outIdx = typeof outName === 'number' ? outName : srcInst.outputNames.indexOf(String(outName))
-        if (outIdx !== -1) srcTypeStr = srcInst.outputPortType(outIdx)
+        if (outIdx !== -1) srcType = srcInst.outputPortType(outIdx)
       }
     }
   }
 
-  if (srcTypeStr === undefined) return { expr: node }
+  if (srcType === undefined) return { expr: node }
 
-  const check = checkArrayConnection(srcTypeStr, dstTypeStr, node)
+  const check = checkArrayConnection(srcType, dstType, node)
   if (!check.compatible) {
     throw new Error(
       `Type mismatch on '${instanceName}'.${inputName}: ${check.error}`
@@ -806,16 +810,16 @@ function handleListPrograms() {
         program_name: typeName,
         inputs:    d.inputNames.map((n, i) => ({
           name: n,
-          type: d.inputPortTypes[i] ?? null,
+          type: portTypeOrNull(d.inputPortTypes[i]),
           bounds: d.inputBounds[i] ?? null,
           default: defaultsMap[n] ?? null,
         })),
         outputs: d.outputNames.map((n, i) => ({
           name: n,
-          type: d.outputPortTypes[i] ?? null,
+          type: portTypeOrNull(d.outputPortTypes[i]),
           bounds: d.outputBounds[i] ?? null,
         })),
-        registers: d.registerNames.map((n, i) => ({ name: n, type: d.registerPortTypes[i] ?? null })),
+        registers: d.registerNames.map((n, i) => ({ name: n, type: portTypeOrNull(d.registerPortTypes[i]) })),
         type_params: null as Record<string, { type: 'int'; default?: number }> | null,
       }
     })

--- a/mcp/test_patch.ts
+++ b/mcp/test_patch.ts
@@ -28,7 +28,7 @@ console.log(`Frames:        ${nFrames}`)
 const json = JSON.parse(readFileSync(patchPath, 'utf-8'))
 
 const session = makeSession(256)
-loadBuiltins(session.typeRegistry)
+loadBuiltins(session)
 loadJSON(json, session)
 
 const runtime = session.runtime

--- a/patches/sequencer_demo.json
+++ b/patches/sequencer_demo.json
@@ -1,0 +1,27 @@
+{
+  "schema": "tropical_program_1",
+  "name": "sequencer_demo",
+  "instances": {
+    "clk": {
+      "program": "Clock",
+      "inputs": { "freq": 4, "ratios_in": [1] }
+    },
+    "seq": {
+      "program": "Sequencer",
+      "type_args": { "N": 8 },
+      "inputs": {
+        "clock": { "op": "ref", "instance": "clk", "output": "output" },
+        "values": [110, 138.59, 164.81, 220, 261.63, 329.63, 220, 164.81]
+      }
+    },
+    "osc": {
+      "program": "BlepSaw",
+      "inputs": {
+        "freq": { "op": "ref", "instance": "seq", "output": "value" }
+      }
+    }
+  },
+  "audio_outputs": [
+    { "instance": "osc", "output": "saw" }
+  ]
+}

--- a/stdlib/BlepSaw.json
+++ b/stdlib/BlepSaw.json
@@ -1,0 +1,73 @@
+{
+  "schema": "tropical_program_1",
+  "name": "BlepSaw",
+  "inputs": [
+    { "name": "freq", "type": "freq", "bounds": [0, null], "default": 440 }
+  ],
+  "outputs": [
+    { "name": "saw", "type": "signal" }
+  ],
+  "regs": { "phase": 0.0 },
+  "input_defaults": { "freq": 440 },
+  "process": {
+    "outputs": {
+      "saw": {
+        "op": "let",
+        "bind": {
+          "inc": { "op": "div", "args": [{ "op": "input", "name": "freq" }, { "op": "sample_rate" }] },
+          "pw":  { "op": "reg", "name": "phase" },
+          "raw": { "op": "sub", "args": [{ "op": "mul", "args": [2.0, { "op": "binding", "name": "pw" }] }, 1.0] },
+          "tp":  { "op": "div", "args": [{ "op": "binding", "name": "pw" }, { "op": "binding", "name": "inc" }] },
+          "tpr": { "op": "div", "args": [{ "op": "sub", "args": [{ "op": "binding", "name": "pw" }, 1.0] }, { "op": "binding", "name": "inc" }] },
+          "bpost": {
+            "op": "select",
+            "args": [
+              { "op": "lt", "args": [{ "op": "binding", "name": "pw" }, { "op": "binding", "name": "inc" }] },
+              { "op": "sub", "args": [
+                { "op": "sub", "args": [
+                  { "op": "mul", "args": [2.0, { "op": "binding", "name": "tp" }] },
+                  { "op": "mul", "args": [{ "op": "binding", "name": "tp" }, { "op": "binding", "name": "tp" }] }
+                ]},
+                1.0
+              ]},
+              0.0
+            ]
+          },
+          "bpre": {
+            "op": "select",
+            "args": [
+              { "op": "gt", "args": [{ "op": "binding", "name": "pw" }, { "op": "sub", "args": [1.0, { "op": "binding", "name": "inc" }] }] },
+              { "op": "add", "args": [
+                { "op": "add", "args": [
+                  { "op": "mul", "args": [{ "op": "binding", "name": "tpr" }, { "op": "binding", "name": "tpr" }] },
+                  { "op": "mul", "args": [2.0, { "op": "binding", "name": "tpr" }] }
+                ]},
+                1.0
+              ]},
+              0.0
+            ]
+          }
+        },
+        "in": {
+          "op": "sub",
+          "args": [
+            { "op": "sub", "args": [{ "op": "binding", "name": "raw" }, { "op": "binding", "name": "bpost" }] },
+            { "op": "binding", "name": "bpre" }
+          ]
+        }
+      }
+    },
+    "next_regs": {
+      "phase": {
+        "op": "mod",
+        "args": [
+          { "op": "add", "args": [
+            { "op": "reg", "name": "phase" },
+            { "op": "div", "args": [{ "op": "input", "name": "freq" }, { "op": "sample_rate" }] }
+          ]},
+          1.0
+        ]
+      }
+    }
+  }
+}

--- a/stdlib/Clock.json
+++ b/stdlib/Clock.json
@@ -3,11 +3,11 @@
   "name": "Clock",
   "inputs": [
     { "name": "freq", "type": "freq" },
-    { "name": "ratios_in", "type": "float[1]" }
+    { "name": "ratios_in", "type": { "kind": "array", "element": "float", "shape": [1] } }
   ],
   "outputs": [
     { "name": "output", "type": "unipolar" },
-    { "name": "ratios_out", "type": "float[1]" }
+    { "name": "ratios_out", "type": { "kind": "array", "element": "float", "shape": [1] } }
   ],
   "input_defaults": { "freq": 1, "ratios_in": [1] },
   "programs": {

--- a/stdlib/Sequencer.json
+++ b/stdlib/Sequencer.json
@@ -1,0 +1,49 @@
+{
+  "schema": "tropical_program_1",
+  "name": "Sequencer",
+  "type_params": { "N": { "type": "int", "default": 8 } },
+  "inputs": [
+    { "name": "clock", "type": "unipolar" },
+    { "name": "values", "type": { "kind": "array", "element": "float", "shape": [{ "op": "type_param", "name": "N" }] } }
+  ],
+  "outputs": [
+    { "name": "value", "type": "float" }
+  ],
+  "regs": { "step": 0 },
+  "delays": {
+    "prev_clock": { "update": { "op": "input", "name": "clock" }, "init": 0 }
+  },
+  "input_defaults": { "clock": 0 },
+  "process": {
+    "outputs": {
+      "value": {
+        "op": "index",
+        "args": [
+          { "op": "input", "name": "values" },
+          { "op": "reg", "name": "step" }
+        ]
+      }
+    },
+    "next_regs": {
+      "step": {
+        "op": "mod",
+        "args": [
+          {
+            "op": "add",
+            "args": [
+              { "op": "reg", "name": "step" },
+              {
+                "op": "mul",
+                "args": [
+                  { "op": "gt", "args": [{ "op": "input", "name": "clock" }, 0.5] },
+                  { "op": "lte", "args": [{ "op": "delay_ref", "id": "prev_clock" }, 0.5] }
+                ]
+              }
+            ]
+          },
+          { "op": "type_param", "name": "N" }
+        ]
+      }
+    }
+  }
+}

--- a/stdlib/SinOsc.json
+++ b/stdlib/SinOsc.json
@@ -1,0 +1,36 @@
+{
+  "schema": "tropical_program_1",
+  "name": "SinOsc",
+  "inputs": [
+    { "name": "freq", "type": "freq" }
+  ],
+  "outputs": [
+    { "name": "sine", "type": "float" }
+  ],
+  "input_defaults": { "freq": 440 },
+  "instances": {
+    "sin": {
+      "program": "Sin",
+      "inputs": {
+        "x": {
+          "op": "mul",
+          "args": [
+            6.283185307179586,
+            { "op": "div", "args": [
+              { "op": "mul", "args": [
+                { "op": "sample_index" },
+                { "op": "input", "name": "freq" }
+              ]},
+              { "op": "sample_rate" }
+            ]}
+          ]
+        }
+      }
+    }
+  },
+  "process": {
+    "outputs": {
+      "sine": { "op": "nested_out", "ref": "sin", "output": "out" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Four-phase refactor extending PR 90's compile-time `type_params` to support generics-aware array port shapes, culminating in a generic `Sequencer<N>` stdlib program.

Motivation: port types were declared as strings (`"float[8]"`) in ProgramJSON and round-tripped through regex parsing. `specialize.ts` could substitute integer type args into ExprNodes but not into array shapes, blocking any generic program whose port type depends on N.

### Phase 1 — Carry `PortType` through the compiler (`8e6f6c1`)
Eliminates internal string round-trip. `ProgramDef.{input,output,register}PortTypes` become `PortType[]`. String decoding retained only at the ProgramJSON boundary.

### Phase 2 — Lossless round-trip through `export_program` / `save` (`149d80b`)
`exportSessionAsProgram` now emits `inputs[].type` / `outputs[].type` / `regs[].type` so exported programs survive save/load.

### Phase 3 — Structured-only ProgramJSON + type_param shape substitution (`7b876b4`)
- Adds structured port type form: `{kind:"array", element:"float", shape:[{op:"type_param",name:"N"}]}`
- Bracketed strings (`"float[8]"`) rejected by schema
- `specialize.ts` walks input/output/reg `type` fields and substitutes `type_param` refs in shape arrays
- Deletes `portTypeFromString` (no remaining callers)
- Migrates `stdlib/Clock.json` to structured form

### Phase 4 — `Sequencer<N>`, `BlepSaw`, `SinOsc` + demo (`be2b37c`)
- `stdlib/Sequencer.json` — clock-gated step sequencer with `type_params:{N}` and `values: float[N]`
- `stdlib/BlepSaw.json`, `stdlib/SinOsc.json` — previously-authored untracked oscillators
- `patches/sequencer_demo.json` — Clock → Sequencer<8> → BlepSaw demo
- Fix in `mcp/test_patch.ts`: the old `loadBuiltins(session.typeRegistry)` Map overload discarded `genericTemplates`

## Known limitation (to be fixed in follow-up)

`Sequencer.regs.step` is declared `float` as a workaround. The clean declaration would be `{type:"int"}`, but integer `type_params` substitute as untyped JS numbers (typed float in emit), producing `mod(int_reg, float_const_N) → float` that gets bitcast into the int state register. This is the type-system leak tracked in the approved follow-up plan: five distinct holes spanning `emit_numeric.ts`, `specialize.ts`, `array_wiring.ts`, and the JIT register writeback. Will land as `feat/rigorous-types` post-merge.

## Test plan
- [x] `bun test` — 287 compiler tests green (added sequencer + specialize integration coverage)
- [x] `ctest --test-dir build` — C++ tests green
- [x] `bun run mcp/test_patch.ts patches/sequencer_demo.json 128` — non-zero audio, no segfault
- [x] Manual MCP workflow: `define_program` with typed port, `export_program`, re-`load` — types preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)