### PR TITLE
feat(parse): ADT type defs + match/tag expressions (Phase B5)

### DIFF
--- a/compiler/parse/adts.test.ts
+++ b/compiler/parse/adts.test.ts
@@ -1,0 +1,394 @@
+/**
+ * adts.test.ts — ADT type defs (struct/enum/type alias) + match/tag
+ * expressions (Phase B5).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { parseProgram, type ProgramNode, type StructTypeDef, type SumTypeDef, type AliasTypeDef } from './declarations.js'
+import { parseExpr, ParseError } from './expressions.js'
+
+// ─────────────────────────────────────────────────────────────
+// Struct decls
+// ─────────────────────────────────────────────────────────────
+
+describe('adts — struct decls', () => {
+  test('empty-program with single struct', () => {
+    const p = parseProgram(`
+      program X() {
+        struct Pair { a: float, b: int }
+      }
+    `)
+    expect(p.ports?.type_defs).toEqual([
+      { kind: 'struct', name: 'Pair', fields: [
+        { name: 'a', scalar_type: 'float' },
+        { name: 'b', scalar_type: 'int' },
+      ]},
+    ])
+  })
+
+  test('multiple struct fields with all scalar kinds', () => {
+    const p = parseProgram(`
+      program X() {
+        struct Sample { left: float, right: float, gain: float, on: bool, count: int }
+      }
+    `)
+    const td = (p.ports!.type_defs![0] as StructTypeDef)
+    expect(td.fields.map(f => f.scalar_type)).toEqual(['float', 'float', 'float', 'bool', 'int'])
+  })
+
+  test('empty struct (no fields)', () => {
+    const p = parseProgram(`program X() { struct Unit {} }`)
+    expect((p.ports!.type_defs![0] as StructTypeDef).fields).toEqual([])
+  })
+
+  test('non-scalar field type rejected', () => {
+    expect(() => parseProgram(`program X() { struct S { a: signal } }`))
+      .toThrow(/float\/int\/bool/)
+  })
+
+  test('duplicate field name in struct rejected', () => {
+    expect(() => parseProgram(`program X() { struct S { a: float, a: int } }`))
+      .toThrow(/duplicate field 'a'/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Enum (sum) decls
+// ─────────────────────────────────────────────────────────────
+
+describe('adts — enum decls', () => {
+  test('all-nullary enum', () => {
+    const p = parseProgram(`
+      program X() {
+        enum Color { Red, Green, Blue }
+      }
+    `)
+    expect(p.ports?.type_defs).toEqual([
+      { kind: 'sum', name: 'Color', variants: [
+        { name: 'Red', payload: [] },
+        { name: 'Green', payload: [] },
+        { name: 'Blue', payload: [] },
+      ]},
+    ])
+  })
+
+  test('mixed nullary and payload variants', () => {
+    const p = parseProgram(`
+      program X() {
+        enum Maybe { Some(value: float), None }
+      }
+    `)
+    const td = p.ports!.type_defs![0] as SumTypeDef
+    expect(td.variants).toEqual([
+      { name: 'Some', payload: [{ name: 'value', scalar_type: 'float' }] },
+      { name: 'None', payload: [] },
+    ])
+  })
+
+  test('multi-field variant payload', () => {
+    const p = parseProgram(`
+      program X() {
+        enum Note { Hz(freq: float, gain: float), Off }
+      }
+    `)
+    const td = p.ports!.type_defs![0] as SumTypeDef
+    expect(td.variants[0]).toEqual({
+      name: 'Hz',
+      payload: [
+        { name: 'freq', scalar_type: 'float' },
+        { name: 'gain', scalar_type: 'float' },
+      ],
+    })
+  })
+
+  test('duplicate variant name rejected', () => {
+    expect(() => parseProgram(`program X() { enum E { A, A } }`))
+      .toThrow(/duplicate variant 'A'/)
+  })
+
+  test('duplicate field within a variant rejected', () => {
+    expect(() => parseProgram(`program X() { enum E { V(a: float, a: int) } }`))
+      .toThrow(/duplicate field 'a'/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Type aliases
+// ─────────────────────────────────────────────────────────────
+
+describe('adts — type aliases', () => {
+  test('alias with positive bounds', () => {
+    const p = parseProgram(`
+      program X() {
+        type Freq = float in [0, 20000]
+      }
+    `)
+    expect(p.ports?.type_defs).toEqual([
+      { kind: 'alias', name: 'Freq', base: 'float', bounds: [0, 20000] },
+    ])
+  })
+
+  test('alias with negative bound', () => {
+    const p = parseProgram(`
+      program X() {
+        type Sig = float in [-1, 1]
+      }
+    `)
+    expect((p.ports!.type_defs![0] as AliasTypeDef).bounds).toEqual([-1, 1])
+  })
+
+  test('alias with null bounds', () => {
+    const p = parseProgram(`
+      program X() {
+        type AnyFloat = float in [null, null]
+      }
+    `)
+    expect((p.ports!.type_defs![0] as AliasTypeDef).bounds).toEqual([null, null])
+  })
+
+  test('alias missing `in` rejected', () => {
+    expect(() => parseProgram(`program X() { type T = float }`)).toThrow(ParseError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Multiple type defs in the same program
+// ─────────────────────────────────────────────────────────────
+
+describe('adts — multiple type defs', () => {
+  test('struct + enum + alias side by side, source order preserved', () => {
+    const p = parseProgram(`
+      program X() {
+        struct Pair { a: float, b: float }
+        enum Tag { A, B }
+        type Freq = float in [0, 20000]
+      }
+    `)
+    expect(p.ports?.type_defs).toHaveLength(3)
+    expect((p.ports!.type_defs![0] as StructTypeDef).kind).toBe('struct')
+    expect((p.ports!.type_defs![1] as SumTypeDef).kind).toBe('sum')
+    expect((p.ports!.type_defs![2] as AliasTypeDef).kind).toBe('alias')
+  })
+
+  test('type defs and regular decls coexist in a body', () => {
+    const p = parseProgram(`
+      program X() -> (out: signal) {
+        struct Pair { a: float, b: float }
+        reg s: float = 0
+        out = s
+      }
+    `)
+    expect(p.ports?.type_defs).toHaveLength(1)
+    expect(p.body.decls).toHaveLength(1)  // just the regDecl
+    expect(p.body.assigns).toHaveLength(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Tag construction in expression position
+// ─────────────────────────────────────────────────────────────
+
+describe('expressions — tag construction', () => {
+  test('nullary tag uses bare ident (no `{}`)', () => {
+    // `Variant` alone parses as a nameRef placeholder; the elaborator
+    // converts to a tag if Variant is a known nullary sum variant.
+    expect(parseExpr('Foo')).toEqual({ op: 'nameRef', name: 'Foo' })
+  })
+
+  test('tag with single-field payload', () => {
+    expect(parseExpr('Some { value: 42 }')).toEqual({
+      op: 'tag',
+      type: '',
+      variant: 'Some',
+      payload: { value: 42 },
+    })
+  })
+
+  test('tag with multi-field payload', () => {
+    expect(parseExpr('Hz { freq: 440, gain: 0.5 }')).toEqual({
+      op: 'tag',
+      type: '',
+      variant: 'Hz',
+      payload: { freq: 440, gain: 0.5 },
+    })
+  })
+
+  test('empty-payload tag via `Variant { }`', () => {
+    expect(parseExpr('Empty { }')).toEqual({
+      op: 'tag',
+      type: '',
+      variant: 'Empty',
+    })
+  })
+
+  test('payload field can be a complex expression', () => {
+    expect(parseExpr('Vec { x: a + b, y: c * 2 }')).toEqual({
+      op: 'tag',
+      type: '',
+      variant: 'Vec',
+      payload: {
+        x: { op: 'add', args: [{ op: 'nameRef', name: 'a' }, { op: 'nameRef', name: 'b' }] },
+        y: { op: 'mul', args: [{ op: 'nameRef', name: 'c' }, 2] },
+      },
+    })
+  })
+
+  test('lowercase ident with `{` does NOT trigger tag construction', () => {
+    // `let { x: 1 } in x` is a let, not a tag
+    const parsed = parseExpr('let { x: 1 } in x') as { op: string }
+    expect(parsed.op).toBe('let')
+  })
+
+  test('duplicate payload field rejected', () => {
+    expect(() => parseExpr('Foo { a: 1, a: 2 }'))
+      .toThrow(/duplicate payload field 'a'/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Match expressions
+// ─────────────────────────────────────────────────────────────
+
+describe('expressions — match', () => {
+  test('all-nullary match', () => {
+    expect(parseExpr(`
+      match v {
+        Red => 1,
+        Green => 2,
+        Blue => 3
+      }
+    `)).toEqual({
+      op: 'match',
+      type: '',
+      scrutinee: { op: 'nameRef', name: 'v' },
+      arms: {
+        Red:   { body: 1 },
+        Green: { body: 2 },
+        Blue:  { body: 3 },
+      },
+    })
+  })
+
+  test('match with single-field bindings', () => {
+    expect(parseExpr(`
+      match v {
+        Some { value: x } => x + 1,
+        None => 0
+      }
+    `)).toEqual({
+      op: 'match',
+      type: '',
+      scrutinee: { op: 'nameRef', name: 'v' },
+      arms: {
+        Some: {
+          bind: 'x',
+          body: { op: 'add', args: [{ op: 'binding', name: 'x' }, 1] },
+        },
+        None: { body: 0 },
+      },
+    })
+  })
+
+  test('match with multi-field bindings emits bind as array', () => {
+    expect(parseExpr(`
+      match v {
+        Hz { freq: f, gain: g } => f * g
+      }
+    `)).toEqual({
+      op: 'match',
+      type: '',
+      scrutinee: { op: 'nameRef', name: 'v' },
+      arms: {
+        Hz: {
+          bind: ['f', 'g'],
+          body: {
+            op: 'mul',
+            args: [{ op: 'binding', name: 'f' }, { op: 'binding', name: 'g' }],
+          },
+        },
+      },
+    })
+  })
+
+  test('match arm bindings shadow outer scope', () => {
+    // Outer `x` via let; inner `Some { value: x }` shadows it.
+    const parsed = parseExpr(`
+      let { x: 1 } in
+      match v {
+        Some { value: x } => x,
+        None => x
+      }
+    ` ) as {
+      in: {
+        arms: {
+          Some: { body: ExprNode }
+          None: { body: ExprNode }
+        }
+      }
+    }
+    // Inner arm's `x` refers to the bound payload (shadowing the outer let).
+    expect(parsed.in.arms.Some.body).toEqual({ op: 'binding', name: 'x' })
+    // Outer arm's `x` refers to the outer let binding (still bound, since
+    // `withScope` doesn't double-add an existing name).
+    expect(parsed.in.arms.None.body).toEqual({ op: 'binding', name: 'x' })
+  })
+
+  test('duplicate arm rejected', () => {
+    expect(() => parseExpr('match v { A => 1, A => 2 }'))
+      .toThrow(/duplicate arm for variant 'A'/)
+  })
+
+  test('trailing comma after last arm allowed', () => {
+    // commaList tolerates a trailing comma
+    expect(() => parseExpr('match v { A => 1, B => 2, }')).not.toThrow()
+  })
+
+  test('match scrutinee can be a complex expression', () => {
+    const parsed = parseExpr('match a + b { A => 0 }') as { scrutinee: { op: string } }
+    expect(parsed.scrutinee.op).toBe('add')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Full-program integration with ADTs
+// ─────────────────────────────────────────────────────────────
+
+describe('adts — program integration', () => {
+  test('program with type defs, regs, instances, and a match expression', () => {
+    const p = parseProgram(`
+      program Synth(freq: freq = 220) -> (out: signal) {
+        enum Mode { Sine, Saw }
+        struct Pair { a: float, b: float }
+        type Bipolar = float in [-1, 1]
+
+        reg mode: Mode = Sine
+
+        out = match mode {
+          Sine => 1,
+          Saw => 0
+        }
+      }
+    `)
+    expect(p.name).toBe('Synth')
+    expect(p.ports?.type_defs).toHaveLength(3)
+    expect(p.body.decls).toHaveLength(1)  // regDecl 'mode'
+    expect(p.body.assigns).toHaveLength(1)
+    const matchExpr = (p.body.assigns[0] as { expr: { op: string } }).expr
+    expect(matchExpr.op).toBe('match')
+  })
+
+  test('struct/enum/type are forbidden when no body opts allow them', () => {
+    // The body parser used by `parseBody` (statements.ts) without opts
+    // raises a clear error rather than silently mistreating the keyword.
+    // We check by parsing a program — declarations.ts wires the
+    // typeDefHandler in, so the program path itself succeeds.
+    expect(() => parseProgram(`program X() { struct S { a: float } }`)).not.toThrow()
+  })
+})
+
+// Top-level type defs in tests need this import for ExprNode.
+type ExprNode =
+  | number
+  | boolean
+  | ExprNode[]
+  | { op: string; [k: string]: unknown }

--- a/compiler/parse/declarations.ts
+++ b/compiler/parse/declarations.ts
@@ -59,9 +59,28 @@ export interface ProgramPortSpec {
 
 export type ProgramPort = string | ProgramPortSpec
 
+/** Permitted scalar element types in struct fields and sum-variant payloads. */
+export type ScalarKind = 'float' | 'int' | 'bool'
+
+export interface StructField { name: string; scalar_type: ScalarKind }
+export interface StructTypeDef { kind: 'struct'; name: string; fields: StructField[] }
+
+export interface SumVariant { name: string; payload: StructField[] }
+export interface SumTypeDef { kind: 'sum'; name: string; variants: SumVariant[] }
+
+export interface AliasTypeDef {
+  kind: 'alias'
+  name: string
+  base: string
+  bounds: [number | null, number | null]
+}
+
+export type TypeDef = StructTypeDef | SumTypeDef | AliasTypeDef
+
 export interface ProgramPorts {
   inputs?: ProgramPort[]
   outputs?: ProgramPort[]
+  type_defs?: TypeDef[]
 }
 
 export interface ProgramNode {
@@ -123,7 +142,27 @@ function parseNestedProgramDecl(
   }
 }
 
-const NESTED_PROGRAM_OPTS: BodyOptions = { programDeclParser: parseNestedProgramDecl }
+/** Body-parser hook: dispatch `struct`/`enum`/`type` to the right ADT
+ *  parser. The body parser collects the result into a separate `typeDefs`
+ *  array (returned alongside the BlockNode), which we then route into
+ *  the program's `ports.type_defs`. */
+function parseBodyTypeDef(
+  toks: Tok[], startIdx: number,
+): { typeDef: unknown; nextIdx: number } {
+  const ctx: Ctx = { toks, i: startIdx, typeParams: new Set() }
+  const t = peek(ctx)
+  let typeDef: TypeDef
+  if (t.kind === 'struct') typeDef = parseStructDecl(ctx)
+  else if (t.kind === 'enum') typeDef = parseEnumDecl(ctx)
+  else if (t.kind === 'type') typeDef = parseAliasDecl(ctx)
+  else throw new ParseError(`expected struct/enum/type, got ${formatTok(t)}`, t)
+  return { typeDef, nextIdx: ctx.i }
+}
+
+const BODY_OPTS: BodyOptions = {
+  programDeclParser: parseNestedProgramDecl,
+  typeDefHandler: parseBodyTypeDef,
+}
 
 // ─────────────────────────────────────────────────────────────
 // Program-declaration parser
@@ -156,7 +195,7 @@ function parseProgramFromCtx(ctx: Ctx): ProgramNode {
 
   // Body
   consume(ctx, '{', `\`{\` opening body of '${name}'`)
-  const { block, nextIdx } = parseBodyFromTokens(ctx.toks, ctx.i, NESTED_PROGRAM_OPTS)
+  const { block, typeDefs, nextIdx } = parseBodyFromTokens(ctx.toks, ctx.i, BODY_OPTS)
   ctx.i = nextIdx
   consume(ctx, '}', `\`}\` closing body of '${name}'`)
 
@@ -170,8 +209,108 @@ function parseProgramFromCtx(ctx: Ctx): ProgramNode {
   const ports: ProgramPorts = {}
   if (inputs.length > 0)  ports.inputs  = inputs
   if (outputs && outputs.length > 0) ports.outputs = outputs
-  if (ports.inputs || ports.outputs) node.ports = ports
+  if (typeDefs.length > 0) ports.type_defs = typeDefs as TypeDef[]
+  if (ports.inputs || ports.outputs || ports.type_defs) node.ports = ports
   return node
+}
+
+// ─────────────────────────────────────────────────────────────
+// ADT decls — struct / enum / type alias (Phase B5)
+// ─────────────────────────────────────────────────────────────
+
+const SCALAR_KINDS: ReadonlySet<string> = new Set(['float', 'int', 'bool'])
+
+function parseScalarKind(ctx: Ctx, what: string): ScalarKind {
+  const t = consume(ctx, 'ident', what)
+  const k = t.value as string
+  if (!SCALAR_KINDS.has(k)) {
+    throw new ParseError(`${what}: expected float/int/bool, got '${k}'`, t)
+  }
+  return k as ScalarKind
+}
+
+/** struct Name { field: scalarType, ... } */
+function parseStructDecl(ctx: Ctx): StructTypeDef {
+  consume(ctx, 'struct', 'struct keyword')
+  const name = consume(ctx, 'ident', 'struct name').value as string
+  consume(ctx, '{', `\`{\` after struct '${name}'`)
+  const fields = parseFieldList(ctx, `struct '${name}'`)
+  consume(ctx, '}', `\`}\` closing struct '${name}'`)
+  const seen = new Set<string>()
+  for (const f of fields) {
+    if (seen.has(f.name)) {
+      throw new ParseError(`struct '${name}': duplicate field '${f.name}'`, peek(ctx))
+    }
+    seen.add(f.name)
+  }
+  return { kind: 'struct', name, fields }
+}
+
+/** Comma-separated `name: scalarType` list inside `{...}`. Used by both
+ *  struct fields and sum-variant payloads. */
+function parseFieldList(ctx: Ctx, where: string): StructField[] {
+  return commaList(ctx, '}', () => {
+    const nameTok = consume(ctx, 'ident', `${where}: field name`)
+    consume(ctx, ':', `${where}: \`:\` after field name`)
+    const scalar_type = parseScalarKind(ctx, `${where}: field type`)
+    return { name: nameTok.value as string, scalar_type }
+  })
+}
+
+/** enum Name { Variant, Variant(field: type, ...), ... } */
+function parseEnumDecl(ctx: Ctx): SumTypeDef {
+  consume(ctx, 'enum', 'enum keyword')
+  const name = consume(ctx, 'ident', 'enum name').value as string
+  consume(ctx, '{', `\`{\` after enum '${name}'`)
+  const variants = commaList(ctx, '}', () => parseSumVariant(ctx, name))
+  consume(ctx, '}', `\`}\` closing enum '${name}'`)
+  const seen = new Set<string>()
+  for (const v of variants) {
+    if (seen.has(v.name)) {
+      throw new ParseError(`enum '${name}': duplicate variant '${v.name}'`, peek(ctx))
+    }
+    seen.add(v.name)
+  }
+  return { kind: 'sum', name, variants }
+}
+
+function parseSumVariant(ctx: Ctx, enumName: string): SumVariant {
+  const nameTok = consume(ctx, 'ident', `enum '${enumName}': variant name`)
+  const variantName = nameTok.value as string
+  if (peek(ctx).kind !== '(') {
+    return { name: variantName, payload: [] }
+  }
+  ctx.i++  // consume `(`
+  const payload = commaList(ctx, ')', () => {
+    const pname = consume(ctx, 'ident', `variant '${variantName}' field name`).value as string
+    consume(ctx, ':', `variant '${variantName}' \`:\` after field name`)
+    const scalar_type = parseScalarKind(ctx, `variant '${variantName}' field type`)
+    return { name: pname, scalar_type }
+  })
+  consume(ctx, ')', `closing \`)\` of variant '${variantName}' payload`)
+  // Reject duplicate field names within a variant.
+  const seen = new Set<string>()
+  for (const f of payload) {
+    if (seen.has(f.name)) {
+      throw new ParseError(
+        `variant '${variantName}': duplicate field '${f.name}'`, nameTok,
+      )
+    }
+    seen.add(f.name)
+  }
+  return { name: variantName, payload }
+}
+
+/** type AliasName = baseScalar in [lo, hi] */
+function parseAliasDecl(ctx: Ctx): AliasTypeDef {
+  consume(ctx, 'type', 'type keyword')
+  const name = consume(ctx, 'ident', 'alias name').value as string
+  consume(ctx, '=', `\`=\` after alias '${name}'`)
+  const baseTok = consume(ctx, 'ident', `base type for alias '${name}'`)
+  const base = baseTok.value as string
+  consume(ctx, 'in', `\`in\` after base type for alias '${name}'`)
+  const bounds = parseBounds(ctx)
+  return { kind: 'alias', name, base, bounds }
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/parse/expressions.ts
+++ b/compiler/parse/expressions.ts
@@ -336,9 +336,27 @@ function parsePrimary(ctx: Ctx): ExprNode {
     return parseLet(ctx)
   }
 
+  if (t.kind === 'match') {
+    ctx.i++
+    return parseMatch(ctx)
+  }
+
   if (t.kind === 'ident') {
     ctx.i++
     const name = t.value as string
+    // Capitalized ident followed by `{` is a tag construction:
+    //   Variant { field: expr, ... } → {op:'tag', type:'', variant, payload}
+    // The empty `type` field is filled in by the elaborator (B6) from the
+    // sum-type registry — variant names uniquely identify a sum type.
+    if (isCapitalizedName(name) && peek(ctx).kind === '{') {
+      ctx.i++  // consume `{`
+      const payload = parseTagPayload(ctx, name)
+      consume(ctx, '}', `closing \`}\` of tag '${name}' payload`)
+      const node: { op: 'tag'; type: string; variant: string; payload?: Record<string, ExprNode> } =
+        { op: 'tag', type: '', variant: name }
+      if (Object.keys(payload).length > 0) node.payload = payload
+      return node as unknown as ExprNode
+    }
     if (ctx.binders.has(name)) {
       return { op: 'binding', name }
     }
@@ -350,6 +368,67 @@ function parsePrimary(ctx: Ctx): ExprNode {
   // the ident branch above. Same for sample_index.
 
   throw new ParseError(`unexpected token in expression: ${formatTok(t)}`, t)
+}
+
+const isCapitalizedName = (s: string): boolean => /^[A-Z]/.test(s)
+
+/** Parse the keyword-arg payload of a tag construction:
+ *    `field: expr, field: expr` (within already-consumed braces). */
+function parseTagPayload(ctx: Ctx, variant: string): Record<string, ExprNode> {
+  const out: Record<string, ExprNode> = {}
+  if (peek(ctx).kind === '}') return out
+  for (;;) {
+    const fnameTok = consume(ctx, 'ident', `tag '${variant}' payload field name`)
+    const fname = fnameTok.value as string
+    if (fname in out) {
+      throw new ParseError(`tag '${variant}': duplicate payload field '${fname}'`, fnameTok)
+    }
+    consume(ctx, ':', `tag '${variant}' \`:\` after field name`)
+    out[fname] = parseTopExpr(ctx)
+    if (peek(ctx).kind === '}') return out
+    consume(ctx, ',', `tag '${variant}' \`,\` between payload fields`)
+  }
+}
+
+/** Parse `match scrutinee { Variant => body, Variant { f: name, ... } => body, ... }`.
+ *  The opening `match` has already been consumed.
+ *  Emits `{op:'match', type:'', scrutinee, arms: { variant: {bind?, body}, ... }}`.
+ *  The `type` field is filled in by the elaborator (B6) from variant
+ *  membership in the sum-type registry. */
+function parseMatch(ctx: Ctx): ExprNode {
+  const scrutinee = parseTopExpr(ctx)
+  consume(ctx, '{', '`{` after match scrutinee')
+  const arms: Record<string, { bind?: string | string[]; body: ExprNode }> = {}
+  while (peek(ctx).kind !== '}') {
+    const variantTok = consume(ctx, 'ident', 'match arm variant name')
+    const variant = variantTok.value as string
+    if (variant in arms) {
+      throw new ParseError(`match: duplicate arm for variant '${variant}'`, variantTok)
+    }
+    let bindNames: string[] = []
+    if (eat(ctx, '{')) {
+      // Pattern: `Variant { field: name, field: name }` — bind payload
+      // fields to local names.
+      const pairs = commaList(ctx, '}', () => {
+        const fname = consume(ctx, 'ident', `arm '${variant}' field name`).value as string
+        consume(ctx, ':', `arm '${variant}' \`:\` after field name`)
+        const localName = consume(ctx, 'ident', `arm '${variant}' bind name`).value as string
+        return localName
+      })
+      consume(ctx, '}', `arm '${variant}' closing \`}\` of pattern`)
+      bindNames = pairs
+    }
+    consume(ctx, '=>', `arm '${variant}' \`=>\` after pattern`)
+    const body = withScope(ctx.binders, bindNames, () => parseTopExpr(ctx))
+    const arm: { bind?: string | string[]; body: ExprNode } = { body }
+    if (bindNames.length === 1) arm.bind = bindNames[0]
+    else if (bindNames.length > 1) arm.bind = bindNames
+    arms[variant] = arm
+    if (peek(ctx).kind === '}') break
+    consume(ctx, ',', 'match: `,` between arms')
+  }
+  consume(ctx, '}', 'match: closing `}`')
+  return { op: 'match', type: '', scrutinee, arms } as unknown as ExprNode
 }
 
 function parseArrayLiteral(ctx: Ctx): ExprNode {

--- a/compiler/parse/statements.ts
+++ b/compiler/parse/statements.ts
@@ -45,7 +45,13 @@ export interface BlockNode {
 /** Optional dependency-injection slot for nested-program parsing.
  *  declarations.ts (Phase B4) passes its program-decl parser via this
  *  callback so that bodies can contain `programDecl` entries. Without
- *  this hook a `program` keyword inside a body raises a parse error. */
+ *  this hook a `program` keyword inside a body raises a parse error.
+ *
+ *  The same dependency-injection shape is used for ADT type defs
+ *  (struct/enum/type — Phase B5). When the body parser sees one of those
+ *  keywords, it calls the typeDefHandler if provided; the parsed type def
+ *  is collected in the body parser's typeDefs array (returned alongside
+ *  the BlockNode), not mixed into body.decls. */
 export interface BodyOptions {
   /** Called when the body parser encounters a `program` keyword as the
    *  leading token of a new body item. Receives the shared token stream
@@ -53,6 +59,13 @@ export interface BodyOptions {
    *  closing `}` and return a `programDecl`-shaped ExprNode plus the
    *  next-token index. */
   programDeclParser?: (toks: Tok[], i: number) => { node: ExprNode; nextIdx: number }
+
+  /** Called when the body parser encounters a `struct`, `enum`, or `type`
+   *  keyword as the leading token of a new body item. The handler must
+   *  consume tokens through the type def's closing brace (or end-of-decl
+   *  for aliases) and return a `tropical_program_2` type-def JSON value
+   *  plus the next-token index. */
+  typeDefHandler?: (toks: Tok[], i: number) => { typeDef: unknown; nextIdx: number }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -78,7 +91,7 @@ export function parseBody(src: string, opts: BodyOptions = {}): BlockNode {
   const toks = tokenize(src)
   const ctx: Ctx = { toks, i: 0, opts }
   consume(ctx, '{', 'opening `{` of body')
-  const block = parseBodyItems(ctx)
+  const { block } = parseBodyItems(ctx)
   consume(ctx, '}', 'closing `}` of body')
   const trailing = ctx.toks[ctx.i]
   if (trailing.kind !== 'eof') {
@@ -90,26 +103,32 @@ export function parseBody(src: string, opts: BodyOptions = {}): BlockNode {
 /** Parse the contents of a body block from a token stream, starting at the
  *  position immediately after the opening `{`. Stops at the matching `}`
  *  (left for the caller to consume). Used by upper-layer parsers (B4
- *  declarations) that share a token stream. */
+ *  declarations) that share a token stream.
+ *
+ *  Returns the BlockNode plus a separate `typeDefs` array (collected from
+ *  any struct/enum/type body items via the typeDefHandler callback —
+ *  empty when the callback isn't provided or no ADT decls appear). */
 export function parseBodyFromTokens(
   toks: Tok[], startIdx: number, opts: BodyOptions = {},
-): { block: BlockNode; nextIdx: number } {
+): { block: BlockNode; typeDefs: unknown[]; nextIdx: number } {
   const ctx: Ctx = { toks, i: startIdx, opts }
-  const block = parseBodyItems(ctx)
-  return { block, nextIdx: ctx.i }
+  const { block, typeDefs } = parseBodyItems(ctx)
+  return { block, typeDefs, nextIdx: ctx.i }
 }
 
-function parseBodyItems(ctx: Ctx): BlockNode {
+function parseBodyItems(ctx: Ctx): { block: BlockNode; typeDefs: unknown[] } {
   const decls: ExprNode[] = []
   const assigns: ExprNode[] = []
+  const typeDefs: unknown[] = []
   while (peek(ctx).kind !== '}' && peek(ctx).kind !== 'eof') {
     const item = parseBodyItem(ctx)
-    if (item.kind === 'decl') decls.push(item.node)
-    else assigns.push(item.node)
+    if (item.kind === 'decl')         decls.push(item.node)
+    else if (item.kind === 'assign')  assigns.push(item.node)
+    else                              typeDefs.push(item.typeDef)
     // Optional `;` separator
     eat(ctx, ';')
   }
-  return { op: 'block', decls, assigns }
+  return { block: { op: 'block', decls, assigns }, typeDefs }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -117,8 +136,9 @@ function parseBodyItems(ctx: Ctx): BlockNode {
 // ─────────────────────────────────────────────────────────────
 
 type BodyItem =
-  | { kind: 'decl';   node: ExprNode }
-  | { kind: 'assign'; node: ExprNode }
+  | { kind: 'decl';    node: ExprNode }
+  | { kind: 'assign';  node: ExprNode }
+  | { kind: 'typeDef'; typeDef: unknown }
 
 function parseBodyItem(ctx: Ctx): BodyItem {
   const t = peek(ctx)
@@ -137,6 +157,17 @@ function parseBodyItem(ctx: Ctx): BodyItem {
     const { node, nextIdx } = ctx.opts.programDeclParser(ctx.toks, ctx.i)
     ctx.i = nextIdx
     return { kind: 'decl', node }
+  }
+
+  if (t.kind === 'struct' || t.kind === 'enum' || t.kind === 'type') {
+    if (!ctx.opts.typeDefHandler) {
+      throw new ParseError(
+        `'${t.kind}' decl is not supported in this parser context`, t,
+      )
+    }
+    const { typeDef, nextIdx } = ctx.opts.typeDefHandler(ctx.toks, ctx.i)
+    ctx.i = nextIdx
+    return { kind: 'typeDef', typeDef }
   }
 
   if (t.kind === 'ident') {


### PR DESCRIPTION
## Summary
Phase B5 — final grammar layer. Adds ADT type defs (struct/enum/type) at the program-body level and match/tag expressions in expression position. The parser now covers the full \`tropical_program_2\` schema's expressive surface.

## Coverage
| Surface | IR |
|---|---|
| \`struct Name { field: float, ... }\` | \`{kind:'struct', name, fields}\` in \`ports.type_defs\` |
| \`enum Name { V, V(field: type, ...) }\` | \`{kind:'sum', name, variants}\` in \`ports.type_defs\` |
| \`type Alias = float in [lo, hi]\` | \`{kind:'alias', name, base, bounds}\` in \`ports.type_defs\` |
| \`Variant { field: expr }\` | \`{op:'tag', type:'', variant, payload}\` |
| \`match scrutinee { V { f: x } => body, V => body }\` | \`{op:'match', type:'', scrutinee, arms}\` |

## Cross-module wiring
- \`statements.ts\` gains a \`typeDefHandler\` callback in \`BodyOptions\` (mirrors the \`programDeclParser\` pattern from B4). When the body parser sees \`struct\`/\`enum\`/\`type\`, it delegates.
- \`parseBodyFromTokens\` now returns \`{ block, typeDefs, nextIdx }\`. Type defs are collected separately from \`body.decls\`/\`body.assigns\`, so the canonical \`BlockNode\` shape is preserved.
- \`declarations.ts\` provides the handler and routes the collected type defs into \`ports.type_defs\`.

## Surface decisions
- **Empty \`type\` field**: both \`tag\` and \`match\` ops emit \`type: ''\` as a placeholder. The elaborator (B6) infers the sum type from variant names by consulting the sum-type registry. This keeps the surface clean (no redundant \`match expr as SumName\` syntax).
- **Capitalization disambiguates tags from lets/structs**: \`Variant { field: expr }\` is a tag; lowercase \`let { x: 1 } in body\` is a let; struct decls require the leading \`struct\` keyword. No ambiguity.
- **Bare \`Variant\` stays as nameRef**: the elaborator decides whether to convert to a nullary tag based on registry lookup. Same uniform treatment as other identifiers.
- **bind serialization**: 0 fields → omit, 1 → string, >1 → array (matches \`MatchArm\` in \`compiler/expr.ts\`).

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test\` — 806 pass, 0 fail across 42 files (was 774 + 32 new in \`compiler/parse/adts.test.ts\`)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes

## What's NOT in this PR
- Elaborator (B6) — converts \`nameRef\` placeholders, fills \`tag.type\` and \`match.type\` from the registry, validates exhaustiveness
- Pretty-printer (B7), stdlib migration (B8), MCP integration (B9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)