### PR TITLE
fix(mcp): pass session (not bare typeRegistry) to loadBuiltins

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -47,7 +47,7 @@ const DEFAULT_SAMPLE_RATE = 44100
 const DEFAULT_DAC_CHANNELS = 2
 
 const session: SessionState = makeSession()
-loadBuiltins(session.typeRegistry)
+loadBuiltins(session)
 
 // Reserved instance name for the audio output boundary leaf. Wires whose
 // destination has `instance === DAC_INSTANCE_NAME` route to session.graphOutputs

--- a/mcp/wire_dac.test.ts
+++ b/mcp/wire_dac.test.ts
@@ -306,3 +306,19 @@ describe('start_audio override validation (Phase A5)', () => {
     expect(env.param).toBe('channels')
   })
 })
+
+describe('generic stdlib types reachable from MCP session', () => {
+  // Regression test for the loadBuiltins(session.typeRegistry) bug: passing
+  // a bare Map made stdlib_loader synthesize a throwaway session, so generic
+  // templates and typeResolver landed there instead of on the real session.
+  // After the fix, generic stdlib types instantiate by name with type_args.
+  test('add_instance with type_args resolves a generic stdlib type', async () => {
+    const data = await client.callOk('add_instance', {
+      program: 'Delay',
+      instance_name: unique('d'),
+      type_args: { N: 4 },
+    })
+    expect(data).toBeDefined()
+    expect((data as { type_args?: Record<string, number> }).type_args?.N).toBe(4)
+  })
+})


### PR DESCRIPTION
## Summary
One-line bug fix in MCP server initialization: \`loadBuiltins(session.typeRegistry)\` → \`loadBuiltins(session)\`. The bare-Map call path triggered the synthesize-throwaway-session branch in \`stdlib_loader.ts:toSession()\`, which routed every generic stdlib type's template (and the \`typeResolver\` itself) into a synthetic object that was unreachable from the real session.

## Why this matters
Every generic stdlib type was unreachable from MCP:
- \`Sequencer<N>\`, \`Delay<N>\`, \`Bubble<N>\`, \`BubbleCloud<N>\`
- \`add_instance\` with a generic program name failed with \`unknown_program\` because the templates lived in a throwaway session

This was masked in tests because \`compiler/program.test.ts:makeTestSession\` calls \`loadBuiltins(session)\` (correct path); only the MCP server hit the broken Map branch.

## How the bug worked
\`stdlib_loader.ts:27-48\`:
\`\`\`ts
function toSession(target: StdlibTarget) {
  if (target instanceof Map) {
    return {
      typeRegistry: target,             // shared with caller
      instanceRegistry: new Map(),      // ← throwaway
      paramRegistry: new Map(),         // ← throwaway
      triggerRegistry: new Map(),       // ← throwaway
      specializationCache: new Map(),   // ← throwaway
      genericTemplates: new Map(),      // ← throwaway, holds Delay<N>, Sequencer<N>, ...
    }
  }
  return target  // pass-through (session-shaped object)
}
\`\`\`

\`loadBuiltins(session.typeRegistry)\` hits the first branch — concrete types end up in the shared Map (visible to the real session), but generic templates end up in the throwaway. \`typeResolver\` is also assigned to the throwaway, so the lazy-load path is broken.

\`loadBuiltins(session)\` hits the pass-through branch — everything lands on the real session.

## Relationship to the A3 lazy-resolver fix
A3 (PR #109) fixed a different bug in \`resolveProgramType\`: re-check \`genericTemplates\` after \`typeResolver\` fires. That fix was correct but couldn't help here because \`session.typeResolver\` was never set in the first place.

## Test plan
- [x] \`bun test\` — 587 pass, 0 fail (was 586 + 1 new regression test)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes
- [x] Manual verification: \`git stash\` the fix → regression test fails with \`unknown_program\` for Delay; restore → passes

## New test
\`mcp/wire_dac.test.ts:generic stdlib types reachable from MCP session\` — \`add_instance({program: 'Delay', type_args: {N: 4}})\` succeeds; verifies the response carries \`type_args: {N: 4}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)