### PR TITLE
feat(compiler): dac.out body wires; save emits dac wires (Phase A4)

### DIFF
--- a/compiler/program.test.ts
+++ b/compiler/program.test.ts
@@ -477,3 +477,175 @@ describe('paramDecl in body decls (Phase A3)', () => {
     session.graph.dispose()
   })
 })
+
+// ─────────────────────────────────────────────────────────────
+// dac.out body wires — outputAssign(name='dac.out') (Phase A4)
+// ─────────────────────────────────────────────────────────────
+
+describe('dac.out body wires (Phase A4)', () => {
+  test('loadProgramAsSession reads body outputAssign(name="dac.out")', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'osc', program: 'BlepSaw', inputs: { freq: 220.0 } } as unknown as ExprNode,
+        ],
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'osc', output: 0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+    expect(session.graphOutputs).toEqual([{ instance: 'osc', output: 'saw' }])
+    session.graph.dispose()
+  })
+
+  test('saveProgramFromSession emits dac.out outputAssigns in body, no topLevel.audio_outputs', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'a', program: 'BlepSaw', inputs: { freq: 110.0 } } as unknown as ExprNode,
+          { op: 'instanceDecl', name: 'b', program: 'BlepSaw', inputs: { freq: 220.0 } } as unknown as ExprNode,
+        ],
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'a', output: 0 } } as unknown as ExprNode,
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'b', output: 0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+
+    const { node, topLevel } = saveProgramFromSession(session)
+    expect(topLevel.audio_outputs).toBeUndefined()
+
+    const assigns = (node.body.assigns ?? []) as Array<Record<string, unknown>>
+    const dacAssigns = assigns.filter(a => a.op === 'outputAssign' && a.name === 'dac.out')
+    expect(dacAssigns).toHaveLength(2)
+    const refs = dacAssigns.map(a => a.expr as { op: string; instance: string; output: number })
+    expect(refs.some(r => r.op === 'ref' && r.instance === 'a')).toBe(true)
+    expect(refs.some(r => r.op === 'ref' && r.instance === 'b')).toBe(true)
+
+    session.graph.dispose()
+  })
+
+  test('round-trip: save then load preserves dac wires', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'osc', program: 'BlepSaw', inputs: { freq: 440.0 } } as unknown as ExprNode,
+        ],
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'osc', output: 0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    loadProgramAsSession(prog, {}, session)
+    const { node, topLevel } = saveProgramFromSession(session)
+
+    const session2 = makeTestSession()
+    loadProgramAsSession(node, topLevel, session2)
+    expect(session2.graphOutputs).toEqual([{ instance: 'osc', output: 'saw' }])
+
+    session.graph.dispose()
+    session2.graph.dispose()
+  })
+
+  test('legacy topLevel.audio_outputs still loads (deprecated fallback)', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'osc', program: 'BlepSaw', inputs: { freq: 100.0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    const topLevel: ProgramTopLevel = {
+      audio_outputs: [{ instance: 'osc', output: 'saw' }],
+    }
+    loadProgramAsSession(prog, topLevel, session)
+    expect(session.graphOutputs).toEqual([{ instance: 'osc', output: 'saw' }])
+    session.graph.dispose()
+  })
+
+  test('body wires + legacy topLevel both contribute (body first, fallback after)', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'a', program: 'BlepSaw', inputs: { freq: 110.0 } } as unknown as ExprNode,
+          { op: 'instanceDecl', name: 'b', program: 'BlepSaw', inputs: { freq: 220.0 } } as unknown as ExprNode,
+        ],
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'a', output: 0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    const topLevel: ProgramTopLevel = {
+      audio_outputs: [{ instance: 'b', output: 'saw' }],
+    }
+    loadProgramAsSession(prog, topLevel, session)
+    expect(session.graphOutputs).toEqual([
+      { instance: 'a', output: 'saw' },
+      { instance: 'b', output: 'saw' },
+    ])
+    session.graph.dispose()
+  })
+
+  test('non-ref expression in dac.out outputAssign throws', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        decls: [
+          { op: 'instanceDecl', name: 'osc', program: 'BlepSaw', inputs: { freq: 100.0 } } as unknown as ExprNode,
+        ],
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out', expr: 0.5 as unknown as ExprNode } as unknown as ExprNode,
+        ],
+      },
+    }
+    expect(() => loadProgramAsSession(prog, {}, session)).toThrow(/ref-shaped/)
+    session.graph.dispose()
+  })
+
+  test('dac.out with unknown instance throws', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: {
+        op: 'block',
+        assigns: [
+          { op: 'outputAssign', name: 'dac.out',
+            expr: { op: 'ref', instance: 'nope', output: 0 } } as unknown as ExprNode,
+        ],
+      },
+    }
+    expect(() => loadProgramAsSession(prog, {}, session)).toThrow(/unknown instance/)
+    session.graph.dispose()
+  })
+})

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -156,6 +156,19 @@ export function* paramDecls(prog: ProgramNode): Iterable<{
   }
 }
 
+/** Iterate `outputAssign` entries whose `name` is "dac.out" — the audio output
+ *  boundary leaf. These are body-resident wires to the DAC; multiple entries
+ *  accumulate (mix-bus). The expression must be a ref-shaped node; arbitrary
+ *  expressions defer to a later phase. */
+export function* dacWires(prog: ProgramNode): Iterable<{ expr: ExprNode }> {
+  for (const a of prog.body?.assigns ?? []) {
+    if (typeof a !== 'object' || a === null || Array.isArray(a)) continue
+    const obj = a as Record<string, unknown>
+    if (obj.op !== 'outputAssign' || obj.name !== 'dac.out') continue
+    yield { expr: obj.expr as ExprNode }
+  }
+}
+
 type ParamSpec = { name: string; value?: number; time_const?: number; type: 'param' | 'trigger' }
 
 /** Merge param sources: body paramDecls canonical, topLevel.params is a
@@ -206,6 +219,81 @@ function applyParamSpecs(session: SessionState, specs: ParamSpec[]): void {
     }
   }
 }
+
+type GraphOutput = { instance: string; output: string }
+
+/** Resolve a body dac-wire expression to {instance, output}. Today's
+ *  session.graphOutputs stores only named instance outputs; the expression
+ *  must be a ref-shaped node. */
+function resolveDacWireExprToGraphOutput(
+  expr: ExprNode,
+  session: SessionState,
+  context: string,
+): GraphOutput {
+  if (typeof expr !== 'object' || expr === null || Array.isArray(expr)) {
+    throw new Error(`${context}: dac.out wire requires a ref-shaped expression (use {op:'ref',instance,output}); got literal/array.`)
+  }
+  const e = expr as { op?: string; instance?: unknown; output?: unknown }
+  if (e.op !== 'ref') {
+    throw new Error(`${context}: dac.out wire requires expr.op === 'ref'; got '${String(e.op)}'.`)
+  }
+  if (typeof e.instance !== 'string') {
+    throw new Error(`${context}: dac.out wire ref.instance must be a string`)
+  }
+  const inst = session.instanceRegistry.get(e.instance)
+  if (!inst) {
+    throw new Error(`${context}: dac.out wire references unknown instance '${e.instance}'.`)
+  }
+  let outputName: string
+  if (typeof e.output === 'number') {
+    if (e.output < 0 || e.output >= inst.outputNames.length) {
+      throw new Error(`${context}: dac.out wire output index ${e.output} out of range for '${e.instance}' (${inst.outputNames.length} outputs).`)
+    }
+    outputName = inst.outputNames[e.output]
+  } else if (typeof e.output === 'string') {
+    if (!inst.outputNames.includes(e.output)) {
+      throw new Error(`${context}: dac.out wire references unknown output '${e.output}' on '${e.instance}'. Valid: ${inst.outputNames.join(', ')}`)
+    }
+    outputName = e.output
+  } else {
+    throw new Error(`${context}: dac.out wire ref.output must be a number or string`)
+  }
+  return { instance: e.instance, output: outputName }
+}
+
+/** Collect graph outputs from canonical body wires (outputAssign with name="dac.out")
+ *  and from the deprecated topLevel.audio_outputs fallback. Body wires take precedence
+ *  in source order; legacy entries are appended after. Emits a one-time deprecation
+ *  warning when topLevel.audio_outputs is non-empty. */
+function collectGraphOutputs(
+  prog: ProgramNode,
+  topLevel: ProgramTopLevel,
+  session: SessionState,
+  context: string,
+): GraphOutput[] {
+  const out: GraphOutput[] = []
+  for (const w of dacWires(prog)) {
+    out.push(resolveDacWireExprToGraphOutput(w.expr, session, context))
+  }
+  if (topLevel.audio_outputs && topLevel.audio_outputs.length > 0) {
+    if (!_topLevelAudioOutputsWarned) {
+      console.warn(
+        'tropical: file-root `audio_outputs` is deprecated; wire to the DAC via outputAssign with name="dac.out" in the program body.',
+      )
+      _topLevelAudioOutputsWarned = true
+    }
+    for (const o of topLevel.audio_outputs) {
+      if ('expr' in o) {
+        throw new Error(`${context}: file-root audio_outputs[].expr form not supported. Use {instance, output} or migrate to body dac.out wires.`)
+      }
+      const inst = session.instanceRegistry.get(o.instance)
+      if (!inst) throw new Error(`${context}: audio_outputs references unknown instance '${o.instance}'.`)
+      out.push({ instance: o.instance, output: String(o.output) })
+    }
+  }
+  return out
+}
+let _topLevelAudioOutputsWarned = false
 
 /**
  * Load a ProgramNode into a session, replacing all existing state.
@@ -294,13 +382,9 @@ export function loadProgramAsSession(
   }
 
   // Set audio outputs
-  for (const out of topLevel.audio_outputs ?? []) {
-    if ('expr' in out) {
-      throw new Error('Output expressions not supported in plan-based path. Use instance output refs instead.')
-    }
-    const inst = session.instanceRegistry.get(out.instance)
-    if (!inst) throw new Error(`Output instance '${out.instance}' not found.`)
-    session.graphOutputs.push({ instance: out.instance, output: String(out.output) })
+  // Set audio outputs — body dac.out wires canonical, topLevel.audio_outputs deprecated fallback
+  for (const o of collectGraphOutputs(prog, topLevel, session, 'loadProgramAsSession')) {
+    session.graphOutputs.push(o)
   }
 
   // Compile and load
@@ -433,14 +517,9 @@ export function mergeProgramIntoSession(
     }
   }
 
-  // Append audio outputs
-  for (const out of topLevel.audio_outputs ?? []) {
-    if ('expr' in out) {
-      throw new Error('Output expressions not supported in plan-based path. Use instance output refs instead.')
-    }
-    const inst = session.instanceRegistry.get(out.instance)
-    if (!inst) throw new Error(`Output instance '${out.instance}' not found.`)
-    session.graphOutputs.push({ instance: out.instance, output: String(out.output) })
+  // Append audio outputs — body dac.out wires canonical, topLevel.audio_outputs deprecated fallback
+  for (const o of collectGraphOutputs(prog, topLevel, session, 'mergeProgramIntoSession')) {
+    session.graphOutputs.push(o)
   }
 
   // Recompile
@@ -522,19 +601,27 @@ export function saveProgramFromSession(
     decls.push(entry as ExprNode)
   }
 
+  // dac.out wires emitted as body assigns (canonical post-A4)
+  const assigns: ExprNode[] = []
+  for (const o of session.graphOutputs) {
+    const inst = session.instanceRegistry.get(o.instance)
+    if (!inst) continue // session has a stale entry; skip silently rather than crash on save
+    const outputIdx = inst.outputNames.indexOf(o.output)
+    if (outputIdx < 0) continue
+    assigns.push({
+      op: 'outputAssign',
+      name: 'dac.out',
+      expr: { op: 'ref', instance: o.instance, output: outputIdx },
+    } as unknown as ExprNode)
+  }
+
   const node: ProgramNode = {
     op: 'program',
     name: 'patch',
-    body: { op: 'block', decls },
+    body: { op: 'block', decls, assigns: assigns.length ? assigns : undefined },
   }
 
   const topLevel: ProgramTopLevel = {}
-  if (session.graphOutputs.length) {
-    topLevel.audio_outputs = session.graphOutputs.map(o => ({
-      instance: o.instance, output: o.output,
-    }))
-  }
-
   return { node, topLevel }
 }
 

--- a/mcp/wire_dac.test.ts
+++ b/mcp/wire_dac.test.ts
@@ -165,13 +165,15 @@ describe('wire to dac.out — basic flow', () => {
       ],
     })
 
-    // graphOutputs surfaces via save → program.audio_outputs
+    // graphOutputs surfaces via save → body assigns of op outputAssign with name 'dac.out'
     const saved = await client.callOk('save')
-    expect(Array.isArray(saved.program?.audio_outputs)).toBe(true)
-    const outs = saved.program.audio_outputs
-    expect(outs.length).toBe(2)
-    expect(outs.some((o: any) => o.instance === a)).toBe(true)
-    expect(outs.some((o: any) => o.instance === b)).toBe(true)
+    const assigns = (saved.program?.body?.assigns ?? []) as Array<Record<string, unknown>>
+    const dacAssigns = assigns.filter(a => a.op === 'outputAssign' && a.name === 'dac.out')
+    expect(dacAssigns.length).toBe(2)
+    expect(dacAssigns.some(a => (a.expr as any)?.instance === a)).toBe(false) // sanity
+    const dacInstances = dacAssigns.map(a => (a.expr as any)?.instance as string)
+    expect(dacInstances).toContain(a)
+    expect(dacInstances).toContain(b)
   })
 
   test('remove clears all dac wires at once', async () => {
@@ -188,7 +190,9 @@ describe('wire to dac.out — basic flow', () => {
     expect(data.dacRemoved).toBeGreaterThanOrEqual(1)
 
     const saved = await client.callOk('save')
-    expect(saved.program?.audio_outputs ?? []).toEqual([])
+    const assigns = (saved.program?.body?.assigns ?? []) as Array<Record<string, unknown>>
+    const dacAssigns = assigns.filter(a => a.op === 'outputAssign' && a.name === 'dac.out')
+    expect(dacAssigns).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary
- Replace top-level \`audio_outputs\` metadata with body \`outputAssign\` entries whose \`name\` is \"dac.out\". The patch=program decision is now visible in the serialized form: a saved patch is a tropical_program_2 whose body wires its outputs to the DAC boundary leaf via the same outputAssign machinery the rest of the program uses.
- The file-root \`audio_outputs\` field still loads (deprecated; one-time stderr warning); pre-A4 patches keep working.
- Schema and FlatPlan unchanged. \`session.graphOutputs\` shape unchanged.

## Why
Phase A4 of the data-model coherence plan in \`create-an-exhaustive-plan-agile-bee.md\`. With dac.out as a boundary leaf (A1) and params declared in body decls (A3), audio output routing is the last piece of session metadata living at the file root. Moving it into body assigns finishes collapsing the session/program duality at the schema level.

## Changes
**\`compiler/program.ts\`**
- Add \`dacWires(prog)\` iterator yielding \`outputAssign\` entries with name=\"dac.out\".
- Add \`collectGraphOutputs(prog, topLevel, session, context)\` — body wires canonical, topLevel.audio_outputs deprecated fallback (with deprecation warning), source order preserved.
- Helper \`resolveDacWireExprToGraphOutput\` extracts \`{instance, output}\` from a ref-shaped expr; numeric output indices resolve to names via \`inst.outputNames\`.
- \`loadProgramAsSession\` and \`mergeProgramIntoSession\` use the helper instead of iterating \`topLevel.audio_outputs\` directly.
- \`saveProgramFromSession\` emits \`outputAssign(name='dac.out', expr=refExpr)\` body entries; \`topLevel.audio_outputs\` is no longer populated.

**\`mcp/wire_dac.test.ts\`**
- Update assertions to inspect \`saved.program.body.assigns\` (the new canonical location) rather than \`saved.program.audio_outputs\`.

## Source-expression restriction
The expr for a dac.out wire must be ref-shaped today (\`{op:'ref',instance,output}\`). Arbitrary expressions (e.g., wiring \`mul(sin1.out, 0.5)\` directly to dac) defer to a later sub-phase. This matches the constraint \`session.graphOutputs\` already enforces.

## What's unchanged
- Schema (\`compiler/schema.ts\`): file-root \`audio_outputs\` field still permitted (deprecated). Schema cleanup deferred — keeping it permissive avoids rejecting pre-A4 patches at validation time.
- FlatPlan, FlatRuntime, JIT, C API: no changes.
- MCP tool surface: \`wire\` to dac.out (A1) unchanged.
- \`session.graphOutputs\` in-memory shape unchanged.

## Test plan
- [x] \`bun test\` — 581 pass, 0 fail across 36 files (was 574 + 7 new in \`program.test.ts\`)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes
- [x] \`apply_plan.test.ts\` golden audio path passes (uses topLevel.audio_outputs in fixtures via deprecation fallback)
- [x] \`mcp/wire_dac.test.ts\` updated and passes

## New tests
- loadProgramAsSession reads body outputAssign(name=\"dac.out\")
- saveProgramFromSession emits dac.out outputAssigns in body, no topLevel.audio_outputs
- round-trip: save then load preserves dac wires
- legacy topLevel.audio_outputs still loads (deprecated fallback)
- body wires + legacy topLevel both contribute (body first)
- non-ref expression in dac.out outputAssign throws
- dac.out with unknown instance throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)