### PR TITLE
feat(parse): program declarations + port-type grammar (Phase B4)

### DIFF
--- a/compiler/parse/declarations.test.ts
+++ b/compiler/parse/declarations.test.ts
@@ -1,0 +1,300 @@
+/**
+ * declarations.test.ts — program-declaration parser coverage (Phase B4).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { parseProgram, type ProgramNode, type ProgramPortSpec } from './declarations.js'
+import { ParseError } from './expressions.js'
+
+describe('declarations — minimal program', () => {
+  test('empty body, no ports', () => {
+    expect(parseProgram('program Empty() { }')).toEqual({
+      op: 'program',
+      name: 'Empty',
+      body: { op: 'block', decls: [], assigns: [] },
+    })
+  })
+
+  test('with single output, no body', () => {
+    const p = parseProgram('program Const() -> (out: signal) { out = 0 }')
+    expect(p.name).toBe('Const')
+    expect(p.ports?.outputs).toEqual([{ name: 'out', type: 'signal' }])
+    expect(p.body.assigns).toHaveLength(1)
+  })
+
+  test('with input + output', () => {
+    const p = parseProgram(`
+      program Passthrough(x: signal) -> (y: signal) {
+        y = x
+      }
+    `)
+    expect(p.ports?.inputs).toEqual([{ name: 'x', type: 'signal' }])
+    expect(p.ports?.outputs).toEqual([{ name: 'y', type: 'signal' }])
+  })
+
+  test('trailing input rejected', () => {
+    expect(() => parseProgram('program X() {} extra')).toThrow(/unexpected trailing/)
+  })
+})
+
+describe('declarations — port specs', () => {
+  test('bare-name port (no type, no default)', () => {
+    const p = parseProgram('program X(a, b) -> (out) { out = 0 }')
+    expect(p.ports?.inputs).toEqual(['a', 'b'])
+    expect(p.ports?.outputs).toEqual(['out'])
+  })
+
+  test('input with type and default', () => {
+    const p = parseProgram(`
+      program X(freq: freq = 220) -> (out: signal) { out = 0 }
+    `)
+    expect(p.ports?.inputs).toEqual([{ name: 'freq', type: 'freq', default: 220 }])
+  })
+
+  test('input with bounds', () => {
+    const p = parseProgram(`
+      program X(g: float in [0, 1]) -> (out: signal) { out = 0 }
+    `)
+    expect(p.ports?.inputs).toEqual([
+      { name: 'g', type: 'float', bounds: [0, 1] },
+    ])
+  })
+
+  test('input with default and bounds', () => {
+    const p = parseProgram(`
+      program X(g: float = 0.5 in [0, 1]) -> (out: signal) { out = 0 }
+    `)
+    expect(p.ports?.inputs).toEqual([
+      { name: 'g', type: 'float', default: 0.5, bounds: [0, 1] },
+    ])
+  })
+
+  test('null bound is accepted', () => {
+    const p = parseProgram(`
+      program X(g: float in [null, 1]) -> (out: signal) { out = 0 }
+    `)
+    expect((p.ports!.inputs![0] as ProgramPortSpec).bounds).toEqual([null, 1])
+  })
+
+  test('negative literal bound', () => {
+    const p = parseProgram(`
+      program X(s: float in [-1, 1]) -> (out: signal) { out = 0 }
+    `)
+    expect((p.ports!.inputs![0] as ProgramPortSpec).bounds).toEqual([-1, 1])
+  })
+
+  test('output cannot have a default', () => {
+    expect(() => parseProgram('program X() -> (y: signal = 0) { y = 0 }'))
+      .toThrow(/cannot have a default/)
+  })
+
+  test('mixed bare and typed ports', () => {
+    const p = parseProgram(`
+      program X(a, b: signal, c: float = 1) -> (out: signal) { out = 0 }
+    `)
+    expect(p.ports?.inputs).toEqual([
+      'a',
+      { name: 'b', type: 'signal' },
+      { name: 'c', type: 'float', default: 1 },
+    ])
+  })
+
+  test('multiple outputs', () => {
+    const p = parseProgram(`
+      program X() -> (lp: signal, bp: signal, hp: signal) {
+        lp = 0
+        bp = 0
+        hp = 0
+      }
+    `)
+    expect(p.ports?.outputs).toEqual([
+      { name: 'lp', type: 'signal' },
+      { name: 'bp', type: 'signal' },
+      { name: 'hp', type: 'signal' },
+    ])
+  })
+})
+
+describe('declarations — array port types', () => {
+  test('array with literal shape dim', () => {
+    const p = parseProgram(`
+      program X(buf: float[4]) -> (out: signal) { out = 0 }
+    `)
+    expect((p.ports!.inputs![0] as ProgramPortSpec).type).toEqual({
+      kind: 'array', element: 'float', shape: [4],
+    })
+  })
+
+  test('array with type-param shape dim', () => {
+    const p = parseProgram(`
+      program X<N: int = 8>(buf: float[N]) -> (out: signal) { out = 0 }
+    `)
+    expect((p.ports!.inputs![0] as ProgramPortSpec).type).toEqual({
+      kind: 'array', element: 'float', shape: [{ op: 'typeParam', name: 'N' }],
+    })
+  })
+
+  test('multi-dim array', () => {
+    const p = parseProgram(`
+      program X<N: int = 4, M: int = 8>(buf: float[N, M]) -> (out: signal) { out = 0 }
+    `)
+    expect((p.ports!.inputs![0] as ProgramPortSpec).type).toEqual({
+      kind: 'array', element: 'float',
+      shape: [{ op: 'typeParam', name: 'N' }, { op: 'typeParam', name: 'M' }],
+    })
+  })
+
+  test('array shape with undeclared name rejected', () => {
+    expect(() => parseProgram(`
+      program X(buf: float[K]) -> (out: signal) { out = 0 }
+    `)).toThrow(/not a declared type-param/)
+  })
+
+  test('non-integer literal shape dim rejected', () => {
+    expect(() => parseProgram(`
+      program X(buf: float[2.5]) -> (out: signal) { out = 0 }
+    `)).toThrow(/non-negative integer/)
+  })
+
+  test('empty shape rejected', () => {
+    expect(() => parseProgram(`
+      program X(buf: float[]) -> (out: signal) { out = 0 }
+    `)).toThrow(/at least one shape dim/)
+  })
+})
+
+describe('declarations — type params', () => {
+  test('single type-param with default', () => {
+    const p = parseProgram('program X<N: int = 8>() -> (out) { out = 0 }')
+    expect(p.type_params).toEqual({ N: { type: 'int', default: 8 } })
+  })
+
+  test('type-param without default', () => {
+    const p = parseProgram('program X<N: int>() -> (out) { out = 0 }')
+    expect(p.type_params).toEqual({ N: { type: 'int' } })
+  })
+
+  test('multiple type-params', () => {
+    const p = parseProgram('program X<N: int = 4, M: int>() -> (out) { out = 0 }')
+    expect(p.type_params).toEqual({
+      N: { type: 'int', default: 4 },
+      M: { type: 'int' },
+    })
+  })
+
+  test('non-int type-param rejected', () => {
+    expect(() => parseProgram('program X<N: float>() -> (out) { out = 0 }'))
+      .toThrow(/must be 'int'/)
+  })
+
+  test('non-integer default rejected', () => {
+    expect(() => parseProgram('program X<N: int = 8.5>() -> (out) { out = 0 }'))
+      .toThrow(/must be an integer/)
+  })
+
+  test('duplicate type-param rejected', () => {
+    expect(() => parseProgram('program X<N: int, N: int>() -> (out) { out = 0 }'))
+      .toThrow(/duplicate type-param/)
+  })
+
+  test('empty type-params <> parses cleanly (degenerate case)', () => {
+    const p = parseProgram('program X<>() -> (out) { out = 0 }')
+    // type_params is omitted from the node when empty
+    expect(p.type_params).toBeUndefined()
+  })
+})
+
+describe('declarations — body integration', () => {
+  test('body with regs, instances, assigns', () => {
+    const p = parseProgram(`
+      program OnePole(x: signal, g: float = 0.5) -> (y: signal) {
+        reg s: float = 0
+        y = s
+        next s = x * (1 - g) + s * g
+      }
+    `)
+    expect(p.body.decls).toHaveLength(1)
+    expect(p.body.assigns).toHaveLength(2)
+  })
+
+  test('body uses dac.out wire', () => {
+    const p = parseProgram(`
+      program Patch() {
+        osc = SinOsc(freq: 220)
+        dac.out = osc.sin
+      }
+    `)
+    expect(p.body.decls).toHaveLength(1)
+    expect(p.body.assigns).toHaveLength(1)
+    const assign = p.body.assigns[0] as { name: string }
+    expect(assign.name).toBe('dac.out')
+  })
+})
+
+describe('declarations — nested programs', () => {
+  test('single nested program', () => {
+    const p = parseProgram(`
+      program Outer() -> (out: signal) {
+        program Inner(x: signal) -> (y: signal) {
+          y = x
+        }
+        i = Inner(x: 0)
+        out = i.y
+      }
+    `)
+    expect(p.body.decls).toHaveLength(2)  // programDecl + instanceDecl
+    const programDecl = p.body.decls[0] as { op: string; name: string; program: ProgramNode }
+    expect(programDecl.op).toBe('programDecl')
+    expect(programDecl.name).toBe('Inner')
+    expect(programDecl.program.name).toBe('Inner')
+    expect(programDecl.program.body.assigns).toHaveLength(1)
+  })
+
+  test('nested type-param scope is independent', () => {
+    // Outer N=8; inner re-declares N=4. Inner's body should see N=4.
+    const p = parseProgram(`
+      program Outer<N: int = 8>() {
+        program Inner<N: int = 4>(buf: float[N]) -> (out) { out = 0 }
+      }
+    `)
+    const inner = (p.body.decls[0] as { program: ProgramNode }).program
+    expect(inner.type_params).toEqual({ N: { type: 'int', default: 4 } })
+    const buf = inner.ports!.inputs![0] as ProgramPortSpec
+    // Should reference N (resolved against inner scope, not outer)
+    expect(buf.type).toEqual({
+      kind: 'array', element: 'float', shape: [{ op: 'typeParam', name: 'N' }],
+    })
+  })
+
+  test('multiple sibling nested programs', () => {
+    const p = parseProgram(`
+      program Outer() {
+        program A() -> (out) { out = 0 }
+        program B() -> (out) { out = 0 }
+      }
+    `)
+    expect(p.body.decls).toHaveLength(2)
+    expect((p.body.decls[0] as { name: string }).name).toBe('A')
+    expect((p.body.decls[1] as { name: string }).name).toBe('B')
+  })
+})
+
+describe('declarations — error cases', () => {
+  test('missing program name', () => {
+    expect(() => parseProgram('program () { }')).toThrow(ParseError)
+  })
+
+  test('missing opening paren', () => {
+    expect(() => parseProgram('program X { }')).toThrow(ParseError)
+  })
+
+  test('missing body', () => {
+    expect(() => parseProgram('program X()')).toThrow(ParseError)
+  })
+
+  test('error position info', () => {
+    let err: ParseError | undefined
+    try { parseProgram('program X(\n  bad: 0\n)') } catch (e) { err = e as ParseError }
+    expect(err).toBeInstanceOf(ParseError)
+  })
+})

--- a/compiler/parse/declarations.ts
+++ b/compiler/parse/declarations.ts
@@ -1,0 +1,374 @@
+/**
+ * declarations.ts — program-declaration grammar (Phase B4, Stage 3).
+ *
+ * Parses a top-level program declaration:
+ *
+ *   program Name<TypeParams>(InputPorts) -> (OutputPorts) { body }
+ *
+ * Produces a `ProgramNode`-shaped value matching the existing
+ * `tropical_program_2` schema:
+ *
+ *   {
+ *     op: 'program',
+ *     name: string,
+ *     type_params?: { N: { type: 'int', default?: number }, ... },
+ *     ports?: {
+ *       inputs?:  Array<string | { name, type?, default?, bounds? }>,
+ *       outputs?: Array<string | { name, type?, bounds? }>,
+ *     },
+ *     body: BlockNode,
+ *   }
+ *
+ * Nested program decls inside a body are wrapped as
+ * `{ op: 'programDecl', name: <inner program name>, program: ProgramNode }`.
+ *
+ * Surface coverage:
+ *  - Type params: `<N: int = 8, M: int>` (optional default)
+ *  - Port type: bare scalar identifiers (e.g. `signal`, `float`, `freq`),
+ *    array form `Element[Shape...]` where each shape dim is a number
+ *    literal or an identifier (resolved as `typeParam` at parse time
+ *    since the parser tracks declared type-param names from the header)
+ *  - Bounds: `in [lo, hi]` after a port type
+ *  - Input ports: `name: type [= default] [in [lo, hi]]`; outputs omit
+ *    the default
+ *  - Bare-name ports (just `name`) emit a string entry
+ *  - Nested `program` decls in body, recursive
+ *
+ * Out of scope (deferred to B5): ADTs and `match` (`type_defs` field).
+ */
+
+import { tokenize, type Tok, type TokKind } from './lexer.js'
+import { parseExprFromTokens, type ExprNode, ParseError } from './expressions.js'
+import { parseBodyFromTokens, type BlockNode, type BodyOptions } from './statements.js'
+
+// ─────────────────────────────────────────────────────────────
+// ProgramNode shape — kept loose to avoid cycles with compiler/program.ts
+// ─────────────────────────────────────────────────────────────
+
+export type ShapeDim = number | { op: 'typeParam'; name: string }
+
+export type PortTypeDecl = string | { kind: 'array'; element: string; shape: ShapeDim[] }
+
+export interface ProgramPortSpec {
+  name: string
+  type?: PortTypeDecl
+  default?: ExprNode
+  bounds?: [number | null, number | null]
+}
+
+export type ProgramPort = string | ProgramPortSpec
+
+export interface ProgramPorts {
+  inputs?: ProgramPort[]
+  outputs?: ProgramPort[]
+}
+
+export interface ProgramNode {
+  op: 'program'
+  name: string
+  type_params?: Record<string, { type: 'int'; default?: number }>
+  ports?: ProgramPorts
+  body: BlockNode
+}
+
+// ─────────────────────────────────────────────────────────────
+// Parser context
+// ─────────────────────────────────────────────────────────────
+
+interface Ctx {
+  toks: Tok[]
+  i: number
+  /** Type-param names in scope at the current point. Populated when a
+   *  program header declares `<N: int, ...>`. Used by the port-type
+   *  parser to recognize array shapes like `float[N]` as
+   *  `{op:'typeParam',name:'N'}` rather than a bare name. */
+  typeParams: Set<string>
+}
+
+function peek(ctx: Ctx, offset = 0): Tok {
+  return ctx.toks[Math.min(ctx.i + offset, ctx.toks.length - 1)]
+}
+
+function consume(ctx: Ctx, kind: TokKind, what?: string): Tok {
+  const t = ctx.toks[ctx.i]
+  if (t.kind !== kind) {
+    throw new ParseError(`expected ${what ?? kind}, got ${formatTok(t)}`, t)
+  }
+  ctx.i++
+  return t
+}
+
+function eat(ctx: Ctx, kind: TokKind): Tok | null {
+  const t = ctx.toks[ctx.i]
+  if (t.kind !== kind) return null
+  ctx.i++
+  return t
+}
+
+function formatTok(t: Tok): string {
+  if (t.kind === 'eof') return 'end of input'
+  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
+  return `'${t.kind}'`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Public entry points
+// ─────────────────────────────────────────────────────────────
+
+/** Parse a top-level program declaration from source text. */
+export function parseProgram(src: string): ProgramNode {
+  const toks = tokenize(src)
+  const ctx: Ctx = { toks, i: 0, typeParams: new Set() }
+  const node = parseProgramFromCtx(ctx)
+  const trailing = ctx.toks[ctx.i]
+  if (trailing.kind !== 'eof') {
+    throw new ParseError(`unexpected trailing input after program: ${formatTok(trailing)}`, trailing)
+  }
+  return node
+}
+
+/** Parse a program declaration starting at the given token index. Used by
+ *  the body parser via the BodyOptions.programDeclParser callback for
+ *  nested program decls. */
+export function parseProgramFromTokens(
+  toks: Tok[], startIdx: number,
+): { node: ProgramNode; nextIdx: number } {
+  const ctx: Ctx = { toks, i: startIdx, typeParams: new Set() }
+  const node = parseProgramFromCtx(ctx)
+  return { node, nextIdx: ctx.i }
+}
+
+/** Body-parser hook: parse a nested `program` decl and wrap it as a
+ *  `programDecl` body item. */
+function parseNestedProgramDecl(
+  toks: Tok[], startIdx: number,
+): { node: ExprNode; nextIdx: number } {
+  const { node: inner, nextIdx } = parseProgramFromTokens(toks, startIdx)
+  return {
+    node: { op: 'programDecl', name: inner.name, program: inner } as unknown as ExprNode,
+    nextIdx,
+  }
+}
+
+const NESTED_PROGRAM_OPTS: BodyOptions = { programDeclParser: parseNestedProgramDecl }
+
+// ─────────────────────────────────────────────────────────────
+// Program-declaration parser
+// ─────────────────────────────────────────────────────────────
+
+function parseProgramFromCtx(ctx: Ctx): ProgramNode {
+  consume(ctx, 'program', 'program keyword')
+  const nameTok = consume(ctx, 'ident', 'program name')
+  const name = nameTok.value as string
+
+  // Type params (optional)
+  let typeParams: Record<string, { type: 'int'; default?: number }> | undefined
+  if (peek(ctx).kind === '<') {
+    typeParams = parseTypeParams(ctx)
+    for (const tp of Object.keys(typeParams)) ctx.typeParams.add(tp)
+  }
+
+  // Input ports
+  consume(ctx, '(', `\`(\` after program name '${name}'`)
+  const inputs = parsePortList(ctx, /*allowDefault=*/ true)
+  consume(ctx, ')', `closing \`)\` of inputs for '${name}'`)
+
+  // Outputs (optional — defaults to [] if omitted)
+  let outputs: ProgramPort[] | undefined
+  if (eat(ctx, '->')) {
+    consume(ctx, '(', `\`(\` after \`->\` for '${name}'`)
+    outputs = parsePortList(ctx, /*allowDefault=*/ false)
+    consume(ctx, ')', `closing \`)\` of outputs for '${name}'`)
+  }
+
+  // Body
+  consume(ctx, '{', `\`{\` opening body of '${name}'`)
+  const { block, nextIdx } = parseBodyFromTokens(ctx.toks, ctx.i, NESTED_PROGRAM_OPTS)
+  ctx.i = nextIdx
+  consume(ctx, '}', `\`}\` closing body of '${name}'`)
+
+  // Pop type params from scope (each program declaration introduces its own)
+  if (typeParams) {
+    for (const tp of Object.keys(typeParams)) ctx.typeParams.delete(tp)
+  }
+
+  const node: ProgramNode = { op: 'program', name, body: block }
+  if (typeParams && Object.keys(typeParams).length > 0) node.type_params = typeParams
+  const ports: ProgramPorts = {}
+  if (inputs.length > 0)  ports.inputs  = inputs
+  if (outputs && outputs.length > 0) ports.outputs = outputs
+  if (ports.inputs || ports.outputs) node.ports = ports
+  return node
+}
+
+// ─────────────────────────────────────────────────────────────
+// Type params: <N: int [= default], M: int>
+// ─────────────────────────────────────────────────────────────
+
+function parseTypeParams(ctx: Ctx): Record<string, { type: 'int'; default?: number }> {
+  consume(ctx, '<', 'opening `<` of type params')
+  const out: Record<string, { type: 'int'; default?: number }> = {}
+  if (eat(ctx, '>')) return out
+  for (;;) {
+    const nameTok = consume(ctx, 'ident', 'type-param name')
+    const name = nameTok.value as string
+    if (name in out) {
+      throw new ParseError(`duplicate type-param '${name}'`, nameTok)
+    }
+    consume(ctx, ':', `\`:\` after type-param '${name}'`)
+    const typeTok = consume(ctx, 'ident', `type-param '${name}' type`)
+    const typeName = typeTok.value as string
+    if (typeName !== 'int') {
+      throw new ParseError(`type-param '${name}' type must be 'int', got '${typeName}'`, typeTok)
+    }
+    const entry: { type: 'int'; default?: number } = { type: 'int' }
+    if (eat(ctx, '=')) {
+      const defTok = consume(ctx, 'num', `default for type-param '${name}'`)
+      if (!Number.isInteger(defTok.value)) {
+        throw new ParseError(`type-param '${name}' default must be an integer`, defTok)
+      }
+      entry.default = defTok.value as number
+    }
+    out[name] = entry
+    if (eat(ctx, '>')) return out
+    consume(ctx, ',', '`,` between type params')
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Port lists and port specs
+// ─────────────────────────────────────────────────────────────
+
+function parsePortList(ctx: Ctx, allowDefault: boolean): ProgramPort[] {
+  const out: ProgramPort[] = []
+  if (peek(ctx).kind === ')') return out
+  for (;;) {
+    out.push(parsePortSpec(ctx, allowDefault))
+    if (peek(ctx).kind === ')') return out
+    consume(ctx, ',', '`,` between port specs')
+  }
+}
+
+/** Parse one port spec. Forms (input):
+ *    name
+ *    name: type
+ *    name: type = default
+ *    name: type in [lo, hi]
+ *    name: type = default in [lo, hi]
+ *  Outputs accept the same forms minus `= default`.
+ *  When the spec has only a name (no type, default, or bounds), emits the
+ *  bare-string form to match stdlib JSON convention. */
+function parsePortSpec(ctx: Ctx, allowDefault: boolean): ProgramPort {
+  const nameTok = consume(ctx, 'ident', 'port name')
+  const name = nameTok.value as string
+
+  if (peek(ctx).kind !== ':') {
+    return name  // bare-string form
+  }
+  ctx.i++  // consume `:`
+
+  const type = parsePortType(ctx)
+  let defaultExpr: ExprNode | undefined
+  let bounds: [number | null, number | null] | undefined
+
+  // Optional `= default` (inputs only)
+  if (peek(ctx).kind === '=') {
+    if (!allowDefault) {
+      throw new ParseError(`output ports cannot have a default value`, peek(ctx))
+    }
+    ctx.i++
+    defaultExpr = parseExprAt(ctx)
+  }
+
+  // Optional `in [lo, hi]`
+  if (peek(ctx).kind === 'in') {
+    ctx.i++
+    bounds = parseBounds(ctx)
+  }
+
+  const spec: ProgramPortSpec = { name, type }
+  if (defaultExpr !== undefined) spec.default = defaultExpr
+  if (bounds !== undefined) spec.bounds = bounds
+  return spec
+}
+
+/** Parse a port type:
+ *    Identifier                — bare scalar (e.g. `signal`, `float`, `freq`)
+ *    Identifier[Dim, ...]      — array with shape dims (numeric or typeParam)
+ *  The opening identifier is the element-type name. Anything else throws. */
+function parsePortType(ctx: Ctx): PortTypeDecl {
+  const elemTok = consume(ctx, 'ident', 'port type name')
+  const element = elemTok.value as string
+  if (peek(ctx).kind !== '[') return element
+
+  ctx.i++  // consume `[`
+  const shape: ShapeDim[] = []
+  if (peek(ctx).kind !== ']') {
+    shape.push(parseShapeDim(ctx))
+    while (eat(ctx, ',')) {
+      shape.push(parseShapeDim(ctx))
+    }
+  }
+  consume(ctx, ']', `closing \`]\` of array type`)
+  if (shape.length === 0) {
+    throw new ParseError(`array type must have at least one shape dim`, elemTok)
+  }
+  return { kind: 'array', element, shape }
+}
+
+function parseShapeDim(ctx: Ctx): ShapeDim {
+  const t = peek(ctx)
+  if (t.kind === 'num') {
+    ctx.i++
+    if (!Number.isInteger(t.value) || (t.value as number) < 0) {
+      throw new ParseError(`array shape dim must be a non-negative integer`, t)
+    }
+    return t.value as number
+  }
+  if (t.kind === 'ident') {
+    ctx.i++
+    const name = t.value as string
+    if (!ctx.typeParams.has(name)) {
+      throw new ParseError(
+        `array shape dim '${name}' is not a declared type-param of the enclosing program`, t,
+      )
+    }
+    return { op: 'typeParam', name }
+  }
+  throw new ParseError(`expected number or type-param name in array shape, got ${formatTok(t)}`, t)
+}
+
+/** Parse `[lo, hi]` after `in`. Each side may be `null` (sentinel) to
+ *  indicate "no bound on this side", or a number literal (signed). */
+function parseBounds(ctx: Ctx): [number | null, number | null] {
+  consume(ctx, '[', '`[` opening bounds')
+  const lo = parseBound(ctx)
+  consume(ctx, ',', '`,` between bound lo/hi')
+  const hi = parseBound(ctx)
+  consume(ctx, ']', '`]` closing bounds')
+  return [lo, hi]
+}
+
+function parseBound(ctx: Ctx): number | null {
+  const t = peek(ctx)
+  if (t.kind === 'ident' && t.value === 'null') {
+    ctx.i++
+    return null
+  }
+  // Allow `-1.0` etc. via expression parsing + literal extraction.
+  const expr = parseExprAt(ctx)
+  if (typeof expr !== 'number') {
+    throw new ParseError(`bound must be a number literal or 'null'`, t)
+  }
+  return expr
+}
+
+// ─────────────────────────────────────────────────────────────
+// Expression delegation
+// ─────────────────────────────────────────────────────────────
+
+function parseExprAt(ctx: Ctx): ExprNode {
+  const { node, nextIdx } = parseExprFromTokens(ctx.toks, ctx.i)
+  ctx.i = nextIdx
+  return node
+}

--- a/compiler/parse/statements.ts
+++ b/compiler/parse/statements.ts
@@ -38,12 +38,30 @@ export interface BlockNode {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Body-parser options
+// ─────────────────────────────────────────────────────────────
+
+/** Optional dependency-injection slot for nested-program parsing.
+ *  declarations.ts (Phase B4) passes its program-decl parser via this
+ *  callback so that bodies can contain `programDecl` entries. Without
+ *  this hook a `program` keyword inside a body raises a parse error. */
+export interface BodyOptions {
+  /** Called when the body parser encounters a `program` keyword as the
+   *  leading token of a new body item. Receives the shared token stream
+   *  plus the current index; must consume tokens through the program's
+   *  closing `}` and return a `programDecl`-shaped ExprNode plus the
+   *  next-token index. */
+  programDeclParser?: (toks: Tok[], i: number) => { node: ExprNode; nextIdx: number }
+}
+
+// ─────────────────────────────────────────────────────────────
 // Parser context
 // ─────────────────────────────────────────────────────────────
 
 interface Ctx {
   toks: Tok[]
   i: number
+  opts: BodyOptions
 }
 
 function peek(ctx: Ctx, offset = 0): Tok {
@@ -81,10 +99,11 @@ function isCapitalized(name: string): boolean {
 // ─────────────────────────────────────────────────────────────
 
 /** Parse a brace-delimited body block from source text, e.g.
- *  `{ reg s = 0; out = s; next s = s + 1 }`. Returns a BlockNode. */
-export function parseBody(src: string): BlockNode {
+ *  `{ reg s = 0; out = s; next s = s + 1 }`. Returns a BlockNode.
+ *  Pass `opts.programDeclParser` to enable nested `program` decls. */
+export function parseBody(src: string, opts: BodyOptions = {}): BlockNode {
   const toks = tokenize(src)
-  const ctx: Ctx = { toks, i: 0 }
+  const ctx: Ctx = { toks, i: 0, opts }
   consume(ctx, '{', 'opening `{` of body')
   const block = parseBodyItems(ctx)
   consume(ctx, '}', 'closing `}` of body')
@@ -99,8 +118,10 @@ export function parseBody(src: string): BlockNode {
  *  position immediately after the opening `{`. Stops at the matching `}`
  *  (left for the caller to consume). Used by upper-layer parsers (B4
  *  declarations) that share a token stream. */
-export function parseBodyFromTokens(toks: Tok[], startIdx: number): { block: BlockNode; nextIdx: number } {
-  const ctx: Ctx = { toks, i: startIdx }
+export function parseBodyFromTokens(
+  toks: Tok[], startIdx: number, opts: BodyOptions = {},
+): { block: BlockNode; nextIdx: number } {
+  const ctx: Ctx = { toks, i: startIdx, opts }
   const block = parseBodyItems(ctx)
   return { block, nextIdx: ctx.i }
 }
@@ -133,6 +154,17 @@ function parseBodyItem(ctx: Ctx): BodyItem {
   if (t.kind === 'delay') return { kind: 'decl',   node: parseDelayDecl(ctx) }
   if (t.kind === 'param') return { kind: 'decl',   node: parseParamDecl(ctx) }
   if (t.kind === 'next')  return { kind: 'assign', node: parseNextUpdate(ctx) }
+
+  if (t.kind === 'program') {
+    if (!ctx.opts.programDeclParser) {
+      throw new ParseError(
+        `nested 'program' decl is not supported in this parser context`, t,
+      )
+    }
+    const { node, nextIdx } = ctx.opts.programDeclParser(ctx.toks, ctx.i)
+    ctx.i = nextIdx
+    return { kind: 'decl', node }
+  }
 
   if (t.kind === 'ident') {
     const name = t.value as string


### PR DESCRIPTION
## Summary
Phase B4 — program-declaration parser. Produces a \`ProgramNode\` matching the existing \`tropical_program_2\` schema. Reuses the body parser from B3, wired up to recognize nested \`program\` decls via an injected callback.

## Surface
\`\`\`
program Name<TypeParams>(InputPorts) -> (OutputPorts) { body }
\`\`\`

| Feature | Form |
|---|---|
| Type params | \`<N: int = 8, M: int>\` |
| Bare-name port | \`name\` |
| Typed port | \`name: type\` |
| Default | \`name: type = expr\` (inputs only) |
| Bounds | \`name: type in [lo, hi]\` |
| Array type | \`Element[Dim, ...]\` (Dim is a literal or type-param) |
| Nested program | \`program Inner(...) { ... }\` inside a body |

## Cross-module wiring
\`statements.ts\` (B3) gains an optional \`BodyOptions.programDeclParser\` callback. When the body parser sees \`program\`, it delegates to the callback. \`declarations.ts\` passes its \`parseNestedProgramDecl\` as the callback. No circular import — the callback is injected at call-time.

## What's NOT in this PR
- ADTs / \`match\` / \`type_defs\` (B5)
- Elaborator (B6) — converts \`nameRef\` placeholders to scope-resolved ops
- Pretty-printer (B7), stdlib migration (B8), MCP integration (B9)

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test\` — 774 pass, 0 fail across 41 files (was 739 + 35 new)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes

## Notable test coverage
- Array shape with undeclared type-param name → rejected
- Inner nested program's \`N\` shadows outer \`N\` (independent type-param scopes)
- Output port with default → rejected
- Negative-literal bounds work via B2's constant-folding (\`-1\` parses as a number, not \`neg(1)\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)