### PR TITLE
Phase D: complete D4/D7 + structural cleanup

### DIFF
--- a/compiler/emit_numeric.ts
+++ b/compiler/emit_numeric.ts
@@ -16,7 +16,7 @@
  * typed LLVM IR (i64 for int, i1 for bool) instead of f64 round-trips.
  */
 
-import type { ExprNode } from './expr.js'
+import type { EmitExprNode as ExprNode } from './ir/emit_node.js'
 
 // ─────────────────────────────────────────────────────────────
 // Public types (mirror OrcJitEngine.hpp FlatProgram / FlatInstr)

--- a/compiler/expr.ts
+++ b/compiler/expr.ts
@@ -913,86 +913,14 @@ export function validateExpr(node: ExprNode, path = 'expr'): void {
   // Leaf ops: no recursion needed
   if (LEAF_OPS.has(op)) return
 
-  // Combinators with nested expr fields
-  if (op === 'let') {
-    if (typeof obj.bind === 'object' && obj.bind !== null) {
-      for (const [k, v] of Object.entries(obj.bind as Record<string, unknown>)) {
-        validateExpr(v as ExprNode, `${path}.bind.${k}`)
-      }
-    }
-    if (obj.in !== undefined) validateExpr(obj.in as ExprNode, `${path}.in`)
-    return
-  }
-  if (op === 'generate' || op === 'chain' || op === 'iterate') {
-    if (obj.init !== undefined) validateExpr(obj.init as ExprNode, `${path}.init`)
-    if (obj.body !== undefined) validateExpr(obj.body as ExprNode, `${path}.body`)
-    return
-  }
-  if (op === 'fold' || op === 'scan') {
-    if (obj.arr !== undefined) validateExpr(obj.arr as ExprNode, `${path}.arr`)
-    if (obj.init !== undefined) validateExpr(obj.init as ExprNode, `${path}.init`)
-    if (obj.body !== undefined) validateExpr(obj.body as ExprNode, `${path}.body`)
-    return
-  }
-  if (op === 'map2') {
-    if (obj.arr !== undefined) validateExpr(obj.arr as ExprNode, `${path}.arr`)
-    if (obj.body !== undefined) validateExpr(obj.body as ExprNode, `${path}.body`)
-    return
-  }
-  if (op === 'zipWith') {
-    if (obj.a !== undefined) validateExpr(obj.a as ExprNode, `${path}.a`)
-    if (obj.b !== undefined) validateExpr(obj.b as ExprNode, `${path}.b`)
-    if (obj.body !== undefined) validateExpr(obj.body as ExprNode, `${path}.body`)
-    return
-  }
-
-  // ── Sum-type wiring expressions ───────────────────────────────────────────
-  // tag (coproduct injection): {op, type, variant, payload?: Record<field, ExprNode>}
-  if (op === 'tag') {
-    if (typeof obj.type !== 'string')
-      throw new Error(`${path}: 'tag' requires type: string (sum type name)`)
-    if (typeof obj.variant !== 'string')
-      throw new Error(`${path}: 'tag' requires variant: string`)
-    if (obj.payload !== undefined) {
-      if (typeof obj.payload !== 'object' || obj.payload === null || Array.isArray(obj.payload))
-        throw new Error(`${path}: 'tag' payload must be an object {fieldName: ExprNode}`)
-      for (const [k, v] of Object.entries(obj.payload as Record<string, unknown>))
-        validateExpr(v as ExprNode, `${path}.payload.${k}`)
-    }
-    return
-  }
-
-  // match (coproduct elimination): {op, type, scrutinee, arms: Record<variantName, MatchArm>}
-  // MatchArm = {bind?: string | string[], body: ExprNode}
-  if (op === 'match') {
-    if (typeof obj.type !== 'string')
-      throw new Error(`${path}: 'match' requires type: string (sum type name)`)
-    if (obj.scrutinee === undefined)
-      throw new Error(`${path}: 'match' requires scrutinee: ExprNode`)
-    validateExpr(obj.scrutinee as ExprNode, `${path}.scrutinee`)
-    if (typeof obj.arms !== 'object' || obj.arms === null || Array.isArray(obj.arms))
-      throw new Error(`${path}: 'match' arms must be an object {variantName: {bind?, body}}`)
-    const arms = obj.arms as Record<string, unknown>
-    if (Object.keys(arms).length === 0)
-      throw new Error(`${path}: 'match' requires at least one arm`)
-    for (const [variantName, arm] of Object.entries(arms)) {
-      if (typeof arm !== 'object' || arm === null || Array.isArray(arm))
-        throw new Error(`${path}.arms.${variantName}: arm must be an object {bind?, body}`)
-      const a = arm as Record<string, unknown>
-      if (a.bind !== undefined) {
-        if (typeof a.bind !== 'string' && !Array.isArray(a.bind))
-          throw new Error(`${path}.arms.${variantName}.bind: must be string or string[], got ${typeof a.bind}`)
-        if (Array.isArray(a.bind))
-          for (let i = 0; i < a.bind.length; i++)
-            if (typeof a.bind[i] !== 'string')
-              throw new Error(`${path}.arms.${variantName}.bind[${i}]: must be a string`)
-      }
-      if (a.body === undefined)
-        throw new Error(`${path}.arms.${variantName}: missing required 'body' field`)
-      validateExpr(a.body as ExprNode, `${path}.arms.${variantName}.body`)
-    }
-    return
-  }
+  // Combinators (let, fold, scan, generate, iterate, chain, map2, zipWith)
+  // and ADT ops (tag, match) are parse-time forms — they're produced by
+  // the .trop parser and lowered by `arrayLower` / `sumLower` before any
+  // expression reaches `validateExpr`. They don't appear on the MCP
+  // wiring surface (instance inputs, gate expressions, dac.out wires).
+  // Their dedicated branches were removed in Phase D D4. An MCP client
+  // sending one will hit the unknown-op fallback below, which is the
+  // intended behavior — the wire format doesn't accept them.
 
   // delay: args[0] is the expression to delay; init is a number; id is an optional string name
   if (op === 'delay') {

--- a/compiler/ir/clone.ts
+++ b/compiler/ir/clone.ts
@@ -242,11 +242,13 @@ function cloneBodyDeclShell(d: BodyDecl, t: CloneTable): BodyDecl {
     case 'regDecl': {
       const fresh: RegDecl = { op: 'regDecl', name: d.name, init: 0 as ResolvedExpr }
       if (d.type !== undefined) fresh.type = d.type   // ScalarKind | AliasTypeDef (shared)
+      if (d._liftedFrom !== undefined) fresh._liftedFrom = d._liftedFrom
       t.regs.set(d, fresh)
       return fresh
     }
     case 'delayDecl': {
       const fresh: DelayDecl = { op: 'delayDecl', name: d.name, update: 0, init: 0 }
+      if (d._liftedFrom !== undefined) fresh._liftedFrom = d._liftedFrom
       t.delays.set(d, fresh)
       return fresh
     }

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -23,7 +23,7 @@
  */
 
 import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl } from './nodes.js'
-import type { ExprNode } from '../expr.js'
+import type { EmitExprNode as ExprNode } from './emit_node.js'
 import type { FlatPlan } from '../flat_plan'
 import { resolvedToSlotted } from './lower_to_exprnode.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -43,9 +43,12 @@ export function compileResolved(prog: ResolvedProgram): FlatPlan {
   }
 
   const memo = new WeakMap<object, ExprNode>()
-  const regCount = slots.regDecls.length
+  // Thread regCount through slots so resolvedToSlotted emits delayRefs
+  // directly as state-reg reads at the combined slot index, eliminating
+  // the previous separate `resolveDelayValues` post-pass.
+  const slotsWithRegCount = { ...slots, regCount: slots.regDecls.length }
   const lower = (e: ResolvedExpr): ExprNode =>
-    resolveDelayValues(resolvedToSlotted(e, slots, memo), regCount)
+    resolvedToSlotted(e, slotsWithRegCount, memo)
 
   // ── Output expressions ──
   const outputExprByDecl = new Map<OutputDecl, ResolvedExpr>()
@@ -175,42 +178,6 @@ function delayInit(d: DelayDecl): number {
   if (typeof d.init === 'number') return d.init
   if (typeof d.init === 'boolean') return d.init ? 1 : 0
   return 0
-}
-
-/** Walk a lowered `ExprNode` tree and rewrite every `{op: 'delayValue',
- *  node_id}` to `{op: 'reg', id: regCount + node_id}` — a state-register
- *  read at the combined slot index. emit_numeric only knows the
- *  unified state-register layout (`reg` op kind); the legacy
- *  `flatten.ts:resolveDelayValues` runs the same rewrite before
- *  emit_numeric. Doing the rewrite here keeps `resolvedToSlotted`'s
- *  output identical across the legacy and new emit paths. */
-function resolveDelayValues(node: ExprNode, regCount: number): ExprNode {
-  if (typeof node !== 'object' || node === null) return node
-  if (Array.isArray(node)) {
-    let mutated = false
-    const out: ExprNode[] = []
-    for (const item of node) {
-      const r = resolveDelayValues(item, regCount)
-      if (r !== item) mutated = true
-      out.push(r)
-    }
-    return mutated ? out : node
-  }
-  const obj = node as Record<string, unknown>
-  if (obj.op === 'delayValue' && typeof obj.node_id === 'number') {
-    return { op: 'reg', id: regCount + obj.node_id }
-  }
-  // Recurse into args (the common case) and any other ExprNode-shaped fields.
-  let mutated = false
-  const fresh: Record<string, unknown> = { ...obj }
-  for (const [k, v] of Object.entries(obj)) {
-    if (k === 'op') continue
-    if (typeof v === 'object' && v !== null) {
-      const r = resolveDelayValues(v as ExprNode, regCount)
-      if (r !== v) { fresh[k] = r; mutated = true }
-    }
-  }
-  return mutated ? (fresh as unknown as ExprNode) : node
 }
 
 void buildSlotMaps  // satisfies linter when SlotMaps is the only export consumed

--- a/compiler/ir/compile_session.ts
+++ b/compiler/ir/compile_session.ts
@@ -117,24 +117,25 @@ export function materializeSessionToResolvedIR(session: SessionState): ResolvedP
 
 /** Wrap every lifted reg/delay update and output expression whose
  *  origin is a gateable session instance with `select(gate, expr,
- *  fallback)`. Identifies origin by the renaming convention
- *  `${instanceName}_${innerName}` that `inlineInstances:liftClonedBody`
- *  applies. (This name-prefix convention is the §2.3 backward-compat
- *  shape; D7 will replace it with a `_liftedFrom` decl-identity tag.) */
+ *  fallback)`. Identifies origin via the `_liftedFrom` provenance tag
+ *  that `inlineInstances:liftClonedBody` stamps onto each lifted decl
+ *  — replaces the §2.3 D7 name-prefix anti-pattern.
+ *
+ *  Synthetic delays from `traceCycles` are tagged
+ *  `_liftedFrom: 'synthetic'`; they don't belong to any gateable
+ *  instance and are skipped. */
 function applyGateableWraps(
   prog: ResolvedProgram,
   gateableInstances: ReadonlyMap<string, ResolvedExpr>,
 ): void {
-  // Match by exact name OR by `${instName}_` prefix (the renaming
-  // convention `inlineInstances:liftClonedBody` applies to lifted
-  // sub-instance regs/delays). Returning a sentinel `null` for
-  // not-found avoids the `!gate` truthy bug when the gate expression
-  // is the boolean literal `false`.
-  const matchInstance = (declName: string): ResolvedExpr | null => {
-    for (const [instName, gate] of gateableInstances) {
-      if (declName === instName || declName.startsWith(`${instName}_`)) return gate
-    }
-    return null
+  /** Look up the gate for a decl based on its `_liftedFrom` tag. Returns
+   *  null when the decl isn't from a gateable instance (or not lifted at
+   *  all — outer-program decls untagged). */
+  const gateFor = (decl: { _liftedFrom?: string }): ResolvedExpr | null => {
+    if (decl._liftedFrom === undefined) return null
+    if (decl._liftedFrom === 'synthetic') return null
+    const gate = gateableInstances.get(decl._liftedFrom)
+    return gate === undefined ? null : gate
   }
 
   // Skip an expression that was already wrapped pre-strata (the
@@ -151,7 +152,7 @@ function applyGateableWraps(
   // didn't exist pre-strata).
   for (const a of prog.body.assigns) {
     if (a.op !== 'nextUpdate') continue
-    const gate = matchInstance(a.target.name)
+    const gate = gateFor(a.target)
     if (gate === null) continue
     if (alreadyWrapped(a.expr, gate)) continue
     const fallback: ResolvedExpr = a.target.op === 'regDecl'
@@ -164,7 +165,7 @@ function applyGateableWraps(
   // nextUpdate. Same skip-if-already-wrapped logic.
   for (const d of prog.body.decls) {
     if (d.op !== 'delayDecl') continue
-    const gate = matchInstance(d.name)
+    const gate = gateFor(d)
     if (gate === null) continue
     const haveNextUpdate = prog.body.assigns.some(
       a => a.op === 'nextUpdate' && a.target === d,

--- a/compiler/ir/emit_node.ts
+++ b/compiler/ir/emit_node.ts
@@ -1,0 +1,29 @@
+/**
+ * emit_node.ts — `EmitExprNode`, the post-strata emit-time tree shape.
+ *
+ * `resolvedToSlotted` (compiler/ir/lower_to_exprnode.ts) produces this
+ * shape from a `ResolvedExpr` — slot-indexed refs, post-arrayLower
+ * combinator residue, ready for `emit_numeric.ts` to walk.
+ *
+ * Phase D D4 split: this type is internal to the emit boundary; the
+ * MCP wire-format `ExprNode` (compiler/expr.ts) is a strict union over
+ * the ~25 ops MCP clients send. The two share the bag-of-fields object
+ * shape but live at different semantic layers — keeping them as
+ * distinct types makes the IR boundary load-bearing for the type
+ * checker.
+ */
+
+/** Post-strata emit-time tree. Bag-of-fields by design: `emit_numeric`'s
+ *  switch dispatches on `obj.op` strings and reaches into shape-specific
+ *  fields (`args`, `id`, `slot`, `node_id`, `output_id`, `name`, `items`,
+ *  `shape`, `count`, `over`, `init`, `body`, `acc_var`, `elem_var`,
+ *  `var`, `bind`, `in`, `arms`, `gate_expr`, `on_skip`, `payload`,
+ *  `type`, `variant`, `rows`, `x_var`, `y_var`).
+ *
+ *  Survives until `emit_numeric` is rewritten to walk `ResolvedExpr`
+ *  directly (PHASE_D_PLAN §2.1; future PR). */
+export type EmitExprNode =
+  | number
+  | boolean
+  | EmitExprNode[]
+  | { op: string; [key: string]: unknown }

--- a/compiler/ir/inline_instances.ts
+++ b/compiler/ir/inline_instances.ts
@@ -286,10 +286,17 @@ function liftClonedBody(
     switch (d.op) {
       case 'regDecl':
         d.name = `${instanceName}_${d.name}`
+        // Stamp provenance with the current outer's name. Each lift
+        // overwrites: the post-strata tag is the *outermost* (session-
+        // level) instance the decl ultimately came from. Consumers
+        // (e.g. applyGateableWraps) match against gateable session
+        // instances by name.
+        d._liftedFrom = instanceName
         liftedDecls.push(d)
         break
       case 'delayDecl':
         d.name = `${instanceName}_${d.name}`
+        d._liftedFrom = instanceName
         liftedDecls.push(d)
         break
       case 'paramDecl':

--- a/compiler/ir/lower_to_exprnode.ts
+++ b/compiler/ir/lower_to_exprnode.ts
@@ -21,6 +21,10 @@ export interface Slots {
   regs:      Map<RegDecl, number>
   delays:    Map<DelayDecl, number>
   instances: Map<InstanceDecl, number>
+  /** Total scalar-register count (regs.size). Threads through so
+   *  `delayRef` can emit `{op:'reg', id: regCount + delaySlot}` directly,
+   *  without a downstream `resolveDelayValues` rewrite pass. */
+  regCount?: number
 }
 
 /**
@@ -69,7 +73,18 @@ function opNodeToSlotted(node: ResolvedExprOpNode, slots: Slots, memo?: WeakMap<
     case 'delayRef': {
       const id = slots.delays.get(node.decl)
       if (id === undefined) throw new Error(`resolvedToSlotted: delay '${node.decl.name}' missing from slot table`)
-      return { op: 'delayValue', node_id: id }
+      // Emit a state-register read at the combined slot index. emit_numeric
+      // sees `{op:'reg', id}` and produces a `state_reg` operand. Folding
+      // this in here lets compile_resolved skip a downstream rewrite pass.
+      if (slots.regCount === undefined) {
+        // Defensive fallback for callers that build a Slots table by hand
+        // (e.g. program_type_builder for input-default lowering, where no
+        // delays appear). Emit the legacy delayValue op; an absent
+        // regCount means there are no regs to combine with, so the bare
+        // node_id matches the delay slot.
+        return { op: 'delayValue', node_id: id }
+      }
+      return { op: 'reg', id: slots.regCount + id }
     }
     case 'nestedOut': {
       const node_id = slots.instances.get(node.instance)

--- a/compiler/ir/lower_to_exprnode.ts
+++ b/compiler/ir/lower_to_exprnode.ts
@@ -14,7 +14,7 @@ import type {
   ResolvedExpr, ResolvedExprOpNode,
   RegDecl, DelayDecl, InstanceDecl, InputDecl,
 } from './nodes.js'
-import type { ExprNode } from '../expr.js'
+import type { EmitExprNode as ExprNode } from './emit_node.js'
 
 export interface Slots {
   inputs:    Map<InputDecl, number>

--- a/compiler/ir/nodes.ts
+++ b/compiler/ir/nodes.ts
@@ -128,11 +128,23 @@ export interface TypeParamDecl {
 // Body decls — names introduced in a program body
 // ─────────────────────────────────────────────────────────────
 
+/** Provenance tag set by `inlineInstances:liftClonedBody` when a reg
+ *  or delay was lifted from a sub-instance. The outer instance's name
+ *  is the originating session-level instance (or 'synthetic' for cycle-
+ *  break delays inserted by `traceCycles`). Used by post-strata passes
+ *  that need to identify decls by their lineage without parsing the
+ *  renamed `${instance}_${innerName}` prefix string. Replaces the
+ *  §2.3 D7 name-prefix anti-pattern. */
+export type LiftedFrom = string | 'synthetic'
+
 export interface RegDecl {
   op: 'regDecl'
   name: string
   init: ResolvedExpr
   type?: ScalarKind | AliasTypeDef
+  /** Optional provenance tag — set when the decl was lifted from a
+   *  sub-instance during `inlineInstances`. */
+  _liftedFrom?: LiftedFrom
 }
 
 export interface DelayDecl {
@@ -140,6 +152,9 @@ export interface DelayDecl {
   name: string
   update: ResolvedExpr
   init: ResolvedExpr
+  /** Optional provenance tag — set when the decl was lifted from a
+   *  sub-instance during `inlineInstances`. */
+  _liftedFrom?: LiftedFrom
 }
 
 export interface ParamDecl {

--- a/compiler/ir/trace_cycles.ts
+++ b/compiler/ir/trace_cycles.ts
@@ -94,6 +94,7 @@ export function traceCycles(prog: ResolvedProgram): ResolvedProgram {
       // breaker — same semantics as legacy flatten.ts.
       update: { op: 'nestedOut', instance: inst, output },
       init: 0,
+      _liftedFrom: 'synthetic',
     }
     breakerDelay.set(key, d)
     syntheticDelays.push(d)


### PR DESCRIPTION
## Summary

Continues Phase D after PR #133. Closes the structural debt the original plan acknowledged:

- **D7** — replaces the §2.3 name-prefix anti-pattern with an explicit `_liftedFrom` decl-identity tag.
- **EmitExprNode split** — separates the post-strata emit-time tree shape from the MCP wire-format `ExprNode`.
- **D4 partial** — strips dead combinator/ADT branches from `validateExpr` (parse-time forms; never appear on the wire surface).
- **`resolveDelayValues` fold** — collapses two ExprNode passes (slottification + delay rewrite) into one in `resolvedToSlotted`.

## Commits

### `c06b7e7` — EmitExprNode for the post-strata emit-time tree

Splits the bag-of-fields tree shape into two named types living at distinct semantic layers:

- **`ExprNode`** (`compiler/expr.ts`) — MCP wire format. What `wire`, `set_param`, `define_program` accept.
- **`EmitExprNode`** (`compiler/ir/emit_node.ts`) — post-strata, post-`resolvedToSlotted`. The closed set of slot-indexed refs + arithmetic + array ops `emit_numeric` dispatches over.

Three consumers updated: `lower_to_exprnode.ts`, `compile_resolved.ts`, `emit_numeric.ts`. Today they share an object shape; the rename makes the IR boundary load-bearing for the type checker without forcing the deeper narrow now.

### `68205f7` — `_liftedFrom` provenance tag (D7)

`compile_session.ts:applyGateableWraps` previously identified lifted sub-instance regs/delays by parsing their renamed `\${instance}_*` prefix. Replaced with an explicit decl-identity tag stamped at lift time:

- `RegDecl._liftedFrom?: string | 'synthetic'` and `DelayDecl._liftedFrom?` in `compiler/ir/nodes.ts`.
- `inline_instances.ts:liftClonedBody` stamps `_liftedFrom = instanceName` on each lift (overwrites — the post-strata tag is the *outermost* session-level origin).
- `trace_cycles.ts` — synthetic feedback delays carry `_liftedFrom: 'synthetic'`.
- `clone.ts` preserves the tag.
- `compile_session.ts:applyGateableWraps` reads `decl._liftedFrom` directly.

Closes the §2.3/D7 acknowledged debt: the backward-compat `\${name}_` parsing convention is gone.

### `43cfc5e` — validateExpr narrow (D4 partial)

`validateExpr` carried 80 LOC of branches for combinators (`let`, `fold`, `scan`, `generate`, `iterate`, `chain`, `map2`, `zipWith`) and ADTs (`tag`, `match`). PHASE_D_PLAN §2.4 flagged these as parse-time forms — they're produced by the .trop parser and lowered by `arrayLower` / `sumLower` strata passes before any expression reaches `validateExpr`. The wire format doesn't accept them. Removed; an MCP client sending one now hits the unknown-op fallback.

**Net: −72 LOC.** No coverage loss (tests didn't exercise these branches via validateExpr — they were already dead code).

### `6a19f0d` — fold `resolveDelayValues` into `resolvedToSlotted`

`compile_resolved.ts:lower` ran two passes: `resolvedToSlotted` produced an intermediate ExprNode tree with `{op:'delayValue', node_id}`, then a separate `resolveDelayValues` post-pass rewrote those to `{op:'reg', id: regCount + node_id}` (the state-reg read `emit_numeric` expects). Folded the rewrite into `resolvedToSlotted`'s `delayRef` case — emit state-reg reads directly. Threads `regCount?: number` through the `Slots` interface; falls back to legacy `delayValue` when not supplied (used by `program_type_builder` for input-default lowering, where no delays appear).

**Net: −34 LOC.**

## Phase D status after this PR

| | | |
|---|---|---|
| D0 | snapshot baseline | ✓ |
| D1 | `compileResolved` | ✓ |
| D2 | `compileSession` + cutover | ✓ |
| D3 | delete `flatten.ts`/retire `ProgramDef` | ✓ |
| D4 | narrow `ExprNode` | partial (validateExpr clean; type narrow held) |
| D5 | snake_case ops | one-shot migration (alternative) |
| D6 | `raise.ts` invariants | ✓ |
| D7 | drop legacy slot-ordering | ✓ |
| §2.1 | rewrite `emit_numeric` to walk `ResolvedExpr` | held |

## Held for follow-up (one focused PR)

The two items that bundle naturally — and were attempted-then-deferred from this PR because they need careful audio-correctness review:

- **§2.1 emit_numeric rewrite** — port to walk `ResolvedExpr` directly, deleting `lower_to_exprnode.ts:resolvedToSlotted` and the bridge layer. ~700 LOC fresh emitter + ~200 LOC delete. The structural-CSE memo, type inference, terminal embedding, source_tag groups, and broadcast_to all need careful porting. Audio gate is the verifier.
- **Deep D4** — narrow `ExprNode` *type* via `Extract<ParsedExprOpNode, { op: WireFormatOp }>`. Touches 121 `as ExprNode` cast sites that need cast-audit. Benefits from §2.1 landing first so post-strata no longer lives in `ExprNode`.

These two unblock each other and want focused review attention; a separate PR with the audio gate, jit-interp equivalence, and snapshot suite watched closely is the right shape.

## Test plan

- [x] `bun run tsc --noEmit` clean
- [x] `bun test` — 814 pass, 1 skip, 1 local-only fail (the same untracked `arp_transpose.json` / `schema_audit` noise)
- [x] All 7 gateable subgraph tests pass under `_liftedFrom`-based wrap
- [x] CI green on previous push (1m29s build)
- [x] CI green on `6a19f0d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)