### PR TITLE
feat(compiler): paramDecl body-decl form for params/triggers (Phase A3)

### DIFF
--- a/compiler/lower_arrays.ts
+++ b/compiler/lower_arrays.ts
@@ -803,7 +803,7 @@ function resolveStrConcats(node: unknown): unknown {
 }
 
 /** Decls that carry a unique `name` field — used for collision detection. */
-const NAMED_DECL_OPS = new Set(['instanceDecl', 'regDecl', 'delayDecl', 'programDecl'])
+const NAMED_DECL_OPS = new Set(['instanceDecl', 'regDecl', 'delayDecl', 'programDecl', 'paramDecl'])
 
 /**
  * Walk a tree and throw if any `{op:'binding'}` node's name is NOT bound by

--- a/compiler/program.test.ts
+++ b/compiler/program.test.ts
@@ -355,3 +355,125 @@ describe('typeResolver', () => {
     session.graph.dispose()
   })
 })
+
+// ─────────────────────────────────────────────────────────────
+// paramDecl — body-decl form for params/triggers (Phase A3)
+// ─────────────────────────────────────────────────────────────
+
+describe('paramDecl in body decls (Phase A3)', () => {
+  test('loadProgramAsSession populates Param/Trigger registry from body paramDecls', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'paramDecl', name: 'cutoff', value: 1234.0, time_const: 0.01 } as unknown as ExprNode,
+          { op: 'paramDecl', name: 'gate', type: 'trigger' } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+
+    expect(session.paramRegistry.has('cutoff')).toBe(true)
+    expect(session.triggerRegistry.has('gate')).toBe(true)
+    const p = session.paramRegistry.get('cutoff')!
+    expect(p.value).toBeCloseTo(1234.0)
+
+    session.graph.dispose()
+  })
+
+  test('saveProgramFromSession emits paramDecls in body, no topLevel.params', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'paramDecl', name: 'freq', value: 440.0, time_const: 0.005 } as unknown as ExprNode,
+          { op: 'paramDecl', name: 'fire', type: 'trigger' } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+
+    const { node, topLevel } = saveProgramFromSession(session)
+    expect(topLevel.params).toBeUndefined()
+
+    const decls = (node.body.decls ?? []) as Array<Record<string, unknown>>
+    const paramDeclEntries = decls.filter(d => d.op === 'paramDecl')
+    expect(paramDeclEntries).toHaveLength(2)
+    const byName = new Map(paramDeclEntries.map(d => [d.name as string, d]))
+    expect(byName.get('freq')?.value).toBeCloseTo(440.0)
+    expect(byName.get('fire')?.type).toBe('trigger')
+
+    session.graph.dispose()
+  })
+
+  test('round-trip: save then load preserves param values and trigger names', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'paramDecl', name: 'q', value: 0.7 } as unknown as ExprNode,
+          { op: 'paramDecl', name: 'reset', type: 'trigger' } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+    // Mutate to verify round-trip preserves the live value.
+    session.paramRegistry.get('q')!.value = 0.42
+
+    const { node, topLevel } = saveProgramFromSession(session)
+
+    const session2 = makeTestSession()
+    loadProgramAsSession(node, topLevel, session2)
+    expect(session2.paramRegistry.get('q')?.value).toBeCloseTo(0.42)
+    expect(session2.triggerRegistry.has('reset')).toBe(true)
+
+    session.graph.dispose()
+    session2.graph.dispose()
+  })
+
+  test('legacy topLevel.params still loads (deprecated fallback)', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: { op: 'block', decls: [] },
+    }
+    const topLevel: ProgramTopLevel = {
+      params: [
+        { name: 'legacy', value: 7.5, time_const: 0.02 },
+        { name: 'tap', type: 'trigger' },
+      ],
+    }
+    loadProgramAsSession(prog, topLevel, session)
+    expect(session.paramRegistry.get('legacy')?.value).toBeCloseTo(7.5)
+    expect(session.triggerRegistry.has('tap')).toBe(true)
+    session.graph.dispose()
+  })
+
+  test('body paramDecl wins over duplicate topLevel.params entry', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [{ op: 'paramDecl', name: 'shared', value: 100.0 } as unknown as ExprNode],
+      },
+    }
+    const topLevel: ProgramTopLevel = {
+      params: [{ name: 'shared', value: 999.0 }],
+    }
+    loadProgramAsSession(prog, topLevel, session)
+    expect(session.paramRegistry.get('shared')?.value).toBeCloseTo(100.0)
+    session.graph.dispose()
+  })
+})

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -132,6 +132,81 @@ function* programDecls(prog: ProgramNode): Iterable<{ name: string; program: Pro
   }
 }
 
+/** Iterate paramDecl entries in a ProgramNode's body. Each entry declares a
+ *  smoothed param or fire-once trigger that the program reads via paramExpr /
+ *  triggerParamExpr. Only the top-level program's paramDecls populate
+ *  session.paramRegistry / session.triggerRegistry; nested-program paramDecls
+ *  (inside `programDecl` entries) are not auto-hoisted. */
+export function* paramDecls(prog: ProgramNode): Iterable<{
+  name: string
+  value?: number
+  time_const?: number
+  type: 'param' | 'trigger'
+}> {
+  for (const d of prog.body?.decls ?? []) {
+    if (typeof d !== 'object' || d === null || Array.isArray(d)) continue
+    const obj = d as Record<string, unknown>
+    if (obj.op !== 'paramDecl') continue
+    yield {
+      name: obj.name as string,
+      value: typeof obj.value === 'number' ? obj.value : undefined,
+      time_const: typeof obj.time_const === 'number' ? obj.time_const : undefined,
+      type: obj.type === 'trigger' ? 'trigger' : 'param',
+    }
+  }
+}
+
+type ParamSpec = { name: string; value?: number; time_const?: number; type: 'param' | 'trigger' }
+
+/** Merge param sources: body paramDecls canonical, topLevel.params is a
+ *  deprecated fallback for pre-A3 patches. Body wins on name collisions; a
+ *  one-time deprecation warning fires if topLevel.params is non-empty. */
+function mergeParamSources(prog: ProgramNode, topLevel: ProgramTopLevel): ParamSpec[] {
+  const out: ParamSpec[] = []
+  const seen = new Set<string>()
+  for (const p of paramDecls(prog)) {
+    out.push(p)
+    seen.add(p.name)
+  }
+  if (topLevel.params && topLevel.params.length > 0) {
+    if (!_topLevelParamsWarned) {
+      console.warn(
+        'tropical: file-root `params` is deprecated; declare params via paramDecl entries in the program body. Pre-A3 patches load with a fallback.',
+      )
+      _topLevelParamsWarned = true
+    }
+    for (const p of topLevel.params) {
+      if (seen.has(p.name)) continue
+      out.push({
+        name: p.name,
+        value: p.value,
+        time_const: p.time_const,
+        type: p.type === 'trigger' ? 'trigger' : 'param',
+      })
+      seen.add(p.name)
+    }
+  }
+  return out
+}
+let _topLevelParamsWarned = false
+
+/** Populate session.paramRegistry / session.triggerRegistry from a ParamSpec list.
+ *  Idempotent within a single load: skip names already present (prevents
+ *  duplicate registration during merge with body+topLevel both supplying same name). */
+function applyParamSpecs(session: SessionState, specs: ParamSpec[]): void {
+  for (const p of specs) {
+    if (p.type === 'trigger') {
+      if (!session.triggerRegistry.has(p.name)) {
+        session.triggerRegistry.set(p.name, new Trigger())
+      }
+    } else {
+      if (!session.paramRegistry.has(p.name)) {
+        session.paramRegistry.set(p.name, new Param(p.value ?? 0.0, p.time_const ?? 0.005))
+      }
+    }
+  }
+}
+
 /**
  * Load a ProgramNode into a session, replacing all existing state.
  * `topLevel` carries session-scoped metadata (params, audio_outputs, config).
@@ -180,14 +255,10 @@ export function loadProgramAsSession(
     loadProgramAsType({ ...sub.program, name: sub.name }, session)
   }
 
-  // Create params and triggers before instances (instances may reference them)
-  for (const p of topLevel.params ?? []) {
-    if (p.type === 'trigger') {
-      session.triggerRegistry.set(p.name, new Trigger())
-    } else {
-      session.paramRegistry.set(p.name, new Param(p.value ?? 0.0, p.time_const ?? 0.005))
-    }
-  }
+  // Create params and triggers before instances (instances may reference them).
+  // Body paramDecls are canonical; topLevel.params is a deprecated fallback for
+  // pre-A3 patches. When both are present, body wins (dedup by name).
+  applyParamSpecs(session, mergeParamSources(prog, topLevel))
 
   // Instantiate programs
   for (const inst of instanceDecls(prog)) {
@@ -297,7 +368,7 @@ export function mergeProgramIntoSession(
     if (session.instanceRegistry.has(inst.name))
       throw new Error(`merge collision: instance '${inst.name}' already exists.`)
   }
-  for (const p of topLevel.params ?? []) {
+  for (const p of mergeParamSources(prog, topLevel)) {
     if (session.paramRegistry.has(p.name) || session.triggerRegistry.has(p.name))
       throw new Error(`merge collision: param/trigger '${p.name}' already exists.`)
   }
@@ -326,14 +397,8 @@ export function mergeProgramIntoSession(
     loadProgramAsType({ ...sub.program, name: sub.name }, session)
   }
 
-  // Create params and triggers
-  for (const p of topLevel.params ?? []) {
-    if (p.type === 'trigger') {
-      session.triggerRegistry.set(p.name, new Trigger())
-    } else {
-      session.paramRegistry.set(p.name, new Param(p.value ?? 0.0, p.time_const ?? 0.005))
-    }
-  }
+  // Create params and triggers — body paramDecls canonical, topLevel fallback
+  applyParamSpecs(session, mergeParamSources(prog, topLevel))
 
   // Instantiate programs
   for (const inst of instanceDecls(prog)) {
@@ -428,6 +493,16 @@ export function saveProgramFromSession(
   session: SessionState,
 ): { node: ProgramNode; topLevel: ProgramTopLevel } {
   const decls: ExprNode[] = []
+
+  // paramDecls go first so they're declared before the instances that may
+  // reference them via paramExpr / triggerParamExpr.
+  for (const [name, p] of session.paramRegistry) {
+    decls.push({ op: 'paramDecl', name, value: p.value, time_const: 0.005 } as ExprNode)
+  }
+  for (const [name] of session.triggerRegistry) {
+    decls.push({ op: 'paramDecl', name, type: 'trigger' } as ExprNode)
+  }
+
   for (const [name, inst] of session.instanceRegistry) {
     const entry: Record<string, unknown> = { op: 'instanceDecl', name, program: inst.typeName }
     if (inst.typeArgs) entry.type_args = inst.typeArgs
@@ -459,15 +534,6 @@ export function saveProgramFromSession(
       instance: o.instance, output: o.output,
     }))
   }
-
-  const params: NonNullable<ProgramTopLevel['params']> = []
-  for (const [name, p] of session.paramRegistry) {
-    params.push({ name, value: p.value, time_const: 0.005 })
-  }
-  for (const [name] of session.triggerRegistry) {
-    params.push({ name, type: 'trigger' })
-  }
-  if (params.length) topLevel.params = params
 
   return { node, topLevel }
 }

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -335,8 +335,7 @@ export function resolveProgramType(
   rawTypeArgs: RawTypeArgs | undefined,
   outerArgs: ResolvedTypeArgs | undefined,
 ): { type: ProgramType; typeArgs?: ResolvedTypeArgs } {
-  const template = session.genericTemplates.get(baseName)
-  if (template) {
+  const specializeFromTemplate = (template: import('./program.js').ProgramNode) => {
     const resolved = resolveTypeArgs(rawTypeArgs, outerArgs, template.type_params, `instance of '${baseName}'`)
     const key = specializationCacheKey(baseName, resolved)
     const cached = session.specializationCache.get(key)
@@ -348,8 +347,18 @@ export function resolveProgramType(
     return { type, typeArgs: resolved }
   }
 
-  const type = session.typeRegistry.get(baseName) ?? session.typeResolver?.(baseName)
-  if (!type) {
+  const template = session.genericTemplates.get(baseName)
+  if (template) return specializeFromTemplate(template)
+
+  // typeResolver may register baseName as a generic template (returning
+  // undefined for the concrete-type case — see stdlib_loader.ts). Re-check
+  // genericTemplates after the resolver fires so the lazy-load path works.
+  const concrete = session.typeRegistry.get(baseName) ?? session.typeResolver?.(baseName)
+  if (concrete === undefined) {
+    const lateTemplate = session.genericTemplates.get(baseName)
+    if (lateTemplate) return specializeFromTemplate(lateTemplate)
+  }
+  if (!concrete) {
     const known = [
       ...session.typeRegistry.keys(),
       ...session.genericTemplates.keys(),
@@ -359,7 +368,7 @@ export function resolveProgramType(
   if (rawTypeArgs && Object.keys(rawTypeArgs).length > 0) {
     throw new Error(`Program '${baseName}' does not declare type_params; got type_args: ${Object.keys(rawTypeArgs).join(', ')}`)
   }
-  return { type }
+  return { type: concrete }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -468,6 +477,9 @@ export function loadProgramDef(
       })
     } else if (op === 'programDecl') {
       // Registered by loadProgramAsType; nothing to do here.
+    } else if (op === 'paramDecl') {
+      // Session-scoped: handled by loadProgramAsSession / mergeProgramIntoSession.
+      // Not part of ProgramDef construction.
     } else {
       throw new Error(`${def.name}: unexpected decl op '${op}' in block.decls`)
     }


### PR DESCRIPTION
## Summary
- Move smoothed-param and trigger declarations from the file-root \`params\` metadata into program-body \`paramDecl\` entries. Brings params under the same body-decl umbrella as regs, delays, instances, and nested programs.
- The file-root \`params\` field still loads (deprecated; one-time stderr warning) so pre-A3 patches keep working until A4.
- Bonus fix: \`resolveProgramType\` was missing a re-check of \`genericTemplates\` after \`typeResolver\` fires, causing \"Unknown program type\" errors for generic stdlib types lazy-loaded via the resolver.

## Why
Phase A3 of the data-model coherence plan in \`create-an-exhaustive-plan-agile-bee.md\`. Params are owned by the program that uses them; the file-root field was a JSON-tree workaround for sharing across the program/session boundary that disappears once the session-vs-program duality is collapsed (A4 finishes that).

## Changes
**\`compiler/program.ts\`**
- Add \`paramDecls(prog)\` iterator (mirrors \`instanceDecls\` / \`programDecls\`).
- \`mergeParamSources(prog, topLevel)\` — body decls canonical, topLevel.params deprecated fallback, body wins on name collision, one-time deprecation warning.
- \`applyParamSpecs(session, specs)\` — populates Param/Trigger registries idempotently.
- \`loadProgramAsSession\` and \`mergeProgramIntoSession\` route params through these helpers.
- \`saveProgramFromSession\` emits \`paramDecl\` entries in body decls; \`topLevel.params\` is no longer populated on save.

**\`compiler/session.ts\`**
- Recognize \`paramDecl\` as a session-scoped op in the \`loadProgramDef\` body walk (no-op at ProgramDef construction).
- \`resolveProgramType\` re-checks \`genericTemplates\` after \`typeResolver\` fires (fixes lazy-load resolver bug).

**\`compiler/lower_arrays.ts\`**
- \`NAMED_DECL_OPS\` now includes \`paramDecl\` for collision detection in \`expandDeclGenerators\`.

## What's unchanged
- Schema (\`compiler/schema.ts\`) — file-root \`params\` field still valid (deprecated).
- FlatPlan, FlatRuntime, JIT, C API — no changes.
- Param/Trigger runtime semantics, smoothing constants, atomic store/load — unchanged.
- MCP tool surface — \`set_param\`, \`list_params\` unchanged at the API level.

## Test plan
- [x] \`bun test\` — 574 pass, 0 fail across 36 files (was 569 + 5 new in \`program.test.ts\`)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes
- [x] \`apply_plan.test.ts\` golden audio path passes
- [x] \`specialize_integration.test.ts\` generic instantiation tests pass

## New tests (\`compiler/program.test.ts\`)
- loadProgramAsSession populates Param/Trigger registry from body paramDecls
- saveProgramFromSession emits paramDecls in body, no topLevel.params
- round-trip: save then load preserves param values and trigger names
- legacy topLevel.params still loads (deprecated fallback)
- body paramDecl wins over duplicate topLevel.params entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)