### PR TITLE
feat: drop source-level config; DAC config via start_audio overrides (Phase A5)

### DIFF
--- a/compiler/program.test.ts
+++ b/compiler/program.test.ts
@@ -649,3 +649,34 @@ describe('dac.out body wires (Phase A4)', () => {
     session.graph.dispose()
   })
 })
+
+// ─────────────────────────────────────────────────────────────
+// Source-level config field removed (Phase A5)
+// ─────────────────────────────────────────────────────────────
+
+describe('source-level `config` removed (Phase A5)', () => {
+  test('files with legacy `config` field still parse — Zod strips it silently', () => {
+    const raw = {
+      schema: 'tropical_program_2',
+      name: 'OldPatch',
+      body: { op: 'block', decls: [], assigns: [] },
+      config: { sample_rate: 96000, buffer_length: 1024 },
+    }
+    const parsed = parseProgramV2(raw) as Record<string, unknown>
+    expect(parsed.config).toBeUndefined()
+    expect(parsed.name).toBe('OldPatch')
+  })
+
+  test('saveProgramFromSession does not emit a config field', () => {
+    const session = makeTestSession()
+    const prog: ProgramNode = {
+      op: 'program',
+      name: 'Patch',
+      body: { op: 'block' },
+    }
+    loadProgramAsSession(prog, {}, session)
+    const { topLevel } = saveProgramFromSession(session)
+    expect((topLevel as Record<string, unknown>).config).toBeUndefined()
+    session.graph.dispose()
+  })
+})

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -73,14 +73,18 @@ export interface ProgramNode {
   body: BlockNode
 }
 
-/** Top-level session metadata carried alongside a root program in a v2 file. */
+/** Top-level session metadata carried alongside a root program in a v2 file.
+ *  Both fields are deprecated: post-A3 saves emit params via paramDecl body
+ *  decls, post-A4 saves emit audio_outputs via outputAssign(name='dac.out')
+ *  body assigns. The fields remain in the type for the deprecated read path
+ *  used by pre-A4 patches. (Source-level `config` was removed in A5: sample
+ *  rate and buffer length are runtime/host concerns, not source concerns.) */
 export interface ProgramTopLevel {
   params?: Array<{ name: string; value?: number; time_const?: number; type?: 'param' | 'trigger' }>
   audio_outputs?: Array<
     | { instance: string; output: string | number }
     | { expr: ExprNode }
   >
-  config?: { buffer_length?: number; sample_rate?: number }
 }
 
 /** On-disk `tropical_program_2` file shape: a program plus session metadata. */

--- a/compiler/schema.ts
+++ b/compiler/schema.ts
@@ -159,10 +159,6 @@ export const ProgramFileSchemaV2: z.ZodType = z.lazy(() => z.object({
     z.object({ instance: z.string(), output: z.union([z.string(), z.number()]) }),
     z.object({ expr: ExprNodeSchema }),
   ])).optional(),
-  config: z.object({
-    buffer_length: z.number().int().positive().optional(),
-    sample_rate: z.number().positive().optional(),
-  }).optional(),
 }))
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -617,15 +617,13 @@ export function normalizeProgramFile(
     schema: 'tropical_program_2'
     params?: ProgramTopLevel['params']
     audio_outputs?: ProgramTopLevel['audio_outputs']
-    config?: ProgramTopLevel['config']
   }
-  const { schema: _schema, params, audio_outputs, config, ...progFields } = v2
+  const { schema: _schema, params, audio_outputs, ...progFields } = v2
   void _schema
   const node: ProgramNode = { op: 'program', ...progFields } as unknown as ProgramNode
   const topLevel: ProgramTopLevel = {}
   if (params !== undefined)        topLevel.params        = params
   if (audio_outputs !== undefined) topLevel.audio_outputs = audio_outputs
-  if (config !== undefined)        topLevel.config        = config
   return { node, topLevel }
 }
 
@@ -642,7 +640,6 @@ export function v2NodeToFile(
   const file: Record<string, unknown> = { schema: 'tropical_program_2', ...fields }
   if (topLevel.params !== undefined)        file.params        = topLevel.params
   if (topLevel.audio_outputs !== undefined) file.audio_outputs = topLevel.audio_outputs
-  if (topLevel.config !== undefined)        file.config        = topLevel.config
   return file as { schema: 'tropical_program_2'; [k: string]: unknown }
 }
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -39,6 +39,13 @@ const portTypeOrNull = (t: PortType | undefined): string | null =>
 
 // ─── Session ──────────────────────────────────────────────────────────────────
 
+// Defaults for DAC configuration. Host config — describes the audio device,
+// not anything semantic about the program. Overridable per-call on
+// `start_audio`; once the DAC is created the values are fixed for the
+// runtime's lifetime.
+const DEFAULT_SAMPLE_RATE = 44100
+const DEFAULT_DAC_CHANNELS = 2
+
 const session: SessionState = makeSession()
 loadBuiltins(session.typeRegistry)
 
@@ -297,6 +304,21 @@ function requireInstance(name: string, param: string) {
       options: [...session.instanceRegistry.keys()],
     })
   return inst
+}
+
+/** Validate an optional positive integer arg; fall back to `defaultValue` when
+ *  the arg is undefined. Throws an `invalid_value` envelope on bad input. */
+function validatePositiveInt(value: unknown, param: string, defaultValue: number): number {
+  if (value === undefined || value === null) return defaultValue
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    failBare({
+      code:    'invalid_value',
+      message: `${param} must be a positive integer; got ${JSON.stringify(value)}`,
+      param,
+      value,
+    })
+  }
+  return value as number
 }
 
 function resolveOutputIdx(inst: { outputNames: string[] }, nameOrIdx: string | number): number {
@@ -659,11 +681,13 @@ const TOOLS = [
 
   {
     name: 'start_audio',
-    description: 'Start audio output. Optionally specify a device by name substring.',
+    description: 'Start audio output. Optional: device by name substring; sample_rate (default 44100); channels (default 2). Sample rate and channel count apply only the first time the DAC is created and are fixed thereafter; subsequent calls ignore those overrides.',
     inputSchema: {
       type: 'object',
       properties: {
         device_name: { type: 'string', description: 'Optional partial device name match' },
+        sample_rate: { type: 'integer', minimum: 1, description: 'DAC sample rate in Hz (default 44100). Used only on first DAC creation.' },
+        channels:    { type: 'integer', minimum: 1, description: 'DAC output channel count (default 2). Used only on first DAC creation.' },
       },
     },
   },
@@ -1382,7 +1406,11 @@ function handleTool(name: string, args: Record<string, unknown>) {
     // ── Audio / params (unchanged) ────────────────────────────────────────
 
     case 'start_audio': return wrap(() => {
-      if (!session.dac) session.dac = DAC.fromRuntime(session.runtime._h)
+      if (!session.dac) {
+        const sampleRate = validatePositiveInt(args.sample_rate, 'sample_rate', DEFAULT_SAMPLE_RATE)
+        const channels   = validatePositiveInt(args.channels,    'channels',    DEFAULT_DAC_CHANNELS)
+        session.dac = DAC.fromRuntime(session.runtime._h, sampleRate, channels)
+      }
 
       const deviceName = args.device_name as string | undefined
       if (deviceName) {

--- a/mcp/wire_dac.test.ts
+++ b/mcp/wire_dac.test.ts
@@ -286,3 +286,23 @@ describe('set_output is removed', () => {
     }
   })
 })
+
+describe('start_audio override validation (Phase A5)', () => {
+  test('rejects non-positive sample_rate', async () => {
+    const env = await client.callError('start_audio', { sample_rate: 0 })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('sample_rate')
+  })
+
+  test('rejects non-integer channels', async () => {
+    const env = await client.callError('start_audio', { channels: 1.5 })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('channels')
+  })
+
+  test('rejects negative channels', async () => {
+    const env = await client.callError('start_audio', { channels: -2 })
+    expect(env.code).toBe('invalid_value')
+    expect(env.param).toBe('channels')
+  })
+})


### PR DESCRIPTION
## Summary
- Remove the file-root `config: { buffer_length?, sample_rate? }` field from the source schema. Sample rate, buffer length, and channel count are runtime/host concerns — they describe the audio device the runtime opens, not anything semantic about the program.
- Add optional `sample_rate` and `channels` overrides to the `start_audio` MCP tool. Defaults: 44100 Hz, 2 channels. Validated as positive integers; the request fails with an `invalid_value` envelope on bad input.
- Channel count and sample rate are applied only the first time the DAC is created. Subsequent `start_audio` calls ignore those args — the DAC already exists and its channel count is fixed for the runtime's lifetime.

## Why
Phase A5 of the data-model coherence plan in `create-an-exhaustive-plan-agile-bee.md`. The `config` field was a no-op pass-through (read from JSON, stored on topLevel, written back on save, never used by the kernel or runtime). With params on programs (A3) and audio_outputs as body wires (A4), `config` was the last cosmetic file-root field that didn't belong in source.

## Why `start_audio` overrides instead of env vars
First implementation used env vars (`TROPICAL_SAMPLE_RATE`, `TROPICAL_CHANNELS`) — they work, but they're not discoverable from the MCP tool list, can't be changed without a server restart, and require out-of-band documentation for agents. Putting the knobs on `start_audio` itself makes them discoverable in the tool schema, settable per-session, and documented in the place an agent would look.

Buffer length stays at 512 (the `makeSession` default) and is not exposed on `start_audio` because the Runtime is constructed before `start_audio` is ever called. If buffer length needs to be configurable later, that's a separate change.

## Backward compatibility
Pre-A5 patches with a top-level `config` field still parse cleanly. Zod's default strip behavior silently drops unknown keys at validation time, so old files load with `config` removed from the in-memory representation. No deprecation warning is needed because nothing was reading the field anyway.

## Changes
**`compiler/schema.ts`** — drop `config` from `ProgramFileSchemaV2`.
**`compiler/program.ts`** — drop `config` from `ProgramTopLevel`; update the type doc to record the field's removal.
**`compiler/session.ts`** — `normalizeProgramFile` and `v2NodeToFile` no longer destructure/emit `config`.
**`mcp/server.ts`** — extend `start_audio` schema with `sample_rate` and `channels` (both optional positive integers); `validatePositiveInt` helper; `DEFAULT_SAMPLE_RATE` / `DEFAULT_DAC_CHANNELS` constants; pass validated values to `DAC.fromRuntime` on first creation.

## Test plan
- [x] `bun test` — 586 pass, 0 fail across 36 files (was 581 + 5 new: 2 in `program.test.ts` for schema strip, 3 in `wire_dac.test.ts` for `start_audio` validation)
- [x] `make build && cmake --build build -j4 && ctest --test-dir build` — `module_process` passes
- [x] Pre-A5 patch JSON with `config` field still loads (Zod strips it)

## New tests
- Files with legacy `config` field still parse — Zod strips it silently.
- `saveProgramFromSession` does not emit a config field.
- `start_audio` rejects non-positive sample_rate.
- `start_audio` rejects non-integer channels.
- `start_audio` rejects negative channels.

## Phase A is complete

| Sub-phase | What it did |
|---|---|
| A1 (#108) | `dac.out` boundary leaf in wire resolver, `dac` reserved as instance name |
| A2 (#108) | `set_output` removed |
| A3 (#109) | `paramDecl` body decls + lazy-resolver bug fix |
| A4 (#110) | `audio_outputs` → body `outputAssign(name='dac.out')` wires |
| A5 (this) | Drop source-level `config`; DAC config via `start_audio` overrides |

The data model is coherent: patches are programs, programs declare their own params, audio output is wired through the same machinery as every other port, host config lives where host config belongs. Phase B (`.trop` literate format) is next per `create-an-exhaustive-plan-agile-bee.md` and `/Users/rhizome/.claude/plans/foamy-swimming-rabin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)