### PR TITLE
feat(stdlib): SVF filter + Bubble voice for physically-motivated bubble synthesis

### DIFF
--- a/compiler/bubble.test.ts
+++ b/compiler/bubble.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, loadJSON } from './session'
+import { loadStdlib } from './program'
+import { flattenExpressions } from './flatten'
+import { interpretSamples } from './interpret'
+
+describe('stdlib Bubble', () => {
+  test('single trigger produces decaying output with audible ringing', () => {
+    const session = makeSession(44100)
+    loadStdlib(session)
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'test',
+      body: { op: 'block', decls: [
+        { op: 'instance_decl', name: 'b', program: 'Bubble', inputs: {
+          trigger: {
+            op: 'select',
+            args: [
+              { op: 'eq', args: [{ op: 'sample_index' }, 100] },
+              1,
+              0,
+            ],
+          },
+          radius: 0.003,
+        }},
+      ]},
+      audio_outputs: [{ instance: 'b', output: 'out' }],
+    }, session)
+
+    const flat = flattenExpressions(session)
+    const out = interpretSamples(flat, 8000)
+
+    let maxAbs = 0
+    for (const v of out) maxAbs = Math.max(maxAbs, Math.abs(v))
+    expect(Number.isFinite(maxAbs)).toBe(true)
+    expect(maxAbs).toBeLessThan(100)
+
+    let preTrigAbs = 0
+    for (let i = 0; i < 100; i++) preTrigAbs = Math.max(preTrigAbs, Math.abs(out[i]))
+    expect(preTrigAbs).toBeLessThan(1e-9)
+
+    let peakAbs = 0
+    for (let i = 100; i < 500; i++) peakAbs = Math.max(peakAbs, Math.abs(out[i]))
+    expect(peakAbs).toBeGreaterThan(0)
+
+    let tailAbs = 0
+    for (let i = 7000; i < 8000; i++) tailAbs = Math.max(tailAbs, Math.abs(out[i]))
+    expect(tailAbs).toBeLessThan(peakAbs * 0.1)
+
+    let zeroCrossings = 0
+    for (let i = 101; i < 2000; i++) {
+      if ((out[i - 1] >= 0) !== (out[i] >= 0)) zeroCrossings++
+    }
+    expect(zeroCrossings).toBeGreaterThan(10)
+  })
+
+  test('radius controls pitch — smaller radius produces more zero crossings per unit time', () => {
+    function runWithRadius(r: number): number {
+      const session = makeSession(44100)
+      loadStdlib(session)
+      loadJSON({
+        schema: 'tropical_program_2',
+        name: 'test',
+        body: { op: 'block', decls: [
+          { op: 'instance_decl', name: 'b', program: 'Bubble', inputs: {
+            trigger: {
+              op: 'select',
+              args: [
+                { op: 'eq', args: [{ op: 'sample_index' }, 100] },
+                1,
+                0,
+              ],
+            },
+            radius: r,
+            sigma: 0,
+          }},
+        ]},
+        audio_outputs: [{ instance: 'b', output: 'out' }],
+      }, session)
+
+      const flat = flattenExpressions(session)
+      const out = interpretSamples(flat, 2000)
+      let zc = 0
+      for (let i = 101; i < 2000; i++) {
+        if ((out[i - 1] >= 0) !== (out[i] >= 0)) zc++
+      }
+      return zc
+    }
+
+    const zcSmall = runWithRadius(0.001)
+    const zcLarge = runWithRadius(0.01)
+    expect(zcSmall).toBeGreaterThan(zcLarge * 2)
+  })
+})

--- a/compiler/envexpdecay.test.ts
+++ b/compiler/envexpdecay.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, loadJSON } from './session'
+import { loadStdlib } from './program'
+import { flattenExpressions } from './flatten'
+import { interpretSamples } from './interpret'
+
+describe('stdlib EnvExpDecay', () => {
+  test('resets to 1 on trigger and decays exponentially', () => {
+    const session = makeSession(44100)
+    loadStdlib(session)
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'test',
+      body: { op: 'block', decls: [
+        { op: 'instance_decl', name: 'env', program: 'EnvExpDecay', inputs: {
+          trigger: {
+            op: 'select',
+            args: [
+              { op: 'eq', args: [{ op: 'sample_index' }, 10] },
+              1,
+              0,
+            ],
+          },
+          decay: 0.99,
+        }},
+      ]},
+      audio_outputs: [{ instance: 'env', output: 'env' }],
+    }, session)
+
+    const flat = flattenExpressions(session)
+    const out = interpretSamples(flat, 200)
+
+    const peak = out[11] * 20.0
+    expect(peak).toBeCloseTo(1.0, 3)
+
+    const late = out[150] * 20.0
+    expect(late).toBeGreaterThan(0)
+    expect(late).toBeLessThan(peak * 0.5)
+  })
+})

--- a/compiler/samplehold.test.ts
+++ b/compiler/samplehold.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, loadJSON } from './session'
+import { loadStdlib } from './program'
+import { flattenExpressions } from './flatten'
+import { interpretSamples } from './interpret'
+
+describe('stdlib SampleHold', () => {
+  test('latches on trigger rising edge', () => {
+    const session = makeSession(44100)
+    loadStdlib(session)
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'test',
+      body: { op: 'block', decls: [
+        { op: 'instance_decl', name: 'sh', program: 'SampleHold', inputs: {
+          trigger: {
+            op: 'select',
+            args: [
+              { op: 'eq', args: [{ op: 'sample_index' }, 100] },
+              1,
+              0,
+            ],
+          },
+          input: {
+            op: 'mul',
+            args: [{ op: 'sample_index' }, 0.01],
+          },
+        }},
+      ]},
+      audio_outputs: [{ instance: 'sh', output: 'value' }],
+    }, session)
+
+    const flat = flattenExpressions(session)
+    const out = interpretSamples(flat, 300)
+
+    expect(out[50] / 20.0 / 0.05).toBeCloseTo(0, 5)
+    const heldValue = out[200] * 20.0
+    expect(heldValue).toBeCloseTo(1.0, 1)
+  })
+})

--- a/compiler/svf.test.ts
+++ b/compiler/svf.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, loadJSON } from './session'
+import { loadStdlib } from './program'
+import { flattenExpressions } from './flatten'
+import { interpretSamples } from './interpret'
+
+describe('stdlib SVF', () => {
+  test('flattens and produces a decaying impulse response on bp output', () => {
+    const session = makeSession(44100)
+    loadStdlib(session)
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'test',
+      body: { op: 'block', decls: [
+        { op: 'instance_decl', name: 'svf', program: 'SVF', inputs: {
+          input: {
+            op: 'select',
+            args: [
+              { op: 'eq', args: [{ op: 'sample_index' }, 0] },
+              1,
+              0,
+            ],
+          },
+          cutoff: 1000,
+          q: 10,
+        }},
+      ]},
+      audio_outputs: [{ instance: 'svf', output: 'bp' }],
+    }, session)
+
+    const flat = flattenExpressions(session)
+    const out = interpretSamples(flat, 2000)
+
+    let earlyPeak = 0
+    for (let i = 0; i < 200; i++) earlyPeak = Math.max(earlyPeak, Math.abs(out[i]))
+    let latePeak = 0
+    for (let i = 1500; i < 2000; i++) latePeak = Math.max(latePeak, Math.abs(out[i]))
+
+    expect(earlyPeak).toBeGreaterThan(0)
+    expect(latePeak).toBeLessThan(earlyPeak * 0.1)
+
+    let maxAbs = 0
+    for (const v of out) maxAbs = Math.max(maxAbs, Math.abs(v))
+    expect(Number.isFinite(maxAbs)).toBe(true)
+    expect(maxAbs).toBeLessThan(10)
+  })
+})

--- a/patches/bubble_drip.json
+++ b/patches/bubble_drip.json
@@ -1,0 +1,35 @@
+{
+  "schema": "tropical_program_2",
+  "name": "bubble_drip",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "instance_decl",
+        "name": "clk",
+        "program": "Clock",
+        "inputs": {
+          "freq": 1.5,
+          "ratios_in": [1]
+        }
+      },
+      {
+        "op": "instance_decl",
+        "name": "b",
+        "program": "Bubble",
+        "inputs": {
+          "trigger": { "op": "ref", "instance": "clk", "output": "output" },
+          "radius": 0.003,
+          "q": 30,
+          "sigma": 0.3,
+          "decay_scale": 10,
+          "amp_scale": 0.3
+        }
+      }
+    ],
+    "assigns": []
+  },
+  "audio_outputs": [
+    { "instance": "b", "output": "out" }
+  ]
+}

--- a/stdlib/Bubble.json
+++ b/stdlib/Bubble.json
@@ -1,0 +1,184 @@
+{
+  "schema": "tropical_program_2",
+  "name": "Bubble",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "instance_decl",
+        "name": "hold",
+        "program": "SampleHold",
+        "inputs": {
+          "trigger": { "op": "input", "name": "trigger" },
+          "input": { "op": "input", "name": "radius" }
+        }
+      },
+      {
+        "op": "instance_decl",
+        "name": "ramp",
+        "program": "TriggerRamp",
+        "inputs": {
+          "trigger": { "op": "input", "name": "trigger" }
+        }
+      },
+      {
+        "op": "instance_decl",
+        "name": "decay_calc",
+        "program": "Exp",
+        "inputs": {
+          "x": {
+            "op": "div",
+            "args": [
+              -1,
+              {
+                "op": "mul",
+                "args": [
+                  { "op": "sample_rate" },
+                  {
+                    "op": "add",
+                    "args": [
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "input", "name": "decay_scale" },
+                          { "op": "nested_out", "ref": "hold", "output": "value" }
+                        ]
+                      },
+                      1e-6
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "op": "instance_decl",
+        "name": "env_gen",
+        "program": "EnvExpDecay",
+        "inputs": {
+          "trigger": { "op": "input", "name": "trigger" },
+          "decay": { "op": "nested_out", "ref": "decay_calc", "output": "out" }
+        }
+      },
+      {
+        "op": "instance_decl",
+        "name": "svf",
+        "program": "SVF",
+        "inputs": {
+          "input": { "op": "input", "name": "trigger" },
+          "cutoff": {
+            "op": "let",
+            "bind": {
+              "r_held": { "op": "nested_out", "ref": "hold", "output": "value" },
+              "t_eff": { "op": "nested_out", "ref": "ramp", "output": "frames" }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "tau": {
+                  "op": "add",
+                  "args": [
+                    {
+                      "op": "mul",
+                      "args": [
+                        { "op": "input", "name": "decay_scale" },
+                        { "op": "binding", "name": "r_held" }
+                      ]
+                    },
+                    1e-6
+                  ]
+                },
+                "f0": {
+                  "op": "div",
+                  "args": [
+                    3.26,
+                    { "op": "add", "args": [{ "op": "binding", "name": "r_held" }, 1e-6] }
+                  ]
+                }
+              },
+              "in": {
+                "op": "mul",
+                "args": [
+                  { "op": "binding", "name": "f0" },
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "div",
+                        "args": [
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "input", "name": "sigma" },
+                              { "op": "binding", "name": "t_eff" }
+                            ]
+                          },
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "sample_rate" },
+                              { "op": "binding", "name": "tau" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "q": { "op": "input", "name": "q" }
+        }
+      }
+    ],
+    "assigns": [
+      {
+        "op": "output_assign",
+        "name": "out",
+        "expr": {
+          "op": "mul",
+          "args": [
+            {
+              "op": "mul",
+              "args": [
+                { "op": "nested_out", "ref": "env_gen", "output": "env" },
+                { "op": "nested_out", "ref": "svf", "output": "bp" }
+              ]
+            },
+            {
+              "op": "mul",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    { "op": "nested_out", "ref": "hold", "output": "value" },
+                    1000
+                  ]
+                },
+                { "op": "input", "name": "amp_scale" }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "value": null
+  },
+  "ports": {
+    "inputs": [
+      { "name": "trigger", "type": "signal", "default": 0 },
+      { "name": "radius", "type": "float", "default": 0.001 },
+      { "name": "q", "type": "float", "default": 30 },
+      { "name": "sigma", "type": "float", "default": 0.3 },
+      { "name": "decay_scale", "type": "float", "default": 10 },
+      { "name": "amp_scale", "type": "float", "default": 1 }
+    ],
+    "outputs": [
+      { "name": "out", "type": "signal" }
+    ]
+  }
+}

--- a/stdlib/Bubble.json
+++ b/stdlib/Bubble.json
@@ -67,7 +67,7 @@
         "name": "svf",
         "program": "SVF",
         "inputs": {
-          "input": { "op": "input", "name": "trigger" },
+          "input": { "op": "nested_out", "ref": "ramp", "output": "edge" },
           "cutoff": {
             "op": "let",
             "bind": {
@@ -178,7 +178,7 @@
       { "name": "amp_scale", "type": "float", "default": 1 }
     ],
     "outputs": [
-      { "name": "out", "type": "signal" }
+      { "name": "out", "type": "float" }
     ]
   }
 }

--- a/stdlib/EnvExpDecay.json
+++ b/stdlib/EnvExpDecay.json
@@ -1,0 +1,79 @@
+{
+  "schema": "tropical_program_2",
+  "name": "EnvExpDecay",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "reg_decl",
+        "name": "env",
+        "init": 0
+      },
+      {
+        "op": "delay_decl",
+        "name": "prev_trigger",
+        "update": { "op": "input", "name": "trigger" },
+        "init": 0
+      }
+    ],
+    "assigns": [
+      {
+        "op": "output_assign",
+        "name": "env",
+        "expr": { "op": "reg", "name": "env" }
+      },
+      {
+        "op": "next_update",
+        "target": { "kind": "reg", "name": "env" },
+        "expr": {
+          "op": "let",
+          "bind": {
+            "tick": {
+              "op": "mul",
+              "args": [
+                {
+                  "op": "gt",
+                  "args": [
+                    { "op": "input", "name": "trigger" },
+                    0.5
+                  ]
+                },
+                {
+                  "op": "lte",
+                  "args": [
+                    { "op": "delay_ref", "id": "prev_trigger" },
+                    0.5
+                  ]
+                }
+              ]
+            }
+          },
+          "in": {
+            "op": "select",
+            "args": [
+              { "op": "binding", "name": "tick" },
+              1,
+              {
+                "op": "mul",
+                "args": [
+                  { "op": "reg", "name": "env" },
+                  { "op": "input", "name": "decay" }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "value": null
+  },
+  "ports": {
+    "inputs": [
+      { "name": "trigger", "type": "signal", "default": 0 },
+      { "name": "decay", "type": "float", "default": 0.999 }
+    ],
+    "outputs": [
+      { "name": "env", "type": "signal" }
+    ]
+  }
+}

--- a/stdlib/SVF.json
+++ b/stdlib/SVF.json
@@ -1,0 +1,690 @@
+{
+  "schema": "tropical_program_2",
+  "name": "SVF",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "reg_decl",
+        "name": "ic1eq",
+        "init": 0
+      },
+      {
+        "op": "reg_decl",
+        "name": "ic2eq",
+        "init": 0
+      }
+    ],
+    "assigns": [
+      {
+        "op": "output_assign",
+        "name": "lp",
+        "expr": {
+          "op": "let",
+          "bind": {
+            "g": {
+              "op": "div",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    3.141592653589793,
+                    { "op": "input", "name": "cutoff" }
+                  ]
+                },
+                { "op": "sample_rate" }
+              ]
+            },
+            "k": {
+              "op": "div",
+              "args": [
+                1,
+                { "op": "input", "name": "q" }
+              ]
+            }
+          },
+          "in": {
+            "op": "let",
+            "bind": {
+              "a1": {
+                "op": "div",
+                "args": [
+                  1,
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "g" },
+                          {
+                            "op": "add",
+                            "args": [
+                              { "op": "binding", "name": "g" },
+                              { "op": "binding", "name": "k" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "a2": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    { "op": "binding", "name": "a1" }
+                  ]
+                }
+              },
+              "in": {
+                "op": "let",
+                "bind": {
+                  "a3": {
+                    "op": "mul",
+                    "args": [
+                      { "op": "binding", "name": "g" },
+                      { "op": "binding", "name": "a2" }
+                    ]
+                  },
+                  "v3": {
+                    "op": "sub",
+                    "args": [
+                      { "op": "input", "name": "input" },
+                      { "op": "reg", "name": "ic2eq" }
+                    ]
+                  }
+                },
+                "in": {
+                  "op": "let",
+                  "bind": {
+                    "v1": {
+                      "op": "add",
+                      "args": [
+                        {
+                          "op": "mul",
+                          "args": [
+                            { "op": "binding", "name": "a1" },
+                            { "op": "reg", "name": "ic1eq" }
+                          ]
+                        },
+                        {
+                          "op": "mul",
+                          "args": [
+                            { "op": "binding", "name": "a2" },
+                            { "op": "binding", "name": "v3" }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "in": {
+                    "op": "add",
+                    "args": [
+                      { "op": "reg", "name": "ic2eq" },
+                      {
+                        "op": "add",
+                        "args": [
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a2" },
+                              { "op": "reg", "name": "ic1eq" }
+                            ]
+                          },
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a3" },
+                              { "op": "binding", "name": "v3" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "op": "output_assign",
+        "name": "bp",
+        "expr": {
+          "op": "let",
+          "bind": {
+            "g": {
+              "op": "div",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    3.141592653589793,
+                    { "op": "input", "name": "cutoff" }
+                  ]
+                },
+                { "op": "sample_rate" }
+              ]
+            },
+            "k": {
+              "op": "div",
+              "args": [
+                1,
+                { "op": "input", "name": "q" }
+              ]
+            }
+          },
+          "in": {
+            "op": "let",
+            "bind": {
+              "a1": {
+                "op": "div",
+                "args": [
+                  1,
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "g" },
+                          {
+                            "op": "add",
+                            "args": [
+                              { "op": "binding", "name": "g" },
+                              { "op": "binding", "name": "k" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "a2": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    { "op": "binding", "name": "a1" }
+                  ]
+                },
+                "v3": {
+                  "op": "sub",
+                  "args": [
+                    { "op": "input", "name": "input" },
+                    { "op": "reg", "name": "ic2eq" }
+                  ]
+                }
+              },
+              "in": {
+                "op": "add",
+                "args": [
+                  {
+                    "op": "mul",
+                    "args": [
+                      { "op": "binding", "name": "a1" },
+                      { "op": "reg", "name": "ic1eq" }
+                    ]
+                  },
+                  {
+                    "op": "mul",
+                    "args": [
+                      { "op": "binding", "name": "a2" },
+                      { "op": "binding", "name": "v3" }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "op": "output_assign",
+        "name": "hp",
+        "expr": {
+          "op": "let",
+          "bind": {
+            "g": {
+              "op": "div",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    3.141592653589793,
+                    { "op": "input", "name": "cutoff" }
+                  ]
+                },
+                { "op": "sample_rate" }
+              ]
+            },
+            "k": {
+              "op": "div",
+              "args": [
+                1,
+                { "op": "input", "name": "q" }
+              ]
+            }
+          },
+          "in": {
+            "op": "let",
+            "bind": {
+              "a1": {
+                "op": "div",
+                "args": [
+                  1,
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "g" },
+                          {
+                            "op": "add",
+                            "args": [
+                              { "op": "binding", "name": "g" },
+                              { "op": "binding", "name": "k" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "a2": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    { "op": "binding", "name": "a1" }
+                  ]
+                },
+                "a3": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    {
+                      "op": "mul",
+                      "args": [
+                        { "op": "binding", "name": "g" },
+                        { "op": "binding", "name": "a1" }
+                      ]
+                    }
+                  ]
+                },
+                "v3": {
+                  "op": "sub",
+                  "args": [
+                    { "op": "input", "name": "input" },
+                    { "op": "reg", "name": "ic2eq" }
+                  ]
+                }
+              },
+              "in": {
+                "op": "let",
+                "bind": {
+                  "v1": {
+                    "op": "add",
+                    "args": [
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "a1" },
+                          { "op": "reg", "name": "ic1eq" }
+                        ]
+                      },
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "a2" },
+                          { "op": "binding", "name": "v3" }
+                        ]
+                      }
+                    ]
+                  },
+                  "v2": {
+                    "op": "add",
+                    "args": [
+                      { "op": "reg", "name": "ic2eq" },
+                      {
+                        "op": "add",
+                        "args": [
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a2" },
+                              { "op": "reg", "name": "ic1eq" }
+                            ]
+                          },
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a3" },
+                              { "op": "binding", "name": "v3" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "in": {
+                  "op": "sub",
+                  "args": [
+                    {
+                      "op": "sub",
+                      "args": [
+                        { "op": "input", "name": "input" },
+                        {
+                          "op": "mul",
+                          "args": [
+                            { "op": "binding", "name": "k" },
+                            { "op": "binding", "name": "v1" }
+                          ]
+                        }
+                      ]
+                    },
+                    { "op": "binding", "name": "v2" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "op": "next_update",
+        "target": { "kind": "reg", "name": "ic1eq" },
+        "expr": {
+          "op": "let",
+          "bind": {
+            "g": {
+              "op": "div",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    3.141592653589793,
+                    { "op": "input", "name": "cutoff" }
+                  ]
+                },
+                { "op": "sample_rate" }
+              ]
+            },
+            "k": {
+              "op": "div",
+              "args": [
+                1,
+                { "op": "input", "name": "q" }
+              ]
+            }
+          },
+          "in": {
+            "op": "let",
+            "bind": {
+              "a1": {
+                "op": "div",
+                "args": [
+                  1,
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "g" },
+                          {
+                            "op": "add",
+                            "args": [
+                              { "op": "binding", "name": "g" },
+                              { "op": "binding", "name": "k" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "a2": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    { "op": "binding", "name": "a1" }
+                  ]
+                },
+                "v3": {
+                  "op": "sub",
+                  "args": [
+                    { "op": "input", "name": "input" },
+                    { "op": "reg", "name": "ic2eq" }
+                  ]
+                }
+              },
+              "in": {
+                "op": "let",
+                "bind": {
+                  "v1": {
+                    "op": "add",
+                    "args": [
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "a1" },
+                          { "op": "reg", "name": "ic1eq" }
+                        ]
+                      },
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "a2" },
+                          { "op": "binding", "name": "v3" }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "in": {
+                  "op": "sub",
+                  "args": [
+                    {
+                      "op": "mul",
+                      "args": [
+                        2,
+                        { "op": "binding", "name": "v1" }
+                      ]
+                    },
+                    { "op": "reg", "name": "ic1eq" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "op": "next_update",
+        "target": { "kind": "reg", "name": "ic2eq" },
+        "expr": {
+          "op": "let",
+          "bind": {
+            "g": {
+              "op": "div",
+              "args": [
+                {
+                  "op": "mul",
+                  "args": [
+                    3.141592653589793,
+                    { "op": "input", "name": "cutoff" }
+                  ]
+                },
+                { "op": "sample_rate" }
+              ]
+            },
+            "k": {
+              "op": "div",
+              "args": [
+                1,
+                { "op": "input", "name": "q" }
+              ]
+            }
+          },
+          "in": {
+            "op": "let",
+            "bind": {
+              "a1": {
+                "op": "div",
+                "args": [
+                  1,
+                  {
+                    "op": "add",
+                    "args": [
+                      1,
+                      {
+                        "op": "mul",
+                        "args": [
+                          { "op": "binding", "name": "g" },
+                          {
+                            "op": "add",
+                            "args": [
+                              { "op": "binding", "name": "g" },
+                              { "op": "binding", "name": "k" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "in": {
+              "op": "let",
+              "bind": {
+                "a2": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    { "op": "binding", "name": "a1" }
+                  ]
+                },
+                "a3": {
+                  "op": "mul",
+                  "args": [
+                    { "op": "binding", "name": "g" },
+                    {
+                      "op": "mul",
+                      "args": [
+                        { "op": "binding", "name": "g" },
+                        { "op": "binding", "name": "a1" }
+                      ]
+                    }
+                  ]
+                },
+                "v3": {
+                  "op": "sub",
+                  "args": [
+                    { "op": "input", "name": "input" },
+                    { "op": "reg", "name": "ic2eq" }
+                  ]
+                }
+              },
+              "in": {
+                "op": "let",
+                "bind": {
+                  "v2": {
+                    "op": "add",
+                    "args": [
+                      { "op": "reg", "name": "ic2eq" },
+                      {
+                        "op": "add",
+                        "args": [
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a2" },
+                              { "op": "reg", "name": "ic1eq" }
+                            ]
+                          },
+                          {
+                            "op": "mul",
+                            "args": [
+                              { "op": "binding", "name": "a3" },
+                              { "op": "binding", "name": "v3" }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "in": {
+                  "op": "sub",
+                  "args": [
+                    {
+                      "op": "mul",
+                      "args": [
+                        2,
+                        { "op": "binding", "name": "v2" }
+                      ]
+                    },
+                    { "op": "reg", "name": "ic2eq" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "value": null
+  },
+  "ports": {
+    "inputs": [
+      {
+        "name": "input",
+        "type": "signal",
+        "default": 0
+      },
+      {
+        "name": "cutoff",
+        "type": "freq",
+        "default": 1000
+      },
+      {
+        "name": "q",
+        "type": "float",
+        "default": 0.707
+      }
+    ],
+    "outputs": [
+      { "name": "lp", "type": "signal" },
+      { "name": "bp", "type": "signal" },
+      { "name": "hp", "type": "signal" }
+    ]
+  }
+}

--- a/stdlib/SampleHold.json
+++ b/stdlib/SampleHold.json
@@ -1,0 +1,104 @@
+{
+  "schema": "tropical_program_2",
+  "name": "SampleHold",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "reg_decl",
+        "name": "held",
+        "init": 0
+      },
+      {
+        "op": "delay_decl",
+        "name": "prev_trigger",
+        "update": { "op": "input", "name": "trigger" },
+        "init": 0
+      }
+    ],
+    "assigns": [
+      {
+        "op": "output_assign",
+        "name": "value",
+        "expr": {
+          "op": "let",
+          "bind": {
+            "tick": {
+              "op": "mul",
+              "args": [
+                {
+                  "op": "gt",
+                  "args": [
+                    { "op": "input", "name": "trigger" },
+                    0.5
+                  ]
+                },
+                {
+                  "op": "lte",
+                  "args": [
+                    { "op": "delay_ref", "id": "prev_trigger" },
+                    0.5
+                  ]
+                }
+              ]
+            }
+          },
+          "in": {
+            "op": "select",
+            "args": [
+              { "op": "binding", "name": "tick" },
+              { "op": "input", "name": "input" },
+              { "op": "reg", "name": "held" }
+            ]
+          }
+        }
+      },
+      {
+        "op": "next_update",
+        "target": { "kind": "reg", "name": "held" },
+        "expr": {
+          "op": "let",
+          "bind": {
+            "tick": {
+              "op": "mul",
+              "args": [
+                {
+                  "op": "gt",
+                  "args": [
+                    { "op": "input", "name": "trigger" },
+                    0.5
+                  ]
+                },
+                {
+                  "op": "lte",
+                  "args": [
+                    { "op": "delay_ref", "id": "prev_trigger" },
+                    0.5
+                  ]
+                }
+              ]
+            }
+          },
+          "in": {
+            "op": "select",
+            "args": [
+              { "op": "binding", "name": "tick" },
+              { "op": "input", "name": "input" },
+              { "op": "reg", "name": "held" }
+            ]
+          }
+        }
+      }
+    ],
+    "value": null
+  },
+  "ports": {
+    "inputs": [
+      { "name": "trigger", "type": "signal", "default": 0 },
+      { "name": "input", "type": "signal", "default": 0 }
+    ],
+    "outputs": [
+      { "name": "value", "type": "signal" }
+    ]
+  }
+}

--- a/stdlib/TriggerRamp.json
+++ b/stdlib/TriggerRamp.json
@@ -1,0 +1,76 @@
+{
+  "schema": "tropical_program_2",
+  "name": "TriggerRamp",
+  "body": {
+    "op": "block",
+    "decls": [
+      {
+        "op": "reg_decl",
+        "name": "t",
+        "init": 0,
+        "type": "int"
+      },
+      {
+        "op": "delay_decl",
+        "name": "prev_trigger",
+        "update": { "op": "input", "name": "trigger" },
+        "init": 0
+      }
+    ],
+    "assigns": [
+      {
+        "op": "output_assign",
+        "name": "frames",
+        "expr": { "op": "reg", "name": "t" }
+      },
+      {
+        "op": "next_update",
+        "target": { "kind": "reg", "name": "t" },
+        "expr": {
+          "op": "let",
+          "bind": {
+            "tick": {
+              "op": "mul",
+              "args": [
+                {
+                  "op": "gt",
+                  "args": [
+                    { "op": "input", "name": "trigger" },
+                    0.5
+                  ]
+                },
+                {
+                  "op": "lte",
+                  "args": [
+                    { "op": "delay_ref", "id": "prev_trigger" },
+                    0.5
+                  ]
+                }
+              ]
+            }
+          },
+          "in": {
+            "op": "select",
+            "args": [
+              { "op": "binding", "name": "tick" },
+              0,
+              {
+                "op": "add",
+                "args": [{ "op": "reg", "name": "t" }, 1]
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "value": null
+  },
+  "ports": {
+    "inputs": [
+      { "name": "trigger", "type": "signal", "default": 0 }
+    ],
+    "outputs": [
+      { "name": "frames", "type": "float" }
+    ]
+  }
+}

--- a/stdlib/TriggerRamp.json
+++ b/stdlib/TriggerRamp.json
@@ -24,6 +24,29 @@
         "expr": { "op": "reg", "name": "t" }
       },
       {
+        "op": "output_assign",
+        "name": "edge",
+        "expr": {
+          "op": "mul",
+          "args": [
+            {
+              "op": "gt",
+              "args": [
+                { "op": "input", "name": "trigger" },
+                0.5
+              ]
+            },
+            {
+              "op": "lte",
+              "args": [
+                { "op": "delay_ref", "id": "prev_trigger" },
+                0.5
+              ]
+            }
+          ]
+        }
+      },
+      {
         "op": "next_update",
         "target": { "kind": "reg", "name": "t" },
         "expr": {
@@ -70,7 +93,8 @@
       { "name": "trigger", "type": "signal", "default": 0 }
     ],
     "outputs": [
-      { "name": "frames", "type": "float" }
+      { "name": "frames", "type": "float" },
+      { "name": "edge", "type": "float" }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the bubble-synth demo. Adds five stdlib programs and one demo patch for synthesizing physically-modeled water/bubble sounds. Expresses the van den Doel / Minnaert bubble model — pitch, damping, glide, and amplitude all derive from a single `radius` parameter.

- **`stdlib/SVF.json`** — trapezoidal (Zavalishin) state-variable filter with per-sample-modulatable `cutoff` and `q`. Stable under fast frequency modulation, unlike biquads — required for the pitch-gliding resonator.
- **`stdlib/SampleHold.json`** — latches `input` on trigger rising edge.
- **`stdlib/TriggerRamp.json`** — outputs a per-voice frame counter (`frames`) that resets on each rising edge, and a one-sample `edge` pulse for impulse excitation.
- **`stdlib/EnvExpDecay.json`** — amplitude envelope: reset to 1.0 on rising edge, else `env *= decay` each sample.
- **`stdlib/Bubble.json`** — composes the above + `Exp` + `SVF` into a single voice. Takes `trigger` and `radius`, computes Minnaert frequency (3.26 / r), decay time, pitch glide during ringdown, and r-scaled amplitude.
- **`patches/bubble_drip.json`** — listenable demo: 1.5 Hz `Clock` driving a single `Bubble` at r = 3 mm.

No engine / JIT / compiler changes.

## Test plan

- [x] `cmake --build build -j4 && ctest --test-dir build` — C++ tests pass (no engine changes, sanity check).
- [x] `bun test` — 319 tests pass (was 315 on main; 4 new tests for SVF, SampleHold, EnvExpDecay, Bubble).
- [x] New tests cover: SVF impulse response ringing + bounded decay; SampleHold latches correctly on edge; EnvExpDecay reset + exponential decay; Bubble single-trigger produces bounded, decaying, zero-crossing output; smaller radii produce more zero crossings per unit time (pitch scales as 1/r).
- [x] End-to-end JIT ↔ TS interpreter bit-exact equivalence verified for `patches/bubble_drip.json` over 2048 samples (maxDiff = 0.0).
- [x] **Perceptual check (reviewer):** `mcp:load({ path: "patches/bubble_drip.json" }); mcp:start_audio()`. You should hear a drip every ~667 ms with a short rising pitch-glide character. Sweep `radius` from 0.0005 (bright tink) to 0.02 (deep bloop); sweep `sigma` from 0 (dry click) to 0.3 (wet plunk) to confirm the glide is doing the perceptual work.

## Known issues discovered during this work (deferred)

Two real bugs in `compiler/flatten.ts` that block future work and deserve their own PR:

1. **Delay refs in nested-instance input wiring.** `collectNestedRegisterExprs` substitutes the parent program's input wiring into nested-call register updates but never subsequently calls `resolveDelayValues` against the parent's delay base. Outer `delay_value(node_id)` nodes survive into the flat plan as unresolved ops and `emit_numeric` substitutes 0. This PR works around the bug by keeping all delays inside leaf primitives (`TriggerRamp` owns its edge-detect delay; `Bubble` has no delay_decl of its own). The fix itself is small (one `resolveDelayValues` call at the right place) but intentionally not done on this branch.

2. **Wrapping any stdlib program with internal state inside a `program_decl` or another stdlib wrapper program produces wrong output.** Discovered while attempting Phase 2 (an 8-voice `BubbleCloud` stdlib program with round-robin voice steering). Repros with a plain `Wrap(LadderFilter)` or `Wrap(Bubble)` — the wrapper produces zero or amplified-unbounded output. Phase 2 is deferred pending this fix; Phase 2 code is not included in this PR.

There is also no JIT ↔ TS interpreter equivalence test suite today. `compiler/apply_plan.test.ts:90` compares two JIT paths against each other, not JIT vs interp. I verified equivalence for `bubble_drip` manually (mentioned above). Systematic coverage is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)