### PR TITLE
feat(mcp): wire-to-dac.out boundary leaf; remove set_output (Phase A1+A2)

### DIFF
--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -37,11 +37,8 @@ Every mutation that affects the signal graph calls `wire()`, which runs the full
 - `export_program` — crystallize session instances into a reusable program type. Specify input/output mappings; current wiring becomes defaults. Optionally removes exported instances from the session.
 
 ### Wiring
-- `wire` — set and/or remove input wiring in a single recompile. Replaces connect_modules, disconnect_modules, set_module_input, set_inputs_batch.
+- `wire` — set and/or remove input wiring in a single recompile. Audio output uses the same tool: wire to `instance: "dac", input: "out"` with a ref-shaped expression. Multiple wires to dac.out sum into the mono output bus; remove with `{instance: "dac", input: "out"}` clears all dac wires.
 - `list_wiring` — show current input expressions, optionally filtered by instance
-
-### Audio output
-- `set_output` — declaratively set the full audio output list (replaces add/remove_graph_output)
 
 ### Control parameters
 - `set_param` — set a named smoothed or trigger parameter value

--- a/mcp/errors.test.ts
+++ b/mcp/errors.test.ts
@@ -368,9 +368,12 @@ describe('unknown_instance — helper-routed across all wiring tools', () => {
     assertEnvelope(env, 'instance')
   })
 
-  test('set_output outputs[].instance', async () => {
-    const env = await client.callError('set_output', {
-      outputs: [{ instance: 'nope', output: 'out' }],
+  test('wire to dac.out — unknown source instance in ref expression', async () => {
+    const env = await client.callError('wire', {
+      set: [{
+        instance: 'dac', input: 'out',
+        expr: { op: 'ref', instance: 'nope', output: 0 },
+      }],
     })
     assertEnvelope(env, 'instance')
   })
@@ -413,8 +416,11 @@ describe('unknown_input / unknown_output — scoped enum', () => {
   })
 
   test('unknown_output — valid.options is exactly this instance\'s outputs', async () => {
-    const env = await client.callError('set_output', {
-      outputs: [{ instance: inst, output: 'ouput' }],
+    const env = await client.callError('wire', {
+      set: [{
+        instance: 'dac', input: 'out',
+        expr: { op: 'ref', instance: inst, output: 'ouput' },
+      }],
     })
     expect(env.code).toBe('unknown_output')
     expect(env.param).toBe('output')

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -42,6 +42,13 @@ const portTypeOrNull = (t: PortType | undefined): string | null =>
 const session: SessionState = makeSession()
 loadBuiltins(session.typeRegistry)
 
+// Reserved instance name for the audio output boundary leaf. Wires whose
+// destination has `instance === DAC_INSTANCE_NAME` route to session.graphOutputs
+// instead of session.inputExprNodes. Multiple wires accumulate (mix-bus sum
+// semantics, matching the C++ kernel's output_targets summing).
+const DAC_INSTANCE_NAME = 'dac'
+const DAC_OUT_PORT = 'out'
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -379,7 +386,7 @@ const TOOLS = [
   },
   {
     name: 'replicate',
-    description: 'Create N instances of a program type in one call. Returns the list of created instance names and their ports. Does NOT trigger recompilation — follow up with wire and/or set_output.',
+    description: 'Create N instances of a program type in one call. Returns the list of created instance names and their ports. Does NOT trigger recompilation — follow up with wire (use `instance: "dac", input: "out"` to wire to audio output).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -560,7 +567,7 @@ const TOOLS = [
   },
   {
     name: 'wire',
-    description: 'Set and/or remove input wiring in a single recompile. Use `set` to wire inputs (each is {instance, input, expr}), `remove` to disconnect (each is {instance, input}).',
+    description: 'Set and/or remove input wiring in a single recompile. Use `set` to wire inputs (each is {instance, input, expr}), `remove` to disconnect (each is {instance, input}). Audio output: use `instance: "dac", input: "out"` to wire to the DAC boundary leaf — `expr` must be a ref-shaped node (e.g. {op:"ref",instance,output}). Multiple wires to dac.out sum into the mono output bus. Removing a dac wire (`remove: [{instance:"dac",input:"out"}]`) clears all dac wires at once.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -598,27 +605,6 @@ const TOOLS = [
       properties: {
         instance: { type: 'string', description: 'If provided, filter to inputs of this instance.' },
       },
-    },
-  },
-  {
-    name: 'set_output',
-    description: 'Set the audio output mix. Provide a complete list of outputs — replaces all current outputs.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        outputs: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              instance:    { type: 'string' },
-              output: { description: 'Output port name or index' },
-            },
-            required: ['instance', 'output'],
-          },
-        },
-      },
-      required: ['outputs'],
     },
   },
   {
@@ -722,6 +708,13 @@ function handleAddInstance(
   gateInput?: ExprNode,
 ) {
   return wrap(() => {
+    if (instanceName === DAC_INSTANCE_NAME)
+      failBare({
+        code:    'invalid_value',
+        message: `'${DAC_INSTANCE_NAME}' is a reserved instance name (audio output boundary). Choose a different name.`,
+        param:   'instance_name',
+        value:   instanceName,
+      })
     if (session.instanceRegistry.has(instanceName))
       failBare({
         code:    'instance_exists',
@@ -763,6 +756,13 @@ function handleReplicate(
       })
 
     const prefix = namePrefix ?? programName.toLowerCase()
+    if (prefix === DAC_INSTANCE_NAME)
+      failBare({
+        code:    'invalid_value',
+        message: `'${DAC_INSTANCE_NAME}' is a reserved instance name (audio output boundary). Choose a different name_prefix.`,
+        param:   'name_prefix',
+        value:   prefix,
+      })
     const created = []
     for (let i = 0; i < count; i++) {
       const name = nextName(session, prefix)
@@ -1115,13 +1115,91 @@ function handleGetInfo(instanceName: string) {
   })
 }
 
+/** Resolve a wire-to-dac.out source expression to an {instance, output} pair.
+ *  Today's session.graphOutputs stores only named instance outputs (matching the
+ *  C++ kernel's output_targets). The `expr` must be a `ref`-shaped node;
+ *  arbitrary expression outputs land in a later phase (A4). */
+function resolveDacSource(expr: ExprNode): { instance: string; output: string } {
+  if (typeof expr !== 'object' || expr === null || Array.isArray(expr)) {
+    failBare({
+      code:    'invalid_value',
+      message: `dac.${DAC_OUT_PORT} requires a ref-shaped expression (use refExpr or {op:'ref',instance,output}). Got literal/array.`,
+      param:   'expr',
+      value:   expr,
+    })
+  }
+  const e = expr as { op?: string; instance?: unknown; output?: unknown }
+  if (e.op !== 'ref') {
+    failBare({
+      code:    'invalid_value',
+      message: `dac.${DAC_OUT_PORT} requires expr.op === 'ref'. Got op='${String(e.op)}'.`,
+      param:   'expr',
+      value:   expr,
+    })
+  }
+  if (typeof e.instance !== 'string') {
+    failBare({
+      code:    'invalid_value',
+      message: `dac.${DAC_OUT_PORT}: ref.instance must be a string`,
+      param:   'instance',
+      value:   e.instance,
+    })
+  }
+  const inst = requireInstance(e.instance, 'instance')
+  let outputName: string
+  if (typeof e.output === 'number') {
+    if (e.output < 0 || e.output >= inst.outputNames.length) {
+      failEnum({
+        code:    'unknown_output',
+        param:   'output',
+        value:   e.output,
+        options: inst.outputNames,
+      })
+    }
+    outputName = inst.outputNames[e.output]
+  } else if (typeof e.output === 'string') {
+    if (!inst.outputNames.includes(e.output)) {
+      failEnum({
+        code:    'unknown_output',
+        param:   'output',
+        value:   e.output,
+        options: inst.outputNames,
+      })
+    }
+    outputName = e.output
+  } else {
+    failBare({
+      code:    'invalid_value',
+      message: `dac.${DAC_OUT_PORT}: ref.output must be a number or string`,
+      param:   'output',
+      value:   e.output,
+    })
+  }
+  return { instance: e.instance, output: outputName }
+}
+
 function handleWire(args: Record<string, unknown>) {
   return wrap(() => {
     const setOps = (args.set ?? []) as Array<{ instance: string; input: string | number; expr: ExprNode }>
     const removeOps = (args.remove ?? []) as Array<{ instance: string; input: string | number }>
 
     // Process removes first
+    let dacRemoved = 0
     for (const r of removeOps) {
+      if (r.instance === DAC_INSTANCE_NAME) {
+        if (r.input !== DAC_OUT_PORT) {
+          failBare({
+            code:    'unknown_output',
+            message: `dac has only one output port: '${DAC_OUT_PORT}'. Got '${r.input}'.`,
+            param:   'remove[].input',
+            value:   r.input,
+          })
+        }
+        // Mass-clear all dac wires; per-wire identity is not encoded.
+        dacRemoved += session.graphOutputs.length
+        session.graphOutputs.length = 0
+        continue
+      }
       const inst = requireInstance(r.instance, 'remove[].instance')
       const inputId = resolveInputIdx(inst, r.input)
       const resolvedName = inst.inputNames[inputId] ?? String(inputId)
@@ -1130,7 +1208,23 @@ function handleWire(args: Record<string, unknown>) {
 
     // Process sets
     const results = []
+    const dacWires = []
     for (const s of setOps) {
+      if (s.instance === DAC_INSTANCE_NAME) {
+        if (s.input !== DAC_OUT_PORT) {
+          failBare({
+            code:    'unknown_output',
+            message: `dac has only one output port: '${DAC_OUT_PORT}'. Got '${s.input}'.`,
+            param:   'set[].input',
+            value:   s.input,
+          })
+        }
+        validateExpr(s.expr, `${DAC_INSTANCE_NAME}.${DAC_OUT_PORT}`)
+        const resolved = resolveDacSource(s.expr)
+        session.graphOutputs.push(resolved)
+        dacWires.push({ instance: s.instance, input: s.input, expr: s.expr })
+        continue
+      }
       const inst = requireInstance(s.instance, 'set[].instance')
       const inputId = resolveInputIdx(inst, s.input)
       const resolvedName = inst.inputNames[inputId] ?? String(inputId)
@@ -1140,7 +1234,13 @@ function handleWire(args: Record<string, unknown>) {
       results.push({ instance: s.instance, input: resolvedName, expr })
     }
 
-    return { set: results, removed: removeOps.length, ...wire() }
+    return {
+      set: results,
+      ...(dacWires.length ? { dac: dacWires } : {}),
+      removed: removeOps.length,
+      ...(dacRemoved ? { dacRemoved } : {}),
+      ...wire(),
+    }
   })
 }
 
@@ -1155,19 +1255,6 @@ function handleListWiring(filterInstance?: string) {
       results.push({ instance: inst, input, expr: prettyExpr(node, session.instanceRegistry) })
     }
     return results
-  })
-}
-
-function handleSetOutput(args: Record<string, unknown>) {
-  return wrap(() => {
-    const outputs = args.outputs as Array<{ instance: string; output: string | number }>
-    session.graphOutputs.length = 0
-    for (const o of outputs) {
-      const inst = requireInstance(o.instance, 'outputs[].instance')
-      const outId = resolveOutputIdx(inst, o.output)
-      session.graphOutputs.push({ instance: o.instance, output: inst.outputNames[outId] })
-    }
-    return { outputs: session.graphOutputs, ...wire() }
   })
 }
 
@@ -1282,9 +1369,6 @@ function handleTool(name: string, args: Record<string, unknown>) {
 
     case 'list_wiring':
       return handleListWiring(args.instance as string | undefined)
-
-    case 'set_output':
-      return handleSetOutput(args)
 
     case 'load':
       return handleLoad(args)

--- a/mcp/wire_dac.test.ts
+++ b/mcp/wire_dac.test.ts
@@ -1,0 +1,284 @@
+/**
+ * wire_dac.test.ts — A1: dac.out boundary-leaf wiring via the unified `wire` tool.
+ *
+ * Verifies that `wire` accepts `instance: "dac", input: "out"` as a destination,
+ * routes ref-shaped expressions into session.graphOutputs (mix-bus append),
+ * supports mass-remove, reserves `dac` as an instance name, and rejects
+ * non-ref expressions for the dac destination.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { resolve } from 'node:path'
+
+type Envelope = {
+  code: string
+  message: string
+  retryable: boolean
+  param?: string
+  value?: unknown
+}
+
+type ToolResult =
+  | { status: 'ok'; data: unknown }
+  | { status: 'error'; error: Envelope }
+
+class Client {
+  private proc: ChildProcess
+  private buf = ''
+  private pending = new Map<number, (v: unknown) => void>()
+  private nextId = 1
+
+  constructor() {
+    const serverPath = resolve(import.meta.dir, 'server.ts')
+    this.proc = spawn('bun', ['run', serverPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: resolve(import.meta.dir, '..'),
+    })
+    this.proc.stdout!.on('data', (chunk: Buffer) => this.onData(chunk.toString()))
+  }
+
+  private onData(s: string) {
+    this.buf += s
+    let idx: number
+    while ((idx = this.buf.indexOf('\n')) >= 0) {
+      const line = this.buf.slice(0, idx).trim()
+      this.buf = this.buf.slice(idx + 1)
+      if (!line) continue
+      try {
+        const msg = JSON.parse(line)
+        if (typeof msg.id === 'number') {
+          const r = this.pending.get(msg.id)
+          if (r) { this.pending.delete(msg.id); r(msg) }
+        }
+      } catch { /* ignore */ }
+    }
+  }
+
+  private request(method: string, params: unknown): Promise<any> {
+    const id = this.nextId++
+    return new Promise((res, rej) => {
+      this.pending.set(id, res)
+      this.proc.stdin!.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
+      setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id)
+          rej(new Error(`Timeout on ${method}`))
+        }
+      }, 5000)
+    })
+  }
+
+  private notify(method: string, params: unknown) {
+    this.proc.stdin!.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
+  }
+
+  async init() {
+    await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'wire-dac-test', version: '0' },
+    })
+    this.notify('notifications/initialized', {})
+  }
+
+  async call(toolName: string, args: Record<string, unknown> = {}): Promise<{
+    isError?: boolean
+    result: ToolResult
+  }> {
+    const resp = await this.request('tools/call', { name: toolName, arguments: args })
+    const content = resp.result?.content?.[0]?.text
+    if (typeof content !== 'string') throw new Error(`No text content in response: ${JSON.stringify(resp)}`)
+    return { isError: resp.result.isError, result: JSON.parse(content) as ToolResult }
+  }
+
+  async callOk(toolName: string, args: Record<string, unknown> = {}): Promise<any> {
+    const { result } = await this.call(toolName, args)
+    if (result.status !== 'ok') {
+      throw new Error(`Expected ok, got error: ${JSON.stringify(result)}`)
+    }
+    return result.data
+  }
+
+  async callError(toolName: string, args: Record<string, unknown> = {}): Promise<Envelope> {
+    const { isError, result } = await this.call(toolName, args)
+    expect(isError).toBe(true)
+    if (result.status !== 'error') {
+      throw new Error(`Expected error, got ok: ${JSON.stringify(result)}`)
+    }
+    return result.error
+  }
+
+  close() {
+    this.proc.kill('SIGTERM')
+  }
+}
+
+let client: Client
+
+beforeAll(async () => {
+  client = new Client()
+  await client.init()
+})
+
+afterAll(() => {
+  client?.close()
+})
+
+let uniq = 0
+const unique = (prefix: string) => `${prefix}_${++uniq}`
+
+describe('wire to dac.out — basic flow', () => {
+  test('ref-shaped expression to dac.out is accepted and routed', async () => {
+    const inst = unique('osc')
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: inst })
+
+    const data = await client.callOk('wire', {
+      set: [{
+        instance: 'dac',
+        input: 'out',
+        expr: { op: 'ref', instance: inst, output: 0 },
+      }],
+    })
+
+    // The handler returns the dac wires under a separate `dac` key.
+    expect(data.dac).toEqual([
+      { instance: 'dac', input: 'out', expr: { op: 'ref', instance: inst, output: 0 } },
+    ])
+  })
+
+  test('multiple wires to dac.out accumulate (mix-bus)', async () => {
+    const a = unique('a')
+    const b = unique('b')
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: a })
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: b })
+
+    // Clear any prior dac wires from earlier tests.
+    await client.callOk('wire', {
+      remove: [{ instance: 'dac', input: 'out' }],
+    })
+
+    await client.callOk('wire', {
+      set: [
+        { instance: 'dac', input: 'out', expr: { op: 'ref', instance: a, output: 0 } },
+        { instance: 'dac', input: 'out', expr: { op: 'ref', instance: b, output: 0 } },
+      ],
+    })
+
+    // graphOutputs surfaces via save → program.audio_outputs
+    const saved = await client.callOk('save')
+    expect(Array.isArray(saved.program?.audio_outputs)).toBe(true)
+    const outs = saved.program.audio_outputs
+    expect(outs.length).toBe(2)
+    expect(outs.some((o: any) => o.instance === a)).toBe(true)
+    expect(outs.some((o: any) => o.instance === b)).toBe(true)
+  })
+
+  test('remove clears all dac wires at once', async () => {
+    // Establish at least one dac wire.
+    const inst = unique('rm')
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: inst })
+    await client.callOk('wire', {
+      set: [{ instance: 'dac', input: 'out', expr: { op: 'ref', instance: inst, output: 0 } }],
+    })
+
+    const data = await client.callOk('wire', {
+      remove: [{ instance: 'dac', input: 'out' }],
+    })
+    expect(data.dacRemoved).toBeGreaterThanOrEqual(1)
+
+    const saved = await client.callOk('save')
+    expect(saved.program?.audio_outputs ?? []).toEqual([])
+  })
+})
+
+describe('wire to dac.out — error envelopes', () => {
+  test('non-ref expression rejected', async () => {
+    const env = await client.callError('wire', {
+      set: [{ instance: 'dac', input: 'out', expr: 0.5 }],
+    })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('expr')
+  })
+
+  test('wrong dac port name rejected', async () => {
+    const inst = unique('w')
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: inst })
+    const env = await client.callError('wire', {
+      set: [{
+        instance: 'dac',
+        input: 'left',
+        expr: { op: 'ref', instance: inst, output: 0 },
+      }],
+    })
+    expect(env.code).toBe('unknown_output')
+    expect(env.param).toBe('set[].input')
+  })
+
+  test('ref to unknown instance rejected with helpful options', async () => {
+    const env = await client.callError('wire', {
+      set: [{
+        instance: 'dac',
+        input: 'out',
+        expr: { op: 'ref', instance: 'does_not_exist', output: 0 },
+      }],
+    })
+    expect(env.code).toBe('unknown_instance')
+  })
+
+  test('ref output index out of range rejected', async () => {
+    const inst = unique('oor')
+    await client.callOk('add_instance', { program: 'OnePole', instance_name: inst })
+    const env = await client.callError('wire', {
+      set: [{
+        instance: 'dac',
+        input: 'out',
+        expr: { op: 'ref', instance: inst, output: 99 },
+      }],
+    })
+    expect(env.code).toBe('unknown_output')
+  })
+
+  test('remove with wrong dac port name rejected', async () => {
+    const env = await client.callError('wire', {
+      remove: [{ instance: 'dac', input: 'left' }],
+    })
+    expect(env.code).toBe('unknown_output')
+    expect(env.param).toBe('remove[].input')
+  })
+})
+
+describe('dac is a reserved instance name', () => {
+  test('add_instance with name "dac" rejected', async () => {
+    const env = await client.callError('add_instance', {
+      program: 'OnePole',
+      instance_name: 'dac',
+    })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('instance_name')
+  })
+
+  test('replicate with name_prefix "dac" rejected', async () => {
+    const env = await client.callError('replicate', {
+      program: 'OnePole',
+      count: 2,
+      name_prefix: 'dac',
+    })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('name_prefix')
+  })
+})
+
+describe('set_output is removed', () => {
+  test('calling set_output returns unknown-tool error', async () => {
+    const { isError, result } = await client.call('set_output', {
+      outputs: [{ instance: 'whatever', output: 'out' }],
+    })
+    expect(isError).toBe(true)
+    if (result.status === 'error') {
+      // Server rejects the unknown tool name; either MethodNotFound at the
+      // protocol level or an internal_error from the dispatcher fall-through.
+      expect(typeof result.error.message).toBe('string')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Replace the parallel `set_output` API with uniform wire-to-`dac.out` semantics on the existing `wire` tool. Audio output is now spelled the same shape as every other wire.
- Reserve `dac` as a special instance name; `add_instance` and `replicate` reject it with a clear error.
- Multiple wires to `dac.out` accumulate (mix-bus, matching the C++ kernel's `output_targets` summing). Remove with `{instance: "dac", input: "out"}` clears all dac wires.
- Remove `set_output` tool, schema, handler, and dispatcher case.

## Why
First two sub-phases of Phase A (data-model coherence) — see plan in `create-an-exhaustive-plan-agile-bee.md` and the conversation that drove it. Eurorack model: the DAC is just another set of jacks at the edge of the system, you patch to it the same way you patch anything else. Subsequent phases (A3-A5) move params into program declarations, replace `audio_outputs` with body wires, fix DAC channel count at runtime startup, and drop session-vs-program duality.

## What's unchanged
- No C++ changes.
- `FlatPlan.output_targets` shape unchanged.
- `SessionState.graphOutputs` shape unchanged (still `Array<{instance, output}>`).
- `wire` accepts the same `{instance, input, expr}` shape it did before; `instance: "dac"` is a new value but the schema is identical.

## Source-expression restriction
The `expr` for a wire to `dac.out` must be a ref-shaped node (`{op: "ref", instance, output}`). Arbitrary expression outputs (e.g., `mul(sin1.out, 0.5)` directly to dac) defer to phase A4, when `audio_outputs` migrates from a session-level field to body wires that can carry any expression.

## Test plan
- [x] `bun test` — 569 pass, 0 fail across 36 files (was 558 + 11 new in `mcp/wire_dac.test.ts`)
- [x] `make build` — clean
- [x] `cmake --build build -j4 && ctest --test-dir build` — `module_process` passes
- [x] `apply_plan.test.ts` golden audio path passes (included in `bun test`)
- [x] `errors.test.ts` updated for unknown_instance + unknown_output enum.options coverage now via wire-to-dac.out

## New tests (`mcp/wire_dac.test.ts`)
- ref-shaped expression to dac.out is accepted and routed
- multiple wires to dac.out accumulate (mix-bus)
- remove clears all dac wires at once
- non-ref expression rejected (`invalid_value` envelope)
- wrong dac port name rejected (`unknown_output`)
- ref to unknown instance rejected (`unknown_instance` with helpful options)
- ref output index out of range rejected (`unknown_output`)
- remove with wrong dac port name rejected
- `dac` is rejected as instance name in `add_instance`
- `dac` is rejected as `name_prefix` in `replicate`
- `set_output` is gone (returns error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)