### PR TITLE
feat(ir): resolved-graph IR + elaborator (Phase B6)

### DIFF
--- a/compiler/ir/elaborator.test.ts
+++ b/compiler/ir/elaborator.test.ts
@@ -1,0 +1,687 @@
+/**
+ * elaborator.test.ts — coverage for the parser → resolved-IR elaborator.
+ *
+ * The elaborator's job is to turn the parsed tree (with NameRefNode
+ * placeholders) into a graph where every reference is a direct decl
+ * reference. These tests verify both:
+ *   - resolution: each reference resolves to the correct decl
+ *   - reference identity: regRef.decl === <the actual RegDecl> (not just
+ *     a structurally-equal copy)
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { parseProgram } from '../parse/declarations.js'
+import { elaborate } from './elaborator.js'
+import { ElaborationError } from './nodes.js'
+import type {
+  ResolvedProgram, ResolvedExpr, ResolvedExprOpNode,
+  RegRef, InputRef, DelayRef, ParamRef, TypeParamRef, BindingRef,
+  NestedOut, BinaryOpNode, ClampNode, SelectNode,
+  TagExpr, MatchExpr, LetExpr, FoldExpr, GenerateExpr,
+  RegDecl, DelayDecl, ParamDecl, InputDecl, TypeParamDecl,
+  InstanceDecl, ProgramDecl, OutputAssign, NextUpdate,
+  SumTypeDef, AliasTypeDef,
+} from './nodes.js'
+
+function elabSrc(src: string): ResolvedProgram {
+  return elaborate(parseProgram(src))
+}
+
+// ─────────────────────────────────────────────────────────────
+// References resolve to decl objects (with `===` reference identity)
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — value references', () => {
+  test('input ref: nameRef resolves to InputRef.decl === the input port', () => {
+    const p = elabSrc('program X(freq: signal) -> (out: signal) { out = freq }')
+    const inputDecl = p.ports.inputs[0]
+    const outputAssign = p.body.assigns[0] as OutputAssign
+    const expr = outputAssign.expr as InputRef
+    expect(expr.op).toBe('inputRef')
+    expect(expr.decl).toBe(inputDecl)  // reference identity
+  })
+
+  test('reg ref: nameRef resolves to RegRef.decl === the regDecl', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        reg s: float = 0
+        out = s
+        next s = s
+      }
+    `)
+    const regDecl = p.body.decls[0] as RegDecl
+    const out = p.body.assigns[0] as OutputAssign
+    const next = p.body.assigns[1] as NextUpdate
+    const outRef = out.expr as RegRef
+    const nextRef = next.expr as RegRef
+    expect(outRef.op).toBe('regRef')
+    expect(outRef.decl).toBe(regDecl)
+    expect(nextRef.decl).toBe(regDecl)
+    // Both refs point at the same object — graph edge identity.
+    expect(outRef.decl).toBe(nextRef.decl)
+    // nextUpdate.target also points at the same RegDecl.
+    expect(next.target).toBe(regDecl)
+  })
+
+  test('delay ref: nameRef resolves to DelayRef.decl', () => {
+    const p = elabSrc(`
+      program X(x: signal) -> (out: signal) {
+        delay z = x init 0
+        out = z
+      }
+    `)
+    const delayDecl = p.body.decls[0] as DelayDecl
+    const out = p.body.assigns[0] as OutputAssign
+    const ref = out.expr as DelayRef
+    expect(ref.op).toBe('delayRef')
+    expect(ref.decl).toBe(delayDecl)
+  })
+
+  test('param ref: nameRef resolves to ParamRef.decl', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        param cutoff: smoothed = 1000
+        out = cutoff
+      }
+    `)
+    const paramDecl = p.body.decls[0] as ParamDecl
+    const out = p.body.assigns[0] as OutputAssign
+    const ref = out.expr as ParamRef
+    expect(ref.op).toBe('paramRef')
+    expect(ref.decl).toBe(paramDecl)
+  })
+
+  test('type-param ref: nameRef resolves to TypeParamRef.decl', () => {
+    const p = elabSrc(`
+      program X<N: int = 4>() -> (out: signal) {
+        out = N
+      }
+    `)
+    const typeParam = p.typeParams[0]
+    const out = p.body.assigns[0] as OutputAssign
+    const ref = out.expr as TypeParamRef
+    expect(ref.op).toBe('typeParamRef')
+    expect(ref.decl).toBe(typeParam)
+  })
+
+  test('unknown name: clear error', () => {
+    expect(() => elabSrc('program X() -> (out: signal) { out = nope }'))
+      .toThrow(/unknown name 'nope'/)
+  })
+})
+
+describe('elaborator — sentinel calls', () => {
+  test('sample_rate() resolves to SampleRate node', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) { out = sample_rate() }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    expect((out.expr as ResolvedExprOpNode).op).toBe('sampleRate')
+  })
+
+  test('sample_index() resolves to SampleIndex node', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) { out = sample_index() }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    expect((out.expr as ResolvedExprOpNode).op).toBe('sampleIndex')
+  })
+
+  test('sample_rate(arg) errors — nullary only', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) { out = sample_rate(0) }
+    `)).toThrow(/no arguments/)
+  })
+})
+
+describe('elaborator — builtin calls', () => {
+  test('clamp(v, lo, hi) resolves to ClampNode', () => {
+    const p = elabSrc(`
+      program X(v: signal) -> (out: signal) { out = clamp(v, -1, 1) }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const c = out.expr as ClampNode
+    expect(c.op).toBe('clamp')
+    expect(c.args.length).toBe(3)
+  })
+
+  test('select(c, t, e) resolves to SelectNode', () => {
+    const p = elabSrc(`
+      program X(g: bool) -> (out: signal) { out = select(g, 1, 0) }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const s = out.expr as SelectNode
+    expect(s.op).toBe('select')
+  })
+
+  test('sqrt(x) resolves to UnaryOpNode with sqrt op', () => {
+    const p = elabSrc(`
+      program X(x: signal) -> (out: signal) { out = sqrt(x) }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const u = out.expr as { op: string }
+    expect(u.op).toBe('sqrt')
+  })
+
+  test('unknown function call errors', () => {
+    expect(() => elabSrc(`
+      program X(x: signal) -> (out: signal) { out = mystery(x) }
+    `)).toThrow(/unknown function 'mystery'/)
+  })
+
+  test('clamp wrong arity errors', () => {
+    expect(() => elabSrc(`
+      program X(v: signal) -> (out: signal) { out = clamp(v, -1) }
+    `)).toThrow(/'clamp' takes 3 arguments/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Binders (let / combinator / match arm) become decl objects
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — binders are decl objects with refs', () => {
+  test('let binders become BinderDecl, body refs hold the decl', () => {
+    const p = elabSrc(`
+      program X(a: signal) -> (out: signal) {
+        out = let { x: a } in x + x
+      }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const letExpr = out.expr as LetExpr
+    expect(letExpr.op).toBe('let')
+    expect(letExpr.binders.length).toBe(1)
+    const xBinder = letExpr.binders[0].binder
+    const body = letExpr.in as BinaryOpNode
+    expect(body.op).toBe('add')
+    const left = body.args[0] as BindingRef
+    const right = body.args[1] as BindingRef
+    expect(left.op).toBe('bindingRef')
+    expect(left.decl).toBe(xBinder)
+    expect(right.decl).toBe(xBinder)
+    // Both occurrences share the same binder decl — graph edge identity.
+    expect(left.decl).toBe(right.decl)
+  })
+
+  test('shadowing: inner let binder shadows outer; refs distinguish', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        out = let { x: 1 } in let { x: 2 } in x
+      }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const outer = out.expr as LetExpr
+    const inner = outer.in as LetExpr
+    const outerX = outer.binders[0].binder
+    const innerX = inner.binders[0].binder
+    expect(outerX).not.toBe(innerX)  // distinct decl objects
+    const innerRef = inner.in as BindingRef
+    expect(innerRef.decl).toBe(innerX)  // refers to inner, not outer
+  })
+
+  test('fold binders (acc, elem) become two BinderDecls', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        out = fold([1, 2, 3], 0, (acc, e) => acc + e)
+      }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const fold = out.expr as FoldExpr
+    expect(fold.op).toBe('fold')
+    const accBinder = fold.acc
+    const elemBinder = fold.elem
+    expect(accBinder.name).toBe('acc')
+    expect(elemBinder.name).toBe('e')
+    const body = fold.body as BinaryOpNode
+    const lhs = body.args[0] as BindingRef
+    const rhs = body.args[1] as BindingRef
+    expect(lhs.decl).toBe(accBinder)
+    expect(rhs.decl).toBe(elemBinder)
+  })
+
+  test('generate binder', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        out = generate(4, (i) => i * i)
+      }
+    `)
+    const out = p.body.assigns[0] as OutputAssign
+    const gen = out.expr as GenerateExpr
+    const iterBinder = gen.iter
+    const body = gen.body as BinaryOpNode
+    const lhs = body.args[0] as BindingRef
+    const rhs = body.args[1] as BindingRef
+    expect(lhs.decl).toBe(iterBinder)
+    expect(rhs.decl).toBe(iterBinder)
+  })
+
+  test('binders do not leak outside their parent', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        out = (let { x: 1 } in x) + x
+      }
+    `)).toThrow(/unknown name 'x'/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// ADTs: tag construction and match elimination
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — tags', () => {
+  test('tag construction: variant resolves, payload field decl-keyed', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        enum Maybe { Some(value: float), None }
+        out = match Some { value: 42 } {
+          Some { value: v } => v,
+          None => 0
+        }
+      }
+    `)
+    const matchExpr = (p.body.assigns[0] as OutputAssign).expr as MatchExpr
+    const tag = matchExpr.scrutinee as TagExpr
+    expect(tag.op).toBe('tag')
+    expect(tag.variant.name).toBe('Some')
+    // Variant carries a back-pointer to its parent SumTypeDef
+    expect(tag.variant.parent.name).toBe('Maybe')
+    // Payload field references the variant's StructField decl
+    expect(tag.payload.length).toBe(1)
+    expect(tag.payload[0].field.name).toBe('value')
+    expect(tag.payload[0].field).toBe(tag.variant.payload[0])
+  })
+
+  test('tag with unknown variant errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        enum Mode { On, Off }
+        out = match Bogus { } {
+          On => 1,
+          Off => 0
+        }
+      }
+    `)).toThrow(/unknown variant 'Bogus'/)
+  })
+
+  test('tag missing required payload field errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        enum Pair { P(a: float, b: float) }
+        out = match P { a: 1 } { P { a: x, b: y } => x + y }
+      }
+    `)).toThrow(/missing payload field 'b'/)
+  })
+
+  test('tag with extra payload field errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        enum Pair { P(a: float) }
+        out = match P { a: 1, b: 2 } { P { a: x } => x }
+      }
+    `)).toThrow(/unknown payload field/)
+  })
+})
+
+describe('elaborator — match', () => {
+  test('match scrutinee + arms resolve; type back-pointer set', () => {
+    const p = elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum Color { Red, Green, Blue }
+        out = match v {
+          Red => 1,
+          Green => 2,
+          Blue => 3
+        }
+      }
+    `)
+    const matchExpr = (p.body.assigns[0] as OutputAssign).expr as MatchExpr
+    expect(matchExpr.op).toBe('match')
+    expect(matchExpr.type.name).toBe('Color')
+    expect(matchExpr.arms.length).toBe(3)
+    // Each arm holds a SumVariant, not a name string.
+    expect(matchExpr.arms[0].variant.name).toBe('Red')
+    expect(matchExpr.arms[0].variant.parent).toBe(matchExpr.type)
+  })
+
+  test('match arm payload binders become BinderDecls in scope of arm body', () => {
+    const p = elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum N { Hz(freq: float, gain: float), Off }
+        out = match v {
+          Hz { freq: f, gain: g } => f * g,
+          Off => 0
+        }
+      }
+    `)
+    const matchExpr = (p.body.assigns[0] as OutputAssign).expr as MatchExpr
+    const hzArm = matchExpr.arms.find(a => a.variant.name === 'Hz')!
+    expect(hzArm.binders.length).toBe(2)
+    expect(hzArm.binders[0].name).toBe('f')
+    expect(hzArm.binders[1].name).toBe('g')
+    const body = hzArm.body as BinaryOpNode
+    const lhs = body.args[0] as BindingRef
+    const rhs = body.args[1] as BindingRef
+    expect(lhs.decl).toBe(hzArm.binders[0])
+    expect(rhs.decl).toBe(hzArm.binders[1])
+  })
+
+  test('non-exhaustive match errors with missing variant name', () => {
+    expect(() => elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum Color { Red, Green, Blue }
+        out = match v { Red => 1, Green => 2 }
+      }
+    `)).toThrow(/non-exhaustive: missing variant 'Blue'/)
+  })
+
+  test('arm with wrong variant for the inferred sum type errors', () => {
+    expect(() => elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum A { On }
+        enum B { Off }
+        out = match v { On => 1, Off => 0 }
+      }
+    `)).toThrow(/'Off' is not a member of sum type 'A'/)
+  })
+
+  test('duplicate arm errors', () => {
+    expect(() => elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum Color { Red, Green }
+        out = match v { Red => 1, Green => 2, Red => 3 }
+      }
+    `)).toThrow(/duplicate arm for variant 'Red'/)
+  })
+
+  test('arm binder count must match payload arity', () => {
+    expect(() => elabSrc(`
+      program X(v: signal) -> (out: signal) {
+        enum E { Two(a: float, b: float) }
+        out = match v { Two { a: x } => x }
+      }
+    `)).toThrow(/expected 2 binder/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Instances + nested programs
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — instances + nested programs', () => {
+  test('instance refs the nested program decl by reference; ports keyed by InputDecl', () => {
+    const p = elabSrc(`
+      program Outer() -> (out: signal) {
+        program Inner(x: signal = 0) -> (y: signal) { y = x }
+        i = Inner(x: 1)
+        out = i.y
+      }
+    `)
+    // The nested ProgramDecl
+    const progDecl = p.body.decls[0] as ProgramDecl
+    expect(progDecl.op).toBe('programDecl')
+    // The instance
+    const instDecl = p.body.decls[1] as InstanceDecl
+    expect(instDecl.op).toBe('instanceDecl')
+    expect(instDecl.type).toBe(progDecl.program)  // shared reference
+    // Input wire is keyed by the actual InputDecl
+    expect(instDecl.inputs.length).toBe(1)
+    expect(instDecl.inputs[0].port).toBe(progDecl.program.ports.inputs[0])
+    // The output assign uses NestedOut with OutputDecl reference
+    const out = p.body.assigns[0] as OutputAssign
+    const nest = out.expr as NestedOut
+    expect(nest.op).toBe('nestedOut')
+    expect(nest.instance).toBe(instDecl)
+    expect(nest.output).toBe(progDecl.program.ports.outputs[0])
+  })
+
+  test('instance with unknown program type errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        osc = NotDeclared(freq: 440)
+        out = 0
+      }
+    `)).toThrow(/program type 'NotDeclared' is not a nested program/)
+  })
+
+  test('instance with unknown input port errors with helpful list', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        program P(a: signal) -> (out: signal) { out = a }
+        i = P(b: 1)
+        out = i.out
+      }
+    `)).toThrow(/input 'b' is not a declared port of 'P' \(have: a\)/)
+  })
+
+  test('instance with unknown output port errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        program P() -> (y: signal) { y = 0 }
+        i = P()
+        out = i.z
+      }
+    `)).toThrow(/has no output 'z'/)
+  })
+
+  test('type-args resolve to the program type\'s TypeParamDecl', () => {
+    const p = elabSrc(`
+      program Outer() -> (out: signal) {
+        program Inner<N: int = 4>() -> (y: signal) { y = N }
+        i = Inner<N=8>()
+        out = i.y
+      }
+    `)
+    const progDecl = p.body.decls[0] as ProgramDecl
+    const instDecl = p.body.decls[1] as InstanceDecl
+    expect(instDecl.typeArgs.length).toBe(1)
+    expect(instDecl.typeArgs[0].param).toBe(progDecl.program.typeParams[0])
+    expect(instDecl.typeArgs[0].value).toBe(8)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Output assigns + dac.out
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — output assigns', () => {
+  test('outputAssign target is the actual OutputDecl', () => {
+    const p = elabSrc('program X() -> (out: signal) { out = 1 }')
+    const out = p.body.assigns[0] as OutputAssign
+    if (out.target !== null && typeof out.target === 'object' && 'kind' in out.target) {
+      throw new Error('expected OutputDecl, got dac sentinel')
+    }
+    expect(out.target).toBe(p.ports.outputs[0])
+  })
+
+  test('dac.out target is the dac sentinel', () => {
+    const p = elabSrc(`
+      program Patch() {
+        program Osc() -> (out: signal) { out = 0 }
+        o = Osc()
+        dac.out = o.out
+      }
+    `)
+    // Find the assign for dac.out
+    const dacAssign = p.body.assigns.find(a =>
+      a.op === 'outputAssign'
+      && (a.target as { kind?: string }).kind === 'dac',
+    ) as OutputAssign
+    expect((dacAssign.target as { kind: string }).kind).toBe('dac')
+  })
+
+  test('outputAssign to undeclared output errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        unknown = 0
+        out = 0
+      }
+    `)).toThrow(/unknown output port 'unknown'/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Type defs
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — type defs', () => {
+  test('alias type-def: base resolves to ScalarKind', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        type Bipolar = float in [-1, 1]
+        out = 0
+      }
+    `)
+    const alias = p.ports.typeDefs[0] as AliasTypeDef
+    expect(alias.op).toBe('aliasTypeDef')
+    expect(alias.base).toBe('float')
+    expect(alias.bounds).toEqual([-1, 1])
+  })
+
+  test('struct type-def: fields preserve scalar kinds', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        struct Pair { a: float, b: int }
+        out = 0
+      }
+    `)
+    const td = p.ports.typeDefs[0] as { op: string; fields: Array<{ type: string }> }
+    expect(td.op).toBe('structTypeDef')
+    expect(td.fields[0].type).toBe('float')
+    expect(td.fields[1].type).toBe('int')
+  })
+
+  test('sum variant carries back-pointer to parent type', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        enum Mode { On, Off }
+        out = 0
+      }
+    `)
+    const sum = p.ports.typeDefs[0] as SumTypeDef
+    expect(sum.variants[0].parent).toBe(sum)
+    expect(sum.variants[1].parent).toBe(sum)
+  })
+
+  test('variant name conflict across sum types errors', () => {
+    expect(() => elabSrc(`
+      program X() -> (out: signal) {
+        enum A { Same, A1 }
+        enum B { Same, B1 }
+        out = 0
+      }
+    `)).toThrow(/variant 'Same' is declared in multiple sum types/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Port types and shape dims
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — port types', () => {
+  test('scalar port type resolves to {kind:scalar, scalar}', () => {
+    const p = elabSrc('program X(x: float) -> (out: signal) { out = x }')
+    const portType = p.ports.inputs[0].type
+    expect(portType).toEqual({ kind: 'scalar', scalar: 'float' })
+  })
+
+  test('array port type with type-param shape dim resolves dim to TypeParamDecl', () => {
+    const p = elabSrc(`
+      program X<N: int = 4>(buf: float[N]) -> (out: signal) { out = 0 }
+    `)
+    const inputType = p.ports.inputs[0].type
+    if (!inputType || inputType.kind !== 'array') throw new Error('expected array')
+    expect(inputType.shape[0]).toBe(p.typeParams[0])  // === reference identity
+  })
+
+  test('shape dim references undeclared type-param errors', () => {
+    expect(() => elabSrc(`
+      program X(buf: float[K]) -> (out: signal) { out = 0 }
+    `)).toThrow(/'K' is not a declared type-param/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Graph integrity invariants
+// ─────────────────────────────────────────────────────────────
+
+describe('elaborator — graph integrity', () => {
+  test('a single declaration produces exactly one decl object', () => {
+    const p = elabSrc(`
+      program X() -> (out: signal) {
+        reg s: float = 0
+        out = s + s + s
+        next s = s
+      }
+    `)
+    const regDecl = p.body.decls[0] as RegDecl
+    // Walk all references; every regRef.decl is the same object.
+    const seen: unknown[] = []
+    walk(p, (obj) => {
+      if ((obj as { op?: string }).op === 'regRef') {
+        seen.push((obj as { decl: unknown }).decl)
+      }
+    })
+    expect(seen.length).toBeGreaterThan(0)
+    for (const s of seen) {
+      expect(s).toBe(regDecl)  // strict reference identity
+    }
+  })
+
+  test('elaborating the same source twice produces structurally identical graphs', () => {
+    const src = `
+      program X(x: signal) -> (out: signal) {
+        reg s: float = 0
+        out = x + s
+        next s = s + 1
+      }
+    `
+    const a = elabSrc(src)
+    const b = elabSrc(src)
+    // Same shape, but DIFFERENT decl objects (the two elaborations
+    // produce distinct graphs). Internal reference identity within each
+    // graph is preserved; cross-graph identity is not.
+    expect(a).not.toBe(b)
+    expect(a.body.decls[0]).not.toBe(b.body.decls[0])  // distinct RegDecls
+    // Structurally equal: same names, same shapes
+    const aReg = a.body.decls[0] as RegDecl
+    const bReg = b.body.decls[0] as RegDecl
+    expect(aReg.name).toBe(bReg.name)
+    expect(aReg.init).toEqual(bReg.init)
+  })
+
+  test('feedback through a register is a graph cycle (decl referenced via next)', () => {
+    const p = elabSrc(`
+      program X(x: signal) -> (out: signal) {
+        reg s: float = 0
+        out = s
+        next s = s + x
+      }
+    `)
+    const regDecl = p.body.decls[0] as RegDecl
+    const next = p.body.assigns[1] as NextUpdate
+    // The reg's nextUpdate target points at the same RegDecl as
+    // p.body.decls[0]. The expr graph contains a regRef that also points
+    // at it. This is a cycle in the graph (decl ↔ ref ↔ decl).
+    expect(next.target).toBe(regDecl)
+    const expr = next.expr as BinaryOpNode
+    expect((expr.args[0] as RegRef).decl).toBe(regDecl)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Helper: walk every plain object in a value, calling visit
+// ─────────────────────────────────────────────────────────────
+function walk(value: unknown, visit: (obj: Record<string, unknown>) => void, seen = new WeakSet()): void {
+  if (Array.isArray(value)) {
+    for (const v of value) walk(v, visit, seen)
+    return
+  }
+  if (value !== null && typeof value === 'object') {
+    if (seen.has(value as object)) return
+    seen.add(value as object)
+    visit(value as Record<string, unknown>)
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      walk(v, visit, seen)
+    }
+  }
+}

--- a/compiler/ir/elaborator.ts
+++ b/compiler/ir/elaborator.ts
@@ -1,0 +1,1071 @@
+/**
+ * compiler/ir/elaborator.ts — parsed tree → resolved graph.
+ *
+ * The elaborator's job is substitution of free variables (NameRefNodes)
+ * by their decl objects. It runs in a single top-down pass over the
+ * parsed program: each declaration is constructed once when its
+ * parsed-counterpart is encountered, registered in the appropriate
+ * scope, and re-used by reference at every site that names it.
+ *
+ * Reference identity falls out of this discipline: every RegRef.decl
+ * for a given register is `===` the same RegDecl object. The output is
+ * a graph (it admits cycles via delays + feedback) where every reference
+ * is a TypeScript reference, not a string lookup.
+ *
+ * This module is one function (`elaborate`) plus its helpers. There are
+ * no factories, no classes, no smart-constructors. Each Decl object is
+ * built by the elaborator at its single construction site; the resolved
+ * IR's introduction rules are the literal object literals in this file.
+ */
+
+import type {
+  ParsedExprNode,
+  ExprOpNode as ParsedExprOpNode,
+  NameRefNode as ParsedNameRefNode,
+  ProgramNode as ParsedProgramNode,
+  BlockNode as ParsedBlockNode,
+  BodyDecl as ParsedBodyDecl,
+  BodyAssign as ParsedBodyAssign,
+  RegDeclNode as ParsedRegDecl,
+  DelayDeclNode as ParsedDelayDecl,
+  ParamDeclNode as ParsedParamDecl,
+  InstanceDeclNode as ParsedInstanceDecl,
+  ProgramDeclNode as ParsedProgramDecl,
+  OutputAssignNode as ParsedOutputAssign,
+  NextUpdateNode as ParsedNextUpdate,
+  ProgramPort as ParsedProgramPort,
+  PortTypeDecl as ParsedPortType,
+  ShapeDim as ParsedShapeDim,
+  TypeDef as ParsedTypeDef,
+  StructTypeDef as ParsedStructTypeDef,
+  SumTypeDef as ParsedSumTypeDef,
+  AliasTypeDef as ParsedAliasTypeDef,
+  StructField as ParsedStructField,
+  CallNode as ParsedCallNode,
+  TagNode as ParsedTag,
+  MatchNode as ParsedMatch,
+  LetNode as ParsedLetNode,
+  FoldNode as ParsedFold,
+  ScanNode as ParsedScan,
+  GenerateNode as ParsedGenerate,
+  IterateNode as ParsedIterate,
+  ChainNode as ParsedChain,
+  Map2Node as ParsedMap2,
+  ZipWithNode as ParsedZipWith,
+  IndexNode as ParsedIndex,
+  NestedOutNode as ParsedNestedOut,
+  BindingNode as ParsedBindingNode,
+  BinaryOpNode as ParsedBinary,
+  UnaryOpNode as ParsedUnary,
+} from '../parse/nodes.js'
+import type {
+  ResolvedProgram, ResolvedBlock, ResolvedProgramPorts,
+  ResolvedExpr, ResolvedExprOpNode,
+  InputDecl, OutputDecl, TypeParamDecl,
+  RegDecl, DelayDecl, ParamDecl, InstanceDecl, ProgramDecl, BodyDecl,
+  BodyAssign, OutputAssign, NextUpdate,
+  TypeDef, StructTypeDef, SumTypeDef, SumVariant, AliasTypeDef, StructField,
+  PortType, ShapeDim, ScalarKind,
+  BinderDecl,
+  InputRef, RegRef, DelayRef, ParamRef, TypeParamRef, BindingRef,
+  NestedOut,
+  TagExpr, MatchExpr, MatchArm,
+  LetExpr,
+  FoldExpr, ScanExpr, GenerateExpr, IterateExpr, ChainExpr, Map2Expr, ZipWithExpr,
+  ClampNode, SelectNode, IndexNode,
+  BinaryOpNode, UnaryOpNode, UnaryOpTag,
+  SampleRateNode, SampleIndexNode,
+} from './nodes.js'
+import { ElaborationError } from './nodes.js'
+
+const SCALAR_KINDS: ReadonlySet<string> = new Set(['float', 'int', 'bool'])
+const SCALAR_ALIASES: ReadonlySet<string> = new Set([
+  // bare scalars
+  'float', 'int', 'bool',
+  // common builtin port-type aliases that pass through to ScalarKind
+  // (these stay as ScalarKind, not AliasTypeDef, since they have no
+  // bounds metadata — they're the user-facing names for raw types)
+  'signal', 'freq', 'unipolar', 'bipolar',
+])
+
+/** Builtin port-type aliases that map to a ScalarKind. */
+const BUILTIN_TYPE_TO_SCALAR: Record<string, ScalarKind> = {
+  float: 'float', int: 'int', bool: 'bool',
+  signal: 'float', freq: 'float', unipolar: 'float', bipolar: 'float',
+}
+
+/** Builtin nullary calls: `sample_rate()`, `sample_index()`. */
+const NULLARY_CALLS: ReadonlySet<string> = new Set(['sample_rate', 'sample_index'])
+
+/** Builtin unary function calls — surface name → resolved op tag. */
+const UNARY_CALLS: Record<string, UnaryOpTag> = {
+  sqrt: 'sqrt', abs: 'abs', neg: 'neg',
+  floor: 'floor', ceil: 'ceil', round: 'round',
+  not: 'not', bit_not: 'bitNot',
+  to_int: 'toInt', to_bool: 'toBool', to_float: 'toFloat',
+  float_exponent: 'floatExponent',
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scope
+// ─────────────────────────────────────────────────────────────
+
+interface Scope {
+  inputs: Map<string, InputDecl>
+  outputs: Map<string, OutputDecl>
+  typeParams: Map<string, TypeParamDecl>
+  regs: Map<string, RegDecl>
+  delays: Map<string, DelayDecl>
+  params: Map<string, ParamDecl>
+  instances: Map<string, InstanceDecl>
+  /** Sub-program decls visible in this scope (nested programDecl). */
+  programs: Map<string, ResolvedProgram>
+  /** Type defs (struct/sum/alias) by name. */
+  typeDefs: Map<string, TypeDef>
+  /** Variant name → its parent SumTypeDef + variant decl. Variants are
+   *  unique across all sum types in a single program; the parser doesn't
+   *  enforce that, so we check on registration here. */
+  variantOf: Map<string, SumVariant>
+  /** Active anonymous binders (let/combinator/match-arm). */
+  binders: Map<string, BinderDecl>
+  /** Parent scope — for nested programs to read outer type-defs and
+   *  external program types. (Decls themselves don't leak — only
+   *  type-defs and program registrations.) */
+  parent?: Scope
+}
+
+function emptyScope(parent?: Scope): Scope {
+  return {
+    inputs: new Map(),
+    outputs: new Map(),
+    typeParams: new Map(),
+    regs: new Map(),
+    delays: new Map(),
+    params: new Map(),
+    instances: new Map(),
+    programs: new Map(),
+    typeDefs: new Map(),
+    variantOf: new Map(),
+    binders: new Map(),
+    parent,
+  }
+}
+
+/** Look up a name across scope categories in a defined order. Used when
+ *  resolving a NameRefNode in expression position — the position has a
+ *  fixed semantic intent (a value-producing reference), and we try each
+ *  applicable scope. */
+function lookupValueRef(scope: Scope, name: string): ResolvedExprOpNode | null {
+  // Local binders (innermost-first via the Scope's own state)
+  const binder = scope.binders.get(name)
+  if (binder) {
+    const ref: BindingRef = { op: 'bindingRef', decl: binder }
+    return ref
+  }
+  const reg = scope.regs.get(name)
+  if (reg) {
+    const ref: RegRef = { op: 'regRef', decl: reg }
+    return ref
+  }
+  const delay = scope.delays.get(name)
+  if (delay) {
+    const ref: DelayRef = { op: 'delayRef', decl: delay }
+    return ref
+  }
+  const param = scope.params.get(name)
+  if (param) {
+    const ref: ParamRef = { op: 'paramRef', decl: param }
+    return ref
+  }
+  const input = scope.inputs.get(name)
+  if (input) {
+    const ref: InputRef = { op: 'inputRef', decl: input }
+    return ref
+  }
+  const tp = scope.typeParams.get(name)
+  if (tp) {
+    const ref: TypeParamRef = { op: 'typeParamRef', decl: tp }
+    return ref
+  }
+  return null
+}
+
+/** Look up a sub-program by name (instances reference these by NameRef). */
+function lookupProgram(scope: Scope, name: string): ResolvedProgram | null {
+  let s: Scope | undefined = scope
+  while (s) {
+    const p = s.programs.get(name)
+    if (p) return p
+    s = s.parent
+  }
+  return null
+}
+
+/** Resolve a port-type's element name (must be a scalar kind or alias). */
+function resolveElement(scope: Scope, ref: ParsedNameRefNode): ScalarKind | AliasTypeDef {
+  const builtin = BUILTIN_TYPE_TO_SCALAR[ref.name]
+  if (builtin) return builtin
+  let s: Scope | undefined = scope
+  while (s) {
+    const td = s.typeDefs.get(ref.name)
+    if (td !== undefined) {
+      if (td.op !== 'aliasTypeDef') {
+        throw new ElaborationError(
+          `port type '${ref.name}' must be a scalar kind or alias; got ${td.op}`,
+        )
+      }
+      return td
+    }
+    s = s.parent
+  }
+  throw new ElaborationError(`unknown type name '${ref.name}'`)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Public entry
+// ─────────────────────────────────────────────────────────────
+
+/** Resolve a parsed program to a graph IR. The returned object carries
+ *  declared inputs/outputs/type-params/type-defs as Decl objects, and
+ *  every reference inside the body is a direct edge to one of those
+ *  decls. */
+export function elaborate(prog: ParsedProgramNode): ResolvedProgram {
+  return elaborateProgram(prog, undefined)
+}
+
+function elaborateProgram(prog: ParsedProgramNode, parent: Scope | undefined): ResolvedProgram {
+  const scope = emptyScope(parent)
+
+  // 1. Type-defs from `ports.type_defs` first — the elaborator's port-type
+  //    + decl walks need them in scope.
+  const typeDefs: TypeDef[] = []
+  for (const td of prog.ports?.type_defs ?? []) {
+    const resolved = resolveTypeDef(td, scope)
+    registerTypeDef(scope, resolved)
+    typeDefs.push(resolved)
+  }
+
+  // 2. Type-params (`<N: int = 4>`).
+  const typeParams: TypeParamDecl[] = []
+  if (prog.type_params) {
+    for (const [name, info] of Object.entries(prog.type_params)) {
+      const decl: TypeParamDecl = { op: 'typeParamDecl', name }
+      if (info.default !== undefined) decl.default = info.default
+      scope.typeParams.set(name, decl)
+      typeParams.push(decl)
+    }
+  }
+
+  // 3. Input ports + output ports. Inputs may have `default` exprs that
+  //    can reference type-params in shape position — type-params are now
+  //    in scope from step 2.
+  const inputs: InputDecl[] = []
+  for (const portSpec of prog.ports?.inputs ?? []) {
+    const decl = resolveInputPort(portSpec, scope)
+    if (scope.inputs.has(decl.name)) {
+      throw new ElaborationError(`duplicate input port '${decl.name}'`)
+    }
+    scope.inputs.set(decl.name, decl)
+    inputs.push(decl)
+  }
+  const outputs: OutputDecl[] = []
+  for (const portSpec of prog.ports?.outputs ?? []) {
+    const decl = resolveOutputPort(portSpec, scope)
+    if (scope.outputs.has(decl.name)) {
+      throw new ElaborationError(`duplicate output port '${decl.name}'`)
+    }
+    scope.outputs.set(decl.name, decl)
+    outputs.push(decl)
+  }
+
+  // 4. Register body decls (reg/delay/param/instance/programDecl) first,
+  //    so expressions in those decls and in body assigns can reference
+  //    one another regardless of source order. Register builds decl
+  //    shells with placeholder expressions; pairing is recorded so the
+  //    second pass can fill them in.
+  const pairing = new Map<ParsedBodyDecl, BodyDecl>()
+  const decls = registerBodyDecls(prog.body, scope, pairing)
+
+  // 5. Resolve expressions inside body decls (init/update/instance inputs).
+  for (const [parsed, resolved] of pairing) {
+    resolveDeclExpressions(parsed, resolved, scope)
+  }
+
+  // 6. Resolve body assigns.
+  const assigns: BodyAssign[] = []
+  for (const a of prog.body.assigns ?? []) {
+    assigns.push(resolveAssign(a, scope))
+  }
+
+  const block: ResolvedBlock = { op: 'block', decls, assigns }
+  const ports: ResolvedProgramPorts = { inputs, outputs, typeDefs }
+  const resolved: ResolvedProgram = {
+    op: 'program',
+    name: prog.name,
+    typeParams,
+    ports,
+    body: block,
+  }
+
+  // Make this program visible to its containing scope (for sibling
+  // nested programs) — caller registers the wrapping ProgramDecl.
+  return resolved
+}
+
+// ─────────────────────────────────────────────────────────────
+// Type defs
+// ─────────────────────────────────────────────────────────────
+
+function resolveTypeDef(td: ParsedTypeDef, scope: Scope): TypeDef {
+  if (td.kind === 'struct') return resolveStructTypeDef(td, scope)
+  if (td.kind === 'sum')    return resolveSumTypeDef(td, scope)
+  if (td.kind === 'alias')  return resolveAliasTypeDef(td, scope)
+  // Defensive: discriminator should be exhaustive.
+  throw new ElaborationError(`unknown type-def kind`)
+}
+
+function resolveStructTypeDef(td: ParsedStructTypeDef, scope: Scope): StructTypeDef {
+  const fields = td.fields.map(f => resolveStructField(f, scope))
+  return { op: 'structTypeDef', name: td.name, fields }
+}
+
+function resolveStructField(f: ParsedStructField, scope: Scope): StructField {
+  // ParsedStructField has `scalar_type: 'float'|'int'|'bool'` (a literal).
+  // The resolved field's `type` can also be an AliasTypeDef, but since
+  // the parser only allows scalar literals here, all parsed fields land
+  // as ScalarKind.
+  return { op: 'structField', name: f.name, type: f.scalar_type }
+}
+
+function resolveSumTypeDef(td: ParsedSumTypeDef, scope: Scope): SumTypeDef {
+  // Build the sum decl shell first so each variant can hold its
+  // back-pointer.
+  const sum: SumTypeDef = { op: 'sumTypeDef', name: td.name, variants: [] }
+  for (const v of td.variants) {
+    const variant: SumVariant = {
+      op: 'sumVariant',
+      name: v.name,
+      payload: v.payload.map(f => resolveStructField(f, scope)),
+      parent: sum,
+    }
+    sum.variants.push(variant)
+  }
+  return sum
+}
+
+function resolveAliasTypeDef(td: ParsedAliasTypeDef, scope: Scope): AliasTypeDef {
+  if (!SCALAR_KINDS.has(td.base.name)) {
+    throw new ElaborationError(
+      `alias '${td.name}' base must be a scalar kind (float/int/bool); got '${td.base.name}'`,
+    )
+  }
+  return {
+    op: 'aliasTypeDef',
+    name: td.name,
+    base: td.base.name as ScalarKind,
+    bounds: td.bounds,
+  }
+}
+
+function registerTypeDef(scope: Scope, td: TypeDef): void {
+  if (scope.typeDefs.has(td.name)) {
+    throw new ElaborationError(`duplicate type def '${td.name}'`)
+  }
+  scope.typeDefs.set(td.name, td)
+  if (td.op === 'sumTypeDef') {
+    for (const v of td.variants) {
+      if (scope.variantOf.has(v.name)) {
+        throw new ElaborationError(
+          `variant '${v.name}' is declared in multiple sum types — variant names must be unique`,
+        )
+      }
+      scope.variantOf.set(v.name, v)
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Port specs
+// ─────────────────────────────────────────────────────────────
+
+function resolveInputPort(spec: ParsedProgramPort, scope: Scope): InputDecl {
+  if (typeof spec === 'string') {
+    return { op: 'inputDecl', name: spec }
+  }
+  const decl: InputDecl = { op: 'inputDecl', name: spec.name }
+  if (spec.type !== undefined) decl.type = resolvePortType(spec.type, scope)
+  if (spec.default !== undefined) decl.default = resolveExpr(spec.default, scope)
+  if (spec.bounds !== undefined) decl.bounds = spec.bounds
+  return decl
+}
+
+function resolveOutputPort(spec: ParsedProgramPort, scope: Scope): OutputDecl {
+  if (typeof spec === 'string') {
+    return { op: 'outputDecl', name: spec }
+  }
+  const decl: OutputDecl = { op: 'outputDecl', name: spec.name }
+  if (spec.type !== undefined) decl.type = resolvePortType(spec.type, scope)
+  if (spec.bounds !== undefined) decl.bounds = spec.bounds
+  return decl
+}
+
+function resolvePortType(pt: ParsedPortType, scope: Scope): PortType {
+  if (isParsedNameRef(pt)) {
+    const builtin = BUILTIN_TYPE_TO_SCALAR[pt.name]
+    if (builtin) return { kind: 'scalar', scalar: builtin }
+    const td = lookupTypeDef(scope, pt.name)
+    if (td && td.op === 'aliasTypeDef') return { kind: 'alias', alias: td }
+    throw new ElaborationError(`unknown port type '${pt.name}'`)
+  }
+  // Array form
+  const element = resolveElement(scope, pt.element)
+  const shape: ShapeDim[] = pt.shape.map(d => resolveShapeDim(d, scope))
+  return { kind: 'array', element, shape }
+}
+
+function resolveShapeDim(d: ParsedShapeDim, scope: Scope): ShapeDim {
+  if (typeof d === 'number') return d
+  // d is a NameRefNode in shape position — must resolve to a TypeParamDecl.
+  let s: Scope | undefined = scope
+  while (s) {
+    const tp = s.typeParams.get(d.name)
+    if (tp) return tp
+    s = s.parent
+  }
+  throw new ElaborationError(
+    `array shape dim '${d.name}' is not a declared type-param of any enclosing program`,
+  )
+}
+
+function lookupTypeDef(scope: Scope, name: string): TypeDef | null {
+  let s: Scope | undefined = scope
+  while (s) {
+    const td = s.typeDefs.get(name)
+    if (td !== undefined) return td
+    s = s.parent
+  }
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────
+// Body decls — register first, then resolve expressions
+// ─────────────────────────────────────────────────────────────
+
+function registerBodyDecls(
+  body: ParsedBlockNode,
+  scope: Scope,
+  pairing: Map<ParsedBodyDecl, BodyDecl>,
+): BodyDecl[] {
+  const out: BodyDecl[] = []
+  // Programs first: nested sub-programs need to be resolved before any
+  // sibling instance decls reference them.
+  for (const d of body.decls ?? []) {
+    if (isParsedProgramDecl(d)) {
+      const inner = elaborateProgram(d.program, scope)
+      const decl: ProgramDecl = { op: 'programDecl', name: d.name, program: inner }
+      if (scope.programs.has(d.name)) {
+        throw new ElaborationError(`duplicate nested program '${d.name}'`)
+      }
+      scope.programs.set(d.name, inner)
+      out.push(decl)
+      // No second-pass work for programDecl — the inner program was
+      // fully elaborated above.
+    }
+  }
+
+  // Then the rest, in source order. We construct decl shells (with
+  // expressions left as placeholders) and register them in scope, so
+  // forward refs work. Expressions are resolved in a second pass via
+  // the pairing map.
+  for (const d of body.decls ?? []) {
+    if (isParsedProgramDecl(d)) continue  // already handled
+    const decl = registerOneDecl(d, scope)
+    pairing.set(d, decl)
+    out.push(decl)
+  }
+  return out
+}
+
+function registerOneDecl(d: ParsedBodyDecl, scope: Scope): BodyDecl {
+  if (d.op === 'regDecl')   return registerRegDecl(d, scope)
+  if (d.op === 'delayDecl') return registerDelayDecl(d, scope)
+  if (d.op === 'paramDecl') return registerParamDecl(d, scope)
+  if (d.op === 'instanceDecl') return registerInstanceDecl(d, scope)
+  // programDecl handled in pre-pass
+  throw new ElaborationError(`unexpected body decl: ${(d as { op: string }).op}`)
+}
+
+function registerRegDecl(d: ParsedRegDecl, scope: Scope): RegDecl {
+  if (scope.regs.has(d.name)) {
+    throw new ElaborationError(`duplicate reg '${d.name}'`)
+  }
+  // type field: NameRef resolved to ScalarKind | AliasTypeDef
+  let type: RegDecl['type']
+  if (d.type) {
+    const builtin = BUILTIN_TYPE_TO_SCALAR[d.type.name]
+    if (builtin) type = builtin
+    else {
+      const td = lookupTypeDef(scope, d.type.name)
+      if (td && td.op === 'aliasTypeDef') type = td
+      else throw new ElaborationError(
+        `reg '${d.name}': unknown type '${d.type.name}'`,
+      )
+    }
+  }
+  // init resolved later (second pass) — placeholder for now
+  const decl: RegDecl = { op: 'regDecl', name: d.name, init: 0, ...(type ? { type } : {}) }
+  scope.regs.set(d.name, decl)
+  return decl
+}
+
+function registerDelayDecl(d: ParsedDelayDecl, scope: Scope): DelayDecl {
+  if (scope.delays.has(d.name)) {
+    throw new ElaborationError(`duplicate delay '${d.name}'`)
+  }
+  const decl: DelayDecl = { op: 'delayDecl', name: d.name, update: 0, init: 0 }
+  scope.delays.set(d.name, decl)
+  return decl
+}
+
+function registerParamDecl(d: ParsedParamDecl, scope: Scope): ParamDecl {
+  if (scope.params.has(d.name)) {
+    throw new ElaborationError(`duplicate param '${d.name}'`)
+  }
+  const decl: ParamDecl = { op: 'paramDecl', name: d.name, kind: d.type }
+  if (d.value !== undefined) decl.value = d.value
+  scope.params.set(d.name, decl)
+  return decl
+}
+
+function registerInstanceDecl(d: ParsedInstanceDecl, scope: Scope): InstanceDecl {
+  if (scope.instances.has(d.name)) {
+    throw new ElaborationError(`duplicate instance '${d.name}'`)
+  }
+  // Resolve program type — only nested programs supported in B6.
+  const targetProgram = lookupProgram(scope, d.program.name)
+  if (!targetProgram) {
+    throw new ElaborationError(
+      `instance '${d.name}': program type '${d.program.name}' is not a nested program in scope. ` +
+      `External program types (stdlib) require the loader to register them — defer to a later phase.`,
+    )
+  }
+  const decl: InstanceDecl = {
+    op: 'instanceDecl',
+    name: d.name,
+    type: targetProgram,
+    typeArgs: [],
+    inputs: [],
+  }
+  scope.instances.set(d.name, decl)
+  return decl
+}
+
+/** Second-pass resolver: fill in the expression-shaped fields of an
+ *  already-registered decl. The decl shell was created with placeholder
+ *  values; this fills them in. Mutation of `resolved` is intentional —
+ *  it's the same object held by reference in scope's maps. */
+function resolveDeclExpressions(
+  parsed: ParsedBodyDecl,
+  resolved: BodyDecl,
+  scope: Scope,
+): void {
+  if (parsed.op === 'regDecl' && resolved.op === 'regDecl') {
+    resolved.init = resolveExpr(parsed.init, scope)
+    return
+  }
+  if (parsed.op === 'delayDecl' && resolved.op === 'delayDecl') {
+    resolved.update = resolveExpr(parsed.update, scope)
+    resolved.init = resolveExpr(parsed.init, scope)
+    return
+  }
+  if (parsed.op === 'instanceDecl' && resolved.op === 'instanceDecl') {
+    resolveInstanceArgs(parsed, resolved, scope)
+    return
+  }
+  if (parsed.op === 'paramDecl') return  // no expressions on paramDecl
+  if (parsed.op === 'programDecl') return  // handled in pre-pass
+  throw new ElaborationError(
+    `internal: paired ${parsed.op} with ${resolved.op}`,
+  )
+}
+
+function resolveInstanceArgs(
+  parsed: ParsedInstanceDecl,
+  resolved: InstanceDecl,
+  scope: Scope,
+): void {
+  const targetProgram = resolved.type
+  // Type args: resolve param NameRef → the target's TypeParamDecl.
+  for (const entry of parsed.type_args ?? []) {
+    const paramDecl = targetProgram.typeParams.find(p => p.name === entry.param.name)
+    if (!paramDecl) {
+      const expected = targetProgram.typeParams.map(p => p.name).join(', ') || '(none)'
+      throw new ElaborationError(
+        `instance '${resolved.name}': type-arg '${entry.param.name}' is not a declared type-param of '${targetProgram.name}' (have: ${expected})`,
+      )
+    }
+    if (resolved.typeArgs.some(a => a.param === paramDecl)) {
+      throw new ElaborationError(
+        `instance '${resolved.name}': duplicate type-arg '${entry.param.name}'`,
+      )
+    }
+    resolved.typeArgs.push({ param: paramDecl, value: entry.value })
+  }
+  // Inputs: resolve port NameRef → the target's InputDecl, value-expr resolved.
+  for (const entry of parsed.inputs ?? []) {
+    const portDecl = targetProgram.ports.inputs.find(p => p.name === entry.port.name)
+    if (!portDecl) {
+      const expected = targetProgram.ports.inputs.map(p => p.name).join(', ') || '(none)'
+      throw new ElaborationError(
+        `instance '${resolved.name}': input '${entry.port.name}' is not a declared port of '${targetProgram.name}' (have: ${expected})`,
+      )
+    }
+    if (resolved.inputs.some(i => i.port === portDecl)) {
+      throw new ElaborationError(
+        `instance '${resolved.name}': duplicate input '${entry.port.name}'`,
+      )
+    }
+    const value = resolveExpr(entry.value, scope)
+    resolved.inputs.push({ port: portDecl, value })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Body assigns
+// ─────────────────────────────────────────────────────────────
+
+function resolveAssign(a: ParsedBodyAssign, scope: Scope): BodyAssign {
+  if (a.op === 'outputAssign') return resolveOutputAssign(a, scope)
+  return resolveNextUpdate(a, scope)
+}
+
+function resolveOutputAssign(a: ParsedOutputAssign, scope: Scope): OutputAssign {
+  let target: OutputAssign['target']
+  if (a.name === 'dac.out') {
+    target = { kind: 'dac' }
+  } else {
+    const out = scope.outputs.get(a.name)
+    if (!out) {
+      throw new ElaborationError(
+        `outputAssign references unknown output port '${a.name}'`,
+      )
+    }
+    target = out
+  }
+  return { op: 'outputAssign', target, expr: resolveExpr(a.expr, scope) }
+}
+
+function resolveNextUpdate(a: ParsedNextUpdate, scope: Scope): NextUpdate {
+  const name = a.target.name
+  const reg = scope.regs.get(name)
+  if (reg) {
+    return { op: 'nextUpdate', target: reg, expr: resolveExpr(a.expr, scope) }
+  }
+  const delay = scope.delays.get(name)
+  if (delay) {
+    return { op: 'nextUpdate', target: delay, expr: resolveExpr(a.expr, scope) }
+  }
+  throw new ElaborationError(
+    `nextUpdate target '${name}' is not a declared reg or delay`,
+  )
+}
+
+// ─────────────────────────────────────────────────────────────
+// Expressions
+// ─────────────────────────────────────────────────────────────
+
+function resolveExpr(node: ParsedExprNode, scope: Scope): ResolvedExpr {
+  if (typeof node === 'number' || typeof node === 'boolean') return node
+  if (Array.isArray(node)) return node.map(n => resolveExpr(n, scope))
+  return resolveOpNode(node, scope)
+}
+
+function resolveOpNode(node: ParsedExprOpNode, scope: Scope): ResolvedExprOpNode {
+  // Discriminated-union switch on `op`. TypeScript narrows each branch
+  // to its specific parsed-node type.
+  switch (node.op) {
+    case 'nameRef':   return resolveNameRef(node, scope)
+    case 'binding':   return resolveParsedBinding(node, scope)
+    case 'nestedOut': return resolveNestedOut(node, scope)
+    case 'index':     return resolveIndex(node, scope)
+    case 'call':      return resolveCall(node, scope)
+    case 'tag':       return resolveTag(node, scope)
+    case 'match':     return resolveMatch(node, scope)
+    case 'let':       return resolveLet(node, scope)
+    case 'fold':      return resolveFold(node, scope)
+    case 'scan':      return resolveScan(node, scope)
+    case 'generate':  return resolveGenerate(node, scope)
+    case 'iterate':   return resolveIterate(node, scope)
+    case 'chain':     return resolveChain(node, scope)
+    case 'map2':      return resolveMap2(node, scope)
+    case 'zipWith':   return resolveZipWith(node, scope)
+    default:
+      // Remaining branches are binary or unary ops by the discriminator.
+      // BinaryOpNode and UnaryOpNode share the `args`-tuple shape; the
+      // op tag selects between them.
+      if (UNARY_OP_TAGS.has(node.op)) {
+        return resolveUnary(node as ParsedUnary, scope)
+      }
+      return resolveBinary(node as ParsedBinary, scope)
+  }
+}
+
+const UNARY_OP_TAGS: ReadonlySet<string> = new Set(['neg', 'not', 'bitNot'])
+
+function resolveBinary(node: ParsedBinary, scope: Scope): BinaryOpNode {
+  return {
+    op: node.op,
+    args: [resolveExpr(node.args[0], scope), resolveExpr(node.args[1], scope)],
+  }
+}
+
+function resolveUnary(node: ParsedUnary, scope: Scope): UnaryOpNode {
+  return {
+    op: node.op as UnaryOpTag,
+    args: [resolveExpr(node.args[0], scope)],
+  }
+}
+
+function resolveNameRef(ref: ParsedNameRefNode, scope: Scope): ResolvedExprOpNode {
+  const resolved = lookupValueRef(scope, ref.name)
+  if (resolved) return resolved
+  throw new ElaborationError(`unknown name '${ref.name}'`)
+}
+
+function resolveParsedBinding(node: ParsedBindingNode, scope: Scope): BindingRef {
+  // The parser already determined this is bound; the elaborator confirms
+  // the binder is in scope and links the ref to the decl.
+  const binder = scope.binders.get(node.name)
+  if (!binder) {
+    throw new ElaborationError(
+      `binding '${node.name}' is not in scope (parser said it was bound — likely a parser bug)`,
+    )
+  }
+  return { op: 'bindingRef', decl: binder }
+}
+
+function resolveNestedOut(node: ParsedNestedOut, scope: Scope): NestedOut {
+  const inst = scope.instances.get(node.ref.name)
+  if (!inst) {
+    throw new ElaborationError(
+      `instance '${node.ref.name}' is not declared in this scope`,
+    )
+  }
+  // node.output is NameRefNode | number; the parser preserves whichever form
+  // the user wrote.
+  const targetProgram = inst.type
+  let output: OutputDecl | undefined
+  if (typeof node.output === 'number') {
+    output = targetProgram.ports.outputs[node.output]
+  } else {
+    output = targetProgram.ports.outputs.find(p => p.name === node.output.name)
+  }
+  if (!output) {
+    const portList = targetProgram.ports.outputs.map(p => p.name).join(', ')
+    const requested = typeof node.output === 'number' ? `index ${node.output}` : `'${node.output.name}'`
+    throw new ElaborationError(
+      `instance '${node.ref.name}': program '${targetProgram.name}' has no output ${requested} (have: ${portList})`,
+    )
+  }
+  return { op: 'nestedOut', instance: inst, output }
+}
+
+function resolveIndex(node: ParsedIndex, scope: Scope): IndexNode {
+  return {
+    op: 'index',
+    args: [resolveExpr(node.args[0], scope), resolveExpr(node.args[1], scope)],
+  }
+}
+
+function resolveCall(node: ParsedCallNode, scope: Scope): ResolvedExprOpNode {
+  // Generic call always has a NameRef callee from the parser (it's the
+  // `f(args)` form where f was an ident). The elaborator either rewrites
+  // to a builtin op, or rejects.
+  if (!isParsedNameRef(node.callee)) {
+    throw new ElaborationError(
+      `unsupported call form: callee must be an identifier (no first-class function values yet)`,
+    )
+  }
+  const fname = node.callee.name
+
+  // Nullary sentinel calls
+  if (NULLARY_CALLS.has(fname)) {
+    if (node.args.length !== 0) {
+      throw new ElaborationError(`'${fname}()' takes no arguments`)
+    }
+    if (fname === 'sample_rate') {
+      const n: SampleRateNode = { op: 'sampleRate' }
+      return n
+    }
+    const n: SampleIndexNode = { op: 'sampleIndex' }
+    return n
+  }
+
+  // Unary builtins
+  const unaryTag = UNARY_CALLS[fname]
+  if (unaryTag) {
+    if (node.args.length !== 1) {
+      throw new ElaborationError(`'${fname}' takes 1 argument; got ${node.args.length}`)
+    }
+    const u: UnaryOpNode = { op: unaryTag, args: [resolveExpr(node.args[0], scope)] }
+    return u
+  }
+
+  // Ternary builtins
+  if (fname === 'clamp') {
+    if (node.args.length !== 3) {
+      throw new ElaborationError(`'clamp' takes 3 arguments (value, lo, hi); got ${node.args.length}`)
+    }
+    const c: ClampNode = {
+      op: 'clamp',
+      args: [
+        resolveExpr(node.args[0], scope),
+        resolveExpr(node.args[1], scope),
+        resolveExpr(node.args[2], scope),
+      ],
+    }
+    return c
+  }
+  if (fname === 'select') {
+    if (node.args.length !== 3) {
+      throw new ElaborationError(`'select' takes 3 arguments (cond, then, else); got ${node.args.length}`)
+    }
+    const s: SelectNode = {
+      op: 'select',
+      args: [
+        resolveExpr(node.args[0], scope),
+        resolveExpr(node.args[1], scope),
+        resolveExpr(node.args[2], scope),
+      ],
+    }
+    return s
+  }
+
+  throw new ElaborationError(
+    `unknown function '${fname}'. The resolved IR has no escape hatch for unknown calls — ` +
+    `add the builtin to the elaborator's registry, or use an instance declaration if it's a program type.`,
+  )
+}
+
+function resolveTag(node: ParsedTag, scope: Scope): TagExpr {
+  // Look up the variant in scope.variantOf (built when sum types were registered).
+  const variantName = node.variant.name
+  let variant: SumVariant | undefined
+  let s: Scope | undefined = scope
+  while (s) {
+    const v = s.variantOf.get(variantName)
+    if (v) { variant = v; break }
+    s = s.parent
+  }
+  if (!variant) {
+    throw new ElaborationError(`tag construction: unknown variant '${variantName}'`)
+  }
+  // Validate payload: every variant.payload field must be supplied;
+  // no extras.
+  const payload: TagExpr['payload'] = []
+  const supplied = new Map<string, ResolvedExpr>()
+  for (const entry of node.payload ?? []) {
+    supplied.set(entry.field.name, resolveExpr(entry.value, scope))
+  }
+  for (const field of variant.payload) {
+    const value = supplied.get(field.name)
+    if (value === undefined) {
+      throw new ElaborationError(
+        `tag '${variantName}': missing payload field '${field.name}'`,
+      )
+    }
+    payload.push({ field, value })
+    supplied.delete(field.name)
+  }
+  if (supplied.size > 0) {
+    const extras = [...supplied.keys()].join(', ')
+    throw new ElaborationError(
+      `tag '${variantName}': unknown payload field(s): ${extras}`,
+    )
+  }
+  return { op: 'tag', variant, payload }
+}
+
+function resolveMatch(node: ParsedMatch, scope: Scope): MatchExpr {
+  if (node.arms.length === 0) {
+    throw new ElaborationError(`match expression has no arms`)
+  }
+  // Determine the sum type from the first arm; check all arms agree.
+  const firstName = node.arms[0].variant.name
+  let firstVariant: SumVariant | undefined
+  let s: Scope | undefined = scope
+  while (s) {
+    firstVariant = s.variantOf.get(firstName)
+    if (firstVariant) break
+    s = s.parent
+  }
+  if (!firstVariant) {
+    throw new ElaborationError(
+      `match: unknown variant '${firstName}' in first arm`,
+    )
+  }
+  const sumType = firstVariant.parent
+
+  const seen = new Set<SumVariant>()
+  const arms: MatchArm[] = []
+  for (const a of node.arms) {
+    const variant = sumType.variants.find(v => v.name === a.variant.name)
+    if (!variant) {
+      throw new ElaborationError(
+        `match: variant '${a.variant.name}' is not a member of sum type '${sumType.name}'`,
+      )
+    }
+    if (seen.has(variant)) {
+      throw new ElaborationError(`match: duplicate arm for variant '${variant.name}'`)
+    }
+    seen.add(variant)
+
+    // Build binders matching variant.payload; the parsed `bind` is
+    // string | string[] | undefined. Empty payload arms must have no
+    // binders; non-empty arms must bind every payload field.
+    const bindNames = a.bind === undefined ? []
+      : (Array.isArray(a.bind) ? a.bind : [a.bind])
+    if (bindNames.length !== variant.payload.length) {
+      throw new ElaborationError(
+        `match arm '${variant.name}': expected ${variant.payload.length} binder(s) (one per payload field), got ${bindNames.length}`,
+      )
+    }
+    const binders: BinderDecl[] = bindNames.map(name => ({ op: 'binderDecl', name }))
+    // Push binders into scope, resolve body, pop.
+    const body = withBinders(scope, binders, () => resolveExpr(a.body, scope))
+    arms.push({ variant, binders, body })
+  }
+
+  // Exhaustiveness: every variant of sumType must have an arm.
+  for (const v of sumType.variants) {
+    if (!seen.has(v)) {
+      throw new ElaborationError(
+        `match on '${sumType.name}' is non-exhaustive: missing variant '${v.name}'`,
+      )
+    }
+  }
+
+  return {
+    op: 'match',
+    type: sumType,
+    scrutinee: resolveExpr(node.scrutinee, scope),
+    arms,
+  }
+}
+
+function resolveLet(node: ParsedLetNode, scope: Scope): LetExpr {
+  // Each binding's value evaluates in the OUTER scope (no let* — bindings
+  // can't see siblings). Then all binders enter scope for the body.
+  const binders: LetExpr['binders'] = []
+  for (const [name, valueExpr] of Object.entries(node.bind)) {
+    const binder: BinderDecl = { op: 'binderDecl', name }
+    const value = resolveExpr(valueExpr, scope)
+    binders.push({ binder, value })
+  }
+  const decls = binders.map(b => b.binder)
+  const inResolved = withBinders(scope, decls, () => resolveExpr(node.in, scope))
+  return { op: 'let', binders, in: inResolved }
+}
+
+function resolveFold(node: ParsedFold, scope: Scope): FoldExpr {
+  const acc: BinderDecl = { op: 'binderDecl', name: node.acc_var }
+  const elem: BinderDecl = { op: 'binderDecl', name: node.elem_var }
+  const body = withBinders(scope, [acc, elem], () => resolveExpr(node.body, scope))
+  return {
+    op: 'fold',
+    over: resolveExpr(node.over, scope),
+    init: resolveExpr(node.init, scope),
+    acc, elem, body,
+  }
+}
+
+function resolveScan(node: ParsedScan, scope: Scope): ScanExpr {
+  const acc: BinderDecl = { op: 'binderDecl', name: node.acc_var }
+  const elem: BinderDecl = { op: 'binderDecl', name: node.elem_var }
+  const body = withBinders(scope, [acc, elem], () => resolveExpr(node.body, scope))
+  return {
+    op: 'scan',
+    over: resolveExpr(node.over, scope),
+    init: resolveExpr(node.init, scope),
+    acc, elem, body,
+  }
+}
+
+function resolveGenerate(node: ParsedGenerate, scope: Scope): GenerateExpr {
+  const iter: BinderDecl = { op: 'binderDecl', name: node.var }
+  const body = withBinders(scope, [iter], () => resolveExpr(node.body, scope))
+  return { op: 'generate', count: resolveExpr(node.count, scope), iter, body }
+}
+
+function resolveIterate(node: ParsedIterate, scope: Scope): IterateExpr {
+  const iter: BinderDecl = { op: 'binderDecl', name: node.var }
+  const body = withBinders(scope, [iter], () => resolveExpr(node.body, scope))
+  return {
+    op: 'iterate',
+    count: resolveExpr(node.count, scope),
+    init: resolveExpr(node.init, scope),
+    iter, body,
+  }
+}
+
+function resolveChain(node: ParsedChain, scope: Scope): ChainExpr {
+  const iter: BinderDecl = { op: 'binderDecl', name: node.var }
+  const body = withBinders(scope, [iter], () => resolveExpr(node.body, scope))
+  return {
+    op: 'chain',
+    count: resolveExpr(node.count, scope),
+    init: resolveExpr(node.init, scope),
+    iter, body,
+  }
+}
+
+function resolveMap2(node: ParsedMap2, scope: Scope): Map2Expr {
+  const elem: BinderDecl = { op: 'binderDecl', name: node.elem_var }
+  const body = withBinders(scope, [elem], () => resolveExpr(node.body, scope))
+  return { op: 'map2', over: resolveExpr(node.over, scope), elem, body }
+}
+
+function resolveZipWith(node: ParsedZipWith, scope: Scope): ZipWithExpr {
+  const x: BinderDecl = { op: 'binderDecl', name: node.x_var }
+  const y: BinderDecl = { op: 'binderDecl', name: node.y_var }
+  const body = withBinders(scope, [x, y], () => resolveExpr(node.body, scope))
+  return {
+    op: 'zipWith',
+    a: resolveExpr(node.a, scope),
+    b: resolveExpr(node.b, scope),
+    x, y, body,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Binder scope management
+// ─────────────────────────────────────────────────────────────
+
+function withBinders<T>(scope: Scope, binders: BinderDecl[], body: () => T): T {
+  const prior: Array<{ name: string; was: BinderDecl | undefined }> = []
+  for (const b of binders) {
+    prior.push({ name: b.name, was: scope.binders.get(b.name) })
+    scope.binders.set(b.name, b)
+  }
+  try {
+    return body()
+  } finally {
+    for (const { name, was } of prior.reverse()) {
+      if (was) scope.binders.set(name, was)
+      else scope.binders.delete(name)
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Type predicates over parsed nodes
+// ─────────────────────────────────────────────────────────────
+
+function isParsedNameRef(v: unknown): v is ParsedNameRefNode {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+    && (v as { op?: unknown }).op === 'nameRef'
+}
+
+function isParsedProgramDecl(d: ParsedBodyDecl): d is ParsedProgramDecl {
+  return d.op === 'programDecl'
+}

--- a/compiler/ir/nodes.ts
+++ b/compiler/ir/nodes.ts
@@ -1,0 +1,458 @@
+/**
+ * compiler/ir/nodes.ts — resolved-phase IR types.
+ *
+ * The elaborator (`compiler/ir/elaborator.ts`) consumes a parsed tree
+ * (`compiler/parse/nodes.ts`) and produces values of the types defined
+ * here. Where the parsed tree had NameRefNode placeholders, the resolved
+ * tree has direct decl references — every reference is a graph edge.
+ *
+ * Categorical shape
+ * -----------------
+ * Decls (introduction sites): InputDecl, OutputDecl, RegDecl, DelayDecl,
+ *   ParamDecl, TypeParamDecl, InstanceDecl, ProgramDecl, BinderDecl, plus
+ *   the sum-type members (SumTypeDef, SumVariant, StructTypeDef,
+ *   StructField, AliasTypeDef). Each carries an identity string `name`.
+ *
+ * Refs (uses): InputRef, RegRef, DelayRef, ParamRef, TypeParamRef,
+ *   BindingRef. Each holds `decl: <its decl type>`. Refs hold the decl
+ *   by reference identity (===) — two `RegRef.decl` for the same
+ *   register are the same object.
+ *
+ * Bridges between term-and-type levels: NestedOut ties an instance ref
+ * to a specific output port of its program type; ResolvedTagNode and
+ * ResolvedMatchNode tie expressions to sum-type variants.
+ *
+ * Graph property: the resolved tree admits cycles. A delay's `update`
+ * may transitively reference its own register; an instance's input may
+ * reference a value that depends on the same instance via feedback.
+ *
+ * Strings: `name` on every Decl is an identity string (the user's chosen
+ * label). It is NOT a reference. There are no other strings in the
+ * resolved IR.
+ *
+ * No `ResolvedCallNode`: builtin function calls are resolved to their
+ * structured op; unknown calls are an elaboration error. User-defined
+ * functions are not a tropical feature today; if they become one, they
+ * earn their own resolved shape with a real function-decl reference.
+ */
+
+// ─────────────────────────────────────────────────────────────
+// Identity strings — primitives that aren't references
+// ─────────────────────────────────────────────────────────────
+
+/** Permitted scalar element types. The resolved IR uses an enum literal,
+ *  not a `NameRefNode` — these are language primitives, not decls. */
+export type ScalarKind = 'float' | 'int' | 'bool'
+
+// ─────────────────────────────────────────────────────────────
+// Type-defs (struct / sum / alias)
+// ─────────────────────────────────────────────────────────────
+
+/** A field of a struct or a payload-field of a sum variant. The `type`
+ *  is either a primitive scalar kind or — for alias types — a reference
+ *  to an AliasTypeDef. */
+export interface StructField {
+  op: 'structField'
+  name: string
+  type: ScalarKind | AliasTypeDef
+}
+
+export interface StructTypeDef {
+  op: 'structTypeDef'
+  name: string
+  fields: StructField[]
+}
+
+/** A single variant of a sum type. Carries a back-pointer to its parent
+ *  SumTypeDef so consumers can navigate variant → type without a
+ *  registry lookup. The cycle (decl ↔ variant) is fine; graphs allow it. */
+export interface SumVariant {
+  op: 'sumVariant'
+  name: string
+  payload: StructField[]
+  parent: SumTypeDef
+}
+
+export interface SumTypeDef {
+  op: 'sumTypeDef'
+  name: string
+  variants: SumVariant[]
+}
+
+export interface AliasTypeDef {
+  op: 'aliasTypeDef'
+  name: string
+  base: ScalarKind
+  bounds: [number | null, number | null]
+}
+
+export type TypeDef = StructTypeDef | SumTypeDef | AliasTypeDef
+
+// ─────────────────────────────────────────────────────────────
+// Port types — the shape of a value flowing on a port
+// ─────────────────────────────────────────────────────────────
+
+/** A compile-time array shape dim: literal integer or a TypeParamDecl. */
+export type ShapeDim = number | TypeParamDecl
+
+/** Resolved port type: a primitive scalar kind, an alias decl, or an
+ *  array of an element type with a shape. */
+export type PortType =
+  | { kind: 'scalar'; scalar: ScalarKind }
+  | { kind: 'alias'; alias: AliasTypeDef }
+  | { kind: 'array'; element: ScalarKind | AliasTypeDef; shape: ShapeDim[] }
+
+// ─────────────────────────────────────────────────────────────
+// Program-header decls (inputs, outputs, type-params)
+// ─────────────────────────────────────────────────────────────
+
+export interface InputDecl {
+  op: 'inputDecl'
+  name: string
+  type?: PortType
+  default?: ResolvedExpr
+  bounds?: [number | null, number | null]
+}
+
+export interface OutputDecl {
+  op: 'outputDecl'
+  name: string
+  type?: PortType
+  bounds?: [number | null, number | null]
+}
+
+export interface TypeParamDecl {
+  op: 'typeParamDecl'
+  name: string
+  default?: number
+}
+
+// ─────────────────────────────────────────────────────────────
+// Body decls — names introduced in a program body
+// ─────────────────────────────────────────────────────────────
+
+export interface RegDecl {
+  op: 'regDecl'
+  name: string
+  init: ResolvedExpr
+  type?: ScalarKind | AliasTypeDef
+}
+
+export interface DelayDecl {
+  op: 'delayDecl'
+  name: string
+  update: ResolvedExpr
+  init: ResolvedExpr
+}
+
+export interface ParamDecl {
+  op: 'paramDecl'
+  name: string
+  kind: 'param' | 'trigger'   // surface 'smoothed' → IR 'param'
+  value?: number
+}
+
+export interface InstanceDecl {
+  op: 'instanceDecl'
+  name: string
+  type: ResolvedProgram
+  /** Type-arg pairs: each holds a reference to one of the target's
+   *  declared type params plus the integer value supplied at the
+   *  instance site. */
+  typeArgs: Array<{ param: TypeParamDecl; value: number }>
+  /** Input wires: each holds a reference to one of the target's declared
+   *  input ports plus the value-expression wired into it. The elaborator
+   *  validates that every required input is supplied (defaults handle
+   *  missing entries). */
+  inputs: Array<{ port: InputDecl; value: ResolvedExpr }>
+}
+
+/** A nested `program` declaration introduces a program type into the
+ *  outer's body scope. The `program` field is the resolved nested program
+ *  itself; instance-decl references use its InputDecls/OutputDecls etc. */
+export interface ProgramDecl {
+  op: 'programDecl'
+  name: string
+  program: ResolvedProgram
+}
+
+export type BodyDecl =
+  | RegDecl
+  | DelayDecl
+  | ParamDecl
+  | InstanceDecl
+  | ProgramDecl
+
+// ─────────────────────────────────────────────────────────────
+// Body assigns — wires pinning a value to a port
+// ─────────────────────────────────────────────────────────────
+
+export interface OutputAssign {
+  op: 'outputAssign'
+  /** Either an OutputDecl from this program's outputs, or the special
+   *  `'dac'` boundary leaf for top-level patches that wire to the DAC. */
+  target: OutputDecl | { kind: 'dac' }
+  expr: ResolvedExpr
+}
+
+export interface NextUpdate {
+  op: 'nextUpdate'
+  target: RegDecl | DelayDecl
+  expr: ResolvedExpr
+}
+
+export type BodyAssign = OutputAssign | NextUpdate
+
+// ─────────────────────────────────────────────────────────────
+// Binders — anonymous names introduced by let / combinators / match arms
+// ─────────────────────────────────────────────────────────────
+
+/** A single anonymous binder. The parent node (LetExpr, FoldExpr, etc.,
+ *  or MatchArm) determines the binder's role. The `name` is an identity
+ *  string — the user's chosen label, not a reference. */
+export interface BinderDecl {
+  op: 'binderDecl'
+  name: string
+}
+
+// ─────────────────────────────────────────────────────────────
+// Refs — uses of decl objects
+// ─────────────────────────────────────────────────────────────
+
+export interface InputRef    { op: 'inputRef';    decl: InputDecl }
+export interface RegRef      { op: 'regRef';      decl: RegDecl }
+export interface DelayRef    { op: 'delayRef';    decl: DelayDecl }
+export interface ParamRef    { op: 'paramRef';    decl: ParamDecl }
+export interface TypeParamRef { op: 'typeParamRef'; decl: TypeParamDecl }
+export interface BindingRef  { op: 'bindingRef';  decl: BinderDecl }
+
+/** Dotted port reference resolved: a specific instance + a specific
+ *  output port of that instance's program type. Both held by reference. */
+export interface NestedOut {
+  op: 'nestedOut'
+  instance: InstanceDecl
+  output: OutputDecl
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sentinel leaves — semantic primitives, no decl
+// ─────────────────────────────────────────────────────────────
+
+export interface SampleRateNode  { op: 'sampleRate' }
+export interface SampleIndexNode { op: 'sampleIndex' }
+
+// ─────────────────────────────────────────────────────────────
+// Builtin op shapes — same as parsed but with resolved children
+// ─────────────────────────────────────────────────────────────
+
+export type BinaryOpTag =
+  | 'add' | 'sub' | 'mul' | 'div' | 'mod'
+  | 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'neq'
+  | 'and' | 'or'
+  | 'bitAnd' | 'bitOr' | 'bitXor' | 'lshift' | 'rshift'
+
+export interface BinaryOpNode {
+  op: BinaryOpTag
+  args: [ResolvedExpr, ResolvedExpr]
+}
+
+export type UnaryOpTag =
+  | 'neg' | 'not' | 'bitNot'
+  | 'sqrt' | 'abs' | 'floor' | 'ceil' | 'round'
+  | 'floatExponent' | 'toInt' | 'toBool' | 'toFloat'
+
+export interface UnaryOpNode {
+  op: UnaryOpTag
+  args: [ResolvedExpr]
+}
+
+/** `clamp(value, lo, hi)` — preserves bounds. */
+export interface ClampNode {
+  op: 'clamp'
+  args: [ResolvedExpr, ResolvedExpr, ResolvedExpr]
+}
+
+/** `select(cond, then, else)` — value-level if. */
+export interface SelectNode {
+  op: 'select'
+  args: [ResolvedExpr, ResolvedExpr, ResolvedExpr]
+}
+
+/** `index(arr, i)` — array element access. */
+export interface IndexNode {
+  op: 'index'
+  args: [ResolvedExpr, ResolvedExpr]
+}
+
+// ─────────────────────────────────────────────────────────────
+// Combinators — each one carries its binder declarations directly
+// ─────────────────────────────────────────────────────────────
+
+export interface FoldExpr {
+  op: 'fold'
+  over: ResolvedExpr
+  init: ResolvedExpr
+  acc: BinderDecl
+  elem: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface ScanExpr {
+  op: 'scan'
+  over: ResolvedExpr
+  init: ResolvedExpr
+  acc: BinderDecl
+  elem: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface GenerateExpr {
+  op: 'generate'
+  count: ResolvedExpr
+  iter: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface IterateExpr {
+  op: 'iterate'
+  count: ResolvedExpr
+  init: ResolvedExpr
+  iter: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface ChainExpr {
+  op: 'chain'
+  count: ResolvedExpr
+  init: ResolvedExpr
+  iter: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface Map2Expr {
+  op: 'map2'
+  over: ResolvedExpr
+  elem: BinderDecl
+  body: ResolvedExpr
+}
+
+export interface ZipWithExpr {
+  op: 'zipWith'
+  a: ResolvedExpr
+  b: ResolvedExpr
+  x: BinderDecl
+  y: BinderDecl
+  body: ResolvedExpr
+}
+
+// ─────────────────────────────────────────────────────────────
+// Let — multiple binder/value pairs, body sees them all
+// ─────────────────────────────────────────────────────────────
+
+export interface LetExpr {
+  op: 'let'
+  /** Each entry introduces one binder. The `value` is evaluated in the
+   *  enclosing scope (no let* semantics inside this single Let — bindings
+   *  don't see siblings). Order is preserved for stable output. */
+  binders: Array<{ binder: BinderDecl; value: ResolvedExpr }>
+  in: ResolvedExpr
+}
+
+// ─────────────────────────────────────────────────────────────
+// ADT expressions — tag construction + match elimination
+// ─────────────────────────────────────────────────────────────
+
+/** A sum-type variant constructor. `variant` carries a back-pointer to
+ *  its `parent` SumTypeDef, so the type name is derivable without a
+ *  registry lookup. */
+export interface TagExpr {
+  op: 'tag'
+  variant: SumVariant
+  /** Each entry is a payload field (StructField from variant.payload)
+   *  paired with the value-expression bound to it. The elaborator
+   *  validates that every variant.payload field has a matching entry. */
+  payload: Array<{ field: StructField; value: ResolvedExpr }>
+}
+
+/** A single match arm. `binders` is an ordered list of binder decls
+ *  (one per payload field, matching variant.payload order). The arm
+ *  body sees these binders in scope. */
+export interface MatchArm {
+  variant: SumVariant
+  binders: BinderDecl[]
+  body: ResolvedExpr
+}
+
+/** Match expression: `type` is the sum type the elaborator inferred
+ *  from the arms; `arms` is the ordered list. The elaborator validates
+ *  exhaustiveness (every variant has an arm) and absence of duplicates. */
+export interface MatchExpr {
+  op: 'match'
+  type: SumTypeDef
+  scrutinee: ResolvedExpr
+  arms: MatchArm[]
+}
+
+// ─────────────────────────────────────────────────────────────
+// ResolvedExpr — the expression universe at the resolved phase
+// ─────────────────────────────────────────────────────────────
+
+/** Value-producing expressions in the resolved phase. */
+export type ResolvedExpr =
+  | number | boolean | ResolvedExpr[]
+  | ResolvedExprOpNode
+
+export type ResolvedExprOpNode =
+  // Operators
+  | BinaryOpNode | UnaryOpNode
+  | ClampNode | SelectNode | IndexNode
+  // References (graph edges)
+  | InputRef | RegRef | DelayRef | ParamRef | TypeParamRef | BindingRef
+  | NestedOut
+  // Sentinels
+  | SampleRateNode | SampleIndexNode
+  // Combinators
+  | FoldExpr | ScanExpr
+  | GenerateExpr | IterateExpr | ChainExpr
+  | Map2Expr | ZipWithExpr
+  // Let
+  | LetExpr
+  // ADT expressions
+  | TagExpr | MatchExpr
+
+// ─────────────────────────────────────────────────────────────
+// Block + Program
+// ─────────────────────────────────────────────────────────────
+
+export interface ResolvedBlock {
+  op: 'block'
+  decls: BodyDecl[]
+  assigns: BodyAssign[]
+}
+
+export interface ResolvedProgramPorts {
+  inputs: InputDecl[]
+  outputs: OutputDecl[]
+  typeDefs: TypeDef[]
+}
+
+export interface ResolvedProgram {
+  op: 'program'
+  name: string
+  typeParams: TypeParamDecl[]
+  ports: ResolvedProgramPorts
+  body: ResolvedBlock
+}
+
+// ─────────────────────────────────────────────────────────────
+// Elaboration error
+// ─────────────────────────────────────────────────────────────
+
+/** Thrown by the elaborator when it encounters an unresolvable name,
+ *  exhaustiveness violation, or other semantic error. */
+export class ElaborationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ElaborationError'
+  }
+}


### PR DESCRIPTION
## Summary
The parser produces a tree-with-free-variables (NameRefNode placeholders); the elaborator substitutes those variables with direct decl references, producing a **graph**. Every reference in the resolved IR is a TypeScript reference to its declaration object.

This PR introduces \`compiler/ir/\` as the home for resolved-phase types and the elaborator. The parser layer (\`compiler/parse/\`) keeps text-shaped types; \`compiler/ir/\` owns the graph IR and downstream consumers.

## Five categorical adjustments folded in (from prior review)
1. **Binders are decl objects, not strings.** \`LetExpr\`, \`FoldExpr\`, \`MatchArm\`, etc. carry binder declarations directly. References hold \`{op:'bindingRef', decl: <BinderDecl>}\`. Shadowing is structurally representable.
2. **No \`ResolvedCallNode\` escape hatch.** Builtin function calls resolve to their structured op; unknown calls are an elaboration error.
3. **No legacy-JSON serialize bridge in this PR.** Self-contained library; bridge work deferred to B8 (stdlib migration).
4. **No \`loadResolvedProgram\` ProgramType bridge.** The resolved IR has no consumer yet; bridge is deferred.
5. **\`Match.arms\` stays an ordered array** with exhaustiveness check at construction. \`Map<SumVariant, Body>\` switch deferred to Phase C.

## What the elaborator does
- \`nameRef → InputRef / RegRef / DelayRef / ParamRef / TypeParamRef / BindingRef\`, by scope dispatch
- \`Tag.variant\` and \`Match\` arms resolve against the sum-type registry; exhaustiveness validated
- Builtin function calls resolved: nullary (\`sample_rate\`, \`sample_index\`), unary (\`sqrt\`, \`abs\`, etc.), ternary (\`clamp\`, \`select\`)
- Port types resolve to scalar/alias/array variants; shape-dim NameRefs to \`TypeParamDecl\`
- Two-pass body resolution: register decls (shells) → scope built → fill expressions. Forward references work regardless of source order
- Recursive elaboration of nested programs

## Graph properties verified by tests
- **Reference identity**: \`regRef.decl === <the regDecl in body.decls>\`
- **Single decl object**: walked from any reference, the decl is the same object
- **Feedback cycles**: registers referenced via \`nextUpdate\` produce cycles in the graph (decl ↔ ref). Tests pin this
- **Re-elaboration is independent**: distinct graphs, internal identity preserved each time, no global state

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test\` — 866 pass, 0 fail across 44 files (was 819 + 47 new)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes
- [x] \`grep -rn "as ExprNode\\|as unknown as" compiler/ir/ | grep -v ".test.ts"\` — empty

## What's NOT in this PR
- Pretty-printer (\`ResolvedProgram → .trop\`) — B7
- Legacy-JSON serializer (\`ResolvedProgram → tropical_program_2\`) — B8 deletion-targeted
- \`loadResolvedProgram\` (\`ResolvedProgram → ProgramType\`) — deferred until a consumer exists
- Stdlib migration to \`.trop\` — B8
- Phase C strata pipeline consuming the graph — Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)