### PR TITLE
Phase D post-cutover: tighten what we have

### DIFF
--- a/compiler/CLAUDE.md
+++ b/compiler/CLAUDE.md
@@ -1,35 +1,96 @@
 # compiler/
 
-TypeScript layer. Handles program definition, expression construction, flattening, instruction emission, and the FFI bridge to C++. No audio processing happens here — this layer produces the `tropical_plan_4` JSON that the C++ engine JIT-compiles.
+TypeScript layer. Handles program definition, expression construction, the strata pipeline, instruction emission, and the FFI bridge to C++. No audio processing happens here — this layer produces the `tropical_plan_4` JSON that the C++ engine JIT-compiles.
 
 ## Layout
 
 ```
 expr.ts               ExprNode type, SignalExpr wrapper, all named operations
-program_types.ts      ProgramDef IR, ProgramType, ProgramInstance (pure data types, no DSL)
+program_types.ts      ProgramType, ProgramInstance (slot-indexed legacy view; D3 retires this)
 program.ts            ProgramNode (tropical_program_2) types, conversions, stdlib loading
-flatten.ts            Session → tropical_plan_4 (inline all instances, resolve refs)
-lower_arrays.ts       Lower array ops + combinators to scalar primitives (static unrolling)
-emit_numeric.ts       ExprNode trees → FlatProgram instruction stream
+session.ts            SessionState, generic-program resolution, JSON ingest
+schema.ts             Zod validation schemas for tropical_program_2
+flat_plan.ts          tropical_plan_4 schema (the boundary type with the C++ engine)
+emit_numeric.ts       ExprNode trees → FlatProgram instruction stream (structural CSE)
+apply_plan.ts         compileSession → JSON.stringify → runtime.loadPlan
 compiler.ts           Dependency graph, topological sort, SCC, port type conversion
 term.ts               Port types (PortType, ScalarKind), shape algebra, type utilities
-session.ts            SessionState, loadProgramDef (ProgramNode → ProgramDef), loadJSON, prettyExpr
-schema.ts             Zod validation schemas for tropical_program_2
-apply_plan.ts         flattenSession → JSON.stringify → runtime.loadPlan
 array_wiring.ts       Typed port validation, auto-broadcast insertion
+flatten.ts            LEGACY session-flattener; not on the runtime path post-D2 cutover.
+                      Retained for the equivalence gates and a handful of consumers; D3
+                      finishes its retirement.
+interpret.ts          Pure-TS evaluator over post-flatten ExprNode trees. Independent
+                      oracle for jit_interp_equiv. D3 will retarget to ResolvedExpr.
 bench_compile.ts      Compilation benchmarks
 
+ir/                   The strata pipeline + resolved-IR emit boundary
+  nodes.ts            ResolvedProgram + decl/ref node types
+  elaborator.ts       ParsedProgram → ResolvedProgram (name resolution → decl identity)
+  specialize.ts       Type-arg substitution (generic monomorphization)
+  sum_lower.ts        Lower sum-typed regs/delays to scalar bundles
+  trace_cycles.ts     Detect cycles, insert synthetic delays
+  inline_instances.ts Recursively inline InstanceDecls into the outer body
+  array_lower.ts      Lower array ops + combinators to scalar primitives
+  strata.ts           strataPipeline: compose specialize → sumLower → traceCycles
+                      → inlineInstances → arrayLower
+  slots.ts            buildSlotMaps: per-call slot allocator (decl identity → integer)
+  load.ts             ResolvedProgram → ProgramDef bridge (legacy emit boundary; D3 retires)
+  compile_resolved.ts Per-program emit: post-strata ResolvedProgram → tropical_plan_4
+  compile_session.ts  Session emit: synthetic top-level + strata + compile_resolved.
+                      Handles wiring translation, gateable subgraph wrap, session-level
+                      delay extraction.
+  clone.ts            Identity-preserving clone with substitution (used by specialize +
+                      inline_instances input substitution)
+
+parse/                .trop surface syntax + JSON-ingest adapter
+  lexer.ts, declarations.ts, expressions.ts, statements.ts, markdown.ts, print.ts
+  raise.ts            JSON `tropical_program_2` → ParsedProgram (one sanctioned input
+                      adapter; produces only NameRef-bearing output, never resolved-IR
+                      refs — that's the elaborator's job)
+  lower_bounds.ts     Parse-time desugaring of `in [lo, hi]` annotations to clamp ops
+  nodes.ts            ParsedProgram + ParsedExprNode (strict discriminated union)
+
 runtime/
-  bindings.ts         koffi FFI declarations mirroring tropical_c.h
+  bindings.ts         koffi FFI declarations matching tropical_c.h
   runtime.ts          Runtime class (tropical_runtime_t wrapper, FinalizationRegistry)
   audio.ts            DAC class (tropical_dac_t wrapper, device listing)
   param.ts            Param (smoothed) and Trigger (fire-once), with .asExpr()
   audio_smoke.ts      Smoke test for audio output
 ```
 
+## Compilation pipeline (post-D2 cutover)
+
+```
+ProgramNode JSON (tropical_program_2)
+  → raiseProgram → ParsedProgram
+  → elaborate → ResolvedProgram (graph IR; refs are decl objects, not names)
+  → loaded into session.resolvedRegistry / genericTemplatesResolved
+
+session has instances + wiring + graph_outputs
+  → compileSession (compiler/ir/compile_session.ts)
+       1. materializeSession: synthetic top-level ResolvedProgram
+          - one InstanceDecl per session instance (type pre-specialized)
+          - wiring expressions translated session-ExprNode → ResolvedExpr
+          - dac.out graph_outputs → outputAssign per wire
+          - gateable instances: pre-strata wrap with __gate__ synthetic input;
+            gate exprs routed through strata as synthetic outputs to inline
+            their nestedOut refs alongside the rest
+       2. strataPipeline (compiler/ir/strata.ts):
+            specialize → sumLower → traceCycles → inlineInstances → arrayLower
+       3. (post-strata gateable wrap of lifted sub-instance regs/delays)
+       4. compileResolved (compiler/ir/compile_resolved.ts):
+            buildSlotMaps + resolvedToSlotted + resolveDelayValues
+            → emit_numeric → FlatProgram → tropical_plan_4
+  ─── C API boundary (tropical_c.h, koffi FFI) ───
+  → NumericProgramParser (JSON → FlatProgram struct)
+  → JIT compilation (FlatProgram → LLVM IR → native kernel)
+  → FlatRuntime (per-sample execution, double-buffered hot-swap)
+  → Audio output (RtAudio / CoreAudio)
+```
+
 ## Expression system (`expr.ts`)
 
-`ExprNode` is the universal IR — a recursive JSON-serializable union:
+`ExprNode` is the recursive JSON-serializable union:
 
 ```typescript
 type ExprNode = number | boolean | ExprNode[] | { op: string; ... }
@@ -37,94 +98,45 @@ type ExprNode = number | boolean | ExprNode[] | { op: string; ... }
 
 `SignalExpr` wraps `ExprNode` with optional static shape metadata. All operations are free functions (no operator overloading in TS):
 
-- **Arithmetic**: `add`, `sub`, `mul`, `div`, `mod`, `floorDiv`, `ldexp`
+- **Arithmetic**: `add`, `sub`, `mul`, `div`, `mod`, `floorDiv`, `ldexp`, `pow`
 - **Comparison**: `lt`, `lte`, `gt`, `gte`, `eq`, `neq`
 - **Bitwise**: `bitAnd`, `bitOr`, `bitXor`, `lshift`, `rshift`, `bitNot`
-- **Math**: `neg`, `abs`, `sqrt`, `float_exponent`, `logicalNot` (transcendentals — sin, cos, tanh, exp, log, pow — live in `stdlib/` as programs, not primitives)
-- **Ternary**: `clamp`, `select`
-- **Array**: `arrayPack`, `arraySet`, `index`, `zeros`, `ones`, `fill`, `reshape`, `transpose`, `slice`, `reduce`, `broadcastTo`, `mapArray`
-- **Matrix**: `matrix`, `matmul` (supports arbitrary semirings via `mul_op`/`add_op`)
-- **Leaf nodes**: `sampleRate`, `sampleIndex`, `inputExpr`, `registerExpr`, `refExpr`, `nestedOutputExpr`, `delayValueExpr`, `paramExpr`, `triggerParamExpr`
+- **Math**: `neg`, `abs`, `sqrt`, `floatExponent`, `not`. Transcendentals (`sin`, `cos`, `tanh`, `exp`, `log`) live in `stdlib/` as program types, not primitives.
+- **Ternary**: `clamp`, `select`, `arraySet`
+- **Array / matrix**: `arrayPack`, `index`, `zeros`, `reshape`, `transpose`, `slice`, `reduce`, `broadcastTo`, `matmul`
+- **References**: `input`, `reg`, `delayValue`, `nestedOutput`, `param`, `trigger`, `binding`
+- **Sentinels**: `sampleRate`, `sampleIndex`
 
-Compile-time combinators (`let`, `generate`, `iterate`, `fold`, `scan`, `map2`, `zip_with`, `chain`) are embedded directly in JSON as ExprNode ops and lowered by `lower_arrays.ts` — no TS wrapper functions needed.
+Compile-time combinators (`let`, `generate`, `iterate`, `fold`, `scan`, `map2`, `zipWith`, `chain`) are embedded directly in JSON as ExprNode ops; the strata `array_lower` stratum unrolls them. Phase D D4 will narrow `ExprNode` to the MCP wire-format ops only — combinators move to parse-time-only types.
 
-## Program types (`program_types.ts`)
+## Resolved IR (`ir/nodes.ts`)
 
-Pure data types — no DSL, no side effects:
+The strata pipeline operates on `ResolvedProgram` — a graph IR where every reference is a direct decl-object pointer:
 
-- **`ProgramDef`** — the compiler's slot-indexed IR consumed by the flattener. Fields: `outputExprNodes`, `registerExprNodes`, `delayUpdateNodes`, `nestedCalls`, etc. Built from ProgramNode by `loadProgramDef()` in `session.ts` via `slottifyExpr()` (pure name→slot tree walk).
-- **`ProgramType`** — wraps a `ProgramDef`, registered in `SessionState.typeRegistry`
-- **`ProgramInstance`** — named instance of a type, with port accessors
+- **Decls**: `InputDecl`, `OutputDecl`, `RegDecl`, `DelayDecl`, `ParamDecl`, `InstanceDecl`, `ProgramDecl`, `BinderDecl`, `TypeParamDecl`
+- **Refs**: `InputRef`, `RegRef`, `DelayRef`, `ParamRef`, `TypeParamRef`, `BindingRef`, `NestedOut` — each carries a `decl` field pointing at the introducing decl
+- **Ops**: `BinaryOpNode`, `UnaryOpNode`, `ClampNode`, `SelectNode`, `IndexNode`, `ZerosNode`, `ArraySetNode`, plus combinator and ADT nodes
 
-## Standard library (`stdlib/*.json`)
+The elaborator (`ir/elaborator.ts`) is the unique site for name resolution. Every other stratum operates on resolved decl identity — no string lookups, no scope walks.
 
-19 built-in types as `tropical_program_2` files, loaded by `loadStdlib()` in `program.ts`:
+## Instruction emission (`emit_numeric.ts`)
 
-- **Transcendentals** (polynomial approximations): Sin, Cos, Tanh, Exp, Log, Pow
-- **Filters / shapers**: OnePole, LadderFilter (4-pole Moog), SoftClip, BitCrusher
-- **Delays**: AllpassDelay, CombDelay, Delay (generic — `type_args: {N}`, default 44100)
-- **Effects**: Phaser, Phaser16
-- **Utility**: VCA, CrossFade, Clock, NoiseLFSR
-
-Complex programs use inline `programs` for subprogram composition (e.g., Phaser defines `_allpassStage` as a nested program) and reference stdlib types via `instances: { name: { program: 'Sin', ... } }`.
-
-## Compilation pipeline
-
-### Flattening (`flatten.ts`)
-
-The critical compilation step. Transforms a multi-instance session into a single flat instruction stream (`tropical_plan_4`).
-
-1. **Input substitution** — replace `input(N)` with wiring expressions
-2. **Reference resolution** — inline `ref(instance, output)` by recursively substituting the referenced instance's output expression
-3. **Nested call resolution** — expand `nested_output(nodeId, outputId)` by inlining nested instance expressions with offset register IDs
-4. **Delay resolution** — convert `delay_value(nodeId)` to register reads
-5. **Function inlining** — expand `call(function(body), args)` via input substitution
-6. **Wiring type normalization** — validate compatibility, insert `broadcast_to` for shape mismatches
-
-WeakMap memoization maintains DAG sharing and prevents exponential blowup.
-
-### Array lowering and combinator expansion (`lower_arrays.ts`)
-
-All shapes are static, so every operation fully unrolls:
-
-- `zeros(shape)` → `ArrayPack` of zeros
-- `reshape`, `transpose`, `slice` → reindexed `ArrayPack`
-- `reduce(axis, op)` → unrolled fold
-- `broadcast_to` → replicated elements
-- `matmul(a, b)` → unrolled dot products (semiring lowering with `mul_op`/`add_op`)
-
-Compile-time combinators expand via `substituteBindings` (replaces `{ op: 'binding', name }` nodes):
-- `let` → sequential let\* evaluation + substitution
-- `generate(n, i, body)` → inline array of body[i=0..n-1]
-- `iterate(n, init, x, body)` → [init, f(init), f(f(init)), ...]
-- `fold(arr, init, acc, elem, body)` → unrolled left fold to scalar
-- `scan` → like fold but keeps intermediates as array
-- `map2(arr, elem, body)` → substitute per element
-- `zip_with(a, b, x, y, body)` → zip + substitute
-- `chain(n, init, x, body)` → n serial applications
-
-### Instruction emission (`emit_numeric.ts`)
-
-Walks flattened ExprNode trees, emits a `FlatProgram`:
+Walks lowered ExprNode trees (post-`resolvedToSlotted`), emits a `FlatProgram`:
 
 - `NInstr`: `tag` (op name → C++ `OpTag`), `dst` (temp slot), `args` (`NOperand[]`), `loop_count`, `strides`, `result_type`
 - Operand kinds: `const`, `input`, `reg`, `array_reg`, `state_reg`, `param`, `rate`, `tick`
-- Terminals (literals, inputs, registers) are embedded as operands, not separate instructions
-- Output includes `register_count`, `array_slot_sizes`, `output_targets`, `register_targets`
+- Terminals embed inline; non-terminals get a temp register
+- **Structural CSE**: `compileNode` keys its memo on a bottom-up structural id (interned via `${op}|${field=}|${child_id}` strings), not node identity. This catches duplicates the strata pipeline's clone-then-substitute introduces.
 
-### Graph utilities (`compiler.ts`)
+## Standard library (`stdlib/*.trop`)
 
-Used by the flattener to determine execution order:
+19+ built-in types as `.trop` surface-syntax files, loaded by `loadStdlib()` in `program.ts` via the parser → elaborator pipeline:
 
-1. `buildDependencyGraph()` — extract instance refs from input expressions
-2. `tarjanSCC()` — cycle detection (feedback cycles are errors)
-3. `topologicalSort()` — Kahn's algorithm with level grouping
-4. `extractInstanceInfo()` — convert ProgramDef to slot-indexed InstanceInfo
-5. `portTypeFromString()` — parse type annotations to PortType
-
-### Plan application (`apply_plan.ts`)
-
-`applyFlatPlan(session, runtime)` ties it together: `flattenSession()` → `JSON.stringify()` → `runtime.loadPlan()`. Called after any wiring mutation.
+- **Transcendentals** (polynomial approximations): `Sin`, `Cos`, `Tanh`, `Exp`, `Log`, `Pow`
+- **Filters / shapers**: `OnePole`, `LadderFilter` (4-pole Moog), `SoftClip`, `BitCrusher`, `SVF`
+- **Delays**: `AllpassDelay`, `CombDelay`, `Delay` (generic — `<N: int = 44100>`)
+- **Effects**: `Phaser`, `Phaser16`
+- **Utility**: `VCA`, `CrossFade`, `Clock`, `NoiseLFSR`, `BlepSaw`, `EnvExpDecay`, `Sequencer`, `Seq4MinorTranspose`, `SampleHold`, `Bubble`, `BubbleCloud`
 
 ## FFI bridge (`runtime/`)
 
@@ -135,21 +147,18 @@ Used by the flattener to determine execution order:
 
 ## Tests
 
-Run with `bun test`. Test files:
+Run with `bun test`. Notable suites:
 
-- `flatten_wiring.test.ts` — flattening and wiring resolution
-- `array_wiring.test.ts` — typed port validation, broadcast insertion
-- `compiler.test.ts` — dependency graph, topological sort, SCC, port type conversion
-- `expr.test.ts` — expression construction and evaluation
-- `lower_arrays.test.ts` — array lowering to scalar primitives
+- `compile_session_equiv.test.ts` — audio-equivalence gate: every unified_ir fixture produces sample-for-sample identical audio under the new and legacy paths
+- `jit_interp_equiv.test.ts` — JIT vs. pure-TS interpreter (independent oracle)
+- `unified_ir.test.ts` — pinned `tropical_plan_4` snapshots over the fixture corpus
+- `ir/*.test.ts` — strata pipeline unit tests (specialize, sum_lower, trace_cycles, inline_instances, array_lower, slots)
+- `parse/*.test.ts` — lexer, parser, raise, round-trip
 - `apply_plan.test.ts` — plan application integration (requires native lib)
-- `combinators.test.ts` — compile-time combinator expansion
-- `program.test.ts` — ProgramNode schema conversions and Zod validation
-- `bounds.test.ts` — bounded type enforcement and clamp insertion
-- `emit_numeric.test.ts` — instruction emission
+- `wasm_runtime.test.ts`, `wasm_vs_jit_equiv.test.ts`, `web_plans_vs_jit.test.ts` — WASM emission
 
 ## Adding a program type
 
-1. Create a `stdlib/MyType.json` file using the `tropical_program_2` schema
-2. The file is automatically loaded by `loadStdlib()` on startup
-3. No C++ changes needed unless you need a new expression op
+1. Create a `stdlib/MyType.trop` file in surface syntax, OR a JSON `tropical_program_2` file.
+2. The file is automatically loaded by `loadStdlib()` on startup; raised through `parse → raise → elaborate` to a `ResolvedProgram`.
+3. No C++ changes needed unless you need a new expression op.

--- a/compiler/__fixtures__/flat_plan/patch_sequencer_demo.json
+++ b/compiler/__fixtures__/flat_plan/patch_sequencer_demo.json
@@ -76,8 +76,8 @@
     ],
     "register_names": [
       "seq_step",
-      "seq_delay_0",
-      "osc_phase"
+      "osc_phase",
+      "seq_prev_clock"
     ],
     "register_types": [
       "int",
@@ -86,7 +86,7 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      3
+      0
     ],
     "instructions": [
       {
@@ -94,12 +94,13 @@
         "dst": 0,
         "args": [
           {
-            "kind": "tick",
-            "scalar_type": "int"
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 4,
+            "kind": "state_reg",
+            "slot": 1,
             "scalar_type": "float"
           }
         ],
@@ -108,7 +109,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 1,
         "args": [
           {
@@ -117,145 +118,8 @@
             "scalar_type": "float"
           },
           {
-            "kind": "rate",
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 2,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 1,
-            "scalar_type": "float"
-          },
-          {
             "kind": "const",
             "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 3,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 4,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 3,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Less",
-        "dst": 5,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Mul",
-        "dst": 6,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 5,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 7,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 6,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 8,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 7,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
             "scalar_type": "float"
           }
         ],
@@ -266,189 +130,6 @@
       {
         "tag": "Pack",
         "dst": 0,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Index",
-        "dst": 9,
-        "args": [
-          {
-            "kind": "array_reg",
-            "slot": 0
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 10,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 9,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 11,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 10,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "rate",
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 12,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 11,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 13,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 12,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 14,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 13,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Less",
-        "dst": 15,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 14,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Mul",
-        "dst": 16,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 15,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 17,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 16,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Pack",
-        "dst": 1,
         "args": [
           {
             "kind": "const",
@@ -497,16 +178,324 @@
       },
       {
         "tag": "Index",
-        "dst": 18,
+        "dst": 2,
         "args": [
           {
             "kind": "array_reg",
-            "slot": 1
+            "slot": 0
           },
           {
             "kind": "state_reg",
             "slot": 0,
             "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 3,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 2,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "rate",
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Less",
+        "dst": 4,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 3,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Div",
+        "dst": 5,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 3,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 6,
+        "args": [
+          {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 7,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 5,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 8,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 6,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 7,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 9,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 8,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Select",
+        "dst": 10,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 4,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "reg",
+            "slot": 9,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 11,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 10,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 12,
+        "args": [
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 3,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Greater",
+        "dst": 13,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 12,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Sub",
+        "dst": 14,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 15,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 14,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 3,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 16,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 17,
+        "args": [
+          {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 17,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -524,7 +513,7 @@
           },
           {
             "kind": "const",
-            "val": 0,
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -533,17 +522,22 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Select",
         "dst": 20,
         "args": [
           {
-            "kind": "const",
-            "val": 2,
+            "kind": "reg",
+            "slot": 13,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "reg",
+            "slot": 19,
             "scalar_type": "float"
           },
           {
-            "kind": "state_reg",
-            "slot": 2,
+            "kind": "const",
+            "val": 0,
             "scalar_type": "float"
           }
         ],
@@ -557,382 +551,12 @@
         "args": [
           {
             "kind": "reg",
+            "slot": 11,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
             "slot": 20,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 22,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 18,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "rate",
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Less",
-        "dst": 23,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 22,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Div",
-        "dst": 24,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 22,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 25,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 24,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 26,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 24,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 24,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 27,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 25,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 26,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 28,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 27,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Select",
-        "dst": 29,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 23,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 28,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 30,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 21,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 29,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 31,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 22,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Greater",
-        "dst": 32,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 31,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Sub",
-        "dst": 33,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 34,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 33,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 22,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 35,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 34,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 34,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 36,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 34,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 37,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 36,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 38,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Select",
-        "dst": 39,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 32,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 38,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 40,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 30,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 39,
             "scalar_type": "float"
           }
         ],
@@ -942,11 +566,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 41,
+        "dst": 22,
         "args": [
           {
             "kind": "reg",
-            "slot": 40,
+            "slot": 21,
             "scalar_type": "float"
           },
           {
@@ -966,11 +590,11 @@
       },
       {
         "tag": "Add",
-        "dst": 42,
+        "dst": 23,
         "args": [
           {
             "kind": "reg",
-            "slot": 41,
+            "slot": 22,
             "scalar_type": "float"
           },
           {
@@ -984,12 +608,105 @@
         "result_type": "float"
       },
       {
-        "tag": "Less",
-        "dst": 43,
+        "tag": "Mul",
+        "dst": 24,
+        "args": [
+          {
+            "kind": "tick",
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 4,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 25,
         "args": [
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 24,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "rate",
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mod",
+        "dst": 26,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 25,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 27,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 26,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mod",
+        "dst": 28,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Less",
+        "dst": 29,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 28,
             "scalar_type": "float"
           },
           {
@@ -1004,11 +721,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 44,
+        "dst": 30,
         "args": [
           {
             "kind": "reg",
-            "slot": 43,
+            "slot": 29,
             "scalar_type": "bool"
           },
           {
@@ -1023,11 +740,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 45,
+        "dst": 31,
         "args": [
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 30,
             "scalar_type": "float"
           },
           {
@@ -1047,11 +764,11 @@
       },
       {
         "tag": "Greater",
-        "dst": 46,
+        "dst": 32,
         "args": [
           {
             "kind": "reg",
-            "slot": 45,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -1066,11 +783,11 @@
       },
       {
         "tag": "LessEq",
-        "dst": 47,
+        "dst": 33,
         "args": [
           {
             "kind": "state_reg",
-            "slot": 1,
+            "slot": 2,
             "scalar_type": "float"
           },
           {
@@ -1085,16 +802,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 48,
+        "dst": 34,
         "args": [
           {
             "kind": "reg",
-            "slot": 46,
+            "slot": 32,
             "scalar_type": "bool"
           },
           {
             "kind": "reg",
-            "slot": 47,
+            "slot": 33,
             "scalar_type": "bool"
           }
         ],
@@ -1104,7 +821,7 @@
       },
       {
         "tag": "Add",
-        "dst": 49,
+        "dst": 35,
         "args": [
           {
             "kind": "state_reg",
@@ -1113,7 +830,7 @@
           },
           {
             "kind": "reg",
-            "slot": 48,
+            "slot": 34,
             "scalar_type": "bool"
           }
         ],
@@ -1123,11 +840,11 @@
       },
       {
         "tag": "Mod",
-        "dst": 50,
+        "dst": 36,
         "args": [
           {
             "kind": "reg",
-            "slot": 49,
+            "slot": 35,
             "scalar_type": "int"
           },
           {
@@ -1142,11 +859,11 @@
       },
       {
         "tag": "Add",
-        "dst": 51,
+        "dst": 37,
         "args": [
           {
             "kind": "reg",
-            "slot": 50,
+            "slot": 36,
             "scalar_type": "int"
           },
           {
@@ -1161,35 +878,16 @@
       },
       {
         "tag": "Add",
-        "dst": 52,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 7,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 53,
+        "dst": 38,
         "args": [
           {
             "kind": "state_reg",
-            "slot": 2,
+            "slot": 1,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 22,
+            "slot": 3,
             "scalar_type": "float"
           }
         ],
@@ -1199,11 +897,11 @@
       },
       {
         "tag": "Mod",
-        "dst": 54,
+        "dst": 39,
         "args": [
           {
             "kind": "reg",
-            "slot": 53,
+            "slot": 38,
             "scalar_type": "float"
           },
           {
@@ -1218,11 +916,92 @@
       },
       {
         "tag": "Add",
-        "dst": 55,
+        "dst": 40,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 39,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Less",
+        "dst": 41,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 28,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Mul",
+        "dst": 42,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 41,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Clamp",
+        "dst": 43,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 42,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 44,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 43,
             "scalar_type": "float"
           },
           {
@@ -1236,22 +1015,18 @@
         "result_type": "float"
       }
     ],
-    "register_count": 56,
-    "array_slot_count": 2,
+    "register_count": 45,
+    "array_slot_count": 1,
     "array_slot_sizes": [
-      1,
       8
     ],
     "output_targets": [
-      8,
-      17,
-      19,
-      42
+      23
     ],
     "register_targets": [
-      51,
-      52,
-      55
+      37,
+      40,
+      44
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_delay.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_delay.json
@@ -1058,12 +1058,85 @@
       "dly_buf"
     ],
     "outputs": [
-      1
+      0
     ],
     "instructions": [
       {
-        "tag": "Mul",
+        "tag": "Mod",
         "dst": 0,
+        "args": [
+          {
+            "kind": "tick",
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 1000,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "Index",
+        "dst": 1,
+        "args": [
+          {
+            "kind": "array_reg",
+            "slot": 0
+          },
+          {
+            "kind": "reg",
+            "slot": 0,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 2,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mod",
+        "dst": 3,
+        "args": [
+          {
+            "kind": "tick",
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 1000,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 4,
         "args": [
           {
             "kind": "tick",
@@ -1081,11 +1154,11 @@
       },
       {
         "tag": "Div",
-        "dst": 1,
+        "dst": 5,
         "args": [
           {
             "kind": "reg",
-            "slot": 0,
+            "slot": 4,
             "scalar_type": "float"
           },
           {
@@ -1099,7 +1172,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 2,
+        "dst": 6,
         "args": [
           {
             "kind": "const",
@@ -1108,7 +1181,7 @@
           },
           {
             "kind": "reg",
-            "slot": 1,
+            "slot": 5,
             "scalar_type": "float"
           }
         ],
@@ -1118,11 +1191,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 3,
+        "dst": 7,
         "args": [
           {
             "kind": "reg",
-            "slot": 2,
+            "slot": 6,
             "scalar_type": "float"
           },
           {
@@ -1137,11 +1210,11 @@
       },
       {
         "tag": "Round",
-        "dst": 4,
+        "dst": 8,
         "args": [
           {
             "kind": "reg",
-            "slot": 3,
+            "slot": 7,
             "scalar_type": "float"
           }
         ],
@@ -1151,11 +1224,11 @@
       },
       {
         "tag": "BitAnd",
-        "dst": 5,
+        "dst": 9,
         "args": [
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 8,
             "scalar_type": "float"
           },
           {
@@ -1170,7 +1243,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 6,
+        "dst": 10,
         "args": [
           {
             "kind": "const",
@@ -1179,7 +1252,7 @@
           },
           {
             "kind": "reg",
-            "slot": 5,
+            "slot": 9,
             "scalar_type": "int"
           }
         ],
@@ -1189,7 +1262,7 @@
       },
       {
         "tag": "Sub",
-        "dst": 7,
+        "dst": 11,
         "args": [
           {
             "kind": "const",
@@ -1198,62 +1271,7 @@
           },
           {
             "kind": "reg",
-            "slot": 6,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 8,
-        "args": [
-          {
-            "kind": "tick",
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 440,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 9,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 8,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "rate",
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 10,
-        "args": [
-          {
-            "kind": "const",
-            "val": 6.283185307179586,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 9,
+            "slot": 10,
             "scalar_type": "float"
           }
         ],
@@ -1263,11 +1281,11 @@
       },
       {
         "tag": "Round",
-        "dst": 11,
+        "dst": 12,
         "args": [
           {
             "kind": "reg",
-            "slot": 3,
+            "slot": 7,
             "scalar_type": "float"
           }
         ],
@@ -1277,11 +1295,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 12,
+        "dst": 13,
         "args": [
           {
             "kind": "reg",
-            "slot": 11,
+            "slot": 12,
             "scalar_type": "float"
           },
           {
@@ -1296,30 +1314,11 @@
       },
       {
         "tag": "Sub",
-        "dst": 13,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 10,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 12,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
         "dst": 14,
         "args": [
           {
             "kind": "reg",
-            "slot": 13,
+            "slot": 6,
             "scalar_type": "float"
           },
           {
@@ -1337,8 +1336,8 @@
         "dst": 15,
         "args": [
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 14,
             "scalar_type": "float"
           },
           {
@@ -1352,12 +1351,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 16,
         "args": [
           {
             "kind": "const",
-            "val": -2.505210838544172e-8,
+            "val": 0,
             "scalar_type": "float"
           },
           {
@@ -1371,17 +1370,36 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 17,
         "args": [
           {
-            "kind": "reg",
-            "slot": 16,
+            "kind": "const",
+            "val": -2.505210838544172e-8,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 17,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -1391,7 +1409,7 @@
       },
       {
         "tag": "Add",
-        "dst": 18,
+        "dst": 19,
         "args": [
           {
             "kind": "const",
@@ -1400,7 +1418,7 @@
           },
           {
             "kind": "reg",
-            "slot": 17,
+            "slot": 18,
             "scalar_type": "float"
           }
         ],
@@ -1410,16 +1428,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 19,
+        "dst": 20,
         "args": [
           {
             "kind": "reg",
-            "slot": 18,
+            "slot": 19,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -1429,7 +1447,7 @@
       },
       {
         "tag": "Add",
-        "dst": 20,
+        "dst": 21,
         "args": [
           {
             "kind": "const",
@@ -1438,7 +1456,7 @@
           },
           {
             "kind": "reg",
-            "slot": 19,
+            "slot": 20,
             "scalar_type": "float"
           }
         ],
@@ -1448,16 +1466,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 21,
+        "dst": 22,
         "args": [
           {
             "kind": "reg",
-            "slot": 20,
+            "slot": 21,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -1467,7 +1485,7 @@
       },
       {
         "tag": "Add",
-        "dst": 22,
+        "dst": 23,
         "args": [
           {
             "kind": "const",
@@ -1476,7 +1494,7 @@
           },
           {
             "kind": "reg",
-            "slot": 21,
+            "slot": 22,
             "scalar_type": "float"
           }
         ],
@@ -1486,16 +1504,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 23,
+        "dst": 24,
         "args": [
           {
             "kind": "reg",
-            "slot": 22,
+            "slot": 23,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -1505,7 +1523,7 @@
       },
       {
         "tag": "Add",
-        "dst": 24,
+        "dst": 25,
         "args": [
           {
             "kind": "const",
@@ -1514,7 +1532,7 @@
           },
           {
             "kind": "reg",
-            "slot": 23,
+            "slot": 24,
             "scalar_type": "float"
           }
         ],
@@ -1524,16 +1542,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 25,
+        "dst": 26,
         "args": [
           {
             "kind": "reg",
-            "slot": 24,
+            "slot": 25,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -1543,30 +1561,11 @@
       },
       {
         "tag": "Add",
-        "dst": 26,
+        "dst": 27,
         "args": [
           {
             "kind": "const",
             "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 25,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 27,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 13,
             "scalar_type": "float"
           },
           {
@@ -1585,7 +1584,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 7,
+            "slot": 14,
             "scalar_type": "float"
           },
           {
@@ -1599,484 +1598,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 29,
         "args": [
           {
             "kind": "reg",
+            "slot": 11,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
             "slot": 28,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 30,
-        "args": [
-          {
-            "kind": "tick",
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 1000,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "Index",
-        "dst": 31,
-        "args": [
-          {
-            "kind": "array_reg",
-            "slot": 0
-          },
-          {
-            "kind": "reg",
-            "slot": 30,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 32,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 31,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 33,
-        "args": [
-          {
-            "kind": "tick",
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 1000,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "BitAnd",
-        "dst": 34,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "Mul",
-        "dst": 35,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 34,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 36,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Round",
-        "dst": 37,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 3,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 38,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 3.141592653589793,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 39,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 38,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 40,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 41,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 42,
-        "args": [
-          {
-            "kind": "const",
-            "val": -2.505210838544172e-8,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 41,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 43,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 42,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 44,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0.0000027557319223985893,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 43,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 45,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 44,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 46,
-        "args": [
-          {
-            "kind": "const",
-            "val": -0.0001984126984126984,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 45,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 47,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 46,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 48,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0.008333333333333333,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 47,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 49,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 48,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 50,
-        "args": [
-          {
-            "kind": "const",
-            "val": -0.16666666666666666,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 49,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 51,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 50,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 52,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 51,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 53,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 52,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 54,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 36,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 53,
             "scalar_type": "float"
           }
         ],
@@ -2094,12 +1626,12 @@
           },
           {
             "kind": "reg",
-            "slot": 33,
+            "slot": 3,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 29,
             "scalar_type": "float"
           }
         ],
@@ -2108,14 +1640,13 @@
         "result_type": "float"
       }
     ],
-    "register_count": 55,
+    "register_count": 30,
     "array_slot_count": 1,
     "array_slot_sizes": [
       1000
     ],
     "output_targets": [
-      29,
-      32
+      2
     ],
     "register_targets": [
       -1

--- a/compiler/__fixtures__/flat_plan/stdlib_ladder.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_ladder.json
@@ -58,7 +58,7 @@
       "filt_pole2_s",
       "filt_pole3_s",
       "filt_pole4_s",
-      "filt_delay_0"
+      "filt_prev_lp"
     ],
     "register_types": [
       "float",
@@ -70,463 +70,12 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      1
+      0
     ],
     "instructions": [
       {
         "tag": "Mul",
         "dst": 0,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 1,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 2,
-        "args": [
-          {
-            "kind": "const",
-            "val": 220,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "rate",
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Less",
-        "dst": 3,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Div",
-        "dst": 4,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 5,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 6,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 7,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 5,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 6,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 8,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 7,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Select",
-        "dst": 9,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 3,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 8,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 10,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 9,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 11,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Greater",
-        "dst": 12,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 11,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Sub",
-        "dst": 13,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 14,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 13,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 15,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 14,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 14,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 16,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 14,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 17,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 15,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 16,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 18,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 17,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Select",
-        "dst": 19,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 12,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 18,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 20,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 10,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 19,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 21,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 20,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": -1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 22,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 21,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 23,
         "args": [
           {
             "kind": "const",
@@ -544,7 +93,7 @@
       },
       {
         "tag": "Clamp",
-        "dst": 24,
+        "dst": 1,
         "args": [
           {
             "kind": "const",
@@ -558,7 +107,7 @@
           },
           {
             "kind": "reg",
-            "slot": 23,
+            "slot": 0,
             "scalar_type": "float"
           }
         ],
@@ -568,11 +117,11 @@
       },
       {
         "tag": "Div",
-        "dst": 25,
+        "dst": 2,
         "args": [
           {
             "kind": "reg",
-            "slot": 24,
+            "slot": 1,
             "scalar_type": "float"
           },
           {
@@ -586,11 +135,441 @@
       },
       {
         "tag": "Mul",
-        "dst": 26,
+        "dst": 3,
         "args": [
           {
             "kind": "const",
             "val": 3.141592653589793,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 2,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 4,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 3,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.3183098861837907,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Round",
+        "dst": 5,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 4,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "BitAnd",
+        "dst": 6,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 5,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "Mul",
+        "dst": 7,
+        "args": [
+          {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 6,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 8,
+        "args": [
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 7,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 9,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0.49,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "rate",
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Clamp",
+        "dst": 10,
+        "args": [
+          {
+            "kind": "const",
+            "val": 1200,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 20,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 9,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 11,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 10,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "rate",
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 12,
+        "args": [
+          {
+            "kind": "const",
+            "val": 3.141592653589793,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 11,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Round",
+        "dst": 13,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 4,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 14,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 13,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 3.141592653589793,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 15,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 12,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 14,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 16,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 17,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "const",
+            "val": -2.505210838544172e-8,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 17,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 19,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 18,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 20,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0.0000027557319223985893,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 19,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 21,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 20,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 22,
+        "args": [
+          {
+            "kind": "const",
+            "val": -0.0001984126984126984,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 21,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 23,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 22,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 24,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0.008333333333333333,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 23,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 25,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 24,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 26,
+        "args": [
+          {
+            "kind": "const",
+            "val": -0.16666666666666666,
             "scalar_type": "float"
           },
           {
@@ -613,8 +592,8 @@
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0.3183098861837907,
+            "kind": "reg",
+            "slot": 16,
             "scalar_type": "float"
           }
         ],
@@ -623,9 +602,14 @@
         "result_type": "float"
       },
       {
-        "tag": "Round",
+        "tag": "Add",
         "dst": 28,
         "args": [
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          },
           {
             "kind": "reg",
             "slot": 27,
@@ -637,37 +621,18 @@
         "result_type": "float"
       },
       {
-        "tag": "BitAnd",
+        "tag": "Mul",
         "dst": 29,
         "args": [
           {
             "kind": "reg",
-            "slot": 28,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "Mul",
-        "dst": 30,
-        "args": [
-          {
-            "kind": "const",
-            "val": 2,
+            "slot": 15,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 29,
-            "scalar_type": "int"
+            "slot": 28,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -675,12 +640,31 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
+        "dst": 30,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 8,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 29,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 31,
         "args": [
           {
             "kind": "const",
-            "val": 1,
+            "val": 2,
             "scalar_type": "float"
           },
           {
@@ -699,11 +683,12 @@
         "args": [
           {
             "kind": "const",
-            "val": 0.49,
+            "val": 2,
             "scalar_type": "float"
           },
           {
-            "kind": "rate",
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "float"
           }
         ],
@@ -712,22 +697,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Clamp",
+        "tag": "Sub",
         "dst": 33,
         "args": [
           {
-            "kind": "const",
-            "val": 1200,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 20,
-            "scalar_type": "float"
-          },
-          {
             "kind": "reg",
             "slot": 32,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -740,8 +720,8 @@
         "dst": 34,
         "args": [
           {
-            "kind": "reg",
-            "slot": 33,
+            "kind": "const",
+            "val": 220,
             "scalar_type": "float"
           },
           {
@@ -754,12 +734,31 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Less",
         "dst": 35,
         "args": [
           {
-            "kind": "const",
-            "val": 3.141592653589793,
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 34,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Div",
+        "dst": 36,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "float"
           },
           {
@@ -773,12 +772,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Round",
-        "dst": 36,
+        "tag": "Mul",
+        "dst": 37,
         "args": [
           {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          },
+          {
             "kind": "reg",
-            "slot": 27,
+            "slot": 36,
             "scalar_type": "float"
           }
         ],
@@ -788,7 +792,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 37,
+        "dst": 38,
         "args": [
           {
             "kind": "reg",
@@ -796,8 +800,8 @@
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 3.141592653589793,
+            "kind": "reg",
+            "slot": 36,
             "scalar_type": "float"
           }
         ],
@@ -807,30 +811,11 @@
       },
       {
         "tag": "Sub",
-        "dst": 38,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
         "dst": 39,
         "args": [
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           },
           {
@@ -844,18 +829,18 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Sub",
         "dst": 40,
         "args": [
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
           {
             "kind": "reg",
             "slot": 39,
             "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -863,18 +848,23 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Select",
         "dst": 41,
         "args": [
           {
-            "kind": "const",
-            "val": -2.505210838544172e-8,
-            "scalar_type": "float"
+            "kind": "reg",
+            "slot": 35,
+            "scalar_type": "bool"
           },
           {
             "kind": "reg",
             "slot": 40,
             "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -882,17 +872,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Sub",
         "dst": 42,
         "args": [
           {
             "kind": "reg",
-            "slot": 41,
+            "slot": 33,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 39,
+            "slot": 41,
             "scalar_type": "float"
           }
         ],
@@ -901,17 +891,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Sub",
         "dst": 43,
         "args": [
           {
             "kind": "const",
-            "val": 0.0000027557319223985893,
+            "val": 1,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 42,
+            "slot": 34,
             "scalar_type": "float"
           }
         ],
@@ -920,36 +910,36 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Greater",
         "dst": 44,
         "args": [
+          {
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "float"
+          },
           {
             "kind": "reg",
             "slot": 43,
             "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
         "strides": [],
-        "result_type": "float"
+        "result_type": "bool"
       },
       {
-        "tag": "Add",
+        "tag": "Sub",
         "dst": 45,
         "args": [
           {
-            "kind": "const",
-            "val": -0.0001984126984126984,
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 44,
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -958,7 +948,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Div",
         "dst": 46,
         "args": [
           {
@@ -968,7 +958,7 @@
           },
           {
             "kind": "reg",
-            "slot": 39,
+            "slot": 34,
             "scalar_type": "float"
           }
         ],
@@ -977,12 +967,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 47,
         "args": [
           {
-            "kind": "const",
-            "val": 0.008333333333333333,
+            "kind": "reg",
+            "slot": 46,
             "scalar_type": "float"
           },
           {
@@ -1000,13 +990,13 @@
         "dst": 48,
         "args": [
           {
-            "kind": "reg",
-            "slot": 47,
+            "kind": "const",
+            "val": 2,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 39,
+            "slot": 46,
             "scalar_type": "float"
           }
         ],
@@ -1019,8 +1009,8 @@
         "dst": 49,
         "args": [
           {
-            "kind": "const",
-            "val": -0.16666666666666666,
+            "kind": "reg",
+            "slot": 47,
             "scalar_type": "float"
           },
           {
@@ -1034,7 +1024,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 50,
         "args": [
           {
@@ -1043,8 +1033,8 @@
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 39,
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -1053,18 +1043,23 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Select",
         "dst": 51,
         "args": [
           {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
+            "kind": "reg",
+            "slot": 44,
+            "scalar_type": "bool"
           },
           {
             "kind": "reg",
             "slot": 50,
             "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -1072,12 +1067,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Sub",
         "dst": 52,
         "args": [
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 42,
             "scalar_type": "float"
           },
           {
@@ -1091,17 +1086,22 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Clamp",
         "dst": 53,
         "args": [
           {
             "kind": "reg",
-            "slot": 31,
+            "slot": 52,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 52,
+            "kind": "const",
+            "val": -1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -1115,7 +1115,7 @@
         "args": [
           {
             "kind": "const",
-            "val": 2,
+            "val": 1,
             "scalar_type": "float"
           },
           {
@@ -1129,31 +1129,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Clamp",
         "dst": 55,
         "args": [
           {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
             "kind": "reg",
-            "slot": 21,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 56,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 55,
+            "slot": 54,
             "scalar_type": "float"
           },
           {
@@ -1173,11 +1154,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 57,
+        "dst": 56,
         "args": [
           {
             "kind": "reg",
-            "slot": 56,
+            "slot": 55,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 55,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 57,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -1191,12 +1191,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 58,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 55,
             "scalar_type": "float"
           },
           {
@@ -1214,32 +1214,13 @@
         "dst": 59,
         "args": [
           {
-            "kind": "reg",
-            "slot": 56,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 58,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 60,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 57,
+            "slot": 56,
             "scalar_type": "float"
           }
         ],
@@ -1249,11 +1230,30 @@
       },
       {
         "tag": "Add",
-        "dst": 61,
+        "dst": 60,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 59,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 61,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 58,
             "scalar_type": "float"
           },
           {
@@ -1267,27 +1267,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 62,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 59,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 61,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Mul",
-        "dst": 63,
+        "dst": 62,
         "args": [
           {
             "kind": "const",
@@ -1306,11 +1287,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 64,
+        "dst": 63,
         "args": [
           {
             "kind": "reg",
-            "slot": 63,
+            "slot": 62,
             "scalar_type": "float"
           },
           {
@@ -1325,16 +1306,16 @@
       },
       {
         "tag": "Sub",
-        "dst": 65,
+        "dst": 64,
         "args": [
           {
             "kind": "reg",
-            "slot": 62,
+            "slot": 61,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 64,
+            "slot": 63,
             "scalar_type": "float"
           }
         ],
@@ -1344,11 +1325,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 66,
+        "dst": 65,
         "args": [
           {
             "kind": "reg",
-            "slot": 65,
+            "slot": 64,
             "scalar_type": "float"
           },
           {
@@ -1368,11 +1349,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 67,
+        "dst": 66,
         "args": [
           {
             "kind": "reg",
-            "slot": 66,
+            "slot": 65,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 65,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 67,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -1386,12 +1386,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 68,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 65,
             "scalar_type": "float"
           },
           {
@@ -1409,32 +1409,13 @@
         "dst": 69,
         "args": [
           {
-            "kind": "reg",
-            "slot": 66,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 68,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 70,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 67,
+            "slot": 66,
             "scalar_type": "float"
           }
         ],
@@ -1444,11 +1425,30 @@
       },
       {
         "tag": "Add",
-        "dst": 71,
+        "dst": 70,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 69,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 71,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 68,
             "scalar_type": "float"
           },
           {
@@ -1462,27 +1462,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 72,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 69,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 71,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 73,
+        "dst": 72,
         "args": [
           {
             "kind": "state_reg",
@@ -1506,11 +1487,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 74,
+        "dst": 73,
         "args": [
           {
             "kind": "reg",
-            "slot": 73,
+            "slot": 72,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 72,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 74,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -1524,12 +1524,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 75,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 72,
             "scalar_type": "float"
           },
           {
@@ -1547,32 +1547,13 @@
         "dst": 76,
         "args": [
           {
-            "kind": "reg",
-            "slot": 73,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 75,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 77,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 74,
+            "slot": 73,
             "scalar_type": "float"
           }
         ],
@@ -1582,11 +1563,30 @@
       },
       {
         "tag": "Add",
-        "dst": 78,
+        "dst": 77,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 76,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 78,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 75,
             "scalar_type": "float"
           },
           {
@@ -1600,12 +1600,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 79,
         "args": [
           {
             "kind": "reg",
-            "slot": 76,
+            "slot": 71,
             "scalar_type": "float"
           },
           {
@@ -1619,12 +1619,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 80,
         "args": [
           {
             "kind": "reg",
-            "slot": 72,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -1638,12 +1638,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 81,
         "args": [
           {
-            "kind": "reg",
-            "slot": 54,
+            "kind": "state_reg",
+            "slot": 1,
             "scalar_type": "float"
           },
           {
@@ -1657,17 +1657,22 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Clamp",
         "dst": 82,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 1,
+            "kind": "reg",
+            "slot": 81,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 81,
+            "kind": "const",
+            "val": -1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -1686,30 +1691,6 @@
           },
           {
             "kind": "const",
-            "val": -1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 84,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 83,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
             "val": -3,
             "scalar_type": "float"
           },
@@ -1725,11 +1706,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 85,
+        "dst": 84,
         "args": [
           {
             "kind": "reg",
-            "slot": 84,
+            "slot": 83,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 83,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 85,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -1743,12 +1743,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 86,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 83,
             "scalar_type": "float"
           },
           {
@@ -1766,32 +1766,13 @@
         "dst": 87,
         "args": [
           {
-            "kind": "reg",
-            "slot": 84,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 86,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 88,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 85,
+            "slot": 84,
             "scalar_type": "float"
           }
         ],
@@ -1801,11 +1782,30 @@
       },
       {
         "tag": "Add",
-        "dst": 89,
+        "dst": 88,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 87,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 89,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 86,
             "scalar_type": "float"
           },
           {
@@ -1819,27 +1819,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 90,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 87,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 89,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 91,
+        "dst": 90,
         "args": [
           {
             "kind": "state_reg",
@@ -1863,11 +1844,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 92,
+        "dst": 91,
         "args": [
           {
             "kind": "reg",
-            "slot": 91,
+            "slot": 90,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 90,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 92,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -1881,12 +1881,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 93,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 90,
             "scalar_type": "float"
           },
           {
@@ -1904,32 +1904,13 @@
         "dst": 94,
         "args": [
           {
-            "kind": "reg",
-            "slot": 91,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 93,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 95,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 92,
+            "slot": 91,
             "scalar_type": "float"
           }
         ],
@@ -1939,11 +1920,30 @@
       },
       {
         "tag": "Add",
-        "dst": 96,
+        "dst": 95,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 94,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 96,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 93,
             "scalar_type": "float"
           },
           {
@@ -1957,12 +1957,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 97,
         "args": [
           {
             "kind": "reg",
-            "slot": 94,
+            "slot": 89,
             "scalar_type": "float"
           },
           {
@@ -1976,12 +1976,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 98,
         "args": [
           {
             "kind": "reg",
-            "slot": 90,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -1995,12 +1995,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 99,
         "args": [
           {
-            "kind": "reg",
-            "slot": 54,
+            "kind": "state_reg",
+            "slot": 2,
             "scalar_type": "float"
           },
           {
@@ -2014,17 +2014,22 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Clamp",
         "dst": 100,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 2,
+            "kind": "reg",
+            "slot": 99,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 99,
+            "kind": "const",
+            "val": -1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -2043,30 +2048,6 @@
           },
           {
             "kind": "const",
-            "val": -1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 102,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 101,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
             "val": -3,
             "scalar_type": "float"
           },
@@ -2082,11 +2063,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 103,
+        "dst": 102,
         "args": [
           {
             "kind": "reg",
-            "slot": 102,
+            "slot": 101,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 101,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 103,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -2100,12 +2100,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 104,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 101,
             "scalar_type": "float"
           },
           {
@@ -2123,32 +2123,13 @@
         "dst": 105,
         "args": [
           {
-            "kind": "reg",
-            "slot": 102,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 104,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 106,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 103,
+            "slot": 102,
             "scalar_type": "float"
           }
         ],
@@ -2158,11 +2139,30 @@
       },
       {
         "tag": "Add",
-        "dst": 107,
+        "dst": 106,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 105,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 107,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 104,
             "scalar_type": "float"
           },
           {
@@ -2176,27 +2176,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 108,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 105,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 107,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 109,
+        "dst": 108,
         "args": [
           {
             "kind": "state_reg",
@@ -2220,11 +2201,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 110,
+        "dst": 109,
         "args": [
           {
             "kind": "reg",
-            "slot": 109,
+            "slot": 108,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 108,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 110,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -2238,12 +2238,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 111,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 108,
             "scalar_type": "float"
           },
           {
@@ -2261,32 +2261,13 @@
         "dst": 112,
         "args": [
           {
-            "kind": "reg",
-            "slot": 109,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 111,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 113,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 110,
+            "slot": 109,
             "scalar_type": "float"
           }
         ],
@@ -2296,11 +2277,30 @@
       },
       {
         "tag": "Add",
-        "dst": 114,
+        "dst": 113,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 112,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 114,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 111,
             "scalar_type": "float"
           },
           {
@@ -2314,12 +2314,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 115,
         "args": [
           {
             "kind": "reg",
-            "slot": 112,
+            "slot": 107,
             "scalar_type": "float"
           },
           {
@@ -2333,12 +2333,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 116,
         "args": [
           {
             "kind": "reg",
-            "slot": 108,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -2352,12 +2352,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 117,
         "args": [
           {
-            "kind": "reg",
-            "slot": 54,
+            "kind": "state_reg",
+            "slot": 3,
             "scalar_type": "float"
           },
           {
@@ -2371,17 +2371,22 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Clamp",
         "dst": 118,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 3,
+            "kind": "reg",
+            "slot": 117,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 117,
+            "kind": "const",
+            "val": -1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -2400,30 +2405,6 @@
           },
           {
             "kind": "const",
-            "val": -1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 120,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 119,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
             "val": -3,
             "scalar_type": "float"
           },
@@ -2439,11 +2420,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 121,
+        "dst": 120,
         "args": [
           {
             "kind": "reg",
-            "slot": 120,
+            "slot": 119,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 119,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 121,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -2457,12 +2457,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 122,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 119,
             "scalar_type": "float"
           },
           {
@@ -2480,32 +2480,13 @@
         "dst": 123,
         "args": [
           {
-            "kind": "reg",
-            "slot": 120,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 122,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 124,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 121,
+            "slot": 120,
             "scalar_type": "float"
           }
         ],
@@ -2515,11 +2496,30 @@
       },
       {
         "tag": "Add",
-        "dst": 125,
+        "dst": 124,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 123,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 125,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 122,
             "scalar_type": "float"
           },
           {
@@ -2533,27 +2533,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 126,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 123,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 125,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 127,
+        "dst": 126,
         "args": [
           {
             "kind": "state_reg",
@@ -2577,11 +2558,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 128,
+        "dst": 127,
         "args": [
           {
             "kind": "reg",
-            "slot": 127,
+            "slot": 126,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 126,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 128,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -2595,12 +2595,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 129,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 126,
             "scalar_type": "float"
           },
           {
@@ -2618,32 +2618,13 @@
         "dst": 130,
         "args": [
           {
-            "kind": "reg",
-            "slot": 127,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 129,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 131,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 128,
+            "slot": 127,
             "scalar_type": "float"
           }
         ],
@@ -2653,11 +2634,30 @@
       },
       {
         "tag": "Add",
-        "dst": 132,
+        "dst": 131,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 130,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 132,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 129,
             "scalar_type": "float"
           },
           {
@@ -2671,12 +2671,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 133,
         "args": [
           {
             "kind": "reg",
-            "slot": 130,
+            "slot": 125,
             "scalar_type": "float"
           },
           {
@@ -2690,12 +2690,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 134,
         "args": [
           {
             "kind": "reg",
-            "slot": 126,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -2709,12 +2709,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 135,
         "args": [
           {
-            "kind": "reg",
-            "slot": 54,
+            "kind": "state_reg",
+            "slot": 4,
             "scalar_type": "float"
           },
           {
@@ -2728,31 +2728,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Clamp",
         "dst": 136,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 4,
-            "scalar_type": "float"
-          },
-          {
             "kind": "reg",
             "slot": 135,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 137,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 136,
             "scalar_type": "float"
           },
           {
@@ -2772,11 +2753,11 @@
       },
       {
         "tag": "Add",
-        "dst": 138,
+        "dst": 137,
         "args": [
           {
             "kind": "reg",
-            "slot": 137,
+            "slot": 136,
             "scalar_type": "float"
           },
           {
@@ -2790,17 +2771,36 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
-        "dst": 139,
+        "tag": "Add",
+        "dst": 138,
         "args": [
           {
-            "kind": "reg",
-            "slot": 101,
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 137,
+            "slot": 34,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mod",
+        "dst": 139,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 138,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -2828,17 +2828,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Add",
         "dst": 141,
         "args": [
           {
             "kind": "reg",
-            "slot": 21,
+            "slot": 81,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 137,
+            "kind": "const",
+            "val": 0,
             "scalar_type": "float"
           }
         ],
@@ -2852,7 +2852,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 141,
+            "slot": 99,
             "scalar_type": "float"
           },
           {
@@ -2871,12 +2871,12 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 141,
+            "slot": 117,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 137,
+            "kind": "const",
+            "val": 0,
             "scalar_type": "float"
           }
         ],
@@ -2890,7 +2890,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 143,
+            "slot": 135,
             "scalar_type": "float"
           },
           {
@@ -2908,120 +2908,6 @@
         "dst": 145,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mod",
-        "dst": 146,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 145,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 147,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 146,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 148,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 82,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 149,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 100,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 150,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 118,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 151,
-        "args": [
-          {
             "kind": "reg",
             "slot": 136,
             "scalar_type": "float"
@@ -3035,44 +2921,21 @@
         "loop_count": 1,
         "strides": [],
         "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 152,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 137,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
       }
     ],
-    "register_count": 153,
+    "register_count": 146,
     "array_slot_count": 0,
     "array_slot_sizes": [],
     "output_targets": [
-      22,
-      138,
-      140,
-      142,
-      144
+      137
     ],
     "register_targets": [
-      147,
-      148,
-      149,
-      150,
-      151,
-      152
+      140,
+      141,
+      142,
+      143,
+      144,
+      145
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_noise_crush.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_noise_crush.json
@@ -50,9 +50,9 @@
     "register_names": [
       "n_state",
       "n_value",
-      "n_delay_0",
       "bc_hold_sample",
-      "bc_hold_counter"
+      "bc_hold_counter",
+      "n_prev_clock"
     ],
     "register_types": [
       "int",
@@ -63,297 +63,16 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      1
+      0
     ],
     "instructions": [
       {
-        "tag": "Greater",
+        "tag": "Add",
         "dst": 0,
         "args": [
           {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "LessEq",
-        "dst": 1,
-        "args": [
-          {
             "kind": "state_reg",
-            "slot": 2,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "Mul",
-        "dst": 2,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 0,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 1,
-            "scalar_type": "bool"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "bool"
-      },
-      {
-        "tag": "BitAnd",
-        "dst": 3,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "RShift",
-        "dst": 4,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "BitXor",
-        "dst": 5,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 4,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 46080,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "RShift",
-        "dst": 6,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "Select",
-        "dst": 7,
-        "args": [
-          {
-            "kind": "reg",
             "slot": 3,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "reg",
-            "slot": 5,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "reg",
-            "slot": 6,
-            "scalar_type": "int"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "int"
-      },
-      {
-        "tag": "Mul",
-        "dst": 8,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 7,
-            "scalar_type": "int"
-          },
-          {
-            "kind": "const",
-            "val": 2,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Div",
-        "dst": 9,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 8,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 65535,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
-        "dst": 10,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 9,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Select",
-        "dst": 11,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 2,
-            "scalar_type": "bool"
-          },
-          {
-            "kind": "reg",
-            "slot": 10,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "state_reg",
-            "slot": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 12,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 11,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": -1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 13,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 12,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 14,
-        "args": [
-          {
-            "kind": "state_reg",
-            "slot": 4,
             "scalar_type": "float"
           },
           {
@@ -368,7 +87,7 @@
       },
       {
         "tag": "Clamp",
-        "dst": 15,
+        "dst": 1,
         "args": [
           {
             "kind": "const",
@@ -391,7 +110,7 @@
       },
       {
         "tag": "FloorDiv",
-        "dst": 16,
+        "dst": 2,
         "args": [
           {
             "kind": "rate",
@@ -399,7 +118,7 @@
           },
           {
             "kind": "reg",
-            "slot": 15,
+            "slot": 1,
             "scalar_type": "float"
           }
         ],
@@ -409,11 +128,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 17,
+        "dst": 3,
         "args": [
           {
             "kind": "reg",
-            "slot": 16,
+            "slot": 2,
             "scalar_type": "float"
           },
           {
@@ -433,16 +152,54 @@
       },
       {
         "tag": "GreaterEq",
-        "dst": 18,
+        "dst": 4,
         "args": [
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 0,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 17,
+            "slot": 3,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Greater",
+        "dst": 5,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "LessEq",
+        "dst": 6,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 4,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.5,
             "scalar_type": "float"
           }
         ],
@@ -452,11 +209,235 @@
       },
       {
         "tag": "Mul",
-        "dst": 19,
+        "dst": 7,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 5,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "reg",
+            "slot": 6,
+            "scalar_type": "bool"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "BitAnd",
+        "dst": 8,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "RShift",
+        "dst": 9,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "BitXor",
+        "dst": 10,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 9,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 46080,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "RShift",
+        "dst": 11,
+        "args": [
+          {
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "Select",
+        "dst": 12,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 8,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "reg",
+            "slot": 10,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "reg",
+            "slot": 11,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "int"
+      },
+      {
+        "tag": "Mul",
+        "dst": 13,
         "args": [
           {
             "kind": "reg",
             "slot": 12,
+            "scalar_type": "int"
+          },
+          {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 14,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 13,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 65535,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Sub",
+        "dst": 15,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 14,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Select",
+        "dst": 16,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 7,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "state_reg",
+            "slot": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Clamp",
+        "dst": 17,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": -1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 17,
             "scalar_type": "float"
           },
           {
@@ -471,11 +452,11 @@
       },
       {
         "tag": "Add",
-        "dst": 20,
+        "dst": 19,
         "args": [
           {
             "kind": "reg",
-            "slot": 19,
+            "slot": 18,
             "scalar_type": "float"
           },
           {
@@ -490,11 +471,11 @@
       },
       {
         "tag": "FloorDiv",
-        "dst": 21,
+        "dst": 20,
         "args": [
           {
             "kind": "reg",
-            "slot": 20,
+            "slot": 19,
             "scalar_type": "float"
           },
           {
@@ -509,11 +490,11 @@
       },
       {
         "tag": "Div",
-        "dst": 22,
+        "dst": 21,
         "args": [
           {
             "kind": "reg",
-            "slot": 21,
+            "slot": 20,
             "scalar_type": "float"
           },
           {
@@ -528,21 +509,21 @@
       },
       {
         "tag": "Select",
-        "dst": 23,
+        "dst": 22,
         "args": [
           {
             "kind": "reg",
-            "slot": 18,
+            "slot": 4,
             "scalar_type": "bool"
           },
           {
             "kind": "reg",
-            "slot": 22,
+            "slot": 21,
             "scalar_type": "float"
           },
           {
             "kind": "state_reg",
-            "slot": 3,
+            "slot": 2,
             "scalar_type": "float"
           }
         ],
@@ -552,11 +533,11 @@
       },
       {
         "tag": "Add",
-        "dst": 24,
+        "dst": 23,
         "args": [
           {
             "kind": "reg",
-            "slot": 23,
+            "slot": 22,
             "scalar_type": "float"
           },
           {
@@ -571,11 +552,11 @@
       },
       {
         "tag": "BitXor",
-        "dst": 25,
+        "dst": 24,
         "args": [
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 9,
             "scalar_type": "int"
           },
           {
@@ -590,21 +571,21 @@
       },
       {
         "tag": "Select",
-        "dst": 26,
+        "dst": 25,
         "args": [
           {
             "kind": "reg",
-            "slot": 3,
+            "slot": 8,
             "scalar_type": "int"
           },
           {
             "kind": "reg",
-            "slot": 25,
+            "slot": 24,
             "scalar_type": "int"
           },
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 9,
             "scalar_type": "int"
           }
         ],
@@ -614,16 +595,16 @@
       },
       {
         "tag": "Select",
-        "dst": 27,
+        "dst": 26,
         "args": [
           {
             "kind": "reg",
-            "slot": 2,
+            "slot": 7,
             "scalar_type": "bool"
           },
           {
             "kind": "reg",
-            "slot": 26,
+            "slot": 25,
             "scalar_type": "int"
           },
           {
@@ -638,11 +619,11 @@
       },
       {
         "tag": "Add",
-        "dst": 28,
+        "dst": 27,
         "args": [
           {
             "kind": "reg",
-            "slot": 27,
+            "slot": 26,
             "scalar_type": "int"
           },
           {
@@ -657,11 +638,30 @@
       },
       {
         "tag": "Add",
+        "dst": 28,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
         "dst": 29,
         "args": [
           {
             "kind": "reg",
-            "slot": 11,
+            "slot": 22,
             "scalar_type": "float"
           },
           {
@@ -679,46 +679,8 @@
         "dst": 30,
         "args": [
           {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 31,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 23,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 32,
-        "args": [
-          {
             "kind": "state_reg",
-            "slot": 4,
+            "slot": 3,
             "scalar_type": "float"
           },
           {
@@ -733,11 +695,11 @@
       },
       {
         "tag": "Select",
-        "dst": 33,
+        "dst": 31,
         "args": [
           {
             "kind": "reg",
-            "slot": 18,
+            "slot": 4,
             "scalar_type": "bool"
           },
           {
@@ -747,7 +709,7 @@
           },
           {
             "kind": "reg",
-            "slot": 32,
+            "slot": 30,
             "scalar_type": "float"
           }
         ],
@@ -757,11 +719,30 @@
       },
       {
         "tag": "Add",
-        "dst": 34,
+        "dst": 32,
         "args": [
           {
             "kind": "reg",
-            "slot": 33,
+            "slot": 31,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 33,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0,
             "scalar_type": "float"
           },
           {
@@ -775,19 +756,18 @@
         "result_type": "float"
       }
     ],
-    "register_count": 35,
+    "register_count": 34,
     "array_slot_count": 0,
     "array_slot_sizes": [],
     "output_targets": [
-      13,
-      24
+      23
     ],
     "register_targets": [
+      27,
       28,
       29,
-      30,
-      31,
-      34
+      32,
+      33
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_onepole.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_onepole.json
@@ -53,7 +53,7 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      1
+      0
     ],
     "instructions": [
       {
@@ -594,27 +594,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
-        "dst": 29,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 28,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 30,
+        "dst": 29,
         "args": [
           {
             "kind": "reg",
@@ -638,11 +619,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 31,
+        "dst": 30,
         "args": [
           {
             "kind": "reg",
-            "slot": 30,
+            "slot": 29,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 29,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 31,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -656,12 +656,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 32,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 29,
             "scalar_type": "float"
           },
           {
@@ -679,32 +679,13 @@
         "dst": 33,
         "args": [
           {
-            "kind": "reg",
-            "slot": 30,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 32,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 34,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 31,
+            "slot": 30,
             "scalar_type": "float"
           }
         ],
@@ -714,11 +695,30 @@
       },
       {
         "tag": "Add",
-        "dst": 35,
+        "dst": 34,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 33,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 35,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 32,
             "scalar_type": "float"
           },
           {
@@ -732,27 +732,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
-        "dst": 36,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 33,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Clamp",
-        "dst": 37,
+        "dst": 36,
         "args": [
           {
             "kind": "state_reg",
@@ -776,11 +757,30 @@
       },
       {
         "tag": "Mul",
-        "dst": 38,
+        "dst": 37,
         "args": [
           {
             "kind": "reg",
-            "slot": 37,
+            "slot": 36,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 36,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 38,
+        "args": [
+          {
+            "kind": "const",
+            "val": 27,
             "scalar_type": "float"
           },
           {
@@ -794,12 +794,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 39,
         "args": [
           {
-            "kind": "const",
-            "val": 27,
+            "kind": "reg",
+            "slot": 36,
             "scalar_type": "float"
           },
           {
@@ -817,32 +817,13 @@
         "dst": 40,
         "args": [
           {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 41,
-        "args": [
-          {
             "kind": "const",
             "val": 9,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -852,11 +833,30 @@
       },
       {
         "tag": "Add",
-        "dst": 42,
+        "dst": 41,
         "args": [
           {
             "kind": "const",
             "val": 27,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 40,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Div",
+        "dst": 42,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 39,
             "scalar_type": "float"
           },
           {
@@ -870,12 +870,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Sub",
         "dst": 43,
         "args": [
           {
             "kind": "reg",
-            "slot": 40,
+            "slot": 35,
             "scalar_type": "float"
           },
           {
@@ -889,12 +889,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 44,
         "args": [
           {
-            "kind": "reg",
-            "slot": 36,
+            "kind": "const",
+            "val": 0.3,
             "scalar_type": "float"
           },
           {
@@ -908,12 +908,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 45,
         "args": [
           {
-            "kind": "const",
-            "val": 0.3,
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "float"
           },
           {
@@ -927,31 +927,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Clamp",
         "dst": 46,
         "args": [
           {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "float"
-          },
-          {
             "kind": "reg",
             "slot": 45,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Clamp",
-        "dst": 47,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 46,
             "scalar_type": "float"
           },
           {
@@ -971,26 +952,7 @@
       },
       {
         "tag": "Add",
-        "dst": 48,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 47,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 49,
+        "dst": 47,
         "args": [
           {
             "kind": "reg",
@@ -1006,17 +968,35 @@
         "loop_count": 1,
         "strides": [],
         "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 48,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 45,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
       }
     ],
-    "register_count": 50,
+    "register_count": 49,
     "array_slot_count": 0,
     "array_slot_sizes": [],
     "output_targets": [
-      29,
-      48
+      47
     ],
     "register_targets": [
-      49
+      48
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_phaser.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_phaser.json
@@ -81,7 +81,7 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      1
+      0
     ],
     "instructions": [
       {
@@ -517,27 +517,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
-        "dst": 22,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 21,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Mul",
-        "dst": 23,
+        "dst": 22,
         "args": [
           {
             "kind": "const",
@@ -556,7 +537,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 24,
+        "dst": 23,
         "args": [
           {
             "kind": "tick",
@@ -574,11 +555,11 @@
       },
       {
         "tag": "Div",
-        "dst": 25,
+        "dst": 24,
         "args": [
           {
             "kind": "reg",
-            "slot": 24,
+            "slot": 23,
             "scalar_type": "float"
           },
           {
@@ -592,7 +573,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 26,
+        "dst": 25,
         "args": [
           {
             "kind": "const",
@@ -601,7 +582,7 @@
           },
           {
             "kind": "reg",
-            "slot": 25,
+            "slot": 24,
             "scalar_type": "float"
           }
         ],
@@ -611,11 +592,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 27,
+        "dst": 26,
         "args": [
           {
             "kind": "reg",
-            "slot": 26,
+            "slot": 25,
             "scalar_type": "float"
           },
           {
@@ -630,11 +611,11 @@
       },
       {
         "tag": "Round",
-        "dst": 28,
+        "dst": 27,
         "args": [
           {
             "kind": "reg",
-            "slot": 27,
+            "slot": 26,
             "scalar_type": "float"
           }
         ],
@@ -644,11 +625,11 @@
       },
       {
         "tag": "BitAnd",
-        "dst": 29,
+        "dst": 28,
         "args": [
           {
             "kind": "reg",
-            "slot": 28,
+            "slot": 27,
             "scalar_type": "float"
           },
           {
@@ -663,7 +644,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 30,
+        "dst": 29,
         "args": [
           {
             "kind": "const",
@@ -672,7 +653,7 @@
           },
           {
             "kind": "reg",
-            "slot": 29,
+            "slot": 28,
             "scalar_type": "int"
           }
         ],
@@ -682,7 +663,7 @@
       },
       {
         "tag": "Sub",
-        "dst": 31,
+        "dst": 30,
         "args": [
           {
             "kind": "const",
@@ -691,7 +672,7 @@
           },
           {
             "kind": "reg",
-            "slot": 30,
+            "slot": 29,
             "scalar_type": "float"
           }
         ],
@@ -701,7 +682,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 32,
+        "dst": 31,
         "args": [
           {
             "kind": "tick",
@@ -719,11 +700,11 @@
       },
       {
         "tag": "Div",
-        "dst": 33,
+        "dst": 32,
         "args": [
           {
             "kind": "reg",
-            "slot": 32,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -737,7 +718,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 34,
+        "dst": 33,
         "args": [
           {
             "kind": "const",
@@ -746,7 +727,7 @@
           },
           {
             "kind": "reg",
-            "slot": 33,
+            "slot": 32,
             "scalar_type": "float"
           }
         ],
@@ -756,11 +737,11 @@
       },
       {
         "tag": "Round",
-        "dst": 35,
+        "dst": 34,
         "args": [
           {
             "kind": "reg",
-            "slot": 27,
+            "slot": 26,
             "scalar_type": "float"
           }
         ],
@@ -770,11 +751,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 36,
+        "dst": 35,
         "args": [
           {
             "kind": "reg",
-            "slot": 35,
+            "slot": 34,
             "scalar_type": "float"
           },
           {
@@ -789,11 +770,30 @@
       },
       {
         "tag": "Sub",
+        "dst": 36,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 33,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 35,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 37,
         "args": [
           {
             "kind": "reg",
-            "slot": 34,
+            "slot": 36,
             "scalar_type": "float"
           },
           {
@@ -811,32 +811,13 @@
         "dst": 38,
         "args": [
           {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 39,
-        "args": [
-          {
             "kind": "const",
             "val": 0,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -846,7 +827,7 @@
       },
       {
         "tag": "Add",
-        "dst": 40,
+        "dst": 39,
         "args": [
           {
             "kind": "const",
@@ -855,25 +836,6 @@
           },
           {
             "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 41,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
             "slot": 38,
             "scalar_type": "float"
           }
@@ -883,8 +845,27 @@
         "result_type": "float"
       },
       {
+        "tag": "Mul",
+        "dst": 40,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 39,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 37,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
         "tag": "Add",
-        "dst": 42,
+        "dst": 41,
         "args": [
           {
             "kind": "const",
@@ -893,7 +874,7 @@
           },
           {
             "kind": "reg",
-            "slot": 41,
+            "slot": 40,
             "scalar_type": "float"
           }
         ],
@@ -903,16 +884,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 43,
+        "dst": 42,
         "args": [
           {
             "kind": "reg",
-            "slot": 42,
+            "slot": 41,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -922,7 +903,7 @@
       },
       {
         "tag": "Add",
-        "dst": 44,
+        "dst": 43,
         "args": [
           {
             "kind": "const",
@@ -931,7 +912,7 @@
           },
           {
             "kind": "reg",
-            "slot": 43,
+            "slot": 42,
             "scalar_type": "float"
           }
         ],
@@ -941,16 +922,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 45,
+        "dst": 44,
         "args": [
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 43,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -960,7 +941,7 @@
       },
       {
         "tag": "Add",
-        "dst": 46,
+        "dst": 45,
         "args": [
           {
             "kind": "const",
@@ -969,7 +950,7 @@
           },
           {
             "kind": "reg",
-            "slot": 45,
+            "slot": 44,
             "scalar_type": "float"
           }
         ],
@@ -979,16 +960,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 47,
+        "dst": 46,
         "args": [
           {
             "kind": "reg",
-            "slot": 46,
+            "slot": 45,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -998,7 +979,7 @@
       },
       {
         "tag": "Add",
-        "dst": 48,
+        "dst": 47,
         "args": [
           {
             "kind": "const",
@@ -1007,7 +988,7 @@
           },
           {
             "kind": "reg",
-            "slot": 47,
+            "slot": 46,
             "scalar_type": "float"
           }
         ],
@@ -1017,16 +998,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 49,
+        "dst": 48,
         "args": [
           {
             "kind": "reg",
-            "slot": 48,
+            "slot": 47,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -1036,11 +1017,30 @@
       },
       {
         "tag": "Add",
-        "dst": 50,
+        "dst": 49,
         "args": [
           {
             "kind": "const",
             "val": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 48,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 50,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 36,
             "scalar_type": "float"
           },
           {
@@ -1059,7 +1059,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 37,
+            "slot": 30,
             "scalar_type": "float"
           },
           {
@@ -1077,8 +1077,8 @@
         "dst": 52,
         "args": [
           {
-            "kind": "reg",
-            "slot": 31,
+            "kind": "const",
+            "val": 0.35,
             "scalar_type": "float"
           },
           {
@@ -1092,12 +1092,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 53,
         "args": [
           {
             "kind": "const",
-            "val": 0.35,
+            "val": 0.6,
             "scalar_type": "float"
           },
           {
@@ -1111,14 +1111,9 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Neg",
         "dst": 54,
         "args": [
-          {
-            "kind": "const",
-            "val": 0.6,
-            "scalar_type": "float"
-          },
           {
             "kind": "reg",
             "slot": 53,
@@ -1130,22 +1125,8 @@
         "result_type": "float"
       },
       {
-        "tag": "Neg",
-        "dst": 55,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 54,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Mul",
-        "dst": 56,
+        "dst": 55,
         "args": [
           {
             "kind": "const",
@@ -1164,11 +1145,30 @@
       },
       {
         "tag": "Add",
-        "dst": 57,
+        "dst": 56,
         "args": [
           {
             "kind": "reg",
             "slot": 21,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 55,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 57,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 54,
             "scalar_type": "float"
           },
           {
@@ -1182,31 +1182,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 58,
         "args": [
           {
             "kind": "reg",
-            "slot": 55,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
             "slot": 57,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 59,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 58,
             "scalar_type": "float"
           },
           {
@@ -1221,11 +1202,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 60,
+        "dst": 59,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 53,
             "scalar_type": "float"
           },
           {
@@ -1240,11 +1221,30 @@
       },
       {
         "tag": "Add",
+        "dst": 60,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 58,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 59,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 61,
         "args": [
           {
             "kind": "reg",
-            "slot": 59,
+            "slot": 54,
             "scalar_type": "float"
           },
           {
@@ -1258,31 +1258,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 62,
         "args": [
           {
             "kind": "reg",
-            "slot": 55,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
             "slot": 61,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 63,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 62,
             "scalar_type": "float"
           },
           {
@@ -1297,11 +1278,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 64,
+        "dst": 63,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 53,
             "scalar_type": "float"
           },
           {
@@ -1316,11 +1297,30 @@
       },
       {
         "tag": "Add",
+        "dst": 64,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 62,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 63,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 65,
         "args": [
           {
             "kind": "reg",
-            "slot": 63,
+            "slot": 54,
             "scalar_type": "float"
           },
           {
@@ -1334,31 +1334,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 66,
         "args": [
           {
             "kind": "reg",
-            "slot": 55,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
             "slot": 65,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 67,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 66,
             "scalar_type": "float"
           },
           {
@@ -1373,11 +1354,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 68,
+        "dst": 67,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 53,
             "scalar_type": "float"
           },
           {
@@ -1392,11 +1373,30 @@
       },
       {
         "tag": "Add",
+        "dst": 68,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 66,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 67,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 69,
         "args": [
           {
             "kind": "reg",
-            "slot": 67,
+            "slot": 54,
             "scalar_type": "float"
           },
           {
@@ -1410,31 +1410,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 70,
         "args": [
           {
             "kind": "reg",
-            "slot": 55,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
             "slot": 69,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 71,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 70,
             "scalar_type": "float"
           },
           {
@@ -1449,11 +1430,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 72,
+        "dst": 71,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 53,
             "scalar_type": "float"
           },
           {
@@ -1468,11 +1449,30 @@
       },
       {
         "tag": "Add",
-        "dst": 73,
+        "dst": 72,
         "args": [
           {
             "kind": "reg",
+            "slot": 70,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
             "slot": 71,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 73,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0.5,
             "scalar_type": "float"
           },
           {
@@ -1486,12 +1486,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 74,
         "args": [
           {
-            "kind": "const",
-            "val": 0.5,
+            "kind": "reg",
+            "slot": 22,
             "scalar_type": "float"
           },
           {
@@ -1510,12 +1510,12 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 23,
+            "slot": 74,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 74,
+            "kind": "const",
+            "val": 0,
             "scalar_type": "float"
           }
         ],
@@ -1526,44 +1526,6 @@
       {
         "tag": "Add",
         "dst": 76,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 75,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 77,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 52,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 78,
         "args": [
           {
             "kind": "state_reg",
@@ -1582,11 +1544,11 @@
       },
       {
         "tag": "Mod",
-        "dst": 79,
+        "dst": 77,
         "args": [
           {
             "kind": "reg",
-            "slot": 78,
+            "slot": 76,
             "scalar_type": "float"
           },
           {
@@ -1601,11 +1563,49 @@
       },
       {
         "tag": "Add",
+        "dst": 78,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 77,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 79,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 72,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
         "dst": 80,
         "args": [
           {
             "kind": "reg",
-            "slot": 79,
+            "slot": 56,
             "scalar_type": "float"
           },
           {
@@ -1624,7 +1624,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 73,
+            "slot": 60,
             "scalar_type": "float"
           },
           {
@@ -1643,7 +1643,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 57,
+            "slot": 60,
             "scalar_type": "float"
           },
           {
@@ -1662,7 +1662,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 61,
+            "slot": 64,
             "scalar_type": "float"
           },
           {
@@ -1681,7 +1681,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 61,
+            "slot": 64,
             "scalar_type": "float"
           },
           {
@@ -1700,7 +1700,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 65,
+            "slot": 68,
             "scalar_type": "float"
           },
           {
@@ -1719,7 +1719,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 65,
+            "slot": 68,
             "scalar_type": "float"
           },
           {
@@ -1738,45 +1738,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 69,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 88,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 69,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 89,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 73,
+            "slot": 72,
             "scalar_type": "float"
           },
           {
@@ -1790,15 +1752,15 @@
         "result_type": "float"
       }
     ],
-    "register_count": 90,
+    "register_count": 88,
     "array_slot_count": 0,
     "array_slot_sizes": [],
     "output_targets": [
-      22,
-      76,
-      77
+      75
     ],
     "register_targets": [
+      78,
+      79,
       80,
       81,
       82,
@@ -1806,9 +1768,7 @@
       84,
       85,
       86,
-      87,
-      88,
-      89
+      87
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_sequencer.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_sequencer.json
@@ -68,7 +68,7 @@
     ],
     "register_names": [
       "seq_step",
-      "seq_delay_0"
+      "seq_prev_clock"
     ],
     "register_types": [
       "int",
@@ -76,20 +76,67 @@
     ],
     "array_slot_names": [],
     "outputs": [
-      3
+      0
     ],
     "instructions": [
       {
-        "tag": "Mul",
+        "tag": "Pack",
         "dst": 0,
+        "args": [
+          {
+            "kind": "const",
+            "val": 200,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 300,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 400,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 500,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Index",
+        "dst": 0,
+        "args": [
+          {
+            "kind": "array_reg",
+            "slot": 0
+          },
+          {
+            "kind": "state_reg",
+            "slot": 0,
+            "scalar_type": "int"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 1,
         "args": [
           {
             "kind": "tick",
             "scalar_type": "int"
           },
           {
-            "kind": "const",
-            "val": 4,
+            "kind": "reg",
+            "slot": 0,
             "scalar_type": "float"
           }
         ],
@@ -99,11 +146,11 @@
       },
       {
         "tag": "Div",
-        "dst": 1,
+        "dst": 2,
         "args": [
           {
             "kind": "reg",
-            "slot": 0,
+            "slot": 1,
             "scalar_type": "float"
           },
           {
@@ -116,37 +163,18 @@
         "result_type": "float"
       },
       {
-        "tag": "Mod",
-        "dst": 2,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 3,
         "args": [
+          {
+            "kind": "const",
+            "val": 6.283185307179586,
+            "scalar_type": "float"
+          },
           {
             "kind": "reg",
             "slot": 2,
             "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -154,7 +182,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Mod",
+        "tag": "Mul",
         "dst": 4,
         "args": [
           {
@@ -164,7 +192,7 @@
           },
           {
             "kind": "const",
-            "val": 1,
+            "val": 0.3183098861837907,
             "scalar_type": "float"
           }
         ],
@@ -173,61 +201,51 @@
         "result_type": "float"
       },
       {
-        "tag": "Less",
+        "tag": "Round",
         "dst": 5,
         "args": [
           {
             "kind": "reg",
             "slot": 4,
             "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
         "strides": [],
-        "result_type": "bool"
+        "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "BitAnd",
         "dst": 6,
         "args": [
           {
             "kind": "reg",
             "slot": 5,
-            "scalar_type": "bool"
+            "scalar_type": "float"
           },
           {
             "kind": "const",
             "val": 1,
-            "scalar_type": "float"
+            "scalar_type": "int"
           }
         ],
         "loop_count": 1,
         "strides": [],
-        "result_type": "float"
+        "result_type": "int"
       },
       {
-        "tag": "Clamp",
+        "tag": "Mul",
         "dst": 7,
         "args": [
           {
+            "kind": "const",
+            "val": 2,
+            "scalar_type": "float"
+          },
+          {
             "kind": "reg",
             "slot": 6,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
+            "scalar_type": "int"
           }
         ],
         "loop_count": 1,
@@ -235,31 +253,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Sub",
         "dst": 8,
         "args": [
           {
-            "kind": "reg",
-            "slot": 7,
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Pack",
-        "dst": 0,
-        "args": [
-          {
-            "kind": "const",
-            "val": 1,
+            "kind": "reg",
+            "slot": 7,
             "scalar_type": "float"
           }
         ],
@@ -276,8 +280,8 @@
             "slot": 0
           },
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "state_reg",
+            "slot": 0,
             "scalar_type": "int"
           }
         ],
@@ -290,9 +294,8 @@
         "dst": 10,
         "args": [
           {
-            "kind": "reg",
-            "slot": 0,
-            "scalar_type": "float"
+            "kind": "tick",
+            "scalar_type": "int"
           },
           {
             "kind": "reg",
@@ -323,18 +326,18 @@
         "result_type": "float"
       },
       {
-        "tag": "Mod",
+        "tag": "Mul",
         "dst": 12,
         "args": [
+          {
+            "kind": "const",
+            "val": 6.283185307179586,
+            "scalar_type": "float"
+          },
           {
             "kind": "reg",
             "slot": 11,
             "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -342,17 +345,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Round",
         "dst": 13,
         "args": [
           {
             "kind": "reg",
-            "slot": 12,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
+            "slot": 4,
             "scalar_type": "float"
           }
         ],
@@ -361,7 +359,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Mod",
+        "tag": "Mul",
         "dst": 14,
         "args": [
           {
@@ -371,7 +369,7 @@
           },
           {
             "kind": "const",
-            "val": 1,
+            "val": 3.141592653589793,
             "scalar_type": "float"
           }
         ],
@@ -380,23 +378,23 @@
         "result_type": "float"
       },
       {
-        "tag": "Less",
+        "tag": "Sub",
         "dst": 15,
         "args": [
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 12,
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0.5,
+            "kind": "reg",
+            "slot": 14,
             "scalar_type": "float"
           }
         ],
         "loop_count": 1,
         "strides": [],
-        "result_type": "bool"
+        "result_type": "float"
       },
       {
         "tag": "Mul",
@@ -405,11 +403,11 @@
           {
             "kind": "reg",
             "slot": 15,
-            "scalar_type": "bool"
+            "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 1,
+            "kind": "reg",
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -418,65 +416,18 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 17,
         "args": [
-          {
-            "kind": "reg",
-            "slot": 16,
-            "scalar_type": "float"
-          },
           {
             "kind": "const",
             "val": 0,
             "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Pack",
-        "dst": 1,
-        "args": [
-          {
-            "kind": "const",
-            "val": 200,
-            "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 300,
+            "kind": "reg",
+            "slot": 16,
             "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 400,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 500,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Index",
-        "dst": 18,
-        "args": [
-          {
-            "kind": "array_reg",
-            "slot": 1
-          },
-          {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "int"
           }
         ],
         "loop_count": 1,
@@ -485,6 +436,25 @@
       },
       {
         "tag": "Add",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "const",
+            "val": -2.505210838544172e-8,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 17,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
         "dst": 19,
         "args": [
           {
@@ -493,8 +463,8 @@
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 16,
             "scalar_type": "float"
           }
         ],
@@ -503,17 +473,18 @@
         "result_type": "float"
       },
       {
-        "tag": "Index",
+        "tag": "Add",
         "dst": 20,
         "args": [
           {
-            "kind": "array_reg",
-            "slot": 1
+            "kind": "const",
+            "val": 0.0000027557319223985893,
+            "scalar_type": "float"
           },
           {
-            "kind": "state_reg",
-            "slot": 0,
-            "scalar_type": "int"
+            "kind": "reg",
+            "slot": 19,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -525,12 +496,13 @@
         "dst": 21,
         "args": [
           {
-            "kind": "tick",
-            "scalar_type": "int"
+            "kind": "reg",
+            "slot": 20,
+            "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 20,
+            "slot": 16,
             "scalar_type": "float"
           }
         ],
@@ -539,16 +511,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Div",
+        "tag": "Add",
         "dst": 22,
         "args": [
           {
-            "kind": "reg",
-            "slot": 21,
+            "kind": "const",
+            "val": -0.0001984126984126984,
             "scalar_type": "float"
           },
           {
-            "kind": "rate",
+            "kind": "reg",
+            "slot": 21,
             "scalar_type": "float"
           }
         ],
@@ -561,13 +534,32 @@
         "dst": 23,
         "args": [
           {
-            "kind": "const",
-            "val": 6.283185307179586,
+            "kind": "reg",
+            "slot": 22,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 22,
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 24,
+        "args": [
+          {
+            "kind": "const",
+            "val": 0.008333333333333333,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 23,
             "scalar_type": "float"
           }
         ],
@@ -577,31 +569,17 @@
       },
       {
         "tag": "Mul",
-        "dst": 24,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 23,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.3183098861837907,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Round",
         "dst": 25,
         "args": [
           {
             "kind": "reg",
             "slot": 24,
             "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 16,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -609,37 +587,37 @@
         "result_type": "float"
       },
       {
-        "tag": "BitAnd",
+        "tag": "Add",
         "dst": 26,
         "args": [
+          {
+            "kind": "const",
+            "val": -0.16666666666666666,
+            "scalar_type": "float"
+          },
           {
             "kind": "reg",
             "slot": 25,
             "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 1,
-            "scalar_type": "int"
           }
         ],
         "loop_count": 1,
         "strides": [],
-        "result_type": "int"
+        "result_type": "float"
       },
       {
         "tag": "Mul",
         "dst": 27,
         "args": [
           {
-            "kind": "const",
-            "val": 2,
+            "kind": "reg",
+            "slot": 26,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 26,
-            "scalar_type": "int"
+            "slot": 16,
+            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -647,7 +625,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Add",
         "dst": 28,
         "args": [
           {
@@ -670,12 +648,69 @@
         "dst": 29,
         "args": [
           {
+            "kind": "reg",
+            "slot": 15,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 28,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 30,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 8,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 29,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 31,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 30,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 32,
+        "args": [
+          {
             "kind": "tick",
             "scalar_type": "int"
           },
           {
-            "kind": "reg",
-            "slot": 18,
+            "kind": "const",
+            "val": 4,
             "scalar_type": "float"
           }
         ],
@@ -685,11 +720,11 @@
       },
       {
         "tag": "Div",
-        "dst": 30,
+        "dst": 33,
         "args": [
           {
             "kind": "reg",
-            "slot": 29,
+            "slot": 32,
             "scalar_type": "float"
           },
           {
@@ -702,69 +737,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
-        "dst": 31,
-        "args": [
-          {
-            "kind": "const",
-            "val": 6.283185307179586,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 30,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Round",
-        "dst": 32,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 24,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 33,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 32,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 3.141592653589793,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Sub",
+        "tag": "Mod",
         "dst": 34,
         "args": [
           {
             "kind": "reg",
-            "slot": 31,
+            "slot": 33,
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 33,
+            "kind": "const",
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -773,7 +756,7 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 35,
         "args": [
           {
@@ -782,237 +765,9 @@
             "scalar_type": "float"
           },
           {
-            "kind": "reg",
-            "slot": 34,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 36,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 37,
-        "args": [
-          {
-            "kind": "const",
-            "val": -2.505210838544172e-8,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 36,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 38,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 37,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 39,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0.0000027557319223985893,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 38,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 40,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 39,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 41,
-        "args": [
-          {
-            "kind": "const",
-            "val": -0.0001984126984126984,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 42,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 41,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 43,
-        "args": [
-          {
-            "kind": "const",
-            "val": 0.008333333333333333,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 42,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 44,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 43,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 45,
-        "args": [
-          {
-            "kind": "const",
-            "val": -0.16666666666666666,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 44,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 46,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 45,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 35,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 47,
-        "args": [
-          {
             "kind": "const",
             "val": 1,
             "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 46,
-            "scalar_type": "float"
           }
         ],
         "loop_count": 1,
@@ -1020,55 +775,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
-        "dst": 48,
+        "tag": "Mod",
+        "dst": 36,
         "args": [
           {
             "kind": "reg",
-            "slot": 34,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 47,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 49,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 28,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 48,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Add",
-        "dst": 50,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 49,
+            "slot": 35,
             "scalar_type": "float"
           },
           {
             "kind": "const",
-            "val": 0,
+            "val": 1,
             "scalar_type": "float"
           }
         ],
@@ -1078,11 +795,11 @@
       },
       {
         "tag": "Less",
-        "dst": 51,
+        "dst": 37,
         "args": [
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 36,
             "scalar_type": "float"
           },
           {
@@ -1097,11 +814,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 52,
+        "dst": 38,
         "args": [
           {
             "kind": "reg",
-            "slot": 51,
+            "slot": 37,
             "scalar_type": "bool"
           },
           {
@@ -1116,11 +833,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 53,
+        "dst": 39,
         "args": [
           {
             "kind": "reg",
-            "slot": 52,
+            "slot": 38,
             "scalar_type": "float"
           },
           {
@@ -1140,11 +857,11 @@
       },
       {
         "tag": "Greater",
-        "dst": 54,
+        "dst": 40,
         "args": [
           {
             "kind": "reg",
-            "slot": 53,
+            "slot": 39,
             "scalar_type": "float"
           },
           {
@@ -1159,7 +876,7 @@
       },
       {
         "tag": "LessEq",
-        "dst": 55,
+        "dst": 41,
         "args": [
           {
             "kind": "state_reg",
@@ -1178,16 +895,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 56,
+        "dst": 42,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 40,
             "scalar_type": "bool"
           },
           {
             "kind": "reg",
-            "slot": 55,
+            "slot": 41,
             "scalar_type": "bool"
           }
         ],
@@ -1197,7 +914,7 @@
       },
       {
         "tag": "Add",
-        "dst": 57,
+        "dst": 43,
         "args": [
           {
             "kind": "state_reg",
@@ -1206,7 +923,7 @@
           },
           {
             "kind": "reg",
-            "slot": 56,
+            "slot": 42,
             "scalar_type": "bool"
           }
         ],
@@ -1216,11 +933,11 @@
       },
       {
         "tag": "Mod",
-        "dst": 58,
+        "dst": 44,
         "args": [
           {
             "kind": "reg",
-            "slot": 57,
+            "slot": 43,
             "scalar_type": "int"
           },
           {
@@ -1235,11 +952,11 @@
       },
       {
         "tag": "Add",
-        "dst": 59,
+        "dst": 45,
         "args": [
           {
             "kind": "reg",
-            "slot": 58,
+            "slot": 44,
             "scalar_type": "int"
           },
           {
@@ -1253,12 +970,74 @@
         "result_type": "int"
       },
       {
-        "tag": "Add",
-        "dst": 60,
+        "tag": "Less",
+        "dst": 46,
         "args": [
           {
             "kind": "reg",
-            "slot": 7,
+            "slot": 36,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "bool"
+      },
+      {
+        "tag": "Mul",
+        "dst": 47,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 46,
+            "scalar_type": "bool"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Clamp",
+        "dst": 48,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 47,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Add",
+        "dst": 49,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 48,
             "scalar_type": "float"
           },
           {
@@ -1272,21 +1051,17 @@
         "result_type": "float"
       }
     ],
-    "register_count": 61,
-    "array_slot_count": 2,
+    "register_count": 50,
+    "array_slot_count": 1,
     "array_slot_sizes": [
-      1,
       4
     ],
     "output_targets": [
-      8,
-      17,
-      19,
-      50
+      31
     ],
     "register_targets": [
-      59,
-      60
+      45,
+      49
     ]
   }
 }

--- a/compiler/__fixtures__/flat_plan/stdlib_vca_xfade.json
+++ b/compiler/__fixtures__/flat_plan/stdlib_vca_xfade.json
@@ -73,12 +73,31 @@
     "register_types": [],
     "array_slot_names": [],
     "outputs": [
-      3
+      0
     ],
     "instructions": [
       {
-        "tag": "Mul",
+        "tag": "Sub",
         "dst": 0,
+        "args": [
+          {
+            "kind": "const",
+            "val": 1,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "const",
+            "val": 0.5,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 1,
         "args": [
           {
             "kind": "tick",
@@ -96,11 +115,11 @@
       },
       {
         "tag": "Div",
-        "dst": 1,
+        "dst": 2,
         "args": [
           {
             "kind": "reg",
-            "slot": 0,
+            "slot": 1,
             "scalar_type": "float"
           },
           {
@@ -114,7 +133,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 2,
+        "dst": 3,
         "args": [
           {
             "kind": "const",
@@ -123,7 +142,7 @@
           },
           {
             "kind": "reg",
-            "slot": 1,
+            "slot": 2,
             "scalar_type": "float"
           }
         ],
@@ -133,11 +152,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 3,
+        "dst": 4,
         "args": [
           {
             "kind": "reg",
-            "slot": 2,
+            "slot": 3,
             "scalar_type": "float"
           },
           {
@@ -152,11 +171,11 @@
       },
       {
         "tag": "Round",
-        "dst": 4,
+        "dst": 5,
         "args": [
           {
             "kind": "reg",
-            "slot": 3,
+            "slot": 4,
             "scalar_type": "float"
           }
         ],
@@ -166,11 +185,11 @@
       },
       {
         "tag": "BitAnd",
-        "dst": 5,
+        "dst": 6,
         "args": [
           {
             "kind": "reg",
-            "slot": 4,
+            "slot": 5,
             "scalar_type": "float"
           },
           {
@@ -185,7 +204,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 6,
+        "dst": 7,
         "args": [
           {
             "kind": "const",
@@ -194,7 +213,7 @@
           },
           {
             "kind": "reg",
-            "slot": 5,
+            "slot": 6,
             "scalar_type": "int"
           }
         ],
@@ -204,7 +223,7 @@
       },
       {
         "tag": "Sub",
-        "dst": 7,
+        "dst": 8,
         "args": [
           {
             "kind": "const",
@@ -213,7 +232,7 @@
           },
           {
             "kind": "reg",
-            "slot": 6,
+            "slot": 7,
             "scalar_type": "float"
           }
         ],
@@ -223,7 +242,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 8,
+        "dst": 9,
         "args": [
           {
             "kind": "tick",
@@ -241,11 +260,11 @@
       },
       {
         "tag": "Div",
-        "dst": 9,
+        "dst": 10,
         "args": [
           {
             "kind": "reg",
-            "slot": 8,
+            "slot": 9,
             "scalar_type": "float"
           },
           {
@@ -259,7 +278,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 10,
+        "dst": 11,
         "args": [
           {
             "kind": "const",
@@ -268,7 +287,7 @@
           },
           {
             "kind": "reg",
-            "slot": 9,
+            "slot": 10,
             "scalar_type": "float"
           }
         ],
@@ -278,11 +297,11 @@
       },
       {
         "tag": "Round",
-        "dst": 11,
+        "dst": 12,
         "args": [
           {
             "kind": "reg",
-            "slot": 3,
+            "slot": 4,
             "scalar_type": "float"
           }
         ],
@@ -292,11 +311,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 12,
+        "dst": 13,
         "args": [
           {
             "kind": "reg",
-            "slot": 11,
+            "slot": 12,
             "scalar_type": "float"
           },
           {
@@ -311,30 +330,11 @@
       },
       {
         "tag": "Sub",
-        "dst": 13,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 10,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 12,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
         "dst": 14,
         "args": [
           {
             "kind": "reg",
-            "slot": 13,
+            "slot": 11,
             "scalar_type": "float"
           },
           {
@@ -352,8 +352,8 @@
         "dst": 15,
         "args": [
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 14,
             "scalar_type": "float"
           },
           {
@@ -367,12 +367,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 16,
         "args": [
           {
             "kind": "const",
-            "val": -2.505210838544172e-8,
+            "val": 0,
             "scalar_type": "float"
           },
           {
@@ -386,17 +386,36 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 17,
         "args": [
           {
-            "kind": "reg",
-            "slot": 16,
+            "kind": "const",
+            "val": -2.505210838544172e-8,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 16,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 18,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 17,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -406,7 +425,7 @@
       },
       {
         "tag": "Add",
-        "dst": 18,
+        "dst": 19,
         "args": [
           {
             "kind": "const",
@@ -415,7 +434,7 @@
           },
           {
             "kind": "reg",
-            "slot": 17,
+            "slot": 18,
             "scalar_type": "float"
           }
         ],
@@ -425,16 +444,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 19,
+        "dst": 20,
         "args": [
           {
             "kind": "reg",
-            "slot": 18,
+            "slot": 19,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -444,7 +463,7 @@
       },
       {
         "tag": "Add",
-        "dst": 20,
+        "dst": 21,
         "args": [
           {
             "kind": "const",
@@ -453,7 +472,7 @@
           },
           {
             "kind": "reg",
-            "slot": 19,
+            "slot": 20,
             "scalar_type": "float"
           }
         ],
@@ -463,16 +482,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 21,
+        "dst": 22,
         "args": [
           {
             "kind": "reg",
-            "slot": 20,
+            "slot": 21,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -482,7 +501,7 @@
       },
       {
         "tag": "Add",
-        "dst": 22,
+        "dst": 23,
         "args": [
           {
             "kind": "const",
@@ -491,7 +510,7 @@
           },
           {
             "kind": "reg",
-            "slot": 21,
+            "slot": 22,
             "scalar_type": "float"
           }
         ],
@@ -501,16 +520,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 23,
+        "dst": 24,
         "args": [
           {
             "kind": "reg",
-            "slot": 22,
+            "slot": 23,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -520,7 +539,7 @@
       },
       {
         "tag": "Add",
-        "dst": 24,
+        "dst": 25,
         "args": [
           {
             "kind": "const",
@@ -529,7 +548,7 @@
           },
           {
             "kind": "reg",
-            "slot": 23,
+            "slot": 24,
             "scalar_type": "float"
           }
         ],
@@ -539,16 +558,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 25,
+        "dst": 26,
         "args": [
           {
             "kind": "reg",
-            "slot": 24,
+            "slot": 25,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 14,
+            "slot": 15,
             "scalar_type": "float"
           }
         ],
@@ -558,30 +577,11 @@
       },
       {
         "tag": "Add",
-        "dst": 26,
+        "dst": 27,
         "args": [
           {
             "kind": "const",
             "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 25,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 27,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 13,
             "scalar_type": "float"
           },
           {
@@ -600,7 +600,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 7,
+            "slot": 14,
             "scalar_type": "float"
           },
           {
@@ -614,17 +614,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 29,
         "args": [
           {
             "kind": "reg",
-            "slot": 28,
+            "slot": 8,
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 28,
             "scalar_type": "float"
           }
         ],
@@ -635,6 +635,25 @@
       {
         "tag": "Mul",
         "dst": 30,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 0,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 29,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 31,
         "args": [
           {
             "kind": "tick",
@@ -652,11 +671,11 @@
       },
       {
         "tag": "Div",
-        "dst": 31,
+        "dst": 32,
         "args": [
           {
             "kind": "reg",
-            "slot": 30,
+            "slot": 31,
             "scalar_type": "float"
           },
           {
@@ -670,7 +689,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 32,
+        "dst": 33,
         "args": [
           {
             "kind": "const",
@@ -679,7 +698,7 @@
           },
           {
             "kind": "reg",
-            "slot": 31,
+            "slot": 32,
             "scalar_type": "float"
           }
         ],
@@ -689,11 +708,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 33,
+        "dst": 34,
         "args": [
           {
             "kind": "reg",
-            "slot": 32,
+            "slot": 33,
             "scalar_type": "float"
           },
           {
@@ -708,11 +727,11 @@
       },
       {
         "tag": "Round",
-        "dst": 34,
+        "dst": 35,
         "args": [
           {
             "kind": "reg",
-            "slot": 33,
+            "slot": 34,
             "scalar_type": "float"
           }
         ],
@@ -722,11 +741,11 @@
       },
       {
         "tag": "BitAnd",
-        "dst": 35,
+        "dst": 36,
         "args": [
           {
             "kind": "reg",
-            "slot": 34,
+            "slot": 35,
             "scalar_type": "float"
           },
           {
@@ -741,7 +760,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 36,
+        "dst": 37,
         "args": [
           {
             "kind": "const",
@@ -750,7 +769,7 @@
           },
           {
             "kind": "reg",
-            "slot": 35,
+            "slot": 36,
             "scalar_type": "int"
           }
         ],
@@ -760,7 +779,7 @@
       },
       {
         "tag": "Sub",
-        "dst": 37,
+        "dst": 38,
         "args": [
           {
             "kind": "const",
@@ -769,7 +788,7 @@
           },
           {
             "kind": "reg",
-            "slot": 36,
+            "slot": 37,
             "scalar_type": "float"
           }
         ],
@@ -779,7 +798,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 38,
+        "dst": 39,
         "args": [
           {
             "kind": "tick",
@@ -797,11 +816,11 @@
       },
       {
         "tag": "Div",
-        "dst": 39,
+        "dst": 40,
         "args": [
           {
             "kind": "reg",
-            "slot": 38,
+            "slot": 39,
             "scalar_type": "float"
           },
           {
@@ -815,7 +834,7 @@
       },
       {
         "tag": "Mul",
-        "dst": 40,
+        "dst": 41,
         "args": [
           {
             "kind": "const",
@@ -824,7 +843,7 @@
           },
           {
             "kind": "reg",
-            "slot": 39,
+            "slot": 40,
             "scalar_type": "float"
           }
         ],
@@ -834,11 +853,11 @@
       },
       {
         "tag": "Round",
-        "dst": 41,
+        "dst": 42,
         "args": [
           {
             "kind": "reg",
-            "slot": 33,
+            "slot": 34,
             "scalar_type": "float"
           }
         ],
@@ -848,11 +867,11 @@
       },
       {
         "tag": "Mul",
-        "dst": 42,
+        "dst": 43,
         "args": [
           {
             "kind": "reg",
-            "slot": 41,
+            "slot": 42,
             "scalar_type": "float"
           },
           {
@@ -867,30 +886,11 @@
       },
       {
         "tag": "Sub",
-        "dst": 43,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 40,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 42,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
         "dst": 44,
         "args": [
           {
             "kind": "reg",
-            "slot": 43,
+            "slot": 41,
             "scalar_type": "float"
           },
           {
@@ -908,8 +908,8 @@
         "dst": 45,
         "args": [
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 44,
             "scalar_type": "float"
           },
           {
@@ -923,12 +923,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 46,
         "args": [
           {
             "kind": "const",
-            "val": -2.505210838544172e-8,
+            "val": 0,
             "scalar_type": "float"
           },
           {
@@ -942,17 +942,36 @@
         "result_type": "float"
       },
       {
-        "tag": "Mul",
+        "tag": "Add",
         "dst": 47,
         "args": [
           {
-            "kind": "reg",
-            "slot": 46,
+            "kind": "const",
+            "val": -2.505210838544172e-8,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 46,
+            "scalar_type": "float"
+          }
+        ],
+        "loop_count": 1,
+        "strides": [],
+        "result_type": "float"
+      },
+      {
+        "tag": "Mul",
+        "dst": 48,
+        "args": [
+          {
+            "kind": "reg",
+            "slot": 47,
+            "scalar_type": "float"
+          },
+          {
+            "kind": "reg",
+            "slot": 45,
             "scalar_type": "float"
           }
         ],
@@ -962,7 +981,7 @@
       },
       {
         "tag": "Add",
-        "dst": 48,
+        "dst": 49,
         "args": [
           {
             "kind": "const",
@@ -971,7 +990,7 @@
           },
           {
             "kind": "reg",
-            "slot": 47,
+            "slot": 48,
             "scalar_type": "float"
           }
         ],
@@ -981,16 +1000,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 49,
+        "dst": 50,
         "args": [
           {
             "kind": "reg",
-            "slot": 48,
+            "slot": 49,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 45,
             "scalar_type": "float"
           }
         ],
@@ -1000,7 +1019,7 @@
       },
       {
         "tag": "Add",
-        "dst": 50,
+        "dst": 51,
         "args": [
           {
             "kind": "const",
@@ -1009,7 +1028,7 @@
           },
           {
             "kind": "reg",
-            "slot": 49,
+            "slot": 50,
             "scalar_type": "float"
           }
         ],
@@ -1019,16 +1038,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 51,
+        "dst": 52,
         "args": [
           {
             "kind": "reg",
-            "slot": 50,
+            "slot": 51,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 45,
             "scalar_type": "float"
           }
         ],
@@ -1038,7 +1057,7 @@
       },
       {
         "tag": "Add",
-        "dst": 52,
+        "dst": 53,
         "args": [
           {
             "kind": "const",
@@ -1047,7 +1066,7 @@
           },
           {
             "kind": "reg",
-            "slot": 51,
+            "slot": 52,
             "scalar_type": "float"
           }
         ],
@@ -1057,16 +1076,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 53,
+        "dst": 54,
         "args": [
           {
             "kind": "reg",
-            "slot": 52,
+            "slot": 53,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 45,
             "scalar_type": "float"
           }
         ],
@@ -1076,7 +1095,7 @@
       },
       {
         "tag": "Add",
-        "dst": 54,
+        "dst": 55,
         "args": [
           {
             "kind": "const",
@@ -1085,7 +1104,7 @@
           },
           {
             "kind": "reg",
-            "slot": 53,
+            "slot": 54,
             "scalar_type": "float"
           }
         ],
@@ -1095,16 +1114,16 @@
       },
       {
         "tag": "Mul",
-        "dst": 55,
+        "dst": 56,
         "args": [
           {
             "kind": "reg",
-            "slot": 54,
+            "slot": 55,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 44,
+            "slot": 45,
             "scalar_type": "float"
           }
         ],
@@ -1114,30 +1133,11 @@
       },
       {
         "tag": "Add",
-        "dst": 56,
+        "dst": 57,
         "args": [
           {
             "kind": "const",
             "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 55,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 57,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 43,
             "scalar_type": "float"
           },
           {
@@ -1156,7 +1156,7 @@
         "args": [
           {
             "kind": "reg",
-            "slot": 37,
+            "slot": 44,
             "scalar_type": "float"
           },
           {
@@ -1170,17 +1170,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
+        "tag": "Mul",
         "dst": 59,
         "args": [
           {
             "kind": "reg",
-            "slot": 58,
+            "slot": 38,
             "scalar_type": "float"
           },
           {
-            "kind": "const",
-            "val": 0,
+            "kind": "reg",
+            "slot": 58,
             "scalar_type": "float"
           }
         ],
@@ -1189,55 +1189,17 @@
         "result_type": "float"
       },
       {
-        "tag": "Sub",
+        "tag": "Mul",
         "dst": 60,
         "args": [
           {
             "kind": "const",
-            "val": 1,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0.5,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 61,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 60,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "reg",
-            "slot": 28,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
-        "tag": "Mul",
-        "dst": 62,
-        "args": [
-          {
-            "kind": "const",
             "val": 0.5,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 58,
+            "slot": 59,
             "scalar_type": "float"
           }
         ],
@@ -1247,16 +1209,16 @@
       },
       {
         "tag": "Add",
-        "dst": 63,
+        "dst": 61,
         "args": [
           {
             "kind": "reg",
-            "slot": 61,
+            "slot": 30,
             "scalar_type": "float"
           },
           {
             "kind": "reg",
-            "slot": 62,
+            "slot": 60,
             "scalar_type": "float"
           }
         ],
@@ -1266,11 +1228,11 @@
       },
       {
         "tag": "Clamp",
-        "dst": 64,
+        "dst": 62,
         "args": [
           {
             "kind": "reg",
-            "slot": 63,
+            "slot": 61,
             "scalar_type": "float"
           },
           {
@@ -1289,31 +1251,12 @@
         "result_type": "float"
       },
       {
-        "tag": "Add",
-        "dst": 65,
-        "args": [
-          {
-            "kind": "reg",
-            "slot": 64,
-            "scalar_type": "float"
-          },
-          {
-            "kind": "const",
-            "val": 0,
-            "scalar_type": "float"
-          }
-        ],
-        "loop_count": 1,
-        "strides": [],
-        "result_type": "float"
-      },
-      {
         "tag": "Mul",
-        "dst": 66,
+        "dst": 63,
         "args": [
           {
             "kind": "reg",
-            "slot": 64,
+            "slot": 62,
             "scalar_type": "float"
           },
           {
@@ -1328,11 +1271,11 @@
       },
       {
         "tag": "Add",
-        "dst": 67,
+        "dst": 64,
         "args": [
           {
             "kind": "reg",
-            "slot": 66,
+            "slot": 63,
             "scalar_type": "float"
           },
           {
@@ -1346,14 +1289,11 @@
         "result_type": "float"
       }
     ],
-    "register_count": 68,
+    "register_count": 65,
     "array_slot_count": 0,
     "array_slot_sizes": [],
     "output_targets": [
-      29,
-      59,
-      65,
-      67
+      64
     ],
     "register_targets": []
   }

--- a/compiler/bench_compile.ts
+++ b/compiler/bench_compile.ts
@@ -3,7 +3,7 @@
  */
 import { makeSession, SessionState } from './session.js'
 import { loadStdlib as loadBuiltins } from './program.js'
-import { flattenSession } from './flatten.js'
+import { compileSession } from './ir/compile_session'
 
 const session: SessionState = makeSession()
 loadBuiltins(session)
@@ -43,7 +43,7 @@ for (const [typeName, instanceName] of modules) {
   solo.graphOutputs.push({ instance: instanceName, output: type._def.outputNames[0] })
   const t = performance.now()
   try {
-    flattenSession(solo)
+    compileSession(solo)
     console.log(`  ${instanceName} (${typeName}): ${(performance.now() - t).toFixed(1)}ms`)
   } catch (e: any) {
     console.log(`  ${instanceName} (${typeName}): ERROR ${e.message} (${(performance.now() - t).toFixed(1)}ms)`)
@@ -54,7 +54,7 @@ console.log(`\nModules: ${session.instanceRegistry.size}`)
 console.log('Starting full flattenSession...')
 
 const t0 = performance.now()
-const plan = flattenSession(session)
+const plan = compileSession(session)
 const t1 = performance.now()
 console.log(`flattenSession: ${(t1 - t0).toFixed(1)}ms`)
 console.log(`  instructions: ${plan.instructions.length}`)

--- a/compiler/delay_generic.test.ts
+++ b/compiler/delay_generic.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, loadJSON, resolveProgramType } from './session'
 import { loadStdlib } from './program'
-import { flattenSession } from './flatten'
+import { compileSession } from './ir/compile_session'
 import { Float, ArrayType } from './term'
 
 describe('stdlib Delay<N>', () => {
@@ -35,7 +35,7 @@ describe('stdlib Delay<N>', () => {
       ]},
       audio_outputs: [{ instance: 'd', output: 'y' }],
     }, session)
-    const plan = flattenSession(session)
+    const plan = compileSession(session)
     expect(plan).toBeDefined()
     const inst = session.instanceRegistry.get('d')!
     expect(inst.typeName).toBe('Delay')

--- a/compiler/emit_wasm.test.ts
+++ b/compiler/emit_wasm.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import type { FlatPlan } from './flatten'
+import type { FlatPlan } from './flat_plan'
 import type { NInstr, NOperand, ScalarType } from './emit_numeric'
 import { emitWasm } from './emit_wasm'
 

--- a/compiler/emit_wasm.ts
+++ b/compiler/emit_wasm.ts
@@ -24,7 +24,7 @@
  *   - param_frame  → f64 cells snapshotted per block for TriggerParam
  */
 
-import type { FlatPlan } from './flatten.js'
+import type { FlatPlan } from './flat_plan'
 import type { NInstr, NOperand, ScalarType } from './emit_numeric.js'
 import { type WasmLayout, computeLayout, collectParamPtrs } from './wasm_memory_layout.js'
 

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -1,0 +1,32 @@
+/**
+ * flat_plan.ts — `tropical_plan_4` JSON schema.
+ *
+ * The FlatPlan type is the contract between the TS compiler layer and
+ * the C++ engine. Every emit boundary (`compile_resolved.ts`,
+ * `compile_session.ts`, the WASM emitter) produces this shape; the
+ * runtime's `loadPlan` consumes it.
+ *
+ * Hoisted here in Phase D D3 so consumers don't have to import from
+ * `flatten.ts`, which is being retired.
+ */
+
+import type { NInstr, GroupInfo, ScalarType } from './emit_numeric'
+
+export interface FlatPlan {
+  schema: 'tropical_plan_4'
+  config: { sampleRate: number }
+  state_init: (number | boolean)[]
+  register_names: string[]
+  register_types: ScalarType[]
+  array_slot_names: string[]
+  outputs: number[]
+  /** Compiled instruction stream from `emitNumericProgram`. */
+  instructions:    NInstr[]
+  register_count:  number
+  array_slot_count: number
+  array_slot_sizes: number[]
+  output_targets:  number[]
+  register_targets: number[]
+  /** Gateable-subgraph metadata, if any source_tag wrappers were emitted. */
+  groups?:         GroupInfo[]
+}

--- a/compiler/flatten.ts
+++ b/compiler/flatten.ts
@@ -119,27 +119,12 @@ function registerScalarTag(t: PortType | undefined): ScalarType {
 }
 
 // ─────────────────────────────────────────────────────────────
-// tropical_plan_4 schema
+// tropical_plan_4 schema — definition lives in `./flat_plan.ts`
+// (Phase D D3 hoist so consumers don't import from this file).
 // ─────────────────────────────────────────────────────────────
 
-export interface FlatPlan {
-  schema: 'tropical_plan_4'
-  config: { sampleRate: number }
-  state_init: (number | boolean)[]
-  register_names: string[]
-  register_types: ScalarType[]
-  array_slot_names: string[]
-  outputs: number[]
-  // Compiled instruction stream (from emitNumericProgram)
-  instructions:    NInstr[]
-  register_count:  number
-  array_slot_count: number
-  array_slot_sizes: number[]
-  output_targets:  number[]
-  register_targets: number[]
-  /** Gateable-subgraph metadata, if any source_tag wrappers were emitted. */
-  groups?:         GroupInfo[]
-}
+import type { FlatPlan } from './flat_plan'
+export type { FlatPlan }
 
 /** Pre-emission representation: flattened ExprNode trees before instruction emission. */
 export interface FlatExpressions {

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -26,7 +26,7 @@
 
 import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl } from './nodes.js'
 import type { ExprNode } from '../expr.js'
-import type { FlatPlan } from '../flatten.js'
+import type { FlatPlan } from '../flat_plan'
 import { resolvedToSlotted } from './load.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'
 import { emitNumericProgram, type ScalarType } from '../emit_numeric.js'

--- a/compiler/ir/compile_session.ts
+++ b/compiler/ir/compile_session.ts
@@ -48,7 +48,7 @@ import type { SessionState } from '../session.js'
 import type { ProgramInstance } from '../program_types.js'
 import { strataPipeline } from './strata.js'
 import { compileResolved } from './compile_resolved.js'
-import type { FlatPlan } from '../flatten.js'
+import type { FlatPlan } from '../flat_plan'
 import { specializeProgram } from './specialize.js'
 import { cloneResolvedProgram } from './clone.js'
 

--- a/compiler/sequencer.test.ts
+++ b/compiler/sequencer.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, loadJSON, resolveProgramType } from './session'
 import { loadStdlib } from './program'
-import { flattenSession } from './flatten'
+import { compileSession } from './ir/compile_session'
 import { Float, Int, ArrayType, portTypeEqual } from './term'
 
 describe('stdlib Sequencer<N>', () => {
@@ -39,7 +39,7 @@ describe('stdlib Sequencer<N>', () => {
       ]},
       audio_outputs: [{ instance: 'seq', output: 'value' }],
     }, session)
-    const plan = flattenSession(session)
+    const plan = compileSession(session)
     expect(plan).toBeDefined()
     const inst = session.instanceRegistry.get('seq')!
     expect(inst.typeName).toBe('Sequencer')

--- a/compiler/unified_ir.test.ts
+++ b/compiler/unified_ir.test.ts
@@ -1,7 +1,13 @@
 /**
- * Golden FlatPlan round-trip: every frozen fixture must reproduce byte-for-byte
- * when its tropical_program_2 input is loaded into a session and re-flattened.
- * Protects the compile pipeline from silent regressions.
+ * Golden FlatPlan round-trip: every frozen fixture must reproduce
+ * byte-for-byte when its `tropical_program_2` input is loaded into a
+ * session and re-compiled through `compileSession`. Protects the
+ * resolved-IR pipeline from silent regressions.
+ *
+ * Audio equivalence between the legacy `flattenSession` and the
+ * post-cutover `compileSession` is gated separately by
+ * `compile_session_equiv.test.ts`; this file pins the
+ * `tropical_plan_4` shape directly.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -11,7 +17,7 @@ import { fileURLToPath } from 'node:url'
 
 import { makeSession, loadJSON } from './session.js'
 import { loadStdlib } from './program.js'
-import { flattenSession } from './flatten.js'
+import { compileSession } from './ir/compile_session'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const FIXTURE_DIR = join(__dirname, '__fixtures__/flat_plan')
@@ -20,11 +26,7 @@ const fixtures = readdirSync(FIXTURE_DIR)
   .filter(f => f.endsWith('.json'))
   .sort()
 
-/** Goldens anchor what the strata pipeline emits. The legacy path was
- *  deleted in Phase C9 — there is only one pipeline now. Four fixtures
- *  (stdlib_delay, stdlib_ladder, stdlib_phaser, stdlib_sequencer) use
- *  instances and would have produced a different slot layout under the
- *  pre-C8 legacy path; the goldens here reflect the strata layout. */
+/** Goldens anchor what `compileSession` emits. */
 
 describe('FlatPlan golden fixtures', () => {
   for (const file of fixtures) {
@@ -36,7 +38,7 @@ describe('FlatPlan golden fixtures', () => {
       const session = makeSession()
       loadStdlib(session)
       loadJSON(input, session)
-      const plan = flattenSession(session)
+      const plan = compileSession(session)
 
       expect(JSON.stringify(plan)).toBe(JSON.stringify(expected_plan))
     })

--- a/compiler/wasm_runtime.test.ts
+++ b/compiler/wasm_runtime.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import type { FlatPlan } from './flatten'
+import type { FlatPlan } from './flat_plan'
 import { flattenSession } from './flatten'
 import { emitWasm } from './emit_wasm'
 import { WasmRuntime, type LoadedPlan } from '../web/worklet/runtime'

--- a/compiler/wasm_runtime.test.ts
+++ b/compiler/wasm_runtime.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, test, expect } from 'bun:test'
 import type { FlatPlan } from './flat_plan'
-import { flattenSession } from './flatten'
+import { compileSession } from './ir/compile_session'
 import { emitWasm } from './emit_wasm'
 import { WasmRuntime, type LoadedPlan } from '../web/worklet/runtime'
 import { makeSession, loadJSON } from './session'
@@ -30,7 +30,7 @@ function buildPureSine440Plan(): FlatPlan {
     ]},
     audio_outputs: [{ instance: 'osc', output: 'sine' }],
   }, session)
-  return flattenSession(session)
+  return compileSession(session)
 }
 
 async function compile(plan: FlatPlan, maxBlockSize: number): Promise<LoadedPlan> {

--- a/compiler/wasm_vs_jit_equiv.test.ts
+++ b/compiler/wasm_vs_jit_equiv.test.ts
@@ -12,7 +12,7 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, loadJSON, type ProgramFile } from './session'
 import { loadStdlib } from './program'
-import { flattenSession } from './flatten'
+import { compileSession } from './ir/compile_session'
 import type { FlatPlan } from './flat_plan'
 import { emitWasm } from './emit_wasm'
 
@@ -74,7 +74,7 @@ function makeSinOscPlan(freqHz: number): FlatPlan {
       audio_outputs: [{ instance: 'osc', output: 'sine' }],
     }
     loadJSON(prog, session)
-    return flattenSession(session)
+    return compileSession(session)
   } finally {
     session.runtime.dispose()
   }
@@ -97,7 +97,7 @@ function makeOnePolePlan(cutoff: number): FlatPlan {
       audio_outputs: [{ instance: 'lp', output: 'out' }],
     }
     loadJSON(prog, session)
-    return flattenSession(session)
+    return compileSession(session)
   } finally {
     session.runtime.dispose()
   }

--- a/compiler/wasm_vs_jit_equiv.test.ts
+++ b/compiler/wasm_vs_jit_equiv.test.ts
@@ -12,7 +12,8 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, loadJSON, type ProgramFile } from './session'
 import { loadStdlib } from './program'
-import { flattenSession, type FlatPlan } from './flatten'
+import { flattenSession } from './flatten'
+import type { FlatPlan } from './flat_plan'
 import { emitWasm } from './emit_wasm'
 
 // Load state_init values into the WASM module's register region.

--- a/compiler/web_plans_vs_jit.test.ts
+++ b/compiler/web_plans_vs_jit.test.ts
@@ -11,7 +11,7 @@ import { readFileSync, readdirSync, existsSync } from 'fs'
 import { join, resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { makeSession } from './session'
-import { type FlatPlan } from './flatten'
+import { type FlatPlan } from './flat_plan'
 import { emitWasm } from './emit_wasm'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -21,7 +21,7 @@ test_patch.ts  Standalone CLI smoke-tester: bun run mcp/test_patch.ts <patch.jso
 
 The server maintains a `SessionState` (from `compiler/session.ts`) containing the type registry, program instances, wiring expressions, graph outputs, control parameters, and a `Runtime` handle.
 
-Every mutation that affects the signal graph calls `wire()`, which runs the full compilation pipeline: `flattenSession()` → `JSON.stringify()` → `runtime.loadPlan()`. This recompiles and hot-swaps the kernel. Errors during compilation are caught and returned as tool error responses.
+Every mutation that affects the signal graph calls `wire()`, which runs the full compilation pipeline through `applyFlatPlan()`: `compileSession()` (resolved-IR strata pipeline) → `JSON.stringify()` → `runtime.loadPlan()`. This recompiles and hot-swaps the kernel. Errors during compilation are caught and returned as tool error responses.
 
 ## Tools
 

--- a/scripts/eval_program.ts
+++ b/scripts/eval_program.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from 'node:fs'
 import { makeSession, loadJSON } from '../compiler/session.js'
 import { loadStdlib }           from '../compiler/program.js'
-import { flattenSession }         from '../compiler/flat_plan.js'
+import { compileSession }       from '../compiler/ir/compile_session.js'
 import type { FlatPlan }        from '../compiler/flat_plan.js'
 import type { NOperand }        from '../compiler/emit_numeric.js'
 
@@ -30,7 +30,7 @@ if (!patchPath) {
 const session = makeSession()
 loadStdlib(session)
 loadJSON(JSON.parse(readFileSync(patchPath, 'utf-8')), session)
-const plan: FlatPlan = flattenSession(session)
+const plan: FlatPlan = compileSession(session)
 
 console.log(`Compiled: ${plan.instructions.length} instrs, ` +
             `${plan.state_init.length} state regs, ` +

--- a/scripts/eval_program.ts
+++ b/scripts/eval_program.ts
@@ -9,8 +9,8 @@
 import { readFileSync } from 'node:fs'
 import { makeSession, loadJSON } from '../compiler/session.js'
 import { loadStdlib }           from '../compiler/program.js'
-import { flattenSession }         from '../compiler/flatten.js'
-import type { FlatPlan }        from '../compiler/flatten.js'
+import { flattenSession }         from '../compiler/flat_plan.js'
+import type { FlatPlan }        from '../compiler/flat_plan.js'
 import type { NOperand }        from '../compiler/emit_numeric.js'
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────

--- a/web/build_patches.ts
+++ b/web/build_patches.ts
@@ -13,7 +13,7 @@ import { dirname, resolve, join } from 'path'
 import { fileURLToPath } from 'url'
 import { makeSession, loadJSON } from '../compiler/session.js'
 import { loadStdlib } from '../compiler/program.js'
-import { flattenSession } from '../compiler/flatten.js'
+import { compileSession } from '../compiler/ir/compile_session.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distDir = resolve(__dirname, 'dist/patches')
@@ -123,7 +123,7 @@ for (const patch of PATCHES) {
     const session = makeSession(1024)
     loadStdlib(session)
     loadJSON(patch.program as { schema: string; [k: string]: unknown }, session)
-    const plan = flattenSession(session)
+    const plan = compileSession(session)
     const out = JSON.stringify(plan)
     const outPath = join(distDir, `${patch.slug}.plan.json`)
     writeFileSync(outPath, out, 'utf-8')

--- a/web/host/compiler.ts
+++ b/web/host/compiler.ts
@@ -12,7 +12,7 @@
  * bundle, no cold-start compile, deterministic.
  */
 
-import type { FlatPlan } from '../../compiler/flatten.js'
+import type { FlatPlan } from '../../compiler/flat_plan.js'
 import { emitWasm } from '../../compiler/emit_wasm.js'
 import type { LoadedPlan } from '../worklet/runtime.js'
 


### PR DESCRIPTION
## Summary

Follow-up to PR #130 (resolved-IR pipeline + runtime cutover). This PR is the *purely additive* cleanup half — tighten consumers, doc-correct, hoist boundary types so the eventual `flatten.ts` deletion is mechanical. The structural deletion work (D3 retirement of `flatten.ts` / `loadProgramDefFromResolved` / `ProgramDef`, plus interpret retarget, plus D4 ExprNode narrowing) is held for the next PR — `phase-d/retire-flatten` — where the focus is purely subtractive.

## What's in here

- **`FlatPlan` hoisted** to `compiler/flat_plan.ts` (`1565f81`). The `tropical_plan_4` schema is the contract with the C++ engine; both legacy and resolved-IR emit boundaries produce it. Every type-only import is now off `flatten.ts`. The legacy file re-exports the type for the few consumers we don't migrate this round.
- **Test + tooling consumers migrated** from `flattenSession` to `compileSession` (`56586d2`). 7 test files, `bench_compile.ts`, `scripts/eval_program.ts`, `web/build_patches.ts`. `unified_ir.test.ts` goldens regenerated against the post-cutover output. Audio equivalence is still gated by `compile_session_equiv.test.ts`.
- **`compiler/CLAUDE.md` rewritten** for post-D2 reality (`ad864c1`). New layout reflects `ir/`, `parse/`, `flat_plan.ts`. Compilation pipeline section walks the actual `raise → elaborate → strata → compileResolved` flow including `compileSession`'s session-materialization steps and the gateable two-phase wrap. Resolved IR section added. emit_numeric structural-CSE noted.
- **`mcp/CLAUDE.md` corrected** (`3cb29a1`). The `wire()` description still said `flattenSession()`; updated to `applyFlatPlan() → compileSession()`.

## What remains for `phase-d/retire-flatten`

- **D3** — delete `flatten.ts`, `compiler/ir/load.ts`, `loadProgramDefFromResolved`, `ProgramDef`, `NestedCall`. Reduce `ProgramType` to `{ name, ports, resolved: ResolvedProgram }`. Retarget `interpret.ts` to walk `ResolvedExpr` (preserves the independent-oracle property of `jit_interp_equiv`). ~−2200 LOC net.
- **D4** — narrow `ExprNode` to MCP wire-format ops only. Drop dead post-arrayLower op cases from `walk.ts:mapChildren` and `validateExpr`. Cast-audit grep checklist.
- **D7** — drop legacy slot-ordering convention; regenerate baselines once more (after release-cycle soak post-D2).

## Test plan

- [x] `bun run tsc --noEmit` clean
- [x] `bun test` — 929 pass, 1 skip, 1 local-only fail (the same untracked `arp_transpose.json` / schema_audit noise that doesn't fire on CI)
- [x] `compile_session_equiv` audio gate green on all 10 fixtures
- [x] `unified_ir.test.ts` snapshot baselines regenerated and passing under `compileSession`
- [x] CI green (typecheck + build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)