### PR TITLE
feat(parse): statement grammar for .trop body items (Phase B3)

### DIFF
--- a/compiler/parse/statements.test.ts
+++ b/compiler/parse/statements.test.ts
@@ -1,0 +1,332 @@
+/**
+ * statements.test.ts — body-statement parser coverage (Phase B3).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { parseBody, type BlockNode } from './statements.js'
+import { ParseError } from './expressions.js'
+
+describe('body — empty and minimal', () => {
+  test('empty body', () => {
+    expect(parseBody('{}')).toEqual({ op: 'block', decls: [], assigns: [] })
+  })
+
+  test('body with whitespace and comments', () => {
+    expect(parseBody('{ /* nothing */ \n  // also nothing\n }'))
+      .toEqual({ op: 'block', decls: [], assigns: [] })
+  })
+
+  test('trailing input after body rejected', () => {
+    expect(() => parseBody('{} extra')).toThrow(/unexpected trailing/)
+  })
+})
+
+describe('body — regDecl', () => {
+  test('reg without type', () => {
+    const b = parseBody('{ reg s = 0 }')
+    expect(b.decls).toEqual([{ op: 'regDecl', name: 's', init: 0 }])
+  })
+
+  test('reg with type', () => {
+    const b = parseBody('{ reg s: float = 0 }')
+    expect(b.decls).toEqual([{ op: 'regDecl', name: 's', init: 0, type: 'float' }])
+  })
+
+  test('reg with expression init', () => {
+    const b = parseBody('{ reg state: float = 1 + 2 }')
+    expect(b.decls).toHaveLength(1)
+    const d = b.decls[0] as { op: string; name: string; type: string; init: { op: string } }
+    expect(d.op).toBe('regDecl')
+    expect(d.name).toBe('state')
+    expect(d.type).toBe('float')
+    expect(d.init.op).toBe('add')
+  })
+
+  test('reg without `=` rejected', () => {
+    expect(() => parseBody('{ reg s 0 }')).toThrow(ParseError)
+  })
+})
+
+describe('body — delayDecl', () => {
+  test('delay with simple update and init', () => {
+    const b = parseBody('{ delay z = x init 0 }')
+    expect(b.decls).toEqual([
+      { op: 'delayDecl', name: 'z', update: { op: 'nameRef', name: 'x' }, init: 0 },
+    ])
+  })
+
+  test('delay with compound update expression', () => {
+    const b = parseBody('{ delay z = a + b * c init -1 }')
+    expect(b.decls).toHaveLength(1)
+    const d = b.decls[0] as { op: string; name: string; init: number; update: { op: string } }
+    expect(d.op).toBe('delayDecl')
+    expect(d.name).toBe('z')
+    expect(d.init).toBe(-1)
+    expect(d.update.op).toBe('add')
+  })
+
+  test('delay missing `init` keyword rejected', () => {
+    expect(() => parseBody('{ delay z = x 0 }')).toThrow(/expected 'init'/)
+  })
+
+  test('delay missing init value rejected', () => {
+    expect(() => parseBody('{ delay z = x init }')).toThrow(ParseError)
+  })
+})
+
+describe('body — paramDecl', () => {
+  test('smoothed param with default', () => {
+    const b = parseBody('{ param cutoff: smoothed = 1000 }')
+    expect(b.decls).toEqual([
+      { op: 'paramDecl', name: 'cutoff', type: 'param', value: 1000 },
+    ])
+  })
+
+  test('smoothed param without default', () => {
+    const b = parseBody('{ param freq: smoothed }')
+    expect(b.decls).toEqual([
+      { op: 'paramDecl', name: 'freq', type: 'param' },
+    ])
+  })
+
+  test('trigger param', () => {
+    const b = parseBody('{ param fire: trigger }')
+    expect(b.decls).toEqual([
+      { op: 'paramDecl', name: 'fire', type: 'trigger' },
+    ])
+  })
+
+  test('trigger param with default rejected', () => {
+    expect(() => parseBody('{ param fire: trigger = 1 }')).toThrow(/cannot have a default/)
+  })
+
+  test('unknown param kind rejected', () => {
+    expect(() => parseBody('{ param x: knob }')).toThrow(/'smoothed' or 'trigger'/)
+  })
+
+  test('param default must be a number literal', () => {
+    expect(() => parseBody('{ param x: smoothed = a + b }')).toThrow(/number literal/)
+  })
+})
+
+describe('body — nextUpdate', () => {
+  test('register update', () => {
+    const b = parseBody('{ next state = state + 1 }')
+    expect(b.assigns).toEqual([{
+      op: 'nextUpdate',
+      target: { kind: 'reg', name: 'state' },
+      expr: {
+        op: 'add',
+        args: [{ op: 'nameRef', name: 'state' }, 1],
+      },
+    }])
+  })
+
+  test('next without `=` rejected', () => {
+    expect(() => parseBody('{ next x x }')).toThrow(ParseError)
+  })
+})
+
+describe('body — outputAssign', () => {
+  test('simple output assign', () => {
+    const b = parseBody('{ out = sig }')
+    expect(b.assigns).toEqual([{
+      op: 'outputAssign', name: 'out', expr: { op: 'nameRef', name: 'sig' },
+    }])
+  })
+
+  test('output assign with expression rhs', () => {
+    const b = parseBody('{ y = a * x + b }')
+    expect(b.assigns).toHaveLength(1)
+    const a = b.assigns[0] as { op: string; name: string; expr: { op: string } }
+    expect(a.op).toBe('outputAssign')
+    expect(a.name).toBe('y')
+    expect(a.expr.op).toBe('add')
+  })
+
+  test('dac.out wire', () => {
+    const b = parseBody('{ dac.out = osc.sin }')
+    expect(b.assigns).toEqual([{
+      op: 'outputAssign',
+      name: 'dac.out',
+      expr: { op: 'nestedOut', ref: 'osc', output: 'sin' },
+    }])
+  })
+
+  test('dac with wrong port rejected', () => {
+    expect(() => parseBody('{ dac.left = sig }')).toThrow(/only one output port/)
+  })
+})
+
+describe('body — instanceDecl', () => {
+  test('instance with positional-keyword args', () => {
+    const b = parseBody('{ osc = SinOsc(freq: 440) }')
+    expect(b.decls).toEqual([{
+      op: 'instanceDecl',
+      name: 'osc',
+      program: 'SinOsc',
+      inputs: { freq: 440 },
+    }])
+  })
+
+  test('instance with multiple inputs', () => {
+    const b = parseBody('{ filt = OnePole(cutoff: 1000, x: osc.sin) }')
+    const d = b.decls[0] as { op: string; name: string; program: string; inputs: Record<string, unknown> }
+    expect(d.op).toBe('instanceDecl')
+    expect(d.name).toBe('filt')
+    expect(d.program).toBe('OnePole')
+    expect(Object.keys(d.inputs).sort()).toEqual(['cutoff', 'x'])
+    expect(d.inputs.cutoff).toBe(1000)
+    expect(d.inputs.x).toEqual({ op: 'nestedOut', ref: 'osc', output: 'sin' })
+  })
+
+  test('instance with type args', () => {
+    const b = parseBody('{ seq = Sequencer<N=4>(clock: trig) }')
+    expect(b.decls).toEqual([{
+      op: 'instanceDecl',
+      name: 'seq',
+      program: 'Sequencer',
+      type_args: { N: 4 },
+      inputs: { clock: { op: 'nameRef', name: 'trig' } },
+    }])
+  })
+
+  test('instance with multiple type args', () => {
+    const b = parseBody('{ d = Delay<N=4, M=8>()  }')
+    const d = b.decls[0] as { type_args: Record<string, number> }
+    expect(d.type_args).toEqual({ N: 4, M: 8 })
+  })
+
+  test('instance with no inputs', () => {
+    const b = parseBody('{ d = Delay<N=44100>() }')
+    const dd = b.decls[0] as { op: string; inputs?: unknown }
+    expect(dd.op).toBe('instanceDecl')
+    expect(dd.inputs).toBeUndefined()
+  })
+
+  test('non-integer type-arg value rejected', () => {
+    expect(() => parseBody('{ d = Delay<N=4.5>() }')).toThrow(/integer/)
+  })
+
+  test('duplicate input port rejected', () => {
+    expect(() => parseBody('{ x = OnePole(cutoff: 1, cutoff: 2) }')).toThrow(/duplicate instance input/)
+  })
+
+  test('duplicate type-arg name rejected', () => {
+    expect(() => parseBody('{ x = Sequencer<N=4, N=8>() }')).toThrow(/duplicate type-arg/)
+  })
+
+  test('lowercase RHS is treated as outputAssign, not instanceDecl', () => {
+    // `out = sinosc(freq: 440)` would be ambiguous if we matched on the
+    // call shape alone. Capitalization disambiguates.
+    const b = parseBody('{ out = sinosc(440) }')
+    expect(b.assigns).toHaveLength(1)
+    expect(b.decls).toHaveLength(0)
+  })
+})
+
+describe('body — multiple statements', () => {
+  test('mixed decls and assigns', () => {
+    const b = parseBody(`{
+      reg s: float = 0
+      osc = SinOsc(freq: 440)
+      out = osc.sin
+      next s = s + 1
+      dac.out = osc.sin
+    }`)
+    expect(b.decls).toHaveLength(2)
+    expect(b.assigns).toHaveLength(3)
+    expect((b.decls[0] as { op: string }).op).toBe('regDecl')
+    expect((b.decls[1] as { op: string }).op).toBe('instanceDecl')
+    expect((b.assigns[0] as { op: string; name: string }).name).toBe('out')
+    expect((b.assigns[1] as { op: string }).op).toBe('nextUpdate')
+    expect((b.assigns[2] as { op: string; name: string }).name).toBe('dac.out')
+  })
+
+  test('semicolon separators are accepted but optional', () => {
+    const a = parseBody('{ reg s = 0; out = s; next s = s + 1; }')
+    const b = parseBody('{ reg s = 0  out = s  next s = s + 1 }')
+    expect(a).toEqual(b)
+  })
+
+  test('source order of decls preserved', () => {
+    const b = parseBody(`{
+      reg a = 1
+      reg b = 2
+      reg c = 3
+    }`)
+    expect((b.decls as Array<{ name: string }>).map(d => d.name)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('body — realistic stdlib-ish patterns', () => {
+  test('VCA-shaped program (rough)', () => {
+    const b = parseBody(`{
+      out = audio * cv
+    }`)
+    expect(b.assigns).toEqual([{
+      op: 'outputAssign',
+      name: 'out',
+      expr: {
+        op: 'mul',
+        args: [{ op: 'nameRef', name: 'audio' }, { op: 'nameRef', name: 'cv' }],
+      },
+    }])
+  })
+
+  test('OnePole-shaped program (rough)', () => {
+    const b = parseBody(`{
+      reg s: float = 0
+      out = s
+      next s = x * (1 - g) + s * g
+    }`)
+    expect(b.decls).toHaveLength(1)
+    expect(b.assigns).toHaveLength(2)
+    expect((b.decls[0] as { name: string }).name).toBe('s')
+    expect((b.assigns[1] as { op: string }).op).toBe('nextUpdate')
+  })
+
+  test('LadderFilter-shaped program (instance composition)', () => {
+    const b = parseBody(`{
+      delay z = x init 0
+      lp1 = OnePole(x: x - 4 * z, cutoff: cutoff)
+      lp2 = OnePole(x: lp1.out, cutoff: cutoff)
+      out = lp2.out
+    }`)
+    expect(b.decls).toHaveLength(3)  // 1 delay + 2 instances
+    expect(b.assigns).toHaveLength(1)
+    expect((b.decls[0] as { op: string }).op).toBe('delayDecl')
+    expect((b.decls[1] as { op: string; name: string }).name).toBe('lp1')
+    expect((b.decls[2] as { op: string; name: string }).name).toBe('lp2')
+  })
+
+  test('patch with dac.out wiring', () => {
+    const b = parseBody(`{
+      osc = SinOsc(freq: 220)
+      filt = OnePole(x: osc.sin, cutoff: 1000)
+      dac.out = filt.out
+    }`)
+    expect(b.decls).toHaveLength(2)
+    expect(b.assigns).toHaveLength(1)
+    expect((b.assigns[0] as { name: string }).name).toBe('dac.out')
+  })
+})
+
+describe('body — error cases', () => {
+  test('missing closing brace', () => {
+    expect(() => parseBody('{ out = sig')).toThrow(ParseError)
+  })
+
+  test('unknown leading token', () => {
+    expect(() => parseBody('{ 42 }')).toThrow(/expected body item/)
+  })
+
+  test('error positions reflect token line/col', () => {
+    let err: ParseError | undefined
+    try { parseBody('{\n  reg\n}') } catch (e) { err = e as ParseError }
+    expect(err).toBeInstanceOf(ParseError)
+    // `reg` is followed by `}` (after newline), so reg-name expected at the
+    // `}` token (line 3, col 1) — the message carries the position.
+    expect(err?.message).toMatch(/3:1/)
+  })
+})

--- a/compiler/parse/statements.ts
+++ b/compiler/parse/statements.ts
@@ -1,0 +1,340 @@
+/**
+ * statements.ts — body-level statement parser (Phase B3, Stage 2).
+ *
+ * Consumes tokens from the lexer and produces a `BlockNode`-shaped value
+ * with `decls` and `assigns` arrays. Body items are dispatched by their
+ * leading token:
+ *
+ *   reg      → regDecl     (regDecl(name, init, type?))
+ *   delay    → delayDecl   (delayDecl(name, update, init))
+ *   param    → paramDecl   (paramDecl(name, type='param'|'trigger', value?))
+ *   next     → nextUpdate  (target.kind='reg' always — delays carry their
+ *                           update inside delayDecl, not via next)
+ *   dac      → outputAssign(name='dac.out', expr) — boundary leaf wire
+ *   Identifier "=" Capitalized(...)  → instanceDecl
+ *   Identifier "=" expr              → outputAssign(name, expr)
+ *
+ * Statements are separated by optional `;` (or just whitespace — the leading
+ * tokens of each statement are unambiguous).
+ *
+ * Out of scope (later sub-phases):
+ *  - Nested `program` decls (B4)
+ *  - Full port-type grammar with bounds, arrays, generics (B4)
+ *  - Type args on instance decls beyond simple `<N=4>` form (B4)
+ *  - ADTs / match (B5)
+ */
+
+import { tokenize, type Tok, type TokKind } from './lexer.js'
+import { parseExprFromTokens, type ExprNode, ParseError } from './expressions.js'
+
+// ─────────────────────────────────────────────────────────────
+// BlockNode shape — kept loose to avoid a hard dependency on compiler/expr.ts
+// ─────────────────────────────────────────────────────────────
+
+export interface BlockNode {
+  op: 'block'
+  decls: ExprNode[]
+  assigns: ExprNode[]
+}
+
+// ─────────────────────────────────────────────────────────────
+// Parser context
+// ─────────────────────────────────────────────────────────────
+
+interface Ctx {
+  toks: Tok[]
+  i: number
+}
+
+function peek(ctx: Ctx, offset = 0): Tok {
+  return ctx.toks[Math.min(ctx.i + offset, ctx.toks.length - 1)]
+}
+
+function consume(ctx: Ctx, kind: TokKind, what?: string): Tok {
+  const t = ctx.toks[ctx.i]
+  if (t.kind !== kind) {
+    throw new ParseError(`expected ${what ?? kind}, got ${formatTok(t)}`, t)
+  }
+  ctx.i++
+  return t
+}
+
+function eat(ctx: Ctx, kind: TokKind): Tok | null {
+  const t = ctx.toks[ctx.i]
+  if (t.kind !== kind) return null
+  ctx.i++
+  return t
+}
+
+function formatTok(t: Tok): string {
+  if (t.kind === 'eof') return 'end of input'
+  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
+  return `'${t.kind}'`
+}
+
+function isCapitalized(name: string): boolean {
+  return /^[A-Z]/.test(name)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Public entry: parse a body block
+// ─────────────────────────────────────────────────────────────
+
+/** Parse a brace-delimited body block from source text, e.g.
+ *  `{ reg s = 0; out = s; next s = s + 1 }`. Returns a BlockNode. */
+export function parseBody(src: string): BlockNode {
+  const toks = tokenize(src)
+  const ctx: Ctx = { toks, i: 0 }
+  consume(ctx, '{', 'opening `{` of body')
+  const block = parseBodyItems(ctx)
+  consume(ctx, '}', 'closing `}` of body')
+  const trailing = ctx.toks[ctx.i]
+  if (trailing.kind !== 'eof') {
+    throw new ParseError(`unexpected trailing input: ${formatTok(trailing)}`, trailing)
+  }
+  return block
+}
+
+/** Parse the contents of a body block from a token stream, starting at the
+ *  position immediately after the opening `{`. Stops at the matching `}`
+ *  (left for the caller to consume). Used by upper-layer parsers (B4
+ *  declarations) that share a token stream. */
+export function parseBodyFromTokens(toks: Tok[], startIdx: number): { block: BlockNode; nextIdx: number } {
+  const ctx: Ctx = { toks, i: startIdx }
+  const block = parseBodyItems(ctx)
+  return { block, nextIdx: ctx.i }
+}
+
+function parseBodyItems(ctx: Ctx): BlockNode {
+  const decls: ExprNode[] = []
+  const assigns: ExprNode[] = []
+  while (peek(ctx).kind !== '}' && peek(ctx).kind !== 'eof') {
+    const item = parseBodyItem(ctx)
+    if (item.kind === 'decl') decls.push(item.node)
+    else assigns.push(item.node)
+    // Optional `;` separator
+    eat(ctx, ';')
+  }
+  return { op: 'block', decls, assigns }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Body-item dispatch
+// ─────────────────────────────────────────────────────────────
+
+type BodyItem =
+  | { kind: 'decl';   node: ExprNode }
+  | { kind: 'assign'; node: ExprNode }
+
+function parseBodyItem(ctx: Ctx): BodyItem {
+  const t = peek(ctx)
+
+  if (t.kind === 'reg')   return { kind: 'decl',   node: parseRegDecl(ctx) }
+  if (t.kind === 'delay') return { kind: 'decl',   node: parseDelayDecl(ctx) }
+  if (t.kind === 'param') return { kind: 'decl',   node: parseParamDecl(ctx) }
+  if (t.kind === 'next')  return { kind: 'assign', node: parseNextUpdate(ctx) }
+
+  if (t.kind === 'ident') {
+    const name = t.value as string
+    if (name === 'dac') return { kind: 'assign', node: parseDacOutAssign(ctx) }
+    // Lookahead: `name = ...` is either instanceDecl or outputAssign
+    return parseAssignOrInstance(ctx)
+  }
+
+  throw new ParseError(`expected body item, got ${formatTok(t)}`, t)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Decls
+// ─────────────────────────────────────────────────────────────
+
+/** `reg name [: type] = init` */
+function parseRegDecl(ctx: Ctx): ExprNode {
+  consume(ctx, 'reg', 'reg keyword')
+  const name = consume(ctx, 'ident', 'reg name').value as string
+  let type: string | undefined
+  if (eat(ctx, ':')) {
+    type = consume(ctx, 'ident', 'reg type name').value as string
+  }
+  consume(ctx, '=', 'reg `=` before init')
+  const init = parseExpr(ctx)
+  const out: Record<string, unknown> = { op: 'regDecl', name, init }
+  if (type !== undefined) out.type = type
+  return out as ExprNode
+}
+
+/** `delay name = update_expr init init_value` —
+ *  `init` is a contextual keyword (parsed as an ident token). */
+function parseDelayDecl(ctx: Ctx): ExprNode {
+  consume(ctx, 'delay', 'delay keyword')
+  const name = consume(ctx, 'ident', 'delay name').value as string
+  consume(ctx, '=', 'delay `=` before update expression')
+  const update = parseExpr(ctx)
+  // Contextual `init` terminator. The expression parser leaves `init` on
+  // the token stream because identifiers don't extend an expression past
+  // a complete operand.
+  const initTok = peek(ctx)
+  if (initTok.kind !== 'ident' || initTok.value !== 'init') {
+    throw new ParseError(`delay decl: expected 'init' after update expression, got ${formatTok(initTok)}`, initTok)
+  }
+  ctx.i++
+  const init = parseExpr(ctx)
+  return { op: 'delayDecl', name, update, init } as unknown as ExprNode
+}
+
+/** `param name: smoothed|trigger [= default]`.
+ *  Surface kind `smoothed` maps to IR `type: 'param'`; `trigger` is identity.
+ *  ('smoothed' is the surface word because 'param' is reserved as the
+ *  declaration keyword.) */
+function parseParamDecl(ctx: Ctx): ExprNode {
+  consume(ctx, 'param', 'param keyword')
+  const name = consume(ctx, 'ident', 'param name').value as string
+  consume(ctx, ':', 'param `:` before kind')
+  const kindTok = consume(ctx, 'ident', 'param kind (smoothed|trigger)')
+  const kindRaw = kindTok.value as string
+  let irKind: 'param' | 'trigger'
+  if (kindRaw === 'smoothed') irKind = 'param'
+  else if (kindRaw === 'trigger') irKind = 'trigger'
+  else throw new ParseError(`param kind must be 'smoothed' or 'trigger', got '${kindRaw}'`, kindTok)
+  const out: Record<string, unknown> = { op: 'paramDecl', name, type: irKind }
+  if (eat(ctx, '=')) {
+    if (irKind === 'trigger') {
+      throw new ParseError(`trigger params cannot have a default value`, peek(ctx))
+    }
+    const valueExpr = parseExpr(ctx)
+    if (typeof valueExpr !== 'number') {
+      throw new ParseError(`param default must be a number literal`, peek(ctx))
+    }
+    out.value = valueExpr
+  }
+  return out as ExprNode
+}
+
+// ─────────────────────────────────────────────────────────────
+// Assigns
+// ─────────────────────────────────────────────────────────────
+
+/** `next name = expr` — register update.
+ *  Delays carry their update inside delayDecl, so target.kind is always
+ *  'reg' here. */
+function parseNextUpdate(ctx: Ctx): ExprNode {
+  consume(ctx, 'next', 'next keyword')
+  const name = consume(ctx, 'ident', 'next target name').value as string
+  consume(ctx, '=', 'next `=` before expression')
+  const expr = parseExpr(ctx)
+  return {
+    op: 'nextUpdate',
+    target: { kind: 'reg', name },
+    expr,
+  } as unknown as ExprNode
+}
+
+/** `dac.out = expr` — boundary-leaf wire (per A4). */
+function parseDacOutAssign(ctx: Ctx): ExprNode {
+  // The leading 'dac' ident is at peek; consume and verify the dotted form.
+  const dacTok = consume(ctx, 'ident', 'dac')
+  if (dacTok.value !== 'dac') {
+    throw new ParseError(`expected 'dac' for boundary-leaf wire, got ${formatTok(dacTok)}`, dacTok)
+  }
+  consume(ctx, '.', 'dac `.`')
+  const portTok = consume(ctx, 'ident', 'dac port name')
+  if (portTok.value !== 'out') {
+    throw new ParseError(`dac has only one output port: 'out'. Got '${portTok.value}'`, portTok)
+  }
+  consume(ctx, '=', 'dac.out `=` before expression')
+  const expr = parseExpr(ctx)
+  return { op: 'outputAssign', name: 'dac.out', expr } as unknown as ExprNode
+}
+
+/** `name = ...` — either an instanceDecl (RHS is `Capitalized(...)`) or an
+ *  outputAssign (RHS is anything else). */
+function parseAssignOrInstance(ctx: Ctx): BodyItem {
+  const nameTok = consume(ctx, 'ident', 'statement target name')
+  const name = nameTok.value as string
+  consume(ctx, '=', `\`=\` after '${name}'`)
+
+  // Lookahead: is the RHS a capitalized identifier followed by `(` or `<`?
+  // If so, parse as instanceDecl. Otherwise parse as outputAssign expr.
+  const t = peek(ctx)
+  const t2 = peek(ctx, 1)
+  if (t.kind === 'ident' && typeof t.value === 'string' && isCapitalized(t.value)
+      && (t2.kind === '(' || t2.kind === '<')) {
+    return { kind: 'decl', node: parseInstanceRhs(ctx, name) }
+  }
+
+  const expr = parseExpr(ctx)
+  return { kind: 'assign', node: { op: 'outputAssign', name, expr } as unknown as ExprNode }
+}
+
+/** Parse `ProgType[<typeArgs>](port: expr, ...)` — the RHS of an instance
+ *  declaration. `name` is the instance binding's name. */
+function parseInstanceRhs(ctx: Ctx, name: string): ExprNode {
+  const typeTok = consume(ctx, 'ident', 'program type name')
+  const programName = typeTok.value as string
+
+  let typeArgs: Record<string, number> | undefined
+  if (eat(ctx, '<')) {
+    typeArgs = parseTypeArgs(ctx, programName)
+  }
+
+  consume(ctx, '(', `\`(\` after program type '${programName}'`)
+  const inputs = parseInstanceInputs(ctx)
+  consume(ctx, ')', `closing \`)\` of '${programName}' inputs`)
+
+  const out: Record<string, unknown> = { op: 'instanceDecl', name, program: programName }
+  if (typeArgs !== undefined && Object.keys(typeArgs).length > 0) out.type_args = typeArgs
+  if (Object.keys(inputs).length > 0) out.inputs = inputs
+  return out as ExprNode
+}
+
+/** Parse `<key=value, key=value>`. The opening `<` is already consumed. */
+function parseTypeArgs(ctx: Ctx, owner: string): Record<string, number> {
+  const args: Record<string, number> = {}
+  if (peek(ctx).kind === '>') {
+    ctx.i++
+    return args
+  }
+  for (;;) {
+    const k = consume(ctx, 'ident', `${owner}: type-arg name`).value as string
+    consume(ctx, '=', `${owner}: \`=\` after type-arg name '${k}'`)
+    const vTok = consume(ctx, 'num', `${owner}: type-arg value (number literal)`)
+    if (!Number.isInteger(vTok.value)) {
+      throw new ParseError(`${owner}: type-arg '${k}' must be an integer`, vTok)
+    }
+    if (k in args) {
+      throw new ParseError(`${owner}: duplicate type-arg '${k}'`, vTok)
+    }
+    args[k] = vTok.value as number
+    if (eat(ctx, '>')) return args
+    consume(ctx, ',', `${owner}: \`,\` between type-args`)
+  }
+}
+
+/** Parse `(port: expr, port: expr)` — keyword arg form. The `(` is already
+ *  consumed; this stops at the matching `)` (left for the caller). */
+function parseInstanceInputs(ctx: Ctx): Record<string, ExprNode> {
+  const inputs: Record<string, ExprNode> = {}
+  if (peek(ctx).kind === ')') return inputs
+  for (;;) {
+    const portTok = consume(ctx, 'ident', 'instance input port name')
+    const port = portTok.value as string
+    if (port in inputs) {
+      throw new ParseError(`duplicate instance input '${port}'`, portTok)
+    }
+    consume(ctx, ':', `\`:\` after input port '${port}'`)
+    inputs[port] = parseExpr(ctx)
+    if (peek(ctx).kind === ')') return inputs
+    consume(ctx, ',', `\`,\` between instance inputs`)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Expression delegation
+// ─────────────────────────────────────────────────────────────
+
+/** Parse one expression at the current position, advancing the context. */
+function parseExpr(ctx: Ctx): ExprNode {
+  const { node, nextIdx } = parseExprFromTokens(ctx.toks, ctx.i)
+  ctx.i = nextIdx
+  return node
+}


### PR DESCRIPTION
## Summary
Phase B3 — body-level statement parser. Consumes tokens from the lexer, delegates expression parsing to expressions.ts, produces a \`BlockNode\` directly compatible with the existing \`tropical_program_2\` schema. Self-contained library; no integration with existing compiler paths yet.

## Coverage
| Surface | IR |
|---|---|
| \`reg name [: type] = init\` | \`regDecl\` |
| \`delay name = update init <n>\` | \`delayDecl\` |
| \`param name: smoothed [= default]\` | \`paramDecl(type='param')\` |
| \`param name: trigger\` | \`paramDecl(type='trigger')\` |
| \`next name = expr\` | \`nextUpdate(target.kind='reg')\` |
| \`dac.out = expr\` | \`outputAssign(name='dac.out')\` |
| \`name = Capitalized<...>(...)\` | \`instanceDecl\` |
| \`name = expr\` | \`outputAssign\` |

Statements separate by leading-token disambiguation; an optional \`;\` is accepted between them but not required. Capitalization disambiguates \`instanceDecl\` from \`outputAssign\`.

## Surface design choices
- **Param kinds: \`smoothed\` and \`trigger\`** (not \`param\`/\`trigger\` — \`param\` is the declaration keyword). \`smoothed\` maps to IR \`type:'param'\`.
- **Delays carry update inside \`delayDecl\`** (matches stdlib JSON). \`next name = expr\` always targets a register (\`target.kind='reg'\`); the \`kind:'delay'\` branch in the IR is reserved but unused on the surface.
- **\`init\` is a contextual keyword in delay position only.** The expression parser stops at the trailing ident, then the delay-decl parser checks for \`init\` and parses the init value.
- **Type args support \`<N=4, M=8>\`.** Bounds and full port-type grammar deferred to B4.

## What's NOT in this PR
- Nested \`program\` decls and program declaration grammar (B4)
- Full port-type grammar (bounds, arrays in type position, generic decls) (B4)
- ADTs / match (B5)
- Elaborator / pretty-printer / stdlib migration / MCP integration (B6-B9)

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test\` — 739 pass, 0 fail across 40 files (was 697 + 42 new)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes

## Tests added (42)
- regDecl/delayDecl/paramDecl/nextUpdate/outputAssign/instanceDecl: each construct + rejection cases
- Multi-statement bodies (mixed decls/assigns, optional \`;\`, source order)
- Realistic stdlib-shaped patterns (VCA, OnePole, LadderFilter)
- Error positions with line/col info

🤖 Generated with [Claude Code](https://claude.com/claude-code)