### PR TITLE
refactor(parse): table-driven lexer + shared parser helpers

### DIFF
--- a/compiler/parse/declarations.ts
+++ b/compiler/parse/declarations.ts
@@ -37,9 +37,10 @@
  * Out of scope (deferred to B5): ADTs and `match` (`type_defs` field).
  */
 
-import { tokenize, type Tok, type TokKind } from './lexer.js'
-import { parseExprFromTokens, type ExprNode, ParseError } from './expressions.js'
+import { tokenize, type Tok } from './lexer.js'
+import { parseExprFromTokens, type ExprNode } from './expressions.js'
 import { parseBodyFromTokens, type BlockNode, type BodyOptions } from './statements.js'
+import { commaList, consume, eat, formatTok, isContextualKw, peek, ParseError, type Cursor } from './shared.js'
 
 // ─────────────────────────────────────────────────────────────
 // ProgramNode shape — kept loose to avoid cycles with compiler/program.ts
@@ -75,40 +76,12 @@ export interface ProgramNode {
 // Parser context
 // ─────────────────────────────────────────────────────────────
 
-interface Ctx {
-  toks: Tok[]
-  i: number
+interface Ctx extends Cursor {
   /** Type-param names in scope at the current point. Populated when a
    *  program header declares `<N: int, ...>`. Used by the port-type
    *  parser to recognize array shapes like `float[N]` as
    *  `{op:'typeParam',name:'N'}` rather than a bare name. */
   typeParams: Set<string>
-}
-
-function peek(ctx: Ctx, offset = 0): Tok {
-  return ctx.toks[Math.min(ctx.i + offset, ctx.toks.length - 1)]
-}
-
-function consume(ctx: Ctx, kind: TokKind, what?: string): Tok {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) {
-    throw new ParseError(`expected ${what ?? kind}, got ${formatTok(t)}`, t)
-  }
-  ctx.i++
-  return t
-}
-
-function eat(ctx: Ctx, kind: TokKind): Tok | null {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) return null
-  ctx.i++
-  return t
-}
-
-function formatTok(t: Tok): string {
-  if (t.kind === 'eof') return 'end of input'
-  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
-  return `'${t.kind}'`
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -208,8 +181,7 @@ function parseProgramFromCtx(ctx: Ctx): ProgramNode {
 function parseTypeParams(ctx: Ctx): Record<string, { type: 'int'; default?: number }> {
   consume(ctx, '<', 'opening `<` of type params')
   const out: Record<string, { type: 'int'; default?: number }> = {}
-  if (eat(ctx, '>')) return out
-  for (;;) {
+  commaList(ctx, '>', () => {
     const nameTok = consume(ctx, 'ident', 'type-param name')
     const name = nameTok.value as string
     if (name in out) {
@@ -230,9 +202,9 @@ function parseTypeParams(ctx: Ctx): Record<string, { type: 'int'; default?: numb
       entry.default = defTok.value as number
     }
     out[name] = entry
-    if (eat(ctx, '>')) return out
-    consume(ctx, ',', '`,` between type params')
-  }
+  })
+  consume(ctx, '>', 'closing `>` of type params')
+  return out
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -240,13 +212,7 @@ function parseTypeParams(ctx: Ctx): Record<string, { type: 'int'; default?: numb
 // ─────────────────────────────────────────────────────────────
 
 function parsePortList(ctx: Ctx, allowDefault: boolean): ProgramPort[] {
-  const out: ProgramPort[] = []
-  if (peek(ctx).kind === ')') return out
-  for (;;) {
-    out.push(parsePortSpec(ctx, allowDefault))
-    if (peek(ctx).kind === ')') return out
-    consume(ctx, ',', '`,` between port specs')
-  }
+  return commaList(ctx, ')', () => parsePortSpec(ctx, allowDefault))
 }
 
 /** Parse one port spec. Forms (input):
@@ -302,13 +268,7 @@ function parsePortType(ctx: Ctx): PortTypeDecl {
   if (peek(ctx).kind !== '[') return element
 
   ctx.i++  // consume `[`
-  const shape: ShapeDim[] = []
-  if (peek(ctx).kind !== ']') {
-    shape.push(parseShapeDim(ctx))
-    while (eat(ctx, ',')) {
-      shape.push(parseShapeDim(ctx))
-    }
-  }
+  const shape = commaList(ctx, ']', () => parseShapeDim(ctx))
   consume(ctx, ']', `closing \`]\` of array type`)
   if (shape.length === 0) {
     throw new ParseError(`array type must have at least one shape dim`, elemTok)
@@ -351,7 +311,7 @@ function parseBounds(ctx: Ctx): [number | null, number | null] {
 
 function parseBound(ctx: Ctx): number | null {
   const t = peek(ctx)
-  if (t.kind === 'ident' && t.value === 'null') {
+  if (isContextualKw(t, 'null')) {
     ctx.i++
     return null
   }

--- a/compiler/parse/expressions.ts
+++ b/compiler/parse/expressions.ts
@@ -29,6 +29,9 @@
  */
 
 import { tokenize, type Tok, type TokKind } from './lexer.js'
+import { commaList, consume, eat, formatTok, peek, withScope, ParseError, type Cursor } from './shared.js'
+
+export { ParseError }
 
 // ─────────────────────────────────────────────────────────────
 // ExprNode local type — kept loose so we don't import from compiler/expr.ts
@@ -41,52 +44,14 @@ export type ExprNode =
   | { op: string; [k: string]: unknown }
 
 // ─────────────────────────────────────────────────────────────
-// Parse error
-// ─────────────────────────────────────────────────────────────
-
-export class ParseError extends Error {
-  constructor(message: string, public tok: Tok) {
-    super(`${tok.line}:${tok.col}: ${message}`)
-  }
-}
-
-// ─────────────────────────────────────────────────────────────
 // Parser context
 // ─────────────────────────────────────────────────────────────
 
-interface Ctx {
-  toks: Tok[]
-  i: number
+interface Ctx extends Cursor {
   /** Names that are lexically bound by an enclosing let or combinator
    *  binder. A bare identifier matching any frame in this stack emits
    *  `binding(name)`; everything else emits `nameRef(name)`. */
   binders: Set<string>
-}
-
-function peek(ctx: Ctx, offset = 0): Tok {
-  return ctx.toks[Math.min(ctx.i + offset, ctx.toks.length - 1)]
-}
-
-function consume(ctx: Ctx, kind: TokKind, what?: string): Tok {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) {
-    throw new ParseError(`expected ${what ?? kind}, got ${formatTokForError(t)}`, t)
-  }
-  ctx.i++
-  return t
-}
-
-function eat(ctx: Ctx, kind: TokKind): Tok | null {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) return null
-  ctx.i++
-  return t
-}
-
-function formatTokForError(t: Tok): string {
-  if (t.kind === 'eof') return 'end of input'
-  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
-  return `'${t.kind}'`
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -101,7 +66,7 @@ export function parseExpr(src: string): ExprNode {
   const node = parseTopExpr(ctx)
   const trailing = ctx.toks[ctx.i]
   if (trailing.kind !== 'eof') {
-    throw new ParseError(`unexpected trailing input: ${formatTokForError(trailing)}`, trailing)
+    throw new ParseError(`unexpected trailing input: ${formatTok(trailing)}`, trailing)
   }
   return node
 }
@@ -115,144 +80,62 @@ export function parseExprFromTokens(toks: Tok[], startIdx: number, binders?: Set
 }
 
 // ─────────────────────────────────────────────────────────────
-// Precedence climbing — top-level expression
+// Precedence climbing — table-driven left-associative infix
 // ─────────────────────────────────────────────────────────────
+//
+// Levels are listed weakest → strongest. At each level we parse the next
+// stronger level for the lhs, then loop on any matching infix operator at
+// this level. A single helper drives all 8 levels.
+
+type InfixTable = Partial<Record<TokKind, string>>
+
+// Listed in precedence order (lowest binding power first). The recursive
+// descent is implicit: level N delegates to level N+1 for both sides.
+const INFIX_LEVELS: ReadonlyArray<InfixTable> = [
+  { '||': 'or' },
+  { '&&': 'and' },
+  { '|':  'bitOr' },
+  { '^':  'bitXor' },
+  { '&':  'bitAnd' },
+  { '==': 'eq', '!=': 'neq' },
+  { '<':  'lt', '<=': 'lte', '>': 'gt', '>=': 'gte' },
+  { '<<': 'lshift', '>>': 'rshift' },
+  { '+':  'add', '-':  'sub' },
+  { '*':  'mul', '/':  'div', '%': 'mod' },
+]
+
+const UNARY_OPS: InfixTable = { '-': 'neg', '!': 'not', '~': 'bitNot' }
+
+const binary = (op: string, lhs: ExprNode, rhs: ExprNode): ExprNode => ({ op, args: [lhs, rhs] })
+const unary = (op: string, operand: ExprNode): ExprNode => ({ op, args: [operand] })
 
 function parseTopExpr(ctx: Ctx): ExprNode {
-  return parseLogicalOr(ctx)
+  return parseInfix(ctx, 0)
 }
 
-function binary(op: string, lhs: ExprNode, rhs: ExprNode): ExprNode {
-  return { op, args: [lhs, rhs] }
-}
-
-function unary(op: string, operand: ExprNode): ExprNode {
-  return { op, args: [operand] }
-}
-
-function parseLogicalOr(ctx: Ctx): ExprNode {
-  let lhs = parseLogicalAnd(ctx)
-  while (peek(ctx).kind === '||') {
-    ctx.i++
-    const rhs = parseLogicalAnd(ctx)
-    lhs = binary('or', lhs, rhs)
-  }
-  return lhs
-}
-
-function parseLogicalAnd(ctx: Ctx): ExprNode {
-  let lhs = parseBitwiseOr(ctx)
-  while (peek(ctx).kind === '&&') {
-    ctx.i++
-    const rhs = parseBitwiseOr(ctx)
-    lhs = binary('and', lhs, rhs)
-  }
-  return lhs
-}
-
-function parseBitwiseOr(ctx: Ctx): ExprNode {
-  let lhs = parseBitwiseXor(ctx)
-  while (peek(ctx).kind === '|') {
-    ctx.i++
-    const rhs = parseBitwiseXor(ctx)
-    lhs = binary('bitOr', lhs, rhs)
-  }
-  return lhs
-}
-
-function parseBitwiseXor(ctx: Ctx): ExprNode {
-  let lhs = parseBitwiseAnd(ctx)
-  while (peek(ctx).kind === '^') {
-    ctx.i++
-    const rhs = parseBitwiseAnd(ctx)
-    lhs = binary('bitXor', lhs, rhs)
-  }
-  return lhs
-}
-
-function parseBitwiseAnd(ctx: Ctx): ExprNode {
-  let lhs = parseEquality(ctx)
-  while (peek(ctx).kind === '&') {
-    ctx.i++
-    const rhs = parseEquality(ctx)
-    lhs = binary('bitAnd', lhs, rhs)
-  }
-  return lhs
-}
-
-const EQUALITY_OPS: Partial<Record<TokKind, string>> = { '==': 'eq', '!=': 'neq' }
-function parseEquality(ctx: Ctx): ExprNode {
-  let lhs = parseRelational(ctx)
+function parseInfix(ctx: Ctx, level: number): ExprNode {
+  if (level >= INFIX_LEVELS.length) return parseUnary(ctx)
+  const ops = INFIX_LEVELS[level]
+  let lhs = parseInfix(ctx, level + 1)
   for (;;) {
-    const op = EQUALITY_OPS[peek(ctx).kind]
+    const op = ops[peek(ctx).kind]
     if (!op) return lhs
     ctx.i++
-    const rhs = parseRelational(ctx)
+    const rhs = parseInfix(ctx, level + 1)
     lhs = binary(op, lhs, rhs)
   }
 }
 
-const RELATIONAL_OPS: Partial<Record<TokKind, string>> = { '<': 'lt', '<=': 'lte', '>': 'gt', '>=': 'gte' }
-function parseRelational(ctx: Ctx): ExprNode {
-  let lhs = parseShift(ctx)
-  for (;;) {
-    const op = RELATIONAL_OPS[peek(ctx).kind]
-    if (!op) return lhs
-    ctx.i++
-    const rhs = parseShift(ctx)
-    lhs = binary(op, lhs, rhs)
-  }
-}
-
-const SHIFT_OPS: Partial<Record<TokKind, string>> = { '<<': 'lshift', '>>': 'rshift' }
-function parseShift(ctx: Ctx): ExprNode {
-  let lhs = parseAdditive(ctx)
-  for (;;) {
-    const op = SHIFT_OPS[peek(ctx).kind]
-    if (!op) return lhs
-    ctx.i++
-    const rhs = parseAdditive(ctx)
-    lhs = binary(op, lhs, rhs)
-  }
-}
-
-const ADDITIVE_OPS: Partial<Record<TokKind, string>> = { '+': 'add', '-': 'sub' }
-function parseAdditive(ctx: Ctx): ExprNode {
-  let lhs = parseMultiplicative(ctx)
-  for (;;) {
-    const op = ADDITIVE_OPS[peek(ctx).kind]
-    if (!op) return lhs
-    ctx.i++
-    const rhs = parseMultiplicative(ctx)
-    lhs = binary(op, lhs, rhs)
-  }
-}
-
-const MULTIPLICATIVE_OPS: Partial<Record<TokKind, string>> = { '*': 'mul', '/': 'div', '%': 'mod' }
-function parseMultiplicative(ctx: Ctx): ExprNode {
-  let lhs = parseUnary(ctx)
-  for (;;) {
-    const op = MULTIPLICATIVE_OPS[peek(ctx).kind]
-    if (!op) return lhs
-    ctx.i++
-    const rhs = parseUnary(ctx)
-    lhs = binary(op, lhs, rhs)
-  }
-}
-
-const UNARY_OPS: Partial<Record<TokKind, string>> = { '-': 'neg', '!': 'not', '~': 'bitNot' }
 function parseUnary(ctx: Ctx): ExprNode {
   const op = UNARY_OPS[peek(ctx).kind]
-  if (op) {
-    ctx.i++
-    const operand = parseUnary(ctx)
-    // Constant-fold `-<number-literal>` into a negative number. Matches the
-    // canonical JSON form (`-0.5`, not `{op:'neg', args:[0.5]}`) and makes
-    // array literals like `[1, -0.5, 0.25]` agree with stdlib JSON.
-    if (op === 'neg' && typeof operand === 'number') return -operand
-    return unary(op, operand)
-  }
-  return parsePostfix(ctx)
+  if (!op) return parsePostfix(ctx)
+  ctx.i++
+  const operand = parseUnary(ctx)
+  // Constant-fold `-<number-literal>` into a negative number. Matches the
+  // canonical JSON form (`-0.5`, not `{op:'neg', args:[0.5]}`) and makes
+  // array literals like `[1, -0.5, 0.25]` agree with stdlib JSON.
+  if (op === 'neg' && typeof operand === 'number') return -operand
+  return unary(op, operand)
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -306,13 +189,7 @@ function parsePostfix(ctx: Ctx): ExprNode {
 }
 
 function parseCallArgs(ctx: Ctx): ExprNode[] {
-  const args: ExprNode[] = []
-  if (peek(ctx).kind === ')') return args
-  args.push(parseTopExpr(ctx))
-  while (eat(ctx, ',')) {
-    args.push(parseTopExpr(ctx))
-  }
-  return args
+  return commaList(ctx, ')', () => parseTopExpr(ctx))
 }
 
 function isNameRef(node: ExprNode): node is { op: 'nameRef'; name: string } {
@@ -407,13 +284,9 @@ function parseZipWith(ctx: Ctx): ExprNode {
  *  Validates the expected arity (0+ allows any). */
 function parseLambdaArgs(ctx: Ctx, expectedArity: number, ownerOp: string): { binders: string[] } {
   const open = consume(ctx, '(', `${ownerOp}: opening \`(\` for lambda`)
-  const binders: string[] = []
-  if (peek(ctx).kind !== ')') {
-    binders.push(consume(ctx, 'ident', `${ownerOp}: binder name`).value as string)
-    while (eat(ctx, ',')) {
-      binders.push(consume(ctx, 'ident', `${ownerOp}: binder name`).value as string)
-    }
-  }
+  const binders = commaList(ctx, ')', () =>
+    consume(ctx, 'ident', `${ownerOp}: binder name`).value as string,
+  )
   consume(ctx, ')', `${ownerOp}: closing \`)\` of lambda args`)
   if (binders.length !== expectedArity) {
     throw new ParseError(
@@ -428,18 +301,7 @@ function parseLambdaArgs(ctx: Ctx, expectedArity: number, ownerOp: string): { bi
 /** Parse a lambda body with the given binders pushed onto the parser's
  *  scope. Restores scope on return. */
 function parseLambdaBody(ctx: Ctx, binders: string[]): ExprNode {
-  const added: string[] = []
-  for (const b of binders) {
-    if (!ctx.binders.has(b)) {
-      ctx.binders.add(b)
-      added.push(b)
-    }
-  }
-  try {
-    return parseTopExpr(ctx)
-  } finally {
-    for (const b of added) ctx.binders.delete(b)
-  }
+  return withScope(ctx.binders, binders, () => parseTopExpr(ctx))
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -487,20 +349,12 @@ function parsePrimary(ctx: Ctx): ExprNode {
   // parser currently lexes 'sample_rate' as an ident, so it's covered by
   // the ident branch above. Same for sample_index.
 
-  throw new ParseError(`unexpected token in expression: ${formatTokForError(t)}`, t)
+  throw new ParseError(`unexpected token in expression: ${formatTok(t)}`, t)
 }
 
 function parseArrayLiteral(ctx: Ctx): ExprNode {
   // The opening `[` has already been consumed.
-  const items: ExprNode[] = []
-  if (peek(ctx).kind !== ']') {
-    items.push(parseTopExpr(ctx))
-    while (eat(ctx, ',')) {
-      // Tolerate trailing comma: `[1, 2, 3,]`
-      if (peek(ctx).kind === ']') break
-      items.push(parseTopExpr(ctx))
-    }
-  }
+  const items = commaList(ctx, ']', () => parseTopExpr(ctx))
   consume(ctx, ']', 'closing `]` of array literal')
   return items
 }
@@ -530,17 +384,7 @@ function parseLet(ctx: Ctx): ExprNode {
   }
   consume(ctx, '}', 'let: closing `}`')
   consume(ctx, 'in', 'let: `in`')
-  const added: string[] = []
-  for (const n of order) {
-    if (!ctx.binders.has(n)) {
-      ctx.binders.add(n)
-      added.push(n)
-    }
-  }
-  try {
-    const body = parseTopExpr(ctx)
-    return { op: 'let', bind, in: body }
-  } finally {
-    for (const b of added) ctx.binders.delete(b)
-  }
+  return withScope(ctx.binders, order, () => ({
+    op: 'let', bind, in: parseTopExpr(ctx),
+  }))
 }

--- a/compiler/parse/lexer.ts
+++ b/compiler/parse/lexer.ts
@@ -10,9 +10,12 @@
  * Output is a flat token stream; the parser layers above (expressions,
  * statements, declarations) consume it via lookahead.
  *
- * Position info: every token carries `pos` (byte offset into the source)
- * and `line`/`col` (1-indexed). Suitable for error reporting once mapped
- * back through the markdown extractor's line offsets.
+ * Design: an unfold over `(src, ctx)`. Each step picks the first matching
+ * rule from a static table, advances the context immutably, and (sometimes)
+ * yields a token. `tokenize` is just `[...lex(src)]` — collection comes from
+ * spread, not push. Position tracking (line/col, 1-indexed) is recovered
+ * from the consumed span by counting newlines; only whitespace and block
+ * comments can ever cross lines.
  */
 
 export type TokKind =
@@ -44,7 +47,7 @@ export type TokKind =
   | 'eof'
 
 /** A lexed token. `value` is set for `num` (number), `ident` (name string),
- *  and `string` (the unquoted contents). All other kinds carry their kind only. */
+ *  and `string` (the unquoted, escape-processed contents). */
 export interface Tok {
   kind: TokKind
   value?: string | number
@@ -63,134 +66,150 @@ const KEYWORDS: Record<string, TokKind> = {
   struct: 'struct', enum: 'enum', type: 'type',
 }
 
+const ESCAPES: Record<string, string> = {
+  n: '\n', t: '\t', r: '\r', '\\': '\\', "'": "'", '"': '"',
+}
+
 export class LexError extends Error {
   constructor(message: string, public pos: number, public line: number, public col: number) {
     super(`${line}:${col}: ${message}`)
   }
 }
 
-export function tokenize(src: string): Tok[] {
-  const toks: Tok[] = []
-  let i = 0
-  let line = 1
-  let lineStart = 0  // byte offset of the start of the current line
+interface LexCtx { i: number; line: number; lineStart: number }
+type Emit = Pick<Tok, 'kind' | 'value'>
+type Match = { length: number; tok?: Emit }
+type Rule = (src: string, ctx: LexCtx) => Match | null
 
-  const colAt = (offset: number) => offset - lineStart + 1
-  const push = (kind: TokKind, pos: number, value?: string | number) =>
-    toks.push({ kind, pos, line, col: colAt(pos), ...(value !== undefined ? { value } : {}) })
-
-  while (i < src.length) {
-    const c = src[i]
-
-    // Whitespace
-    if (c === ' ' || c === '\t' || c === '\r') { i++; continue }
-    if (c === '\n') { i++; line++; lineStart = i; continue }
-
-    // Line comment
-    if (c === '/' && src[i + 1] === '/') {
-      while (i < src.length && src[i] !== '\n') i++
-      continue
-    }
-
-    // Block comment /* ... */ (non-nesting)
-    if (c === '/' && src[i + 1] === '*') {
-      i += 2
-      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
-        if (src[i] === '\n') { line++; lineStart = i + 1 }
-        i++
-      }
-      if (i >= src.length) throw new LexError('unterminated block comment', i, line, colAt(i))
-      i += 2
-      continue
-    }
-
-    const start = i
-
-    // Number: optional leading dot, digits, optional fractional, optional exponent.
-    if (/[0-9]/.test(c) || (c === '.' && /[0-9]/.test(src[i + 1] ?? ''))) {
-      let j = i
-      while (j < src.length && /[0-9]/.test(src[j])) j++
-      if (src[j] === '.' && /[0-9]/.test(src[j + 1] ?? '')) {
-        j++
-        while (j < src.length && /[0-9]/.test(src[j])) j++
-      }
-      if (src[j] === 'e' || src[j] === 'E') {
-        j++
-        if (src[j] === '+' || src[j] === '-') j++
-        if (!/[0-9]/.test(src[j] ?? '')) {
-          throw new LexError(`malformed number (exponent missing digits): ${src.slice(start, j)}`, start, line, colAt(start))
-        }
-        while (j < src.length && /[0-9]/.test(src[j])) j++
-      }
-      const text = src.slice(i, j)
-      const n = Number(text)
-      if (!Number.isFinite(n)) throw new LexError(`invalid number: ${text}`, start, line, colAt(start))
-      push('num', start, n)
-      i = j
-      continue
-    }
-
-    // Identifier or keyword
-    if (/[A-Za-z_]/.test(c)) {
-      let j = i
-      while (j < src.length && /[A-Za-z0-9_]/.test(src[j])) j++
-      const text = src.slice(i, j)
-      const kw = KEYWORDS[text]
-      if (kw) push(kw, start)
-      else push('ident', start, text)
-      i = j
-      continue
-    }
-
-    // String literal (single or double quoted; same semantics)
-    if (c === '"' || c === "'") {
-      const quote = c
-      let j = i + 1
-      let buf = ''
-      while (j < src.length && src[j] !== quote) {
-        if (src[j] === '\n') throw new LexError('unterminated string literal', start, line, colAt(start))
-        if (src[j] === '\\') {
-          const next = src[j + 1]
-          if (next === undefined) throw new LexError('unterminated escape', j, line, colAt(j))
-          const esc: Record<string, string> = { n: '\n', t: '\t', r: '\r', '\\': '\\', "'": "'", '"': '"' }
-          if (!(next in esc)) throw new LexError(`unknown escape: \\${next}`, j, line, colAt(j))
-          buf += esc[next]
-          j += 2
-          continue
-        }
-        buf += src[j]
-        j++
-      }
-      if (j >= src.length) throw new LexError('unterminated string literal', start, line, colAt(start))
-      push('string', start, buf)
-      i = j + 1
-      continue
-    }
-
-    // Three-char punctuation (none currently — reserved for future "..." or "==>")
-    // Two-char punctuation (longest-match wins)
-    const two = src.slice(i, i + 2)
-    if (two === '<=' || two === '>=' || two === '==' || two === '!=' ||
-        two === '<<' || two === '>>' || two === '&&' || two === '||' ||
-        two === '=>' || two === '->') {
-      push(two as TokKind, start)
-      i += 2
-      continue
-    }
-
-    // Single-char punctuation
-    if ('()[]{},.;:=+-*/%<>&|^~!'.includes(c)) {
-      push(c as TokKind, start)
-      i++
-      continue
-    }
-
-    throw new LexError(`unexpected character: ${JSON.stringify(c)}`, start, line, colAt(start))
-  }
-
-  toks.push({ kind: 'eof', pos: i, line, col: colAt(i) })
-  return toks
+function errAt(msg: string, ctx: LexCtx, offset = ctx.i): never {
+  throw new LexError(msg, offset, ctx.line, offset - ctx.lineStart + 1)
 }
+
+/** Wraps a sticky regex into a Rule. If `emit` is omitted the match is skipped. */
+const re = (pattern: RegExp, emit?: (m: string) => Emit): Rule => {
+  if (!pattern.sticky) throw new Error(`lexer rule regex must be sticky: ${pattern}`)
+  return (src, ctx) => {
+    pattern.lastIndex = ctx.i
+    const m = pattern.exec(src)
+    if (!m || m.index !== ctx.i) return null
+    return emit ? { length: m[0].length, tok: emit(m[0]) } : { length: m[0].length }
+  }
+}
+
+// --- skip rules (whitespace / comments emit no token) ---------------------
+
+const skipSpace = re(/[ \t\r\n]+/y)
+const skipLineComment = re(/\/\/[^\n]*/y)
+
+const skipBlockComment: Rule = (src, ctx) => {
+  if (src[ctx.i] !== '/' || src[ctx.i + 1] !== '*') return null
+  const end = src.indexOf('*/', ctx.i + 2)
+  if (end < 0) errAt('unterminated block comment', ctx)
+  return { length: end - ctx.i + 2 }
+}
+
+// --- value-bearing rules --------------------------------------------------
+
+// Greedy: matches `1e` (with empty exponent digits) so we can report a
+// targeted error instead of letting the trailing `e` re-tokenize as an ident.
+const NUM_RE = /(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+)(?:[eE][+-]?[0-9]*)?/y
+
+const number: Rule = (src, ctx) => {
+  NUM_RE.lastIndex = ctx.i
+  const m = NUM_RE.exec(src)
+  if (!m || m.index !== ctx.i) return null
+  const text = m[0]
+  const eAt = text.search(/[eE]/)
+  if (eAt >= 0 && !/[0-9]$/.test(text)) {
+    errAt(`malformed number (exponent missing digits): ${text}`, ctx)
+  }
+  return { length: text.length, tok: { kind: 'num', value: Number(text) } }
+}
+
+const identOrKeyword = re(/[A-Za-z_][A-Za-z0-9_]*/y, m =>
+  KEYWORDS[m] ? { kind: KEYWORDS[m] } : { kind: 'ident', value: m },
+)
+
+// Body: any backslash + char (escape), or any non-quote/backslash/newline char.
+const STRING_RE = /"((?:\\[^]|[^"\\\n])*)"|'((?:\\[^]|[^'\\\n])*)'/y
+
+const stringLit: Rule = (src, ctx) => {
+  const c = src[ctx.i]
+  if (c !== '"' && c !== "'") return null
+  STRING_RE.lastIndex = ctx.i
+  const m = STRING_RE.exec(src)
+  if (!m || m.index !== ctx.i) errAt('unterminated string literal', ctx)
+  const body = (m[1] ?? m[2])!
+  // Body offset = ctx.i + 1 (skip opening quote); used to point escape errors precisely.
+  const value = body.replace(/\\(.)/g, (_, ch: string, idx: number) => {
+    const replacement = ESCAPES[ch]
+    if (replacement === undefined) errAt(`unknown escape: \\${ch}`, ctx, ctx.i + 1 + idx)
+    return replacement
+  })
+  return { length: m[0].length, tok: { kind: 'string', value } }
+}
+
+const punct2 = re(/<=|>=|==|!=|<<|>>|&&|\|\||=>|->/y, m => ({ kind: m as TokKind }))
+const punct1 = re(/[()\[\]{},.;:=+\-*/%<>&|^~!]/y, m => ({ kind: m as TokKind }))
+
+// Order: skips first, then literals, then ident/keyword, then strings, then
+// longest-match punctuation before single-char.
+const RULES: ReadonlyArray<Rule> = [
+  skipSpace,
+  skipLineComment,
+  skipBlockComment,
+  number,
+  identOrKeyword,
+  stringLit,
+  punct2,
+  punct1,
+]
+
+/** First-non-null map: applies `f` and returns the first defined result. */
+function firstMatch(src: string, ctx: LexCtx): Match | null {
+  for (const rule of RULES) {
+    const m = rule(src, ctx)
+    if (m) return m
+  }
+  return null
+}
+
+/** Advance the context by `length` chars, immutably. Recomputes line/lineStart
+ *  from the consumed span — cheap because newlines only occur in skip rules. */
+function advance(src: string, ctx: LexCtx, length: number): LexCtx {
+  const span = src.slice(ctx.i, ctx.i + length)
+  const last = span.lastIndexOf('\n')
+  if (last < 0) return { i: ctx.i + length, line: ctx.line, lineStart: ctx.lineStart }
+  const newlines = (span.match(/\n/g) as string[]).length
+  return {
+    i: ctx.i + length,
+    line: ctx.line + newlines,
+    lineStart: ctx.i + last + 1,
+  }
+}
+
+const at = (ctx: LexCtx, tok: Emit): Tok => ({
+  ...tok,
+  pos: ctx.i,
+  line: ctx.line,
+  col: ctx.i - ctx.lineStart + 1,
+})
+
+const eof = (ctx: LexCtx): Tok => ({ kind: 'eof', pos: ctx.i, line: ctx.line, col: ctx.i - ctx.lineStart + 1 })
+
+/** The unfold: `(src, ctx) → Maybe (Tok, nextCtx)`, repeated until EOF. */
+function* lex(src: string): Generator<Tok> {
+  let ctx: LexCtx = { i: 0, line: 1, lineStart: 0 }
+  while (ctx.i < src.length) {
+    const match = firstMatch(src, ctx)
+    if (!match) errAt(`unexpected character: ${JSON.stringify(src[ctx.i])}`, ctx)
+    if (match.tok) yield at(ctx, match.tok)
+    ctx = advance(src, ctx, match.length)
+  }
+  yield eof(ctx)
+}
+
+export const tokenize = (src: string): Tok[] => [...lex(src)]
 
 /** Pretty-format a token for diagnostic messages. */
 export function formatTok(t: Tok): string {

--- a/compiler/parse/shared.ts
+++ b/compiler/parse/shared.ts
@@ -1,0 +1,85 @@
+/**
+ * shared.ts — parser plumbing common to expressions / statements / declarations.
+ *
+ * The three parser layers all walk the same `Tok[]` stream with the same
+ * lookahead idioms (peek, consume, eat) and the same comma-separated-list
+ * shapes. This module gives them one set of helpers so each layer stays
+ * focused on its grammar.
+ */
+
+import type { Tok, TokKind } from './lexer.js'
+
+export class ParseError extends Error {
+  constructor(message: string, public tok: Tok) {
+    super(`${tok.line}:${tok.col}: ${message}`)
+  }
+}
+
+/** Minimal cursor that all parser contexts extend. Helpers operate on this
+ *  surface only — layer-specific state (binders, type-params, etc.) lives
+ *  on the concrete Ctx and is invisible here. */
+export interface Cursor {
+  toks: Tok[]
+  i: number
+}
+
+export const peek = (c: Cursor, offset = 0): Tok =>
+  c.toks[Math.min(c.i + offset, c.toks.length - 1)]
+
+export function consume(c: Cursor, kind: TokKind, what?: string): Tok {
+  const t = c.toks[c.i]
+  if (t.kind !== kind) {
+    throw new ParseError(`expected ${what ?? kind}, got ${formatTok(t)}`, t)
+  }
+  c.i++
+  return t
+}
+
+export function eat(c: Cursor, kind: TokKind): Tok | null {
+  const t = c.toks[c.i]
+  if (t.kind !== kind) return null
+  c.i++
+  return t
+}
+
+export function formatTok(t: Tok): string {
+  if (t.kind === 'eof') return 'end of input'
+  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
+  return `'${t.kind}'`
+}
+
+/** Parse a comma-separated list, stopping at `terminator`. Does not consume
+ *  the terminator. Tolerates an empty list and a trailing comma. */
+export function commaList<T>(c: Cursor, terminator: TokKind, parse: () => T): T[] {
+  const items: T[] = []
+  if (peek(c).kind === terminator) return items
+  items.push(parse())
+  while (eat(c, ',')) {
+    if (peek(c).kind === terminator) break
+    items.push(parse())
+  }
+  return items
+}
+
+/** Run `body` with `names` added to a scope set, then remove only the names
+ *  this call actually added (so nested binders nest cleanly). Replaces the
+ *  manual `added: string[]` + try/finally idiom. */
+export function withScope<T>(scope: Set<string>, names: Iterable<string>, body: () => T): T {
+  const added: string[] = []
+  for (const n of names) {
+    if (!scope.has(n)) {
+      scope.add(n)
+      added.push(n)
+    }
+  }
+  try {
+    return body()
+  } finally {
+    for (const n of added) scope.delete(n)
+  }
+}
+
+/** True iff `t` is an `ident` token whose value equals `name` — for
+ *  contextual keywords like `init`, `null`, `dac`, `smoothed`, `trigger`. */
+export const isContextualKw = (t: Tok, name: string): boolean =>
+  t.kind === 'ident' && t.value === name

--- a/compiler/parse/statements.ts
+++ b/compiler/parse/statements.ts
@@ -24,8 +24,9 @@
  *  - ADTs / match (B5)
  */
 
-import { tokenize, type Tok, type TokKind } from './lexer.js'
-import { parseExprFromTokens, type ExprNode, ParseError } from './expressions.js'
+import { tokenize, type Tok } from './lexer.js'
+import { parseExprFromTokens, type ExprNode } from './expressions.js'
+import { commaList, consume, eat, formatTok, isContextualKw, peek, ParseError, type Cursor } from './shared.js'
 
 // ─────────────────────────────────────────────────────────────
 // BlockNode shape — kept loose to avoid a hard dependency on compiler/expr.ts
@@ -58,36 +59,8 @@ export interface BodyOptions {
 // Parser context
 // ─────────────────────────────────────────────────────────────
 
-interface Ctx {
-  toks: Tok[]
-  i: number
+interface Ctx extends Cursor {
   opts: BodyOptions
-}
-
-function peek(ctx: Ctx, offset = 0): Tok {
-  return ctx.toks[Math.min(ctx.i + offset, ctx.toks.length - 1)]
-}
-
-function consume(ctx: Ctx, kind: TokKind, what?: string): Tok {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) {
-    throw new ParseError(`expected ${what ?? kind}, got ${formatTok(t)}`, t)
-  }
-  ctx.i++
-  return t
-}
-
-function eat(ctx: Ctx, kind: TokKind): Tok | null {
-  const t = ctx.toks[ctx.i]
-  if (t.kind !== kind) return null
-  ctx.i++
-  return t
-}
-
-function formatTok(t: Tok): string {
-  if (t.kind === 'eof') return 'end of input'
-  if (t.value !== undefined) return `${t.kind}(${JSON.stringify(t.value)})`
-  return `'${t.kind}'`
 }
 
 function isCapitalized(name: string): boolean {
@@ -206,7 +179,7 @@ function parseDelayDecl(ctx: Ctx): ExprNode {
   // the token stream because identifiers don't extend an expression past
   // a complete operand.
   const initTok = peek(ctx)
-  if (initTok.kind !== 'ident' || initTok.value !== 'init') {
+  if (!isContextualKw(initTok, 'init')) {
     throw new ParseError(`delay decl: expected 'init' after update expression, got ${formatTok(initTok)}`, initTok)
   }
   ctx.i++
@@ -319,35 +292,32 @@ function parseInstanceRhs(ctx: Ctx, name: string): ExprNode {
   return out as ExprNode
 }
 
-/** Parse `<key=value, key=value>`. The opening `<` is already consumed. */
+/** Parse `<key=value, key=value>`. The opening `<` is already consumed;
+ *  this consumes through the closing `>`. */
 function parseTypeArgs(ctx: Ctx, owner: string): Record<string, number> {
   const args: Record<string, number> = {}
-  if (peek(ctx).kind === '>') {
-    ctx.i++
-    return args
-  }
-  for (;;) {
-    const k = consume(ctx, 'ident', `${owner}: type-arg name`).value as string
+  commaList(ctx, '>', () => {
+    const kTok = consume(ctx, 'ident', `${owner}: type-arg name`)
+    const k = kTok.value as string
     consume(ctx, '=', `${owner}: \`=\` after type-arg name '${k}'`)
     const vTok = consume(ctx, 'num', `${owner}: type-arg value (number literal)`)
     if (!Number.isInteger(vTok.value)) {
       throw new ParseError(`${owner}: type-arg '${k}' must be an integer`, vTok)
     }
     if (k in args) {
-      throw new ParseError(`${owner}: duplicate type-arg '${k}'`, vTok)
+      throw new ParseError(`${owner}: duplicate type-arg '${k}'`, kTok)
     }
     args[k] = vTok.value as number
-    if (eat(ctx, '>')) return args
-    consume(ctx, ',', `${owner}: \`,\` between type-args`)
-  }
+  })
+  consume(ctx, '>', `${owner}: closing \`>\` of type-args`)
+  return args
 }
 
 /** Parse `(port: expr, port: expr)` — keyword arg form. The `(` is already
  *  consumed; this stops at the matching `)` (left for the caller). */
 function parseInstanceInputs(ctx: Ctx): Record<string, ExprNode> {
   const inputs: Record<string, ExprNode> = {}
-  if (peek(ctx).kind === ')') return inputs
-  for (;;) {
+  commaList(ctx, ')', () => {
     const portTok = consume(ctx, 'ident', 'instance input port name')
     const port = portTok.value as string
     if (port in inputs) {
@@ -355,9 +325,8 @@ function parseInstanceInputs(ctx: Ctx): Record<string, ExprNode> {
     }
     consume(ctx, ':', `\`:\` after input port '${port}'`)
     inputs[port] = parseExpr(ctx)
-    if (peek(ctx).kind === ')') return inputs
-    consume(ctx, ',', `\`,\` between instance inputs`)
-  }
+  })
+  return inputs
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Side-quest cleanup of the recently-landed parse layer (PRs through B4). Two refactors, no behavior change.

### 1. Lexer: imperative loops → table-driven unfold (`lexer.ts`)
The old lexer scanned with three inner `while(j < src.length && /.../.test(src[j])) j++` loops, a manual char-by-char string-escape walker, and an if/continue dispatch cascade.

The new lexer is a small table of `(src, ctx) => Match | null` rules driven by a generator unfold:
- Collection via `[...lex(src)]` — no `.push`
- Immutable context threading via `advance(src, ctx, length)`
- Newline counting via `lastIndexOf('\n')` + `match(/\n/g).length`
- Number rule uses one greedy regex + post-validation, so `1e` still errors precisely instead of re-tokenizing the `e` as an ident

### 2. Parser dedup + precedence collapse (`shared.ts` new; `expressions/statements/declarations.ts`)
All three parser layers carried near-identical `peek` / `consume` / `eat` / `formatTok` plus the same comma-separated-list `for(;;)` idiom. New `compiler/parse/shared.ts`:
- `Cursor` base interface and the four lookahead helpers
- `commaList(ctx, terminator, parse)` for comma-separated lists with optional trailing comma
- `withScope(set, names, body)` for binder push/pop, replacing the manual added-array + try/finally
- `isContextualKw(t, name)` for `init`, `null`, etc.
- `ParseError` (moved here to avoid an import cycle)

In `expressions.ts`, the eight-tier precedence cascade (`parseLogicalOr` → … → `parseMultiplicative`) collapses into one table-driven `parseInfix(ctx, level)` over an `INFIX_LEVELS` array listed weakest → strongest.

**Net diff across `compiler/parse/`: -170 lines** (with `shared.ts` accounted for) and the per-file imperative residue is gone.

## Test plan
- [x] `bun test compiler/parse/` — 187/187 pass
- [x] `bun test` — 774/774 pass (1 pre-existing skip)
- [x] `bunx tsc --noEmit -p tsconfig.json` — strict clean
- [x] Verify CI green