### PR TITLE
feat(parse): pretty-printer — ParsedProgram → .trop text (Phase B7)

### DIFF
--- a/compiler/parse/print.test.ts
+++ b/compiler/parse/print.test.ts
@@ -1,0 +1,487 @@
+/**
+ * print.test.ts — pretty-printer round-trip tests (Phase B7).
+ *
+ * Round-trip property:
+ *
+ *     parseProgram(printProgram(parseProgram(text))) === parseProgram(text)
+ *
+ * The printer doesn't try to preserve original whitespace, ordering of
+ * synonymous separators, or comments. It produces *canonical* `.trop`.
+ * Two textually-distinct sources that parse to the same tree should
+ * print to the same text.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { parseProgram } from './declarations.js'
+import { parseExpr } from './expressions.js'
+import { parseBody } from './statements.js'
+import { extractMarkdown } from './markdown.js'
+import { printProgram, printExpr, printProgramDecl } from './print.js'
+
+/** Strip the markdown wrapper to get just the program-decl text. */
+function unwrap(printed: string): string {
+  const ext = extractMarkdown(printed)
+  if (ext.blocks.length !== 1) {
+    throw new Error(`expected 1 tropical block, got ${ext.blocks.length}`)
+  }
+  return ext.blocks[0].source
+}
+
+/** Round-trip helper: parse, print, parse again, return both trees. */
+function roundTrip(src: string): { first: ReturnType<typeof parseProgram>; second: ReturnType<typeof parseProgram> } {
+  const first = parseProgram(src)
+  const printed = printProgram(first)
+  const reparseSource = unwrap(printed)
+  const second = parseProgram(reparseSource)
+  return { first, second }
+}
+
+/** Idempotent-printing helper: parse, print, print-of-reparse, assert
+ *  the second print equals the first. */
+function idempotent(src: string): void {
+  const first = parseProgram(src)
+  const printed1 = printProgram(first)
+  const second = parseProgram(unwrap(printed1))
+  const printed2 = printProgram(second)
+  expect(printed2).toBe(printed1)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Basic round-trips
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — basic programs', () => {
+  test('empty program', () => {
+    const { first, second } = roundTrip('program X() { }')
+    expect(second).toEqual(first)
+  })
+
+  test('with single output', () => {
+    const { first, second } = roundTrip(`
+      program Const() -> (out: signal) { out = 0 }
+    `)
+    expect(second).toEqual(first)
+  })
+
+  test('input + output passthrough', () => {
+    const { first, second } = roundTrip(`
+      program P(x: signal) -> (y: signal) { y = x }
+    `)
+    expect(second).toEqual(first)
+  })
+
+  test('printed output is a literate-program markdown block', () => {
+    const printed = printProgram(parseProgram('program X() { }'))
+    expect(printed).toContain('```tropical')
+    expect(printed).toContain('```\n')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Port specs
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — ports', () => {
+  test('typed inputs and outputs', () => {
+    idempotent(`
+      program X(freq: freq = 220, x: signal) -> (out: signal, lp: signal) {
+        out = x
+        lp = x
+      }
+    `)
+  })
+
+  test('bare-name ports', () => {
+    idempotent(`
+      program X(a, b) -> (out) { out = a }
+    `)
+  })
+
+  test('bounds on inputs', () => {
+    idempotent(`
+      program X(g: float in [0, 1]) -> (out: signal) { out = 0 }
+    `)
+  })
+
+  test('null-bound', () => {
+    idempotent(`
+      program X(g: float in [null, 1]) -> (out: signal) { out = 0 }
+    `)
+  })
+
+  test('negative-literal bound', () => {
+    idempotent(`
+      program X(s: float in [-1, 1]) -> (out: signal) { out = 0 }
+    `)
+  })
+
+  test('default + bounds', () => {
+    idempotent(`
+      program X(g: float = 0.5 in [0, 1]) -> (out: signal) { out = 0 }
+    `)
+  })
+
+  test('array port type with type-param', () => {
+    idempotent(`
+      program X<N: int = 4>(buf: float[N]) -> (out: signal) { out = 0 }
+    `)
+  })
+
+  test('multi-dim array', () => {
+    idempotent(`
+      program X<N: int = 2, M: int = 3>(buf: float[N, M]) -> (out: signal) { out = 0 }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Type params
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — type params', () => {
+  test('single, with default', () => {
+    idempotent(`program X<N: int = 8>() -> (out) { out = 0 }`)
+  })
+
+  test('multiple, mixed defaults', () => {
+    idempotent(`program X<N: int = 4, M: int>() -> (out) { out = 0 }`)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Body decls
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — body decls', () => {
+  test('regDecl with type', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        reg s: float = 0
+        out = s
+        next s = s + 1
+      }
+    `)
+  })
+
+  test('regDecl without type', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        reg s = 0
+        out = s
+      }
+    `)
+  })
+
+  test('delayDecl', () => {
+    idempotent(`
+      program X(x: signal) -> (out: signal) {
+        delay z = x init 0
+        out = z
+      }
+    `)
+  })
+
+  test('paramDecl smoothed with default', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        param cutoff: smoothed = 1000
+        out = cutoff
+      }
+    `)
+  })
+
+  test('paramDecl trigger', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        param fire: trigger
+        out = fire
+      }
+    `)
+  })
+
+  test('instanceDecl with type-args + inputs', () => {
+    idempotent(`
+      program Outer() -> (out: signal) {
+        program Inner<N: int = 4>(x: signal = 0) -> (y: signal) { y = x }
+        i = Inner<N=8>(x: 1)
+        out = i.y
+      }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Body assigns
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — body assigns', () => {
+  test('outputAssign + nextUpdate', () => {
+    idempotent(`
+      program X(x: signal) -> (out: signal) {
+        reg s: float = 0
+        out = s + x
+        next s = s
+      }
+    `)
+  })
+
+  test('dac.out wire', () => {
+    idempotent(`
+      program Patch() {
+        program Osc() -> (out: signal) { out = 0 }
+        o = Osc()
+        dac.out = o.out
+      }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Expression-level round-trips
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — expressions', () => {
+  function exprIdempotent(src: string): void {
+    const a = parseExpr(src)
+    const printed = printExpr(a)
+    const b = parseExpr(printed)
+    expect(b).toEqual(a)
+  }
+
+  test('arithmetic with precedence', () => {
+    exprIdempotent('a + b * c')
+    exprIdempotent('(a + b) * c')
+    exprIdempotent('a + b + c')   // left-assoc: a+b first
+    exprIdempotent('a - b - c')
+    exprIdempotent('-a * b')
+  })
+
+  test('comparison + logical', () => {
+    exprIdempotent('a < b && c > d')
+    exprIdempotent('a == b || c != d')
+  })
+
+  test('bitwise', () => {
+    exprIdempotent('a & b | c')
+    exprIdempotent('a << 2 + 1')
+  })
+
+  test('unary', () => {
+    exprIdempotent('-x')
+    exprIdempotent('!flag')
+    exprIdempotent('~bits')
+    exprIdempotent('-(a + b)')
+  })
+
+  test('dotted port refs', () => {
+    exprIdempotent('osc.sin')
+    exprIdempotent('a.b + c.d')
+  })
+
+  test('indexing', () => {
+    exprIdempotent('a[i]')
+    exprIdempotent('osc.out[0]')
+  })
+
+  test('function calls', () => {
+    exprIdempotent('clamp(x, 0, 1)')
+    exprIdempotent('sample_rate()')
+    exprIdempotent('sqrt(x * x)')
+  })
+
+  test('let binding', () => {
+    exprIdempotent('let { x: 1 } in x + x')
+    exprIdempotent('let { x: 1; y: 2 } in x + y')
+  })
+
+  test('combinators', () => {
+    exprIdempotent('fold(a, 0, (acc, e) => acc + e)')
+    exprIdempotent('scan(a, 0, (acc, e) => acc + e)')
+    exprIdempotent('generate(8, (i) => i * i)')
+    exprIdempotent('iterate(4, 1, (x) => x * 2)')
+    exprIdempotent('chain(3, 0, (x) => x + 1)')
+    exprIdempotent('map2(a, (e) => e * 2)')
+    exprIdempotent('zipWith(a, b, (x, y) => x + y)')
+  })
+
+  test('nested combinators', () => {
+    exprIdempotent('fold([1, 2, 3], 0, (a, e) => a + e * e)')
+  })
+
+  test('array literal', () => {
+    exprIdempotent('[1, 2, 3]')
+    exprIdempotent('[1, -0.5, 0.25]')
+  })
+
+  test('tag construction', () => {
+    exprIdempotent('Some { value: 42 }')
+    exprIdempotent('Hz { freq: 440, gain: 0.5 }')
+    exprIdempotent('Empty { }')
+  })
+
+  test('match — all-nullary', () => {
+    exprIdempotent('match v { Red => 1, Green => 2, Blue => 3 }')
+  })
+
+  test('match — with bindings', () => {
+    exprIdempotent('match v { Some { value: x } => x, None => 0 }')
+  })
+
+  test('boolean literals', () => {
+    exprIdempotent('true')
+    exprIdempotent('false')
+    exprIdempotent('!true')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Type defs
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — type defs', () => {
+  test('struct', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        struct Pair { a: float, b: int }
+        out = 0
+      }
+    `)
+  })
+
+  test('enum with mixed nullary/payload', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        enum Maybe { Some(value: float), None }
+        out = 0
+      }
+    `)
+  })
+
+  test('alias with bounds', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        type Bipolar = float in [-1, 1]
+        out = 0
+      }
+    `)
+  })
+
+  test('multiple type defs side by side', () => {
+    idempotent(`
+      program X() -> (out: signal) {
+        struct Pair { a: float, b: float }
+        enum Mode { On, Off }
+        type Freq = float in [0, 20000]
+        out = 0
+      }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Nested programs
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — nested programs', () => {
+  test('single nested program', () => {
+    idempotent(`
+      program Outer() -> (out: signal) {
+        program Inner(x: signal) -> (y: signal) { y = x }
+        i = Inner(x: 0)
+        out = i.y
+      }
+    `)
+  })
+
+  test('nested with type-params', () => {
+    idempotent(`
+      program Outer<N: int = 4>() -> (out: signal) {
+        program Inner<M: int = 8>(buf: float[M]) -> (out) { out = 0 }
+        i = Inner<M=2>(buf: [0, 0])
+        out = i.out
+      }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Realistic stdlib-shaped programs (round-trip)
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — stdlib-shaped patterns', () => {
+  test('OnePole-shaped', () => {
+    idempotent(`
+      program OnePole(x: signal, g: float = 0.5) -> (y: signal) {
+        reg s: float = 0
+        y = s
+        next s = x * (1 - g) + s * g
+      }
+    `)
+  })
+
+  test('LadderFilter-shaped (instance composition)', () => {
+    idempotent(`
+      program LadderFilter(cutoff: signal, x: signal) -> (out: signal) {
+        program OnePole(x: signal, g: signal) -> (y: signal) {
+          reg s: float = 0
+          y = s
+          next s = x * (1 - g) + s * g
+        }
+        delay z = x init 0
+        lp1 = OnePole(x: x - 4 * z, g: cutoff)
+        lp2 = OnePole(x: lp1.y, g: cutoff)
+        out = lp2.y
+      }
+    `)
+  })
+
+  test('patch with dac.out', () => {
+    idempotent(`
+      program Patch() {
+        program Osc() -> (out: signal) { out = 0 }
+        o = Osc()
+        dac.out = o.out
+      }
+    `)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Canonicalization: textually-different sources that parse-equal
+// should print-equal.
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — canonicalization', () => {
+  test('extra whitespace is normalized', () => {
+    const a = parseProgram('program  X (  ) ->  (out: signal) {  out = 0  }')
+    const b = parseProgram('program X() -> (out: signal) { out = 0 }')
+    expect(printProgram(a)).toBe(printProgram(b))
+  })
+
+  test('semicolons vs newlines normalize identically', () => {
+    const a = parseProgram(`
+      program X() -> (out: signal) { reg s = 0; out = s; next s = s }
+    `)
+    const b = parseProgram(`
+      program X() -> (out: signal) {
+        reg s = 0
+        out = s
+        next s = s
+      }
+    `)
+    expect(printProgram(a)).toBe(printProgram(b))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// printProgramDecl (no markdown wrapper)
+// ─────────────────────────────────────────────────────────────
+
+describe('printer — printProgramDecl', () => {
+  test('produces the program-decl text without markdown fences', () => {
+    const prog = parseProgram('program X() -> (out: signal) { out = 0 }')
+    const inner = printProgramDecl(prog, 0)
+    expect(inner).not.toContain('```')
+    expect(inner.startsWith('program X')).toBe(true)
+  })
+})

--- a/compiler/parse/print.ts
+++ b/compiler/parse/print.ts
@@ -1,0 +1,474 @@
+/**
+ * print.ts — pretty-printer: ParsedProgram → `.trop` text.
+ *
+ * Inverse of the parser. The contract is round-trip equivalence:
+ *
+ *     parseProgram(printProgram(parseProgram(text))) === parseProgram(text)
+ *
+ * The printer walks the parsed tree and emits canonically-formatted
+ * `.trop` source. Output choices:
+ *
+ *  - Program declaration wrapped in a single ```tropical fenced block
+ *    (markdown literate-program shell).
+ *  - Body items on their own lines, 2-space indented.
+ *  - No `;` separators between statements (newlines suffice; the parser
+ *    accepts both).
+ *  - Binary expressions emit minimal parens — only when the operand's
+ *    precedence is lower than the surrounding operator's.
+ *  - Number literals use shortest round-trip representation
+ *    (default JS `String(n)` covers this for finite numbers).
+ *  - No prose preservation. Format-preserving rewrites are a follow-up;
+ *    MVP emits fresh `.trop`.
+ */
+
+import type {
+  ParsedExprNode,
+  ExprOpNode,
+  ProgramNode,
+  BlockNode,
+  BodyDecl,
+  BodyAssign,
+  RegDeclNode,
+  DelayDeclNode,
+  ParamDeclNode,
+  InstanceDeclNode,
+  ProgramDeclNode,
+  OutputAssignNode,
+  NextUpdateNode,
+  ProgramPort,
+  ProgramPortSpec,
+  PortTypeDecl,
+  ShapeDim,
+  TypeDef,
+  StructTypeDef,
+  StructField,
+  SumTypeDef,
+  SumVariant,
+  AliasTypeDef,
+  TagNode,
+  MatchNode,
+  MatchArmEntry,
+  LetNode,
+  FoldNode,
+  ScanNode,
+  GenerateNode,
+  IterateNode,
+  ChainNode,
+  Map2Node,
+  ZipWithNode,
+  IndexNode,
+  CallNode,
+  NestedOutNode,
+  BindingNode,
+  NameRefNode,
+  BinaryOpNode,
+  UnaryOpNode,
+  BinaryOpTag,
+  TypeArgEntry,
+  InstanceInputEntry,
+  TagPayloadEntry,
+} from './nodes.js'
+
+// ─────────────────────────────────────────────────────────────
+// Public entry points
+// ─────────────────────────────────────────────────────────────
+
+/** Print a parsed program as a `.trop` document (markdown with a single
+ *  fenced `tropical` block). Round-trip via the parser is structurally
+ *  identity. */
+export function printProgram(prog: ProgramNode): string {
+  return ['```tropical', printProgramDecl(prog, 0), '```', ''].join('\n')
+}
+
+/** Print a single expression — useful for tests and debugging. */
+export function printExpr(expr: ParsedExprNode): string {
+  return printExprAt(expr, PREC_LOWEST)
+}
+
+/** Print a parsed program *without* the markdown wrapper. Used by tools
+ *  that already have a literate-program shell.
+ *
+ *  Output order inside the body: type defs (struct/enum/type aliases)
+ *  first, then body decls in source order, then body assigns. This
+ *  matches the parser's expectations and reads top-down. */
+export function printProgramDecl(prog: ProgramNode, indent: number): string {
+  const ind = '  '.repeat(indent)
+  const header = printProgramHeader(prog)
+  const lines: string[] = []
+  for (const td of prog.ports?.type_defs ?? []) {
+    lines.push(printTypeDef(td, indent + 1))
+  }
+  for (const decl of prog.body.decls ?? []) {
+    if (decl.op === 'programDecl') {
+      lines.push(printProgramDeclItem(decl, indent + 1))
+    } else {
+      lines.push(printBodyDecl(decl, indent + 1))
+    }
+  }
+  for (const assign of prog.body.assigns ?? []) {
+    lines.push(printBodyAssign(assign, indent + 1))
+  }
+  return lines.length === 0
+    ? `${ind}${header} { }`
+    : `${ind}${header} {\n${lines.join('\n')}\n${ind}}`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Program header
+// ─────────────────────────────────────────────────────────────
+
+function printProgramHeader(prog: ProgramNode): string {
+  let out = `program ${prog.name}`
+  if (prog.type_params && Object.keys(prog.type_params).length > 0) {
+    const parts: string[] = []
+    for (const [name, info] of Object.entries(prog.type_params)) {
+      let s = `${name}: ${info.type}`
+      if (info.default !== undefined) s += ` = ${info.default}`
+      parts.push(s)
+    }
+    out += `<${parts.join(', ')}>`
+  }
+  const inputs = prog.ports?.inputs ?? []
+  out += `(${inputs.map(p => printPortSpec(p, /*allowDefault=*/ true)).join(', ')})`
+  const outputs = prog.ports?.outputs ?? []
+  if (outputs.length > 0) {
+    out += ` -> (${outputs.map(p => printPortSpec(p, /*allowDefault=*/ false)).join(', ')})`
+  }
+  return out
+}
+
+function printPortSpec(spec: ProgramPort, allowDefault: boolean): string {
+  if (typeof spec === 'string') return spec
+  let out = spec.name
+  if (spec.type !== undefined) out += `: ${printPortType(spec.type)}`
+  if (allowDefault && spec.default !== undefined) {
+    out += ` = ${printExprAt(spec.default, PREC_LOWEST)}`
+  }
+  if (spec.bounds !== undefined) {
+    out += ` in [${printBound(spec.bounds[0])}, ${printBound(spec.bounds[1])}]`
+  }
+  return out
+}
+
+function printBound(b: number | null): string {
+  return b === null ? 'null' : String(b)
+}
+
+function printPortType(pt: PortTypeDecl): string {
+  if (isNameRef(pt)) return pt.name
+  return `${pt.element.name}[${pt.shape.map(printShapeDim).join(', ')}]`
+}
+
+function printShapeDim(d: ShapeDim): string {
+  if (typeof d === 'number') return String(d)
+  return d.name
+}
+
+// ─────────────────────────────────────────────────────────────
+// Body items
+// ─────────────────────────────────────────────────────────────
+
+function printBodyDecl(decl: BodyDecl, indent: number): string {
+  const ind = '  '.repeat(indent)
+  switch (decl.op) {
+    case 'regDecl':       return ind + printRegDecl(decl)
+    case 'delayDecl':     return ind + printDelayDecl(decl)
+    case 'paramDecl':     return ind + printParamDecl(decl)
+    case 'instanceDecl':  return ind + printInstanceDecl(decl)
+    case 'programDecl':   return printProgramDeclItem(decl, indent)
+  }
+}
+
+function printRegDecl(d: RegDeclNode): string {
+  let out = `reg ${d.name}`
+  if (d.type !== undefined) out += `: ${d.type.name}`
+  out += ` = ${printExprAt(d.init, PREC_LOWEST)}`
+  return out
+}
+
+function printDelayDecl(d: DelayDeclNode): string {
+  return `delay ${d.name} = ${printExprAt(d.update, PREC_LOWEST)} init ${printExprAt(d.init, PREC_LOWEST)}`
+}
+
+function printParamDecl(d: ParamDeclNode): string {
+  const surface = d.type === 'param' ? 'smoothed' : 'trigger'
+  let out = `param ${d.name}: ${surface}`
+  if (d.value !== undefined) out += ` = ${d.value}`
+  return out
+}
+
+function printInstanceDecl(d: InstanceDeclNode): string {
+  let out = `${d.name} = ${d.program.name}`
+  if (d.type_args && d.type_args.length > 0) {
+    out += `<${d.type_args.map(printTypeArg).join(', ')}>`
+  }
+  out += `(${(d.inputs ?? []).map(printInstanceInput).join(', ')})`
+  return out
+}
+
+function printTypeArg(e: TypeArgEntry): string {
+  return `${e.param.name}=${e.value}`
+}
+
+function printInstanceInput(e: InstanceInputEntry): string {
+  return `${e.port.name}: ${printExprAt(e.value, PREC_LOWEST)}`
+}
+
+function printProgramDeclItem(d: ProgramDeclNode, indent: number): string {
+  return printProgramDecl(d.program, indent)
+}
+
+function printBodyAssign(a: BodyAssign, indent: number): string {
+  const ind = '  '.repeat(indent)
+  if (a.op === 'outputAssign') {
+    return `${ind}${a.name} = ${printExprAt(a.expr, PREC_LOWEST)}`
+  }
+  // nextUpdate
+  return `${ind}next ${a.target.name} = ${printExprAt(a.expr, PREC_LOWEST)}`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Expressions — precedence-aware
+// ─────────────────────────────────────────────────────────────
+
+// Higher number = tighter binding. Levels match the parser's INFIX_LEVELS.
+const PREC_LOWEST    = 0
+const PREC_OR        = 1   // ||
+const PREC_AND       = 2   // &&
+const PREC_BIT_OR    = 3   // |
+const PREC_BIT_XOR   = 4   // ^
+const PREC_BIT_AND   = 5   // &
+const PREC_EQUALITY  = 6   // == !=
+const PREC_RELATION  = 7   // < <= > >=
+const PREC_SHIFT     = 8   // << >>
+const PREC_ADDITIVE  = 9   // + -
+const PREC_MULT      = 10  // * / %
+const PREC_UNARY     = 11  // -, !, ~ (prefix)
+const PREC_POSTFIX   = 12  // .access [index] (call)
+const PREC_ATOM      = 13  // numbers, identifiers, parenthesized
+
+const BINARY_PREC: Record<BinaryOpTag, number> = {
+  or: PREC_OR,
+  and: PREC_AND,
+  bitOr: PREC_BIT_OR,
+  bitXor: PREC_BIT_XOR,
+  bitAnd: PREC_BIT_AND,
+  eq: PREC_EQUALITY, neq: PREC_EQUALITY,
+  lt: PREC_RELATION, lte: PREC_RELATION, gt: PREC_RELATION, gte: PREC_RELATION,
+  lshift: PREC_SHIFT, rshift: PREC_SHIFT,
+  add: PREC_ADDITIVE, sub: PREC_ADDITIVE,
+  mul: PREC_MULT, div: PREC_MULT, mod: PREC_MULT,
+}
+
+const BINARY_SYM: Record<BinaryOpTag, string> = {
+  or: '||', and: '&&',
+  bitOr: '|', bitXor: '^', bitAnd: '&',
+  eq: '==', neq: '!=',
+  lt: '<', lte: '<=', gt: '>', gte: '>=',
+  lshift: '<<', rshift: '>>',
+  add: '+', sub: '-',
+  mul: '*', div: '/', mod: '%',
+}
+
+function printExprAt(node: ParsedExprNode, contextPrec: number): string {
+  if (typeof node === 'number')  return formatNumber(node)
+  if (typeof node === 'boolean') return node ? 'true' : 'false'
+  if (Array.isArray(node)) {
+    return `[${node.map(n => printExprAt(n, PREC_LOWEST)).join(', ')}]`
+  }
+  return printOpNode(node, contextPrec)
+}
+
+function formatNumber(n: number): string {
+  // Prefer compact form. JS `String(n)` already does shortest-round-trip
+  // for finite numbers in practice (e.g. 0.1 → "0.1", -0.5 → "-0.5").
+  return Number.isFinite(n) ? String(n) : 'NaN'
+}
+
+function printOpNode(node: ExprOpNode, contextPrec: number): string {
+  switch (node.op) {
+    case 'nameRef':   return (node as NameRefNode).name
+    case 'binding':   return (node as BindingNode).name
+    case 'nestedOut': return printNestedOut(node as NestedOutNode)
+    case 'index':     return printIndex(node as IndexNode)
+    case 'call':      return printCall(node as CallNode)
+    case 'tag':       return printTag(node as TagNode)
+    case 'match':     return printMatch(node as MatchNode)
+    case 'let':       return parens(printLet(node as LetNode), contextPrec, PREC_LOWEST)
+    case 'fold':      return printFold(node as FoldNode)
+    case 'scan':      return printScan(node as ScanNode)
+    case 'generate':  return printGenerate(node as GenerateNode)
+    case 'iterate':   return printIterate(node as IterateNode)
+    case 'chain':     return printChain(node as ChainNode)
+    case 'map2':      return printMap2(node as Map2Node)
+    case 'zipWith':   return printZipWith(node as ZipWithNode)
+    default:
+      if (node.op in BINARY_PREC) return printBinary(node as BinaryOpNode, contextPrec)
+      // Unary
+      return printUnary(node as UnaryOpNode, contextPrec)
+  }
+}
+
+function parens(s: string, contextPrec: number, ownPrec: number): string {
+  return ownPrec < contextPrec ? `(${s})` : s
+}
+
+function printBinary(node: BinaryOpNode, contextPrec: number): string {
+  const prec = BINARY_PREC[node.op]
+  const sym = BINARY_SYM[node.op]
+  // Left-associative: left side accepts equal-prec without parens; right
+  // side requires strictly greater (i.e., must escalate to one tighter).
+  const lhs = printExprAt(node.args[0], prec)
+  const rhs = printExprAt(node.args[1], prec + 1)
+  return parens(`${lhs} ${sym} ${rhs}`, contextPrec, prec)
+}
+
+const UNARY_SYM: Record<string, string> = { neg: '-', not: '!', bitNot: '~' }
+
+function printUnary(node: UnaryOpNode, contextPrec: number): string {
+  const sym = UNARY_SYM[node.op]
+  if (sym === undefined) {
+    // Defensive — every parsed UnaryOpNode should be in UNARY_SYM.
+    throw new Error(`printer: unknown unary op '${node.op}'`)
+  }
+  // Unary binds tighter than any binary; emit without parens unless the
+  // surrounding context demands them.
+  return parens(`${sym}${printExprAt(node.args[0], PREC_UNARY)}`, contextPrec, PREC_UNARY)
+}
+
+function printNestedOut(node: NestedOutNode): string {
+  const portName = isNameRef(node.output) ? node.output.name : String(node.output)
+  return `${node.ref.name}.${portName}`
+}
+
+function printIndex(node: IndexNode): string {
+  return `${printExprAt(node.args[0], PREC_POSTFIX)}[${printExprAt(node.args[1], PREC_LOWEST)}]`
+}
+
+function printCall(node: CallNode): string {
+  // The callee is always a NameRef from the parser (only ident-call form
+  // is supported in expressions). Defensive cast for the unlikely future.
+  const callee = isNameRef(node.callee) ? node.callee.name
+    : printExprAt(node.callee, PREC_POSTFIX)
+  const args = node.args.map(a => printExprAt(a, PREC_LOWEST))
+  return `${callee}(${args.join(', ')})`
+}
+
+function printTag(node: TagNode): string {
+  if (!node.payload || node.payload.length === 0) {
+    return `${node.variant.name} { }`
+  }
+  return `${node.variant.name} { ${node.payload.map(printTagPayloadEntry).join(', ')} }`
+}
+
+function printTagPayloadEntry(e: TagPayloadEntry): string {
+  return `${e.field.name}: ${printExprAt(e.value, PREC_LOWEST)}`
+}
+
+function printMatch(node: MatchNode): string {
+  const arms = node.arms.map(printMatchArm).join(', ')
+  return `match ${printExprAt(node.scrutinee, PREC_LOWEST)} { ${arms} }`
+}
+
+function printMatchArm(arm: MatchArmEntry): string {
+  const v = arm.variant.name
+  const body = printExprAt(arm.body, PREC_LOWEST)
+  if (arm.bind === undefined) return `${v} => ${body}`
+  // bind is the local name(s). The parser doesn't preserve which payload
+  // field maps to which name (it dropped the field-name → bind-name
+  // pairing), so we emit positional pattern binds: `Variant { _: name }`
+  // becomes `Variant { name }` — but the parser's surface required
+  // `field: bindname`. Since the parser drops the field label, round-
+  // trip CANNOT exactly preserve the field-name in the pattern. We emit
+  // the placeholder field name `_` (the parser also accepts plain ident
+  // → ident here? No — the parser requires `field: bindname`).
+  //
+  // Concrete consequence: the pretty-printer emits the bind name
+  // alongside the variant payload's field positions, but since payload
+  // field names aren't reachable from the parsed MatchArmEntry, we emit
+  // them with synthetic field names `f0, f1, ...`. The round-trip
+  // through the parser is then `Variant { f0: name, f1: name2 } => body`
+  // which re-parses to the same semantic shape (the payload field
+  // names are anonymous inside a match arm — the only thing the parser
+  // keeps is the bind list). This is the canonical re-parsable form.
+  const binds = Array.isArray(arm.bind) ? arm.bind : [arm.bind]
+  const pattern = binds.map((bn, i) => `f${i}: ${bn}`).join(', ')
+  return `${v} { ${pattern} } => ${body}`
+}
+
+function printLet(node: LetNode): string {
+  const entries = Object.entries(node.bind).map(([k, v]) =>
+    `${k}: ${printExprAt(v, PREC_LOWEST)}`
+  )
+  return `let { ${entries.join('; ')} } in ${printExprAt(node.in, PREC_LOWEST)}`
+}
+
+function printFold(node: FoldNode): string {
+  return `fold(${printExprAt(node.over, PREC_LOWEST)}, ${printExprAt(node.init, PREC_LOWEST)}, (${node.acc_var}, ${node.elem_var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printScan(node: ScanNode): string {
+  return `scan(${printExprAt(node.over, PREC_LOWEST)}, ${printExprAt(node.init, PREC_LOWEST)}, (${node.acc_var}, ${node.elem_var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printGenerate(node: GenerateNode): string {
+  return `generate(${printExprAt(node.count, PREC_LOWEST)}, (${node.var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printIterate(node: IterateNode): string {
+  return `iterate(${printExprAt(node.count, PREC_LOWEST)}, ${printExprAt(node.init, PREC_LOWEST)}, (${node.var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printChain(node: ChainNode): string {
+  return `chain(${printExprAt(node.count, PREC_LOWEST)}, ${printExprAt(node.init, PREC_LOWEST)}, (${node.var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printMap2(node: Map2Node): string {
+  return `map2(${printExprAt(node.over, PREC_LOWEST)}, (${node.elem_var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+function printZipWith(node: ZipWithNode): string {
+  return `zipWith(${printExprAt(node.a, PREC_LOWEST)}, ${printExprAt(node.b, PREC_LOWEST)}, (${node.x_var}, ${node.y_var}) => ${printExprAt(node.body, PREC_LOWEST)})`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Type defs (printed at program level when present)
+// ─────────────────────────────────────────────────────────────
+
+export function printTypeDef(td: TypeDef, indent: number): string {
+  const ind = '  '.repeat(indent)
+  if (td.kind === 'struct') return `${ind}${printStructTypeDef(td)}`
+  if (td.kind === 'sum')    return `${ind}${printSumTypeDef(td)}`
+  return `${ind}${printAliasTypeDef(td)}`
+}
+
+function printStructTypeDef(td: StructTypeDef): string {
+  if (td.fields.length === 0) return `struct ${td.name} { }`
+  return `struct ${td.name} { ${td.fields.map(printStructField).join(', ')} }`
+}
+
+function printStructField(f: StructField): string {
+  return `${f.name}: ${f.scalar_type}`
+}
+
+function printSumTypeDef(td: SumTypeDef): string {
+  return `enum ${td.name} { ${td.variants.map(printSumVariant).join(', ')} }`
+}
+
+function printSumVariant(v: SumVariant): string {
+  if (v.payload.length === 0) return v.name
+  return `${v.name}(${v.payload.map(printStructField).join(', ')})`
+}
+
+function printAliasTypeDef(td: AliasTypeDef): string {
+  return `type ${td.name} = ${td.base.name} in [${printBound(td.bounds[0])}, ${printBound(td.bounds[1])}]`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+function isNameRef(v: unknown): v is NameRefNode {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+    && (v as { op?: unknown }).op === 'nameRef'
+}


### PR DESCRIPTION
## Summary
Pretty-printer is the inverse of the parser. The contract is round-trip equivalence:

\`\`\`
parseProgram(printProgram(parseProgram(text))) === parseProgram(text)
\`\`\`

Output is precedence-aware (minimal parens), canonically formatted, and wrapped in a single \`\`\`tropical fenced markdown block.

## Coverage
- **Programs**: typed/bare ports, bounds (numeric/null/negative), array port types (literal / typeParam / multi-dim), type-params, nested programs, type defs.
- **Expressions**: arithmetic with precedence, comparison/logical/bitwise, unary, dotted refs, indexing, function calls, \`let\`, all seven combinators, array literals, tag construction, match expressions.
- **Body items**: regDecl/delayDecl/paramDecl/instanceDecl, programDecl, outputAssign (incl. dac.out), nextUpdate.
- **Stdlib-shaped patterns**: OnePole, LadderFilter, patch with dac.out.

## Public API
- \`printProgram(prog)\` — full markdown document with \`\`\`tropical wrapper
- \`printProgramDecl(prog, indent)\` — program-decl text without markdown fences
- \`printExpr(expr)\` — single expression (tests / debugging)
- \`printTypeDef(td, indent)\` — single type def

## Canonicalization
Textually-different sources that parse to the same tree print to identical text — extra whitespace, optional \`;\` separators, etc. are normalized.

## Match-arm patterns: known cosmetic divergence
The parsed \`MatchArmEntry\` carries \`bind?: string | string[]\` but drops the field-name → bind-name pairing the user wrote. The printer emits synthetic positional field names (\`f0\`, \`f1\`, ...) to round-trip through the parser. The parser ignores match-arm field names (the bind list is what matters semantically), so re-parsing produces the same MatchArmEntry shape. The user's original field labels in match arms are NOT preserved on round-trip — only the bind names. This is the cleanest outcome given what the parser keeps.

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test\` — 915 pass, 0 fail across 45 files (was 866 + 49 new in \`compiler/parse/print.test.ts\`)
- [x] \`make build && cmake --build build -j4 && ctest --test-dir build\` — \`module_process\` passes

## What's NOT in this PR
- \`ResolvedProgram → text\`. The graph IR has shared references that would need re-deriving names from decls during print. Defer until a consumer needs it.
- Format-preserving rewrites (preserve prose between code blocks on save). MVP emits fresh \`.trop\`.
- Stdlib migration (B8). Uses this printer as one half of the round-trip validator; that PR is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)