### PR TITLE
Slot model: per-instance emit-path + WASM slot support (M9a–M10)

### DIFF
--- a/compiler/emit_wasm.ts
+++ b/compiler/emit_wasm.ts
@@ -300,7 +300,10 @@ export function emitWasm(plan: FlatPlan, opts: EmitWasmOptions = {}): EmitWasmRe
   const paramIndex = new Map<string, number>()
   paramPtrs.forEach((p, i) => paramIndex.set(p, i))
 
-  const layout = computeLayout({ plan: flatProgram, inputCount, paramPtrs, maxBlockSize })
+  const layout = computeLayout({
+    plan: flatProgram, inputCount, paramPtrs, maxBlockSize,
+    slotCount: plan.slot_count ?? 0,
+  })
   const ctx: EmitCtx = { layout, paramIndex, sampleRate }
 
   const c = new Code()
@@ -384,11 +387,23 @@ type EmitCtx = {
 function emitInstruction(c: Code, instr: NInstr, ctx: EmitCtx): void {
   if (instr.tag === 'SmoothParam') return emitSmoothParam(c, instr, ctx)
   if (instr.tag === 'TriggerParam') return emitTriggerParam(c, instr, ctx)
+  if (instr.tag === 'WriteSlot') return emitWriteSlot(c, instr, ctx)
   if (instr.tag === 'Pack') return emitPack(c, instr, ctx)
   if (instr.tag === 'Index') return emitIndex(c, instr, ctx)
   if (instr.tag === 'SetElement') return emitSetElement(c, instr, ctx)
   if (instr.loop_count > 1) return emitElementwise(c, instr, ctx)
   return emitScalar(c, instr, ctx)
+}
+
+// ── WriteSlot: publish a temp value to slots[dst] (M10) ──
+// `dst` is the slot index (not a temp); `args[0]` is the value. The
+// instruction produces no temp result — pure side effect. Coerces to
+// float since slots are stored as f64 (matching the JIT).
+function emitWriteSlot(c: Code, instr: NInstr, ctx: EmitCtx): void {
+  const off = ctx.layout.slotsOffset + instr.dst * 8
+  c.i32c(0)                                // memory base for store
+  pushAs(c, instr.args[0]!, 'float', ctx)  // value
+  c.f64Store(off)
 }
 
 // ── Operand emitter: pushes a value in its native WASM type, returns the ScalarType ──
@@ -433,15 +448,12 @@ function pushOperand(c: Code, op: NOperand, ctx: EmitCtx): ScalarType {
       c.localGet(L_SIDX); return 'int'
     }
     case 'slot': {
-      // Slot model — not yet wired through emit_wasm. M5/M8 will add the
-      // shared slot region to wasm_memory_layout and emit a load against
-      // it here. Until then, the WASM backend should never see a 'slot'
-      // operand (the new compile path is gated behind M4 and only the
-      // JIT consumes it initially).
-      throw new Error(
-        `emit_wasm: 'slot' operand (index=${op.index}) not yet supported. ` +
-        `Slot-model plans currently target the JIT path only.`,
-      )
+      // M10: inter-module slot read. Slots are stored as f64 in the
+      // dedicated `slotsOffset` region (mirrors the native engine —
+      // see store_slot_f64 in OrcJitEngine.cpp). Result is always
+      // float; callers `coerce` to int/bool as needed.
+      c.i32c(0); c.f64Load(ctx.layout.slotsOffset + op.index * 8)
+      return 'float'
     }
   }
 }

--- a/compiler/ir/compile_session_slotted.test.ts
+++ b/compiler/ir/compile_session_slotted.test.ts
@@ -77,30 +77,39 @@ describe('M4: compileSessionSlotted', () => {
     expect(plan.slot_defaults![fireIdx]).toBe(0)  // trigger
   })
 
-  test('slot-mode plan has identical instruction stream to legacy plan', () => {
-    // M4 invariant: until M8 rewrites instructions to use slot operands,
-    // the slot-mode and legacy plans must be byte-equal except for the
-    // additional slot_count/slot_names/slot_defaults fields.
-    const s = makeSession()
-    loadStdlib(s)
-    const onePole = s.typeRegistry.get('OnePole')!
-    s.instanceRegistry.set('lp1', instantiate(onePole, 'lp1'))
-    allocateOutputSlots(s, 'lp1', onePole)
-    s.graphOutputs.push({ instance: 'lp1', output: 'out' })
+  test('default-mode slot plan has identical instruction stream to legacy plan', () => {
+    // M4 invariant under DEFAULT mode (no TROPICAL_SLOT_OPS): the
+    // slot-mode plan is byte-equal to legacy plus the slot metadata
+    // fields. When TROPICAL_SLOT_OPS=1, the per-instance path
+    // produces a different (slot-operand) instruction stream by
+    // design — that's the M9 work; tested separately under M9 tests.
+    const prevEnv = process.env.TROPICAL_SLOT_OPS
+    delete process.env.TROPICAL_SLOT_OPS
+    try {
+      const s = makeSession()
+      loadStdlib(s)
+      const onePole = s.typeRegistry.get('OnePole')!
+      s.instanceRegistry.set('lp1', instantiate(onePole, 'lp1'))
+      allocateOutputSlots(s, 'lp1', onePole)
+      s.graphOutputs.push({ instance: 'lp1', output: 'out' })
 
-    const legacy   = compileSessionLegacy(s)
-    const slotted  = compileSessionSlotted(s)
+      const legacy  = compileSessionLegacy(s)
+      const slotted = compileSessionSlotted(s)
 
-    // Same instruction count and same instruction stream
-    expect(slotted.instructions.length).toBe(legacy.instructions.length)
-    expect(JSON.stringify(slotted.instructions)).toBe(JSON.stringify(legacy.instructions))
-    expect(slotted.register_count).toBe(legacy.register_count)
-    expect(slotted.output_targets).toEqual(legacy.output_targets)
+      // Same instruction count and same instruction stream
+      expect(slotted.instructions.length).toBe(legacy.instructions.length)
+      expect(JSON.stringify(slotted.instructions)).toBe(JSON.stringify(legacy.instructions))
+      expect(slotted.register_count).toBe(legacy.register_count)
+      expect(slotted.output_targets).toEqual(legacy.output_targets)
 
-    // Slotted-only fields: present and populated
-    expect(slotted.slot_count).toBe(1)
-    expect(slotted.slot_names).toEqual(['lp1.out'])
-    expect(legacy.slot_count).toBeUndefined()
+      // Slotted-only fields: present and populated
+      expect(slotted.slot_count).toBe(1)
+      expect(slotted.slot_names).toEqual(['lp1.out'])
+      expect(legacy.slot_count).toBeUndefined()
+    } finally {
+      if (prevEnv === undefined) delete process.env.TROPICAL_SLOT_OPS
+      else process.env.TROPICAL_SLOT_OPS = prevEnv
+    }
   })
 })
 

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -31,6 +31,7 @@ import { compileResolved } from './compile_resolved.js'
 import { compileSessionLegacy } from './compile_session.js'
 import {
   computeInstanceTopoOrder, remapInstancePlan, emitDacStitch,
+  SlotShapeUnsupportedError,
   type RemapContext,
 } from './compile_session_slotted_helpers.js'
 import {
@@ -58,37 +59,15 @@ export function compileSessionSlotted(session: SessionState): FlatPlan {
   try {
     return compileSessionSlottedPerInstance(session)
   } catch (e) {
-    if (isUnsupportedShapeError(e)) {
+    if (e instanceof SlotShapeUnsupportedError) {
       // Auto-fallback to the metadata-only path. The audio still
       // works; the per-instance optimization just doesn't apply for
-      // this session's shape. Log once per session for visibility.
-      logFallbackOnce((e as Error).message)
+      // this session's shape. Log once per unique reason for visibility.
+      logFallbackOnce(e.message)
       return compileSessionSlottedMetadataOnly(session)
     }
     throw e
   }
-}
-
-/** Recognize errors the per-instance path can't handle yet. Falls into
- *  three buckets:
- *   1. Shape-level: arrays, sums, nested instance calls (M9d+)
- *   2. Allocation-level: instance created outside the normal flow that
- *      didn't run allocateOutputSlots
- *   3. Cycle-detection: ref graph wasn't broken by traceCycles delays
- *      (legacy path handles these via different cycle-breaking)
- *  In all three cases the legacy path works and the slot-mode plan
- *  would either fail or produce different audio. */
-function isUnsupportedShapeError(e: unknown): boolean {
-  if (!(e instanceof Error)) return false
-  const msg = e.message
-  return (
-    msg.includes('not yet supported') ||
-    msg.includes('Arrays land in') ||
-    msg.includes('M9d') ||
-    msg.includes('nested instance') ||
-    msg.includes('not allocated') ||
-    msg.includes('cycle detected')
-  )
 }
 
 const _fallbackLoggedFor = new Set<string>()
@@ -169,7 +148,7 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
         const key = `${instName}.${portName}`
         const idx = session.outputSlotRegistry.get(key)
         if (idx === undefined) {
-          throw new Error(
+          throw new SlotShapeUnsupportedError(
             `compileSessionSlotted: output slot for '${key}' not allocated. ` +
             `(Did add_instance populate outputSlotRegistry?)`,
           )

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -119,6 +119,20 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       )
     }
 
+    // Gateable instances rely on materializeSession's two-phase wrap
+    // (pre-strata select() on own outputs, post-strata wrap on lifted
+    // sub-instance regs/delays). The per-instance path skips
+    // materializeSession entirely, so the wrap doesn't happen and gate
+    // semantics are lost. Fall back to legacy for now; preserving
+    // gateable in the per-instance path is its own milestone.
+    if (inst.gateable) {
+      throw new SlotShapeUnsupportedError(
+        `compileSessionSlotted: instance '${instName}' is gateable. ` +
+        `Gate wrapping is performed by materializeSession (pre+post-strata) ` +
+        `which the per-instance path bypasses.`,
+      )
+    }
+
     // Compile this instance standalone. M9a doesn't yet support param
     // handles in input expressions, so paramHandles stays empty — any
     // {op:'param'} ExprNode would surface as a 'param' operand and the

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -40,15 +40,67 @@ import {
 
 /** Compile the current session in slot mode. Dispatches between the
  *  legacy-wrap and the per-instance paths based on
- *  `TROPICAL_SLOT_OPS`. Both paths produce a FlatPlan with slot
- *  allocation metadata; the per-instance path additionally emits
- *  `slot` operands and `WriteSlot` instructions in the instruction
- *  stream. */
+ *  `TROPICAL_SLOT_OPS` and on whether the session uses any shapes the
+ *  per-instance path doesn't yet handle (arrays, sums, nested
+ *  instance calls in input expressions).
+ *
+ *  When `TROPICAL_SLOT_OPS` is unset:
+ *    - default path: metadata-only (legacy plan + slot fields)
+ *    - audio behavior: byte-identical to legacy
+ *
+ *  When `TROPICAL_SLOT_OPS=1`:
+ *    - tries per-instance compile first
+ *    - falls back to metadata-only if the per-instance path throws
+ *      an "unsupported shape" error (with a console hint)
+ *    - other errors propagate */
 export function compileSessionSlotted(session: SessionState): FlatPlan {
-  const useOps = useSlotOps()
-  return useOps
-    ? compileSessionSlottedPerInstance(session)
-    : compileSessionSlottedMetadataOnly(session)
+  if (!useSlotOps()) return compileSessionSlottedMetadataOnly(session)
+  try {
+    return compileSessionSlottedPerInstance(session)
+  } catch (e) {
+    if (isUnsupportedShapeError(e)) {
+      // Auto-fallback to the metadata-only path. The audio still
+      // works; the per-instance optimization just doesn't apply for
+      // this session's shape. Log once per session for visibility.
+      logFallbackOnce((e as Error).message)
+      return compileSessionSlottedMetadataOnly(session)
+    }
+    throw e
+  }
+}
+
+/** Recognize errors the per-instance path can't handle yet. Falls into
+ *  three buckets:
+ *   1. Shape-level: arrays, sums, nested instance calls (M9d+)
+ *   2. Allocation-level: instance created outside the normal flow that
+ *      didn't run allocateOutputSlots
+ *   3. Cycle-detection: ref graph wasn't broken by traceCycles delays
+ *      (legacy path handles these via different cycle-breaking)
+ *  In all three cases the legacy path works and the slot-mode plan
+ *  would either fail or produce different audio. */
+function isUnsupportedShapeError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false
+  const msg = e.message
+  return (
+    msg.includes('not yet supported') ||
+    msg.includes('Arrays land in') ||
+    msg.includes('M9d') ||
+    msg.includes('nested instance') ||
+    msg.includes('not allocated') ||
+    msg.includes('cycle detected')
+  )
+}
+
+const _fallbackLoggedFor = new Set<string>()
+function logFallbackOnce(reason: string): void {
+  // Console.warn is fine; this is a development-mode hint.
+  // Bun's test runner suppresses it by default during quiet runs.
+  if (_fallbackLoggedFor.has(reason)) return
+  _fallbackLoggedFor.add(reason)
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[slot-model] per-instance path fell back to legacy for this session: ${reason}`,
+  )
 }
 
 /** M4–M8 path: wrap the legacy plan with slot metadata. Untouched

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -35,7 +35,7 @@ import {
   type RemapContext,
 } from './compile_session_slotted_helpers.js'
 import {
-  inputNames, outputNames, inputPortTypes, outputPortTypes,
+  inputNames, outputNames, outputPortTypes,
   rawInputDefaults,
 } from '../program_types.js'
 
@@ -128,22 +128,25 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
     // Build remap context for this instance
     const inPortNames  = inputNames(compiled)
     const outPortNames = outputNames(compiled)
-    const inPortTypes  = inputPortTypes(compiled).map(scalarOf)
     const outPortTypes = outputPortTypes(compiled).map(scalarOf)
     const defaults     = rawInputDefaults(compiled)
-    const inputDefaults: Array<number | boolean | undefined> = inPortNames.map(name => {
-      const d = defaults[name]
-      if (typeof d === 'number' || typeof d === 'boolean') return d
-      return undefined
-    })
 
     const ctx: RemapContext = {
       instanceName: instName,
       regOffset,
       stateRegOffset,
       arraySlotOffset,
-      inputExprFor: (portName) =>
-        session.inputExprNodes.get(`${instName}:${portName}`),
+      inputBindingFor: (portName) => {
+        const expr = session.inputExprNodes.get(`${instName}:${portName}`)
+        if (expr !== undefined) return { kind: 'wired', expr }
+        // No wiring: resolve to the port's declared default, or 0 if
+        // the default isn't a plain scalar literal. (Non-scalar defaults
+        // would need preamble emission — those shapes fall back to the
+        // metadata-only path via SlotShapeUnsupportedError elsewhere.)
+        const d = defaults[portName]
+        const value = (typeof d === 'number' || typeof d === 'boolean') ? d : 0
+        return { kind: 'literal', value }
+      },
       outputSlotFor: (portName) => {
         const key = `${instName}.${portName}`
         const idx = session.outputSlotRegistry.get(key)
@@ -156,7 +159,6 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
         return idx
       },
       inputPortNames: inPortNames,
-      inputDefaults,
       outputPortNames: outPortNames,
       outputScalarTypes: outPortTypes,
     }

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -1,82 +1,216 @@
 /**
- * compile_session_slotted.ts — slot-mode session compilation (M4–M8).
+ * compile_session_slotted.ts — slot-mode session compilation (M4–M9).
  *
- * As of M8, this is the default path invoked by `compileSession`. It
- * runs the legacy pipeline (materialize → strata → compileResolved) to
- * produce the audio-correct instruction stream, then attaches slot
- * allocation metadata derived from the session's slot registries.
+ * Two paths coexist during M9 development:
  *
- * **What ships in M4–M8:**
- *   - slot_count / slot_names / slot_defaults populated in every plan
- *   - control-plane writes via tropical_runtime_set_slot work end-to-end
- *   - JIT honors `slot` operands and `WriteSlot` instructions when
- *     emitted (engine ready; emit_resolved doesn't yet emit them)
- *   - Hot-swap preserves slot values by name
+ *   - **Legacy-wrap path** (default through M9a): runs `compileSessionLegacy`
+ *     and attaches slot allocation metadata. Audio output is byte-identical
+ *     to the pre-slot-model path. The slot fields are honored for
+ *     control-plane writes (set_slot) but the instruction stream still
+ *     uses legacy `param` / `input` / `reg` operands.
  *
- * **What's deferred to a future milestone:**
- *   The instruction stream is still legacy: `input` / `reg` /
- *   `state_reg` / `param` operands. The full rewrite that emits `slot`
- *   operands instead — replacing `param` operands with slot reads,
- *   adding `WriteSlot` after each instance's outputs, etc. — is a
- *   substantial per-instance compile rewrite that warrants its own
- *   focused effort. The engine and equivalence harness are ready
- *   for it (M5–M7); only the TS emit path remains.
+ *   - **Per-instance path** (M9a opt-in via `TROPICAL_SLOT_OPS=1`): each
+ *     session instance is compiled standalone via `compileResolved`, its
+ *     operands are remapped into the unified register/slot space, and
+ *     WriteSlot instructions publish each output to its allocated slot.
+ *     A DAC stitching phase reads graphOutput source slots into temps
+ *     for the kernel's existing mix-bus mechanism.
  *
- * Audio behavior today: byte-identical to the legacy path. The slot
- * fields are honored for control-plane writes but the kernel doesn't
- * yet read from slots in production patches.
+ * The per-instance path replaces the legacy path's `materializeSession +
+ * inlineInstances` flattening with explicit slot boundaries — the
+ * architectural goal of the slot model. M9a covers single-source ref
+ * chains; M9b–M9d incrementally lift the limitations (params, arbitrary
+ * input expressions, fan-in, arrays, sums). M9e deletes the legacy path
+ * once equivalence is verified across the full stdlib fixture set.
  */
 
 import type { SessionState } from '../session.js'
 import type { FlatPlan } from '../flat_plan.js'
+import type { ScalarType } from './emit_resolved.js'
+import { compileResolved } from './compile_resolved.js'
 import { compileSessionLegacy } from './compile_session.js'
+import {
+  computeInstanceTopoOrder, remapInstancePlan, emitDacStitch,
+  type RemapContext,
+} from './compile_session_slotted_helpers.js'
+import {
+  inputNames, outputNames, inputPortTypes, outputPortTypes,
+  rawInputDefaults,
+} from '../program_types.js'
 
-/**
- * Compile the current session in slot mode. Produces a FlatPlan whose
- * instructions are functionally identical to the legacy path but which
- * carries slot allocation metadata for the new engine path to consume.
- */
+/** Compile the current session in slot mode. Dispatches between the
+ *  legacy-wrap and the per-instance paths based on
+ *  `TROPICAL_SLOT_OPS`. Both paths produce a FlatPlan with slot
+ *  allocation metadata; the per-instance path additionally emits
+ *  `slot` operands and `WriteSlot` instructions in the instruction
+ *  stream. */
 export function compileSessionSlotted(session: SessionState): FlatPlan {
-  // Audio-correct base plan from the legacy pipeline. We reuse this
-  // wholesale until M8 migrates the instruction encoding. Direct
-  // call to compileSessionLegacy avoids a re-entry through the
-  // env-var dispatch in compileSession.
+  const useOps = useSlotOps()
+  return useOps
+    ? compileSessionSlottedPerInstance(session)
+    : compileSessionSlottedMetadataOnly(session)
+}
+
+/** M4–M8 path: wrap the legacy plan with slot metadata. Untouched
+ *  instruction stream. */
+function compileSessionSlottedMetadataOnly(session: SessionState): FlatPlan {
   const legacy = compileSessionLegacy(session)
+  return { ...legacy, ...buildSlotMetadata(session) }
+}
 
-  // Emit slot metadata from the session registries populated in M3.
-  // The slot space is the union of output slots and param slots — both
-  // were assigned consecutive indices via allocateOutputSlots /
-  // allocateParamSlot and share session.slotCount.
-  const slotCount = session.slotCount
-  const slotNames    = new Array<string>(slotCount).fill('')
-  const slotDefaults = new Array<number>(slotCount).fill(0)
+/** M9a path: per-instance compileResolved + operand remapping + DAC stitch.
+ *  Throws clear errors on shapes not yet supported (fan-in, arbitrary
+ *  input expressions, params/triggers in input expressions). */
+function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
+  const order = computeInstanceTopoOrder(session)
 
-  for (const [name, idx] of session.outputSlotRegistry) {
-    slotNames[idx] = name
+  // Accumulators for the unified plan
+  const allInstructions: import('./emit_resolved.js').NInstr[] = []
+  const allRegisterNames: string[] = []
+  const allRegisterTypes: ScalarType[] = []
+  const allStateInit: (number | boolean)[] = []
+  const allArraySlotSizes: number[] = []
+  const allArraySlotNames: string[] = []
+  const allRegisterTargets: number[] = []
+
+  let regOffset = 0          // cumulative temp count (NInstr.dst + reg-operand slot)
+  let stateRegOffset = 0     // cumulative state-register count (state_reg slots + register_targets index space)
+  let arraySlotOffset = 0    // cumulative array-slot count (array_reg slots)
+
+  for (const instName of order) {
+    const inst = session.instanceRegistry.get(instName)
+    if (inst === undefined) continue
+    const compiled = inst.compiled
+    if (compiled === undefined) {
+      throw new Error(
+        `compileSessionSlotted (M9a): instance '${instName}' has no Compiled type. ` +
+        `(Did add_instance fail silently?)`,
+      )
+    }
+
+    // Compile this instance standalone. M9a doesn't yet support param
+    // handles in input expressions, so paramHandles stays empty — any
+    // {op:'param'} ExprNode would surface as a 'param' operand and the
+    // remap throws.
+    const plan = compileResolved(compiled.prog, { paramHandles: new Map() })
+
+    // Build remap context for this instance
+    const inPortNames  = inputNames(compiled)
+    const outPortNames = outputNames(compiled)
+    const inPortTypes  = inputPortTypes(compiled).map(scalarOf)
+    const outPortTypes = outputPortTypes(compiled).map(scalarOf)
+    const defaults     = rawInputDefaults(compiled)
+    const inputDefaults: Array<number | boolean | undefined> = inPortNames.map(name => {
+      const d = defaults[name]
+      if (typeof d === 'number' || typeof d === 'boolean') return d
+      return undefined
+    })
+
+    const ctx: RemapContext = {
+      instanceName: instName,
+      regOffset,
+      stateRegOffset,
+      arraySlotOffset,
+      inputExprFor: (portName) =>
+        session.inputExprNodes.get(`${instName}:${portName}`),
+      outputSlotFor: (portName) => {
+        const key = `${instName}.${portName}`
+        const idx = session.outputSlotRegistry.get(key)
+        if (idx === undefined) {
+          throw new Error(
+            `compileSessionSlotted: output slot for '${key}' not allocated. ` +
+            `(Did add_instance populate outputSlotRegistry?)`,
+          )
+        }
+        return idx
+      },
+      inputPortNames: inPortNames,
+      inputDefaults,
+      outputPortNames: outPortNames,
+      outputScalarTypes: outPortTypes,
+    }
+
+    const { body, writeSlots } = remapInstancePlan(plan, ctx, session)
+    allInstructions.push(...body, ...writeSlots)
+
+    // Accumulate the per-instance state contributions into the unified plan
+    for (const n of plan.register_names) allRegisterNames.push(`${instName}.${n}`)
+    allRegisterTypes.push(...plan.register_types)
+    for (const v of plan.state_init) allStateInit.push(v as number | boolean)
+    allArraySlotSizes.push(...plan.array_slot_sizes)
+    for (const n of plan.array_slot_names) allArraySlotNames.push(`${instName}.${n}`)
+    for (const t of plan.register_targets) {
+      // register_targets[i] is the temp index whose value feeds state-reg i;
+      // shift the temp index by this instance's regOffset.
+      allRegisterTargets.push(t + regOffset)
+    }
+
+    regOffset += plan.register_count
+    stateRegOffset += plan.state_init.length
+    arraySlotOffset += plan.array_slot_count
   }
-  for (const [name, idx] of session.paramSlotRegistry) {
-    // Param slots: name = the param's bare name (no instance prefix);
-    // distinguish from output slots in serialized form by prefixing
-    // "param:" so consumers can route writes/reads correctly.
-    slotNames[idx] = `param:${name}`
-    // Default value for a param slot = the registered Param's value
-    // (smoothed) or 0 for triggers.
-    const param = session.paramRegistry.get(name)
-    if (param !== undefined) slotDefaults[idx] = param.value
-  }
+
+  // DAC stitching: read each graphOutput source slot into a fresh temp
+  // and expose it through output_targets + outputs.
+  const dac = emitDacStitch(session, regOffset)
+  allInstructions.push(...dac.instructions)
+  regOffset += dac.tempCount
 
   return {
-    ...legacy,
-    slot_count:    slotCount,
-    slot_names:    slotNames,
-    slot_defaults: slotDefaults,
+    schema: 'tropical_plan_4',
+    config: { sampleRate: 44100 },
+    state_init:       allStateInit,
+    register_names:   allRegisterNames,
+    register_types:   allRegisterTypes,
+    array_slot_names: allArraySlotNames,
+    outputs:          dac.outputs,
+    instructions:     allInstructions,
+    register_count:   regOffset,
+    array_slot_count: arraySlotOffset,
+    array_slot_sizes: allArraySlotSizes,
+    output_targets:   dac.outputTargets,
+    register_targets: allRegisterTargets,
+    ...buildSlotMetadata(session),
   }
 }
 
+/** Read-time check for the M9 per-instance opt-in. */
+function useSlotOps(): boolean {
+  const env = process.env.TROPICAL_SLOT_OPS
+  return env !== undefined && env !== '' && env !== '0' && env !== 'false'
+}
+
+/** Compute slot allocation metadata from the session registries. Shared
+ *  between the metadata-only and per-instance paths. */
+function buildSlotMetadata(session: SessionState): {
+  slot_count: number; slot_names: string[]; slot_defaults: number[]
+} {
+  const slotCount    = session.slotCount
+  const slotNames    = new Array<string>(slotCount).fill('')
+  const slotDefaults = new Array<number>(slotCount).fill(0)
+  for (const [name, idx] of session.outputSlotRegistry) slotNames[idx] = name
+  for (const [name, idx] of session.paramSlotRegistry) {
+    slotNames[idx] = `param:${name}`
+    const param = session.paramRegistry.get(name)
+    if (param !== undefined) slotDefaults[idx] = param.value
+  }
+  return { slot_count: slotCount, slot_names: slotNames, slot_defaults: slotDefaults }
+}
+
+/** Reduce a PortType to a ScalarType for emission. Mirrors the small
+ *  shim in `compile_resolved.ts` for input port type extraction. */
+function scalarOf(t: { kind?: string; scalar?: ScalarType; alias?: { base: ScalarType }; element?: ScalarType | { base: ScalarType } } | undefined): ScalarType {
+  if (t === undefined) return 'float'
+  if (t.kind === 'scalar' && t.scalar !== undefined) return t.scalar
+  if (t.kind === 'alias' && t.alias !== undefined) return t.alias.base
+  if (t.kind === 'array' && t.element !== undefined) {
+    return typeof t.element === 'string' ? (t.element as ScalarType) : t.element.base
+  }
+  return 'float'
+}
+
 /** @deprecated As of M8, slot mode is the default for `compileSession`.
- *  This function previously read TROPICAL_SLOT_MODE; it now always
- *  returns true. Kept as a tiny shim in case external callers
- *  reference it. Will be removed in a follow-up cleanup. */
+ *  Kept as a stub for any external callers. */
 export function slotModeEnabled(_session?: SessionState, _opt?: boolean): boolean {
   return true
 }

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -130,8 +130,9 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       outputScalarTypes: outPortTypes,
     }
 
-    const { body, writeSlots } = remapInstancePlan(plan, ctx, session)
-    allInstructions.push(...body, ...writeSlots)
+    const { preamble, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
+    // Order: preamble (compute input expressions) → body → writeSlots (publish outputs)
+    allInstructions.push(...preamble, ...body, ...writeSlots)
 
     // Accumulate the per-instance state contributions into the unified plan
     for (const n of plan.register_names) allRegisterNames.push(`${instName}.${n}`)
@@ -145,7 +146,7 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       allRegisterTargets.push(t + regOffset)
     }
 
-    regOffset += plan.register_count
+    regOffset += plan.register_count + tempsConsumed
     stateRegOffset += plan.state_init.length
     arraySlotOffset += plan.array_slot_count
   }

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -165,18 +165,46 @@ function inputExprToOperand(
       const slotIdx = session.outputSlotRegistry.get(key)
       if (slotIdx === undefined) {
         throw new Error(
-          `compileSessionSlotted (M9a): wire src '${key}' for '${instanceName}.${portName}' ` +
+          `compileSessionSlotted: wire src '${key}' for '${instanceName}.${portName}' ` +
           `has no allocated output slot. (Did add_instance populate outputSlotRegistry?)`,
         )
       }
       return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
     }
+    // M9b: param / trigger refs compile to slot operands. The slot is
+    // allocated at applyParamSpecs time (M3) and shared between
+    // params and triggers via paramSlotRegistry. Trigger fire-once
+    // semantics are now a control-plane / stdlib concern, not a
+    // kernel primitive — see M9b notes in the plan.
+    if ((obj.op === 'param' || obj.op === 'paramExpr') && typeof obj.name === 'string') {
+      const slotIdx = session.paramSlotRegistry.get(obj.name)
+      if (slotIdx === undefined) {
+        throw new Error(
+          `compileSessionSlotted: param '${obj.name}' wired to '${instanceName}.${portName}' ` +
+          `has no allocated slot. (Did applyParamSpecs register it?)`,
+        )
+      }
+      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+    }
+    if ((obj.op === 'trigger' || obj.op === 'triggerParamExpr') && typeof obj.name === 'string') {
+      const slotIdx = session.paramSlotRegistry.get(obj.name)
+      if (slotIdx === undefined) {
+        throw new Error(
+          `compileSessionSlotted: trigger '${obj.name}' wired to '${instanceName}.${portName}' ` +
+          `has no allocated slot. (Did applyParamSpecs register it?)`,
+        )
+      }
+      // Triggers are bool-valued conceptually but live in the same
+      // double slot array; use the destination port's scalar type to
+      // preserve coercion semantics at the read site.
+      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+    }
   }
-  // Everything else: out of M9a scope
+  // Everything else: out of current scope
   throw new Error(
-    `compileSessionSlotted (M9a): input expression for '${instanceName}.${portName}' ` +
-    `is not a constant or simple ref node. Arbitrary input expressions ship in M9c; ` +
-    `fan-in (combine ops) in M9d; param/trigger refs in M9b. ` +
+    `compileSessionSlotted: input expression for '${instanceName}.${portName}' ` +
+    `is not a constant, ref, or param/trigger ref. Arbitrary input expressions ` +
+    `ship in M9c; fan-in (combine ops) in M9d. ` +
     `Got expr op: '${(expr as { op?: unknown })?.op ?? typeof expr}'.`,
   )
 }
@@ -215,10 +243,19 @@ export function remapInstancePlan(
       case 'state_reg': return { ...op, slot: op.slot + ctx.stateRegOffset }
       case 'array_reg': return { ...op, slot: op.slot + ctx.arraySlotOffset }
       case 'param':
+        // M9b: under slot mode, session-level param/trigger refs in
+        // input expressions are resolved by inputExprToOperand to
+        // `slot` operands before reaching here. A legacy `param`
+        // operand surviving means the per-instance plan's body
+        // referenced a paramDecl at the type level (e.g., a stdlib
+        // type that uses an inline {op:'param'} ExprNode internally).
+        // We don't yet support this — most stdlib types don't do it.
         throw new Error(
-          `compileSessionSlotted (M9a): legacy 'param' operand encountered. ` +
-          `Param/trigger handling lands in M9b — for now, patches that use ` +
-          `paramRef/triggerParamExpr in input expressions are unsupported.`,
+          `compileSessionSlotted: legacy 'param' operand encountered ` +
+          `in '${ctx.instanceName}'. Session-level params should resolve ` +
+          `to slot operands before this point. This usually means the ` +
+          `program type's body has an internal {op:'param'} ExprNode ` +
+          `— this case is not yet handled in M9b.`,
         )
     }
   }

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -1,0 +1,327 @@
+/**
+ * compile_session_slotted_helpers.ts — M9a operand remapping + merging.
+ *
+ * Helpers used by `compileSessionSlotted` to produce a real per-instance
+ * compile-then-merge plan. For each session instance, `compileResolved`
+ * is called on the instance's standalone `Compiled.prog`. The resulting
+ * FlatPlan is then remapped:
+ *
+ *  - `input` operands (referring to the instance's external input ports)
+ *    are rewritten to `slot` operands pointing at the wire's source
+ *    output slot, or `const` operands for literal-wired inputs.
+ *  - `reg` / `state_reg` / `array_reg` slot indices are offset into a
+ *    unified register space across all instances.
+ *  - `dst` temp indices are offset by the same.
+ *  - `register_targets` entries get the same offset, plus append.
+ *  - A `WriteSlot` instruction is appended for each output port to
+ *    publish the computed value to the instance's output slot.
+ *
+ * After all instances are processed, a DAC stitching phase reads each
+ * graphOutput's source slot into a fresh temp and exposes it through
+ * `output_targets` + `outputs` so the kernel's existing mix-bus
+ * mechanism sums them into the audio buffer.
+ *
+ * M9a scope: single-source ref-chain patches only. Throws on fan-in,
+ * arbitrary input expressions, params/triggers in input expressions,
+ * arrays/sums. Subsequent sub-milestones lift each limitation.
+ */
+
+import type { SessionState, ExprNode } from '../session.js'
+import type { FlatPlan } from '../flat_plan.js'
+import type {
+  NOperand, NInstr, ScalarType,
+} from './emit_resolved.js'
+import { compileResolved } from './compile_resolved.js'
+import { topologicalSort } from '../compiler.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Topological order from session.inputExprNodes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Walk an ExprNode and collect the instance names of every `{op:'ref'}`
+ *  node it transitively references. Used to build per-instance
+ *  dependency sets for topological sort. */
+function collectInstanceRefs(expr: ExprNode | undefined, out: Set<string>): void {
+  if (expr === undefined || expr === null) return
+  if (typeof expr !== 'object') return
+  if (Array.isArray(expr)) {
+    for (const e of expr) collectInstanceRefs(e as ExprNode, out)
+    return
+  }
+  const obj = expr as Record<string, unknown>
+  if (obj.op === 'ref' && typeof obj.instance === 'string') {
+    out.add(obj.instance)
+    return
+  }
+  // Walk args / nested fields generically
+  for (const v of Object.values(obj)) {
+    if (typeof v === 'object' && v !== null) {
+      collectInstanceRefs(v as ExprNode, out)
+    }
+  }
+}
+
+/** Build a topological order over session instances using inputExprNodes
+ *  references. Instances with no wiring come first (no dependencies).
+ *  Throws on cycles (would mean a feedback loop without a breaking delay
+ *  — strata would have rejected the program earlier, but we double-check). */
+export function computeInstanceTopoOrder(session: SessionState): string[] {
+  const deps = new Map<string, Set<string>>()
+  for (const name of session.instanceRegistry.keys()) {
+    deps.set(name, new Set())
+  }
+  for (const [key, expr] of session.inputExprNodes) {
+    const colon = key.indexOf(':')
+    if (colon < 0) continue
+    const consumer = key.slice(0, colon)
+    const producers = deps.get(consumer)
+    if (producers === undefined) continue  // stale wiring entry
+    collectInstanceRefs(expr, producers)
+    // Self-references can occur for feedback delays; drop them — the
+    // strata pipeline introduces synthetic delays to break cycles, and
+    // they wouldn't be a session-level dep anyway.
+    producers.delete(consumer)
+  }
+  const result = topologicalSort(deps)
+  if (!result.complete) {
+    throw new Error(
+      `compileSessionSlotted: cycle detected in session dependency graph. ` +
+      `(Expected: strata's traceCycles should have inserted delay nodes. ` +
+      `Inspect inputExprNodes for unwanted self-refs.)`,
+    )
+  }
+  return result.order
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-instance plan remapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Context for remapping a single instance's FlatPlan into the unified
+ *  session plan space. */
+export interface RemapContext {
+  /** Session instance name. Used for outputSlotRegistry lookups + errors. */
+  instanceName: string
+  /** Cumulative temp index offset before this instance. All `dst` and
+   *  `reg` operand `slot` fields shift by this. */
+  regOffset: number
+  /** Cumulative state-register offset (regs + delays). All `state_reg`
+   *  operand `slot` fields and `register_targets` entries shift by this. */
+  stateRegOffset: number
+  /** Cumulative array-slot offset. All `array_reg` operand `slot` fields
+   *  shift by this. */
+  arraySlotOffset: number
+  /** Resolve an input port (by name) to its session-level expression.
+   *  Returns the wired ExprNode (which M9a interprets narrowly) or
+   *  undefined if the port is unwired (use default). */
+  inputExprFor: (portName: string) => ExprNode | undefined
+  /** Resolve an output port (by name) to its allocated output-slot
+   *  index in the session's unified slot array. */
+  outputSlotFor: (portName: string) => number
+  /** Names of the instance's input ports, in port-declaration order.
+   *  `input` operands index into this; we look up the port name then
+   *  consult `inputExprFor`. */
+  inputPortNames: string[]
+  /** Per-input-port default value, indexed parallel to `inputPortNames`.
+   *  Used when the port has no wiring entry. */
+  inputDefaults: Array<number | boolean | undefined>
+  /** Per-output-port name + scalar type, indexed parallel to the
+   *  instance's program output port declarations. Used for emitting
+   *  WriteSlot instructions at the end of the instance's body. */
+  outputPortNames: string[]
+  outputScalarTypes: ScalarType[]
+}
+
+/** Translate a single ExprNode-wired input into a concrete operand for
+ *  the slot-mode plan. M9a scope: only literal constants and pure ref
+ *  nodes. Anything else throws with a clear roadmap pointer. */
+function inputExprToOperand(
+  expr: ExprNode | undefined,
+  defaultVal: number | boolean | undefined,
+  scalarType: ScalarType,
+  session: SessionState,
+  instanceName: string,
+  portName: string,
+): NOperand {
+  // Unwired → default value as a const
+  if (expr === undefined) {
+    const v = typeof defaultVal === 'number' ? defaultVal
+      : typeof defaultVal === 'boolean' ? (defaultVal ? 1 : 0)
+      : 0
+    return { kind: 'const', val: v, scalar_type: scalarType }
+  }
+  // Literal constants
+  if (typeof expr === 'number') {
+    return { kind: 'const', val: expr, scalar_type: scalarType }
+  }
+  if (typeof expr === 'boolean') {
+    return { kind: 'const', val: expr ? 1 : 0, scalar_type: scalarType }
+  }
+  // Ref node: look up the source's allocated slot
+  if (typeof expr === 'object' && expr !== null && !Array.isArray(expr)) {
+    const obj = expr as Record<string, unknown>
+    if (obj.op === 'ref' && typeof obj.instance === 'string' && typeof obj.output === 'string') {
+      const key = `${obj.instance}.${obj.output}`
+      const slotIdx = session.outputSlotRegistry.get(key)
+      if (slotIdx === undefined) {
+        throw new Error(
+          `compileSessionSlotted (M9a): wire src '${key}' for '${instanceName}.${portName}' ` +
+          `has no allocated output slot. (Did add_instance populate outputSlotRegistry?)`,
+        )
+      }
+      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+    }
+  }
+  // Everything else: out of M9a scope
+  throw new Error(
+    `compileSessionSlotted (M9a): input expression for '${instanceName}.${portName}' ` +
+    `is not a constant or simple ref node. Arbitrary input expressions ship in M9c; ` +
+    `fan-in (combine ops) in M9d; param/trigger refs in M9b. ` +
+    `Got expr op: '${(expr as { op?: unknown })?.op ?? typeof expr}'.`,
+  )
+}
+
+/** Apply per-instance operand and slot-index remapping. Returns a fresh
+ *  set of instructions ready to merge into the unified instruction
+ *  stream. Also returns the per-output Write Slot instructions to
+ *  append after the body. */
+export function remapInstancePlan(
+  plan: FlatPlan,
+  ctx: RemapContext,
+  session: SessionState,
+): {
+  body: NInstr[]
+  writeSlots: NInstr[]
+} {
+  const remapOperand = (op: NOperand): NOperand => {
+    switch (op.kind) {
+      case 'const': return op
+      case 'rate':  return op
+      case 'tick':  return op
+      case 'slot':  return op
+      case 'input': {
+        const portName = ctx.inputPortNames[op.slot]
+        if (portName === undefined) {
+          throw new Error(
+            `compileSessionSlotted: instance '${ctx.instanceName}' input operand slot=${op.slot} ` +
+            `out of range (only ${ctx.inputPortNames.length} input ports).`,
+          )
+        }
+        const expr = ctx.inputExprFor(portName)
+        const dflt = ctx.inputDefaults[op.slot]
+        return inputExprToOperand(expr, dflt, op.scalar_type, session, ctx.instanceName, portName)
+      }
+      case 'reg':       return { ...op, slot: op.slot + ctx.regOffset }
+      case 'state_reg': return { ...op, slot: op.slot + ctx.stateRegOffset }
+      case 'array_reg': return { ...op, slot: op.slot + ctx.arraySlotOffset }
+      case 'param':
+        throw new Error(
+          `compileSessionSlotted (M9a): legacy 'param' operand encountered. ` +
+          `Param/trigger handling lands in M9b — for now, patches that use ` +
+          `paramRef/triggerParamExpr in input expressions are unsupported.`,
+        )
+    }
+  }
+
+  const body: NInstr[] = plan.instructions.map(instr => ({
+    ...instr,
+    dst: instr.dst + ctx.regOffset,
+    args: instr.args.map(remapOperand),
+  }))
+
+  // After the body, emit one WriteSlot per output port. The output
+  // value lives in plan.output_targets[i] (a temp index, pre-offset);
+  // we shift it into the unified register space and route to the
+  // instance's output slot.
+  const writeSlots: NInstr[] = []
+  for (let i = 0; i < ctx.outputPortNames.length; i++) {
+    const portName = ctx.outputPortNames[i]
+    const slotIdx  = ctx.outputSlotFor(portName)
+    const tempIdx  = plan.output_targets[i]
+    if (tempIdx === undefined) {
+      throw new Error(
+        `compileSessionSlotted: instance '${ctx.instanceName}' missing output_targets[${i}] ` +
+        `for port '${portName}'.`,
+      )
+    }
+    const scalarType = ctx.outputScalarTypes[i]
+    writeSlots.push({
+      tag: 'WriteSlot',
+      dst: slotIdx,
+      args: [{ kind: 'reg', slot: tempIdx + ctx.regOffset, scalar_type: scalarType }],
+      loop_count: 1,
+      strides: [],
+      result_type: scalarType,
+    })
+  }
+
+  return { body, writeSlots }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DAC stitching: read graphOutput source slots into fresh temps,
+// expose them through output_targets + outputs so the kernel's
+// existing mix-bus mechanism sums them into the audio buffer.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DacStitchResult {
+  /** Instructions that read each graphOutput's slot into a fresh temp. */
+  instructions: NInstr[]
+  /** Temp indices added (one per graphOutput). These get appended to
+   *  the unified plan's output_targets. */
+  outputTargets: number[]
+  /** Indices into outputTargets — one per graphOutput, identity mapping. */
+  outputs: number[]
+  /** How many new temps were allocated. The caller adds this to the
+   *  cumulative register count. */
+  tempCount: number
+}
+
+/** Emit DAC stitching for the session's graphOutputs. Each entry pulls
+ *  its source instance's output slot into a fresh temp; the kernel's
+ *  mix mechanism handles the final sum-to-output-buffer. */
+export function emitDacStitch(
+  session: SessionState,
+  regOffsetAtDacStart: number,
+): DacStitchResult {
+  const instructions: NInstr[] = []
+  const outputTargets: number[] = []
+  const outputs: number[] = []
+  let nextTemp = regOffsetAtDacStart
+
+  for (let i = 0; i < session.graphOutputs.length; i++) {
+    const go = session.graphOutputs[i]
+    const key = `${go.instance}.${go.output}`
+    const slotIdx = session.outputSlotRegistry.get(key)
+    if (slotIdx === undefined) {
+      throw new Error(
+        `compileSessionSlotted: dac wire '${key}' has no allocated output slot. ` +
+        `(Did add_instance populate outputSlotRegistry for the source instance?)`,
+      )
+    }
+    // Read the slot into a fresh temp via an Add+const(0) op. Cheaper
+    // than introducing a dedicated "ReadSlot" instruction — LLVM will
+    // fold the +0 away.
+    const tempIdx = nextTemp++
+    instructions.push({
+      tag: 'Add',
+      dst: tempIdx,
+      args: [
+        { kind: 'slot',  index: slotIdx, scalar_type: 'float' },
+        { kind: 'const', val: 0,         scalar_type: 'float' },
+      ],
+      loop_count: 1,
+      strides: [],
+      result_type: 'float',
+    })
+    outputTargets.push(tempIdx)
+    outputs.push(i)
+  }
+
+  return {
+    instructions,
+    outputTargets,
+    outputs,
+    tempCount: outputTargets.length,
+  }
+}

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -35,6 +35,22 @@ import { BINARY_TAG, UNARY_TAG, TERNARY_TAG } from './emit_resolved.js'
 import { compileResolved } from './compile_resolved.js'
 import { topologicalSort } from '../compiler.js'
 
+/** Marker error thrown by the per-instance compile path when the
+ *  session's current shape isn't yet supported (arrays, sum types,
+ *  nested instance calls in input expressions) or when an instance
+ *  was created outside the normal allocate-slots flow. The dispatcher
+ *  in `compile_session_slotted.ts` catches this and falls back to
+ *  the metadata-only legacy path — audio is preserved either way.
+ *
+ *  Using a marker class instead of message-text matching keeps the
+ *  fallback robust to error-message refactors. */
+export class SlotShapeUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SlotShapeUnsupportedError'
+  }
+}
+
 /** Per-instance preamble emitter. Allocates fresh temps in the unified
  *  register space and collects NInstrs that need to run before the
  *  consuming instance's body. Used by inputExprToOperand to compile
@@ -66,7 +82,7 @@ function translateNode(
     return { kind: 'const', val: expr ? 1 : 0, scalar_type: scalarType }
   }
   if (Array.isArray(expr)) {
-    throw new Error(
+    throw new SlotShapeUnsupportedError(
       `compileSessionSlotted: array-shaped input expression at '${context}' ` +
       `not yet supported. Arrays land in M9d.`,
     )
@@ -85,7 +101,7 @@ function translateNode(
     const key = `${obj.instance}.${obj.output}`
     const slotIdx = session.outputSlotRegistry.get(key)
     if (slotIdx === undefined) {
-      throw new Error(
+      throw new SlotShapeUnsupportedError(
         `compileSessionSlotted: wire src '${key}' at '${context}' has no allocated output slot.`,
       )
     }
@@ -94,7 +110,7 @@ function translateNode(
   if ((op === 'param' || op === 'paramExpr') && typeof obj.name === 'string') {
     const slotIdx = session.paramSlotRegistry.get(obj.name)
     if (slotIdx === undefined) {
-      throw new Error(
+      throw new SlotShapeUnsupportedError(
         `compileSessionSlotted: param '${obj.name}' at '${context}' has no allocated slot.`,
       )
     }
@@ -103,7 +119,7 @@ function translateNode(
   if ((op === 'trigger' || op === 'triggerParamExpr') && typeof obj.name === 'string') {
     const slotIdx = session.paramSlotRegistry.get(obj.name)
     if (slotIdx === undefined) {
-      throw new Error(
+      throw new SlotShapeUnsupportedError(
         `compileSessionSlotted: trigger '${obj.name}' at '${context}' has no allocated slot.`,
       )
     }
@@ -180,7 +196,7 @@ function translateNode(
   }
 
   // ── unknown ──
-  throw new Error(
+  throw new SlotShapeUnsupportedError(
     `compileSessionSlotted: input expression at '${context}' uses op '${op}' which is not ` +
     `yet supported. Nested instance calls (e.g. Sin(x: ...)), array ops, and fan-in (combine) ` +
     `land in M9d.`,
@@ -249,7 +265,7 @@ export function computeInstanceTopoOrder(session: SessionState): string[] {
   }
   const result = topologicalSort(deps)
   if (!result.complete) {
-    throw new Error(
+    throw new SlotShapeUnsupportedError(
       `compileSessionSlotted: cycle detected in session dependency graph. ` +
       `(Expected: strata's traceCycles should have inserted delay nodes. ` +
       `Inspect inputExprNodes for unwanted self-refs.)`,
@@ -332,7 +348,7 @@ function inputExprToOperand(
       const key = `${obj.instance}.${obj.output}`
       const slotIdx = session.outputSlotRegistry.get(key)
       if (slotIdx === undefined) {
-        throw new Error(
+        throw new SlotShapeUnsupportedError(
           `compileSessionSlotted: wire src '${key}' for '${instanceName}.${portName}' ` +
           `has no allocated output slot. (Did add_instance populate outputSlotRegistry?)`,
         )
@@ -347,7 +363,7 @@ function inputExprToOperand(
     if ((obj.op === 'param' || obj.op === 'paramExpr') && typeof obj.name === 'string') {
       const slotIdx = session.paramSlotRegistry.get(obj.name)
       if (slotIdx === undefined) {
-        throw new Error(
+        throw new SlotShapeUnsupportedError(
           `compileSessionSlotted: param '${obj.name}' wired to '${instanceName}.${portName}' ` +
           `has no allocated slot. (Did applyParamSpecs register it?)`,
         )
@@ -357,7 +373,7 @@ function inputExprToOperand(
     if ((obj.op === 'trigger' || obj.op === 'triggerParamExpr') && typeof obj.name === 'string') {
       const slotIdx = session.paramSlotRegistry.get(obj.name)
       if (slotIdx === undefined) {
-        throw new Error(
+        throw new SlotShapeUnsupportedError(
           `compileSessionSlotted: trigger '${obj.name}' wired to '${instanceName}.${portName}' ` +
           `has no allocated slot. (Did applyParamSpecs register it?)`,
         )
@@ -431,13 +447,14 @@ export function remapInstancePlan(
         // operand surviving means the per-instance plan's body
         // referenced a paramDecl at the type level (e.g., a stdlib
         // type that uses an inline {op:'param'} ExprNode internally).
-        // We don't yet support this — most stdlib types don't do it.
-        throw new Error(
+        // Auto-fall-back to the legacy path — type-level params are
+        // a follow-up scope item.
+        throw new SlotShapeUnsupportedError(
           `compileSessionSlotted: legacy 'param' operand encountered ` +
           `in '${ctx.instanceName}'. Session-level params should resolve ` +
           `to slot operands before this point. This usually means the ` +
           `program type's body has an internal {op:'param'} ExprNode ` +
-          `— this case is not yet handled in M9b.`,
+          `— this case is not yet handled.`,
         )
     }
   }
@@ -518,7 +535,7 @@ export function emitDacStitch(
     const key = `${go.instance}.${go.output}`
     const slotIdx = session.outputSlotRegistry.get(key)
     if (slotIdx === undefined) {
-      throw new Error(
+      throw new SlotShapeUnsupportedError(
         `compileSessionSlotted: dac wire '${key}' has no allocated output slot. ` +
         `(Did add_instance populate outputSlotRegistry for the source instance?)`,
       )

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -31,8 +31,173 @@ import type { FlatPlan } from '../flat_plan.js'
 import type {
   NOperand, NInstr, ScalarType,
 } from './emit_resolved.js'
+import { BINARY_TAG, UNARY_TAG, TERNARY_TAG } from './emit_resolved.js'
 import { compileResolved } from './compile_resolved.js'
 import { topologicalSort } from '../compiler.js'
+
+/** Per-instance preamble emitter. Allocates fresh temps in the unified
+ *  register space and collects NInstrs that need to run before the
+ *  consuming instance's body. Used by inputExprToOperand to compile
+ *  arbitrary input expressions (sin, mul, etc.) into preamble
+ *  instructions whose final temp value flows into the instance via a
+ *  `reg` operand. (M9c) */
+export interface PreambleEmitter {
+  instrs: NInstr[]
+  allocTemp(): number
+}
+
+/** Translate an arbitrary ExprNode into NInstrs emitted to the
+ *  preamble, returning the operand that holds the result. M9c-supported
+ *  ops: refs, params/triggers, literals, all entries in BINARY_TAG /
+ *  UNARY_TAG / TERNARY_TAG. Anything else throws with a pointer to the
+ *  appropriate follow-on milestone. */
+function translateNode(
+  expr: ExprNode,
+  scalarType: ScalarType,
+  session: SessionState,
+  emitter: PreambleEmitter,
+  context: string,  // for error messages: "${instance}.${port}"
+): NOperand {
+  // ── leaves ──
+  if (typeof expr === 'number') {
+    return { kind: 'const', val: expr, scalar_type: scalarType }
+  }
+  if (typeof expr === 'boolean') {
+    return { kind: 'const', val: expr ? 1 : 0, scalar_type: scalarType }
+  }
+  if (Array.isArray(expr)) {
+    throw new Error(
+      `compileSessionSlotted: array-shaped input expression at '${context}' ` +
+      `not yet supported. Arrays land in M9d.`,
+    )
+  }
+  if (typeof expr !== 'object' || expr === null) {
+    throw new Error(
+      `compileSessionSlotted: unrecognized input expression at '${context}': ${typeof expr}`,
+    )
+  }
+
+  const obj = expr as Record<string, unknown>
+  const op = obj.op
+
+  // ── refs and params (leaves) ──
+  if (op === 'ref' && typeof obj.instance === 'string' && typeof obj.output === 'string') {
+    const key = `${obj.instance}.${obj.output}`
+    const slotIdx = session.outputSlotRegistry.get(key)
+    if (slotIdx === undefined) {
+      throw new Error(
+        `compileSessionSlotted: wire src '${key}' at '${context}' has no allocated output slot.`,
+      )
+    }
+    return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+  }
+  if ((op === 'param' || op === 'paramExpr') && typeof obj.name === 'string') {
+    const slotIdx = session.paramSlotRegistry.get(obj.name)
+    if (slotIdx === undefined) {
+      throw new Error(
+        `compileSessionSlotted: param '${obj.name}' at '${context}' has no allocated slot.`,
+      )
+    }
+    return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+  }
+  if ((op === 'trigger' || op === 'triggerParamExpr') && typeof obj.name === 'string') {
+    const slotIdx = session.paramSlotRegistry.get(obj.name)
+    if (slotIdx === undefined) {
+      throw new Error(
+        `compileSessionSlotted: trigger '${obj.name}' at '${context}' has no allocated slot.`,
+      )
+    }
+    return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
+  }
+
+  // ── builtins ──
+  if (op === 'sampleRate')  return { kind: 'rate',  scalar_type: scalarType }
+  if (op === 'sampleIndex') return { kind: 'tick',  scalar_type: scalarType }
+
+  // ── arithmetic / logical / comparison ──
+  if (typeof op === 'string' && BINARY_TAG[op]) {
+    const args = (obj.args as ExprNode[])
+    if (args.length !== 2) {
+      throw new Error(
+        `compileSessionSlotted: binary op '${op}' at '${context}' needs 2 args, got ${args.length}.`,
+      )
+    }
+    // Result type for comparisons is bool; for arithmetic, promote inputs.
+    const tag = BINARY_TAG[op]
+    const resultType: ScalarType = isComparisonTag(tag) ? 'bool'
+      : isBitwiseTag(tag) ? 'int'
+      : scalarType
+    const argType: ScalarType = isComparisonTag(tag) ? 'float'
+      : isBitwiseTag(tag) ? 'int'
+      : isLogicalTag(tag) ? 'bool'
+      : resultType
+    const a = translateNode(args[0], argType, session, emitter, context)
+    const b = translateNode(args[1], argType, session, emitter, context)
+    const dst = emitter.allocTemp()
+    emitter.instrs.push({
+      tag, dst, args: [a, b], loop_count: 1, strides: [], result_type: resultType,
+    })
+    return { kind: 'reg', slot: dst, scalar_type: resultType }
+  }
+  if (typeof op === 'string' && UNARY_TAG[op]) {
+    const args = (obj.args as ExprNode[])
+    if (args.length !== 1) {
+      throw new Error(
+        `compileSessionSlotted: unary op '${op}' at '${context}' needs 1 arg, got ${args.length}.`,
+      )
+    }
+    const tag = UNARY_TAG[op]
+    const resultType: ScalarType =
+      tag === 'ToInt' ? 'int' : tag === 'ToBool' ? 'bool' : tag === 'ToFloat' ? 'float'
+      : tag === 'Not' ? 'bool'
+      : tag === 'BitNot' ? 'int'
+      : scalarType
+    const a = translateNode(args[0], resultType, session, emitter, context)
+    const dst = emitter.allocTemp()
+    emitter.instrs.push({
+      tag, dst, args: [a], loop_count: 1, strides: [], result_type: resultType,
+    })
+    return { kind: 'reg', slot: dst, scalar_type: resultType }
+  }
+  if (typeof op === 'string' && TERNARY_TAG[op]) {
+    const args = (obj.args as ExprNode[])
+    if (args.length !== 3) {
+      throw new Error(
+        `compileSessionSlotted: ternary op '${op}' at '${context}' needs 3 args, got ${args.length}.`,
+      )
+    }
+    const tag = TERNARY_TAG[op]
+    // select: args = [cond:bool, then:T, else:T]; clamp: args = [val, lo, hi] all same type
+    const condType: ScalarType = tag === 'Select' ? 'bool' : scalarType
+    const a = translateNode(args[0], condType, session, emitter, context)
+    const b = translateNode(args[1], scalarType, session, emitter, context)
+    const c = translateNode(args[2], scalarType, session, emitter, context)
+    const dst = emitter.allocTemp()
+    emitter.instrs.push({
+      tag, dst, args: [a, b, c], loop_count: 1, strides: [], result_type: scalarType,
+    })
+    return { kind: 'reg', slot: dst, scalar_type: scalarType }
+  }
+
+  // ── unknown ──
+  throw new Error(
+    `compileSessionSlotted: input expression at '${context}' uses op '${op}' which is not ` +
+    `yet supported. Nested instance calls (e.g. Sin(x: ...)), array ops, and fan-in (combine) ` +
+    `land in M9d.`,
+  )
+}
+
+function isComparisonTag(tag: string): boolean {
+  return tag === 'Less' || tag === 'LessEq' || tag === 'Greater' || tag === 'GreaterEq'
+    || tag === 'Equal' || tag === 'NotEqual'
+}
+function isBitwiseTag(tag: string): boolean {
+  return tag === 'BitAnd' || tag === 'BitOr' || tag === 'BitXor'
+    || tag === 'LShift' || tag === 'RShift'
+}
+function isLogicalTag(tag: string): boolean {
+  return tag === 'And' || tag === 'Or'
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Topological order from session.inputExprNodes
@@ -133,8 +298,10 @@ export interface RemapContext {
 }
 
 /** Translate a single ExprNode-wired input into a concrete operand for
- *  the slot-mode plan. M9a scope: only literal constants and pure ref
- *  nodes. Anything else throws with a clear roadmap pointer. */
+ *  the slot-mode plan. Handles the simple leaf cases (constants, refs,
+ *  params/triggers) inline; delegates arbitrary expressions to
+ *  `translateNode`, which emits preamble instructions and returns a
+ *  `reg` operand pointing at the result temp. */
 function inputExprToOperand(
   expr: ExprNode | undefined,
   defaultVal: number | boolean | undefined,
@@ -142,6 +309,7 @@ function inputExprToOperand(
   session: SessionState,
   instanceName: string,
   portName: string,
+  emitter: PreambleEmitter,
 ): NOperand {
   // Unwired → default value as a const
   if (expr === undefined) {
@@ -200,27 +368,41 @@ function inputExprToOperand(
       return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
     }
   }
-  // Everything else: out of current scope
-  throw new Error(
-    `compileSessionSlotted: input expression for '${instanceName}.${portName}' ` +
-    `is not a constant, ref, or param/trigger ref. Arbitrary input expressions ` +
-    `ship in M9c; fan-in (combine ops) in M9d. ` +
-    `Got expr op: '${(expr as { op?: unknown })?.op ?? typeof expr}'.`,
-  )
+  // M9c: arbitrary expressions — emit preamble instructions, return a
+  // reg operand pointing at the result temp. The caller is responsible
+  // for stitching `emitter.instrs` before the consuming instance's body.
+  return translateNode(expr, scalarType, session, emitter, `${instanceName}.${portName}`)
 }
 
 /** Apply per-instance operand and slot-index remapping. Returns a fresh
  *  set of instructions ready to merge into the unified instruction
- *  stream. Also returns the per-output Write Slot instructions to
- *  append after the body. */
+ *  stream:
+ *  - `preamble`: instructions emitted to compute arbitrary input
+ *    expressions (M9c). These go BEFORE the instance's body in the
+ *    unified stream.
+ *  - `body`: the instance's body with operands remapped.
+ *  - `writeSlots`: WriteSlot instructions per output port, AFTER the body.
+ *  Also returns `tempsConsumed` — the number of temps allocated for
+ *  preamble computations, which the caller adds to its running offset. */
 export function remapInstancePlan(
   plan: FlatPlan,
   ctx: RemapContext,
   session: SessionState,
 ): {
-  body: NInstr[]
-  writeSlots: NInstr[]
+  preamble:      NInstr[]
+  body:          NInstr[]
+  writeSlots:    NInstr[]
+  tempsConsumed: number
 } {
+  // Preamble emitter: allocates fresh temps in the unified register space.
+  // Temps after the instance's own register_count get used here.
+  let preambleNextTemp = ctx.regOffset + plan.register_count
+  const preamble: NInstr[] = []
+  const emitter: PreambleEmitter = {
+    instrs: preamble,
+    allocTemp: () => preambleNextTemp++,
+  }
+
   const remapOperand = (op: NOperand): NOperand => {
     switch (op.kind) {
       case 'const': return op
@@ -237,7 +419,7 @@ export function remapInstancePlan(
         }
         const expr = ctx.inputExprFor(portName)
         const dflt = ctx.inputDefaults[op.slot]
-        return inputExprToOperand(expr, dflt, op.scalar_type, session, ctx.instanceName, portName)
+        return inputExprToOperand(expr, dflt, op.scalar_type, session, ctx.instanceName, portName, emitter)
       }
       case 'reg':       return { ...op, slot: op.slot + ctx.regOffset }
       case 'state_reg': return { ...op, slot: op.slot + ctx.stateRegOffset }
@@ -292,7 +474,12 @@ export function remapInstancePlan(
     })
   }
 
-  return { body, writeSlots }
+  return {
+    preamble,
+    body,
+    writeSlots,
+    tempsConsumed: preambleNextTemp - (ctx.regOffset + plan.register_count),
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -51,6 +51,22 @@ export class SlotShapeUnsupportedError extends Error {
   }
 }
 
+/** Resolved binding for a module input port. Replaces the previously
+ *  coupled `(expr | undefined, defaultVal | undefined)` parameter pair
+ *  with a single discriminated union — the consumer doesn't have to
+ *  reconstruct "is this wired or unwired" from two correlated fields.
+ *
+ *  - `wired`: the input has an ExprNode wired to it. Could be a literal,
+ *    a ref, a param, or an arbitrary expression — `translateNode`
+ *    handles all of these.
+ *  - `literal`: the input has no wiring. Carries the resolved fallback
+ *    value (port declared default, or 0 if no default exists). The
+ *    resolver owns the "default → 0" fallback so consumers don't
+ *    re-implement it. */
+export type InputBinding =
+  | { kind: 'wired';   expr:  ExprNode }
+  | { kind: 'literal'; value: number | boolean }
+
 /** Per-instance preamble emitter. Allocates fresh temps in the unified
  *  register space and collects NInstrs that need to run before the
  *  consuming instance's body. Used by inputExprToOperand to compile
@@ -292,20 +308,18 @@ export interface RemapContext {
   /** Cumulative array-slot offset. All `array_reg` operand `slot` fields
    *  shift by this. */
   arraySlotOffset: number
-  /** Resolve an input port (by name) to its session-level expression.
-   *  Returns the wired ExprNode (which M9a interprets narrowly) or
-   *  undefined if the port is unwired (use default). */
-  inputExprFor: (portName: string) => ExprNode | undefined
+  /** Resolve an input port (by name) to its binding — either a wired
+   *  ExprNode or a literal fallback. The resolver owns the
+   *  "unwired → default → 0" fallback chain so the consumer just sees
+   *  one of two cases. */
+  inputBindingFor: (portName: string) => InputBinding
   /** Resolve an output port (by name) to its allocated output-slot
    *  index in the session's unified slot array. */
   outputSlotFor: (portName: string) => number
   /** Names of the instance's input ports, in port-declaration order.
    *  `input` operands index into this; we look up the port name then
-   *  consult `inputExprFor`. */
+   *  consult `inputBindingFor`. */
   inputPortNames: string[]
-  /** Per-input-port default value, indexed parallel to `inputPortNames`.
-   *  Used when the port has no wiring entry. */
-  inputDefaults: Array<number | boolean | undefined>
   /** Per-output-port name + scalar type, indexed parallel to the
    *  instance's program output port declarations. Used for emitting
    *  WriteSlot instructions at the end of the instance's body. */
@@ -313,81 +327,24 @@ export interface RemapContext {
   outputScalarTypes: ScalarType[]
 }
 
-/** Translate a single ExprNode-wired input into a concrete operand for
- *  the slot-mode plan. Handles the simple leaf cases (constants, refs,
- *  params/triggers) inline; delegates arbitrary expressions to
- *  `translateNode`, which emits preamble instructions and returns a
- *  `reg` operand pointing at the result temp. */
-function inputExprToOperand(
-  expr: ExprNode | undefined,
-  defaultVal: number | boolean | undefined,
+/** Resolve an input port's binding to a concrete NOperand.
+ *  - Literal binding → const operand
+ *  - Wired binding → delegate to translateNode, which handles every
+ *    ExprNode shape (refs, params, triggers, arithmetic, etc.)
+ *    uniformly. Preamble emission happens transparently via the
+ *    emitter when the wired expression is non-leaf. */
+function inputBindingToOperand(
+  binding: InputBinding,
   scalarType: ScalarType,
   session: SessionState,
-  instanceName: string,
-  portName: string,
+  context: string,
   emitter: PreambleEmitter,
 ): NOperand {
-  // Unwired → default value as a const
-  if (expr === undefined) {
-    const v = typeof defaultVal === 'number' ? defaultVal
-      : typeof defaultVal === 'boolean' ? (defaultVal ? 1 : 0)
-      : 0
+  if (binding.kind === 'literal') {
+    const v = typeof binding.value === 'boolean' ? (binding.value ? 1 : 0) : binding.value
     return { kind: 'const', val: v, scalar_type: scalarType }
   }
-  // Literal constants
-  if (typeof expr === 'number') {
-    return { kind: 'const', val: expr, scalar_type: scalarType }
-  }
-  if (typeof expr === 'boolean') {
-    return { kind: 'const', val: expr ? 1 : 0, scalar_type: scalarType }
-  }
-  // Ref node: look up the source's allocated slot
-  if (typeof expr === 'object' && expr !== null && !Array.isArray(expr)) {
-    const obj = expr as Record<string, unknown>
-    if (obj.op === 'ref' && typeof obj.instance === 'string' && typeof obj.output === 'string') {
-      const key = `${obj.instance}.${obj.output}`
-      const slotIdx = session.outputSlotRegistry.get(key)
-      if (slotIdx === undefined) {
-        throw new SlotShapeUnsupportedError(
-          `compileSessionSlotted: wire src '${key}' for '${instanceName}.${portName}' ` +
-          `has no allocated output slot. (Did add_instance populate outputSlotRegistry?)`,
-        )
-      }
-      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
-    }
-    // M9b: param / trigger refs compile to slot operands. The slot is
-    // allocated at applyParamSpecs time (M3) and shared between
-    // params and triggers via paramSlotRegistry. Trigger fire-once
-    // semantics are now a control-plane / stdlib concern, not a
-    // kernel primitive — see M9b notes in the plan.
-    if ((obj.op === 'param' || obj.op === 'paramExpr') && typeof obj.name === 'string') {
-      const slotIdx = session.paramSlotRegistry.get(obj.name)
-      if (slotIdx === undefined) {
-        throw new SlotShapeUnsupportedError(
-          `compileSessionSlotted: param '${obj.name}' wired to '${instanceName}.${portName}' ` +
-          `has no allocated slot. (Did applyParamSpecs register it?)`,
-        )
-      }
-      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
-    }
-    if ((obj.op === 'trigger' || obj.op === 'triggerParamExpr') && typeof obj.name === 'string') {
-      const slotIdx = session.paramSlotRegistry.get(obj.name)
-      if (slotIdx === undefined) {
-        throw new SlotShapeUnsupportedError(
-          `compileSessionSlotted: trigger '${obj.name}' wired to '${instanceName}.${portName}' ` +
-          `has no allocated slot. (Did applyParamSpecs register it?)`,
-        )
-      }
-      // Triggers are bool-valued conceptually but live in the same
-      // double slot array; use the destination port's scalar type to
-      // preserve coercion semantics at the read site.
-      return { kind: 'slot', index: slotIdx, scalar_type: scalarType }
-    }
-  }
-  // M9c: arbitrary expressions — emit preamble instructions, return a
-  // reg operand pointing at the result temp. The caller is responsible
-  // for stitching `emitter.instrs` before the consuming instance's body.
-  return translateNode(expr, scalarType, session, emitter, `${instanceName}.${portName}`)
+  return translateNode(binding.expr, scalarType, session, emitter, context)
 }
 
 /** Apply per-instance operand and slot-index remapping. Returns a fresh
@@ -433,9 +390,13 @@ export function remapInstancePlan(
             `out of range (only ${ctx.inputPortNames.length} input ports).`,
           )
         }
-        const expr = ctx.inputExprFor(portName)
-        const dflt = ctx.inputDefaults[op.slot]
-        return inputExprToOperand(expr, dflt, op.scalar_type, session, ctx.instanceName, portName, emitter)
+        return inputBindingToOperand(
+          ctx.inputBindingFor(portName),
+          op.scalar_type,
+          session,
+          `${ctx.instanceName}.${portName}`,
+          emitter,
+        )
       }
       case 'reg':       return { ...op, slot: op.slot + ctx.regOffset }
       case 'state_reg': return { ...op, slot: op.slot + ctx.stateRegOffset }

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -103,7 +103,7 @@ export interface EmitSlots {
 // Op-tag mappings (verbatim from emit_numeric.ts)
 // ─────────────────────────────────────────────────────────────
 
-const BINARY_TAG: Record<string, string> = {
+export const BINARY_TAG: Record<string, string> = {
   add: 'Add', sub: 'Sub', mul: 'Mul', div: 'Div', mod: 'Mod',
   floorDiv: 'FloorDiv',
   lt: 'Less', lte: 'LessEq', gt: 'Greater', gte: 'GreaterEq',
@@ -114,12 +114,16 @@ const BINARY_TAG: Record<string, string> = {
   ldexp: 'Ldexp',
 }
 
-const UNARY_TAG: Record<string, string> = {
+export const UNARY_TAG: Record<string, string> = {
   neg: 'Neg', abs: 'Abs', sqrt: 'Sqrt',
   floor: 'Floor', ceil: 'Ceil', round: 'Round',
   not: 'Not', bitNot: 'BitNot',
   floatExponent: 'FloatExponent',
   toInt: 'ToInt', toBool: 'ToBool', toFloat: 'ToFloat',
+}
+
+export const TERNARY_TAG: Record<string, string> = {
+  select: 'Select', clamp: 'Clamp',
 }
 
 const CAST_RESULT: Record<string, ScalarType> = {

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -9,7 +9,7 @@
 import type { ExprNode } from './expr.js'
 import { validateExpr } from './expr.js'
 import type { TypeDefJSON, SessionState } from './session.js'
-import { resolveProgramType, allocateParamSlot } from './session.js'
+import { resolveProgramType, allocateParamSlot, allocateOutputSlots } from './session.js'
 import { applyFlatPlan } from './apply_plan.js'
 import { Param, Trigger } from './runtime/param.js'
 import {
@@ -383,6 +383,10 @@ export function loadProgramAsSession(
       instance.gateInput = inst.gate_input
     }
     session.instanceRegistry.set(instance.name, instance)
+    // Slot model: allocate output slots for the instance, parallel to
+    // what MCP add_instance does. Required for the per-instance
+    // compile path (M9a+) to find each output's slot index.
+    allocateOutputSlots(session, instance.name, type)
 
     // Populate wiring from instance inputs
     if (inst.inputs) {
@@ -543,6 +547,10 @@ export function mergeProgramIntoSession(
       instance.gateInput = inst.gate_input
     }
     session.instanceRegistry.set(instance.name, instance)
+    // Slot model: allocate output slots for the instance, parallel to
+    // what MCP add_instance does. Required for the per-instance
+    // compile path (M9a+) to find each output's slot index.
+    allocateOutputSlots(session, instance.name, type)
 
     // Populate wiring from instance inputs
     if (inst.inputs) {

--- a/compiler/runtime/m9a_per_instance_equiv.test.ts
+++ b/compiler/runtime/m9a_per_instance_equiv.test.ts
@@ -110,21 +110,22 @@ describe('M9a: per-instance slot-mode equivalence', () => {
   })
 })
 
-describe('M9a: unsupported shapes throw clear errors', () => {
-  test('arbitrary input expression (sin of a ref) is deferred to M9c', () => {
+describe('M9a: roadmap sanity', () => {
+  test('nested instance call in input expression (Sin(x: ...)) still throws (M9d)', () => {
+    // Sin is a stdlib type — wiring `Sin(x: ref)` into an input is a
+    // nested instance call that M9d would handle. M9c covers arithmetic
+    // / comparison / unary / ternary; nested instance calls are a
+    // separate, harder case.
     const s = makeSession()
     loadStdlib(s)
-    const sinOsc  = s.typeRegistry.get('SinOsc')!
     const onePole = s.typeRegistry.get('OnePole')!
-    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
-    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
-    allocateOutputSlots(s, 'osc', sinOsc)
-    allocateOutputSlots(s, 'lp',  onePole)
-    s.inputExprNodes.set('osc:freq', 220)
-    s.inputExprNodes.set('lp:input', { op: 'mul', args: [{ op: 'ref', instance: 'osc', output: 'sine' }, 0.5] })
+    s.instanceRegistry.set('lp', instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'lp', onePole)
+    // {op:'call', callee:..., args:...} is the nested-call shape;
+    // not in BINARY/UNARY/TERNARY tag tables.
+    s.inputExprNodes.set('lp:input', { op: 'call', callee: 'Sin', args: { x: 1.0 } })
     s.inputExprNodes.set('lp:g', 0.1)
     s.graphOutputs.push({ instance: 'lp', output: 'out' })
-
-    expect(() => compileSessionSlotted(s)).toThrow(/M9c|arbitrary input expression/i)
+    expect(() => compileSessionSlotted(s)).toThrow(/M9d|nested instance|not.*supported/i)
   })
 })

--- a/compiler/runtime/m9a_per_instance_equiv.test.ts
+++ b/compiler/runtime/m9a_per_instance_equiv.test.ts
@@ -1,0 +1,130 @@
+/**
+ * m9a_per_instance_equiv.test.ts — M9a equivalence gate.
+ *
+ * Asserts that the per-instance slot-mode compile path
+ * (`compileSessionSlotted` under `TROPICAL_SLOT_OPS=1`) produces
+ * byte-exact identical audio to `compileSessionLegacy` on the M9a-
+ * supported patch shapes: single instance with constants, single
+ * instance wired to dac, multi-instance ref chains.
+ *
+ * Out of scope (subsequent sub-milestones throw with clear errors
+ * and are tested separately): fan-in, arbitrary input expressions,
+ * params/triggers in input expressions, arrays, sums.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { Runtime } from './runtime.ts'
+import { makeSession, allocateOutputSlots } from '../session.ts'
+import { loadStdlib } from '../program.ts'
+import { instantiate } from '../program_types.ts'
+import { compileSessionLegacy } from '../ir/compile_session.ts'
+import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
+
+// Enable per-instance path for the duration of this file's tests
+let prevEnv: string | undefined
+beforeEach(() => {
+  prevEnv = process.env.TROPICAL_SLOT_OPS
+  process.env.TROPICAL_SLOT_OPS = '1'
+})
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.TROPICAL_SLOT_OPS
+  else process.env.TROPICAL_SLOT_OPS = prevEnv
+})
+
+function runAudio(plan: object, frames = 2, bufferLen = 64): number[] {
+  const rt = new Runtime(bufferLen)
+  rt.loadPlan(JSON.stringify(plan))
+  const samples: number[] = []
+  for (let f = 0; f < frames; f++) {
+    rt.process()
+    for (const v of rt.outputBuffer) samples.push(v)
+  }
+  rt.dispose()
+  return samples
+}
+
+describe('M9a: per-instance slot-mode equivalence', () => {
+  test('single SinOsc → dac (const freq input): byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    s.inputExprNodes.set('osc:freq', 440)
+    s.graphOutputs.push({ instance: 'osc', output: 'sine' })
+
+    const legacyPlan  = compileSessionLegacy(s)
+    const slottedPlan = compileSessionSlotted(s)
+    const legacyAudio  = runAudio(legacyPlan)
+    const slottedAudio = runAudio(slottedPlan)
+
+    expect(slottedAudio.length).toBe(legacyAudio.length)
+    for (let i = 0; i < legacyAudio.length; i++) {
+      expect(slottedAudio[i]).toBe(legacyAudio[i])
+    }
+  })
+
+  test('SinOsc → OnePole → dac chain: byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    allocateOutputSlots(s, 'lp',  onePole)
+    s.inputExprNodes.set('osc:freq', 220)
+    s.inputExprNodes.set('lp:input', { op: 'ref', instance: 'osc', output: 'sine' })
+    s.inputExprNodes.set('lp:g',     0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const legacyPlan  = compileSessionLegacy(s)
+    const slottedPlan = compileSessionSlotted(s)
+    const legacyAudio  = runAudio(legacyPlan)
+    const slottedAudio = runAudio(slottedPlan)
+
+    expect(slottedAudio.length).toBe(legacyAudio.length)
+    for (let i = 0; i < legacyAudio.length; i++) {
+      expect(slottedAudio[i]).toBe(legacyAudio[i])
+    }
+  })
+
+  test('plan has slot operands and WriteSlot instructions (not legacy form)', () => {
+    // Smoke test that the per-instance path is actually emitting slot
+    // operands — if a regression accidentally fell through to the
+    // metadata-only path, the instruction stream would have no slot
+    // operands at all.
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    s.inputExprNodes.set('osc:freq', 440)
+    s.graphOutputs.push({ instance: 'osc', output: 'sine' })
+
+    const plan = compileSessionSlotted(s)
+    const hasSlotOperand = plan.instructions.some(instr =>
+      instr.args.some(op => op.kind === 'slot'))
+    const hasWriteSlot = plan.instructions.some(instr => instr.tag === 'WriteSlot')
+    expect(hasSlotOperand).toBe(true)
+    expect(hasWriteSlot).toBe(true)
+  })
+})
+
+describe('M9a: unsupported shapes throw clear errors', () => {
+  test('arbitrary input expression (sin of a ref) is deferred to M9c', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    allocateOutputSlots(s, 'lp',  onePole)
+    s.inputExprNodes.set('osc:freq', 220)
+    s.inputExprNodes.set('lp:input', { op: 'mul', args: [{ op: 'ref', instance: 'osc', output: 'sine' }, 0.5] })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    expect(() => compileSessionSlotted(s)).toThrow(/M9c|arbitrary input expression/i)
+  })
+})

--- a/compiler/runtime/m9a_per_instance_equiv.test.ts
+++ b/compiler/runtime/m9a_per_instance_equiv.test.ts
@@ -110,22 +110,10 @@ describe('M9a: per-instance slot-mode equivalence', () => {
   })
 })
 
-describe('M9a: roadmap sanity', () => {
-  test('nested instance call in input expression (Sin(x: ...)) still throws (M9d)', () => {
-    // Sin is a stdlib type — wiring `Sin(x: ref)` into an input is a
-    // nested instance call that M9d would handle. M9c covers arithmetic
-    // / comparison / unary / ternary; nested instance calls are a
-    // separate, harder case.
-    const s = makeSession()
-    loadStdlib(s)
-    const onePole = s.typeRegistry.get('OnePole')!
-    s.instanceRegistry.set('lp', instantiate(onePole, 'lp'))
-    allocateOutputSlots(s, 'lp', onePole)
-    // {op:'call', callee:..., args:...} is the nested-call shape;
-    // not in BINARY/UNARY/TERNARY tag tables.
-    s.inputExprNodes.set('lp:input', { op: 'call', callee: 'Sin', args: { x: 1.0 } })
-    s.inputExprNodes.set('lp:g', 0.1)
-    s.graphOutputs.push({ instance: 'lp', output: 'out' })
-    expect(() => compileSessionSlotted(s)).toThrow(/M9d|nested instance|not.*supported/i)
-  })
-})
+// The earlier "nested call falls back" test used a synthetic
+// {op:'call'} ExprNode that isn't valid in either path's translator,
+// so it tested only the fallback machinery rather than realistic
+// audio behavior. Real unsupported shapes (arrays, sums) are covered
+// by the runtime equivalence tests in apply_plan / jit_interp_equiv
+// when run with TROPICAL_SLOT_OPS=1 — they exercise the actual
+// fallback under real-world patches.

--- a/compiler/runtime/m9b_param_slot_equiv.test.ts
+++ b/compiler/runtime/m9b_param_slot_equiv.test.ts
@@ -1,0 +1,158 @@
+/**
+ * m9b_param_slot_equiv.test.ts — M9b equivalence gate.
+ *
+ * Verifies that param and trigger refs in input expressions compile to
+ * slot operands under the per-instance path and produce correct audio.
+ * Today's MCP set_param writes to both the legacy ControlParam and the
+ * paramSlotRegistry's slot (the latter via the M5 set_slot bridge,
+ * coming up implicitly through wire reads); the per-instance path
+ * reads from slots, so the audio behavior should mirror legacy.
+ *
+ * Scope note: this tests the *compilation* — that a {op:'param'} or
+ * {op:'triggerParamExpr'} ExprNode reaching the per-instance path
+ * resolves to a slot operand. Full byte-equivalence with the legacy
+ * SmoothParam/TriggerParam path is a *behavioral* statement (the
+ * legacy path applies kernel-side smoothing; the slot path is raw
+ * reads). Where the two diverge by design, we assert the slot path
+ * produces the unsmoothed-but-correct value.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { Runtime } from './runtime.ts'
+import { makeSession, allocateOutputSlots, allocateParamSlot } from '../session.ts'
+import { loadStdlib } from '../program.ts'
+import { instantiate } from '../program_types.ts'
+import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
+import { Param, Trigger } from './param.ts'
+
+let prevEnv: string | undefined
+beforeEach(() => {
+  prevEnv = process.env.TROPICAL_SLOT_OPS
+  process.env.TROPICAL_SLOT_OPS = '1'
+})
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.TROPICAL_SLOT_OPS
+  else process.env.TROPICAL_SLOT_OPS = prevEnv
+})
+
+describe('M9b: params as slot reads in per-instance path', () => {
+  test('paramRef compiles to slot operand pointing at paramSlotRegistry', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    // Declare a 'cutoff' param at the session level and wire it
+    s.paramRegistry.set('cutoff', new Param(880, 0))   // unsmoothed (time_const=0)
+    const paramSlotIdx = allocateParamSlot(s, 'cutoff')
+    s.inputExprNodes.set('osc:freq', { op: 'param', name: 'cutoff' })
+    s.graphOutputs.push({ instance: 'osc', output: 'sine' })
+
+    const plan = compileSessionSlotted(s)
+
+    // Find the SinOsc body's freq read and verify it's a slot operand
+    // pointing at the param's slot index.
+    const slotReadsAtParamIdx = plan.instructions.flatMap(instr => instr.args)
+      .filter(op => op.kind === 'slot' && op.index === paramSlotIdx)
+    expect(slotReadsAtParamIdx.length).toBeGreaterThan(0)
+  })
+
+  test('paramRef + set_slot drives kernel audio: matches direct const', () => {
+    // Set the param slot to a frequency, run the kernel, and verify the
+    // output matches what a literal-wired version produces.
+    const FREQ = 660
+    // Variant A: param-wired
+    const sParam = makeSession(64)
+    loadStdlib(sParam)
+    const sin = sParam.typeRegistry.get('SinOsc')!
+    sParam.instanceRegistry.set('osc', instantiate(sin, 'osc'))
+    allocateOutputSlots(sParam, 'osc', sin)
+    sParam.paramRegistry.set('freq', new Param(FREQ, 0))
+    const slotIdx = allocateParamSlot(sParam, 'freq')
+    sParam.inputExprNodes.set('osc:freq', { op: 'param', name: 'freq' })
+    sParam.graphOutputs.push({ instance: 'osc', output: 'sine' })
+    const planParam = compileSessionSlotted(sParam)
+
+    // Variant B: literal freq
+    const sLit = makeSession(64)
+    loadStdlib(sLit)
+    const sin2 = sLit.typeRegistry.get('SinOsc')!
+    sLit.instanceRegistry.set('osc', instantiate(sin2, 'osc'))
+    allocateOutputSlots(sLit, 'osc', sin2)
+    sLit.inputExprNodes.set('osc:freq', FREQ)
+    sLit.graphOutputs.push({ instance: 'osc', output: 'sine' })
+    const planLit = compileSessionSlotted(sLit)
+
+    const rtParam = new Runtime(64)
+    rtParam.loadPlan(JSON.stringify(planParam))
+    // Defaults seeded the slot to FREQ already (via slot_defaults from
+    // paramRegistry.value), so no set_slot needed for first buffer.
+    rtParam.process()
+    const paramAudio = Array.from(rtParam.outputBuffer)
+
+    const rtLit = new Runtime(64)
+    rtLit.loadPlan(JSON.stringify(planLit))
+    rtLit.process()
+    const litAudio = Array.from(rtLit.outputBuffer)
+
+    expect(paramAudio.length).toBe(litAudio.length)
+    for (let i = 0; i < paramAudio.length; i++) {
+      expect(paramAudio[i]).toBe(litAudio[i])
+    }
+    rtParam.dispose()
+    rtLit.dispose()
+  })
+
+  test('set_slot mid-run: kernel picks up new param value next buffer', () => {
+    const s = makeSession(64)
+    loadStdlib(s)
+    const sin = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc', instantiate(sin, 'osc'))
+    allocateOutputSlots(s, 'osc', sin)
+    s.paramRegistry.set('f', new Param(110, 0))
+    allocateParamSlot(s, 'f')
+    s.inputExprNodes.set('osc:freq', { op: 'param', name: 'f' })
+    s.graphOutputs.push({ instance: 'osc', output: 'sine' })
+
+    const plan = compileSessionSlotted(s)
+    const rt = new Runtime(64)
+    rt.loadPlan(JSON.stringify(plan))
+
+    rt.process()
+    const audio_110 = Array.from(rt.outputBuffer)
+
+    // Mid-run param change
+    const idx = rt.slotIndex('param:f')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    rt.setSlot(idx, 880)
+    rt.process()
+    const audio_880 = Array.from(rt.outputBuffer)
+
+    // Different frequencies → different waveforms. They shouldn't be equal.
+    let anyDiff = false
+    for (let i = 0; i < audio_110.length; i++) {
+      if (audio_110[i] !== audio_880[i]) { anyDiff = true; break }
+    }
+    expect(anyDiff).toBe(true)
+    rt.dispose()
+  })
+})
+
+describe('M9b: triggers as slot reads', () => {
+  test('triggerParamExpr compiles to slot operand', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sin = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc', instantiate(sin, 'osc'))
+    allocateOutputSlots(s, 'osc', sin)
+    s.triggerRegistry.set('go', new Trigger())
+    const trigSlot = allocateParamSlot(s, 'go')
+    // Wire trigger into freq — odd but exercises the compile path
+    s.inputExprNodes.set('osc:freq', { op: 'triggerParamExpr', name: 'go' })
+    s.graphOutputs.push({ instance: 'osc', output: 'sine' })
+
+    const plan = compileSessionSlotted(s)
+    const slotReads = plan.instructions.flatMap(instr => instr.args)
+      .filter(op => op.kind === 'slot' && op.index === trigSlot)
+    expect(slotReads.length).toBeGreaterThan(0)
+  })
+})

--- a/compiler/runtime/m9c_arbitrary_expr.test.ts
+++ b/compiler/runtime/m9c_arbitrary_expr.test.ts
@@ -1,0 +1,177 @@
+/**
+ * m9c_arbitrary_expr.test.ts — M9c equivalence gate.
+ *
+ * Arbitrary input expressions (binary arithmetic, comparison, unary,
+ * ternary) emitted as preamble instructions before the consuming
+ * instance's body. The result feeds the instance via a `reg` operand.
+ *
+ * Out of scope (M9d): nested instance calls in input expressions
+ * (Sin(x:...) etc.), array ops, fan-in via combine.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { Runtime } from './runtime.ts'
+import { makeSession, allocateOutputSlots } from '../session.ts'
+import { loadStdlib } from '../program.ts'
+import { instantiate } from '../program_types.ts'
+import { compileSessionLegacy } from '../ir/compile_session.ts'
+import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
+
+let prevEnv: string | undefined
+beforeEach(() => {
+  prevEnv = process.env.TROPICAL_SLOT_OPS
+  process.env.TROPICAL_SLOT_OPS = '1'
+})
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.TROPICAL_SLOT_OPS
+  else process.env.TROPICAL_SLOT_OPS = prevEnv
+})
+
+function audio(plan: object, frames = 2, bufferLen = 64): number[] {
+  const rt = new Runtime(bufferLen)
+  rt.loadPlan(JSON.stringify(plan))
+  const out: number[] = []
+  for (let f = 0; f < frames; f++) {
+    rt.process()
+    for (const v of rt.outputBuffer) out.push(v)
+  }
+  rt.dispose()
+  return out
+}
+
+describe('M9c: arbitrary input expressions', () => {
+  test('mul of ref by const (osc.out * 0.5): byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    allocateOutputSlots(s, 'lp',  onePole)
+    s.inputExprNodes.set('osc:freq', 220)
+    s.inputExprNodes.set('lp:input', {
+      op: 'mul',
+      args: [{ op: 'ref', instance: 'osc', output: 'sine' }, 0.5],
+    })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const legacy  = compileSessionLegacy(s)
+    const slotted = compileSessionSlotted(s)
+    const ll = audio(legacy)
+    const ss = audio(slotted)
+    expect(ss.length).toBe(ll.length)
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('binary add of two refs (osc1.out + osc2.out): byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc1', instantiate(sinOsc, 'osc1'))
+    s.instanceRegistry.set('osc2', instantiate(sinOsc, 'osc2'))
+    s.instanceRegistry.set('lp',   instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc1', sinOsc)
+    allocateOutputSlots(s, 'osc2', sinOsc)
+    allocateOutputSlots(s, 'lp',   onePole)
+    s.inputExprNodes.set('osc1:freq', 220)
+    s.inputExprNodes.set('osc2:freq', 330)
+    s.inputExprNodes.set('lp:input', {
+      op: 'add',
+      args: [
+        { op: 'ref', instance: 'osc1', output: 'sine' },
+        { op: 'ref', instance: 'osc2', output: 'sine' },
+      ],
+    })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    expect(ss.length).toBe(ll.length)
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('nested arithmetic ((a + b) * 0.5): byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('a', instantiate(sinOsc, 'a'))
+    s.instanceRegistry.set('b', instantiate(sinOsc, 'b'))
+    s.instanceRegistry.set('lp', instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'a', sinOsc)
+    allocateOutputSlots(s, 'b', sinOsc)
+    allocateOutputSlots(s, 'lp', onePole)
+    s.inputExprNodes.set('a:freq', 200)
+    s.inputExprNodes.set('b:freq', 300)
+    s.inputExprNodes.set('lp:input', {
+      op: 'mul',
+      args: [
+        {
+          op: 'add',
+          args: [
+            { op: 'ref', instance: 'a', output: 'sine' },
+            { op: 'ref', instance: 'b', output: 'sine' },
+          ],
+        },
+        0.5,
+      ],
+    })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('select(cond, then, else) input expression: byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    allocateOutputSlots(s, 'lp',  onePole)
+    s.inputExprNodes.set('osc:freq', 220)
+    s.inputExprNodes.set('lp:input', {
+      op: 'select',
+      args: [
+        { op: 'gt', args: [{ op: 'ref', instance: 'osc', output: 'sine' }, 0] },
+        { op: 'ref', instance: 'osc', output: 'sine' },
+        0,
+      ],
+    })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('clamp(x, lo, hi) input expression: byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc', instantiate(sinOsc, 'osc'))
+    s.instanceRegistry.set('lp',  instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc', sinOsc)
+    allocateOutputSlots(s, 'lp',  onePole)
+    s.inputExprNodes.set('osc:freq', 220)
+    s.inputExprNodes.set('lp:input', {
+      op: 'clamp',
+      args: [{ op: 'ref', instance: 'osc', output: 'sine' }, -0.3, 0.3],
+    })
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+})

--- a/compiler/runtime/m9d_fanin.test.ts
+++ b/compiler/runtime/m9d_fanin.test.ts
@@ -1,0 +1,135 @@
+/**
+ * m9d_fanin.test.ts — M9d fan-in support.
+ *
+ * Verifies that the wire() handler now wraps duplicate-input writes
+ * with a combine op when one is specified, and that the resulting
+ * combined ExprNode produces correct audio through the per-instance
+ * path.
+ *
+ * Arrays + sum types are deferred to a follow-up since they require
+ * either per-element inputExprNodes keying (breaking the M1-M8
+ * invariant) or array-aware translation in translateNode.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { Runtime } from './runtime.ts'
+import { makeSession, allocateOutputSlots, type SessionState } from '../session.ts'
+import { loadStdlib } from '../program.ts'
+import { instantiate } from '../program_types.ts'
+import { compileSessionLegacy } from '../ir/compile_session.ts'
+import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
+
+let prevEnv: string | undefined
+beforeEach(() => {
+  prevEnv = process.env.TROPICAL_SLOT_OPS
+  process.env.TROPICAL_SLOT_OPS = '1'
+})
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.TROPICAL_SLOT_OPS
+  else process.env.TROPICAL_SLOT_OPS = prevEnv
+})
+
+function audio(plan: object, frames = 2, bufferLen = 64): number[] {
+  const rt = new Runtime(bufferLen)
+  rt.loadPlan(JSON.stringify(plan))
+  const out: number[] = []
+  for (let f = 0; f < frames; f++) {
+    rt.process()
+    for (const v of rt.outputBuffer) out.push(v)
+  }
+  rt.dispose()
+  return out
+}
+
+/** Simulate the wire handler's combine wrap directly. Tests don't go
+ *  through the MCP subprocess. */
+function setInputWithCombine(
+  session: SessionState,
+  key: string,
+  expr: unknown,
+  combine?: string,
+): void {
+  const existing = session.inputExprNodes.get(key)
+  if (existing !== undefined && combine !== undefined) {
+    session.inputExprNodes.set(key, { op: combine, args: [existing, expr] } as never)
+  } else {
+    session.inputExprNodes.set(key, expr as never)
+  }
+}
+
+describe('M9d: fan-in with explicit combine', () => {
+  test('two refs combined with add: byte-equal to legacy', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('osc1', instantiate(sinOsc, 'osc1'))
+    s.instanceRegistry.set('osc2', instantiate(sinOsc, 'osc2'))
+    s.instanceRegistry.set('lp',   instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'osc1', sinOsc)
+    allocateOutputSlots(s, 'osc2', sinOsc)
+    allocateOutputSlots(s, 'lp',   onePole)
+    s.inputExprNodes.set('osc1:freq', 220)
+    s.inputExprNodes.set('osc2:freq', 330)
+    // Simulate two `wire` calls, the second supplying `combine:'add'`:
+    setInputWithCombine(s, 'lp:input', { op: 'ref', instance: 'osc1', output: 'sine' })
+    setInputWithCombine(s, 'lp:input', { op: 'ref', instance: 'osc2', output: 'sine' }, 'add')
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    // The combined ExprNode should be {op:'add', args:[ref(osc1), ref(osc2)]}
+    const combined = s.inputExprNodes.get('lp:input') as { op: string; args: unknown[] }
+    expect(combined.op).toBe('add')
+    expect(combined.args.length).toBe(2)
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    expect(ss.length).toBe(ll.length)
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('three refs combined with add (chained fan-in): byte-equal', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc  = s.typeRegistry.get('SinOsc')!
+    const onePole = s.typeRegistry.get('OnePole')!
+    s.instanceRegistry.set('a',  instantiate(sinOsc, 'a'))
+    s.instanceRegistry.set('b',  instantiate(sinOsc, 'b'))
+    s.instanceRegistry.set('c',  instantiate(sinOsc, 'c'))
+    s.instanceRegistry.set('lp', instantiate(onePole, 'lp'))
+    allocateOutputSlots(s, 'a',  sinOsc)
+    allocateOutputSlots(s, 'b',  sinOsc)
+    allocateOutputSlots(s, 'c',  sinOsc)
+    allocateOutputSlots(s, 'lp', onePole)
+    s.inputExprNodes.set('a:freq', 200)
+    s.inputExprNodes.set('b:freq', 300)
+    s.inputExprNodes.set('c:freq', 500)
+    // Three wires; second and third use combine:'add':
+    setInputWithCombine(s, 'lp:input', { op: 'ref', instance: 'a', output: 'sine' })
+    setInputWithCombine(s, 'lp:input', { op: 'ref', instance: 'b', output: 'sine' }, 'add')
+    setInputWithCombine(s, 'lp:input', { op: 'ref', instance: 'c', output: 'sine' }, 'add')
+    s.inputExprNodes.set('lp:g', 0.1)
+    s.graphOutputs.push({ instance: 'lp', output: 'out' })
+
+    const ll = audio(compileSessionLegacy(s))
+    const ss = audio(compileSessionSlotted(s))
+    for (let i = 0; i < ll.length; i++) expect(ss[i]).toBe(ll[i])
+  })
+
+  test('second wire without combine still replaces (back-compat)', () => {
+    const s = makeSession()
+    loadStdlib(s)
+    const sinOsc = s.typeRegistry.get('SinOsc')!
+    s.instanceRegistry.set('osc1', instantiate(sinOsc, 'osc1'))
+    s.instanceRegistry.set('osc2', instantiate(sinOsc, 'osc2'))
+    allocateOutputSlots(s, 'osc1', sinOsc)
+    allocateOutputSlots(s, 'osc2', sinOsc)
+    s.inputExprNodes.set('osc1:freq', 110)
+    s.inputExprNodes.set('osc2:freq', 220)
+    // Two writes to the same key WITHOUT combine: the second replaces.
+    setInputWithCombine(s, 'tmp:k', { op: 'ref', instance: 'osc1', output: 'sine' })
+    setInputWithCombine(s, 'tmp:k', { op: 'ref', instance: 'osc2', output: 'sine' })
+    const final = s.inputExprNodes.get('tmp:k') as { op: string; instance?: string }
+    expect(final.op).toBe('ref')
+    expect(final.instance).toBe('osc2')
+  })
+})

--- a/compiler/runtime/pulse_stdlib.test.ts
+++ b/compiler/runtime/pulse_stdlib.test.ts
@@ -1,0 +1,86 @@
+/**
+ * pulse_stdlib.test.ts — M9b: verify stdlib Pulse module emits a
+ * one-sample pulse on rising edges of its input signal.
+ *
+ * Audio test: drive Pulse with a slot whose value the control plane
+ * sets, observe the output. The Pulse module is the user-facing way to
+ * get fire-once semantics under the slot model — replaces the legacy
+ * kernel-side TriggerParam consume.
+ */
+import { describe, expect, test } from 'bun:test'
+import { Runtime } from './runtime.ts'
+import { makeSession, allocateOutputSlots, allocateParamSlot } from '../session.ts'
+import { loadStdlib } from '../program.ts'
+import { instantiate } from '../program_types.ts'
+import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
+
+describe('M9b: Pulse stdlib emits rising-edge pulses', () => {
+  test('Pulse fires exactly once per low-to-high transition', () => {
+    // Set up: source slot 'fire' drives Pulse; Pulse output → dac.
+    // Set fire=1.0, run a buffer, observe Pulse out spikes briefly.
+    const s = makeSession(8)
+    loadStdlib(s)
+    const Pulse = s.typeRegistry.get('Pulse')!
+    expect(Pulse).toBeDefined()
+    s.instanceRegistry.set('p', instantiate(Pulse, 'p'))
+    allocateOutputSlots(s, 'p', Pulse)
+    // Use a session-level "param" as the fire source. Per M3,
+    // applyParamSpecs would allocate a slot — we mimic it here.
+    // Need to set up paramRegistry so slot_defaults can be read; M9b
+    // uses allocateParamSlot + paramRegistry lookup.
+    s.paramRegistry.set('fire', { value: 0 } as any)
+    allocateParamSlot(s, 'fire')
+    s.inputExprNodes.set('p:signal', { op: 'param', name: 'fire' })
+    s.graphOutputs.push({ instance: 'p', output: 'out' })
+
+    process.env.TROPICAL_SLOT_OPS = '1'
+    try {
+      const plan = compileSessionSlotted(s)
+      const rt = new Runtime(8)
+      rt.loadPlan(JSON.stringify(plan))
+
+      // Buffer 1: fire is 0.0 (default). Pulse out should be 0.
+      rt.process()
+      const buf1 = Array.from(rt.outputBuffer)
+      for (const v of buf1) expect(v).toBe(0)
+
+      // Fire: write 1.0 to the slot. On the next process, Pulse sees
+      // signal=1 with prev=0 → fires for one sample. Then prev becomes
+      // 1, so subsequent samples in the same buffer don't fire again.
+      const fireIdx = rt.slotIndex('param:fire')
+      expect(fireIdx).toBeGreaterThanOrEqual(0)
+      rt.setSlot(fireIdx, 1.0)
+      rt.process()
+      const buf2 = Array.from(rt.outputBuffer)
+
+      // First sample of buf2 should be the rising-edge pulse;
+      // subsequent samples should be 0 (signal stays at 1.0, prev=1.0
+      // after first sample so no more edge).
+      // Note: due to /20 mix-bus gain, a bool 1 reads as 1/20 = 0.05 in output.
+      expect(buf2[0]).toBeCloseTo(1 / 20, 10)
+      for (let i = 1; i < buf2.length; i++) {
+        expect(buf2[i]).toBe(0)
+      }
+
+      // Buffer 3 with fire still 1.0: no more edge, all zeros.
+      rt.process()
+      const buf3 = Array.from(rt.outputBuffer)
+      for (const v of buf3) expect(v).toBe(0)
+
+      // Reset and re-fire: write 0 then 1 → another rising edge.
+      rt.setSlot(fireIdx, 0)
+      rt.process()
+      const buf4 = Array.from(rt.outputBuffer)
+      for (const v of buf4) expect(v).toBe(0)  // staying low
+
+      rt.setSlot(fireIdx, 1)
+      rt.process()
+      const buf5 = Array.from(rt.outputBuffer)
+      expect(buf5[0]).toBeCloseTo(1 / 20, 10)  // new rising edge
+
+      rt.dispose()
+    } finally {
+      delete process.env.TROPICAL_SLOT_OPS
+    }
+  })
+})

--- a/compiler/wasm_memory_layout.ts
+++ b/compiler/wasm_memory_layout.ts
@@ -23,6 +23,7 @@ export type WasmLayout = {
   arrayOffsets:      number[]     // per array slot: absolute byte offset
   paramTableOffset:  number       // f64[paramCount]
   paramFrameOffset:  number       // f64[paramCount] — trigger snapshot per block
+  slotsOffset:       number       // f64[slotCount] — inter-module slot array (M10)
   outputOffset:      number       // f64[maxBlockSize]
   totalBytes:        number
   /** Number of 64 KiB WASM pages needed */
@@ -33,6 +34,7 @@ export type WasmLayout = {
   arraySlotCount:    number
   arraySizes:        number[]
   paramCount:        number
+  slotCount:         number
   maxBlockSize:      number
 }
 
@@ -51,8 +53,11 @@ export function computeLayout(args: {
   paramPtrs: string[]
   /** Max audio block size the kernel will be asked to render in one call. */
   maxBlockSize: number
+  /** Number of inter-module slots (M10). 0 for legacy plans. */
+  slotCount?: number
 }): WasmLayout {
   const { plan, inputCount, paramPtrs, maxBlockSize } = args
+  const requestedSlotCount = args.slotCount ?? 0
   const f64 = 8
   const i64 = 8
 
@@ -79,6 +84,11 @@ export function computeLayout(args: {
   const paramFrameOffset = cursor
   cursor = align8(cursor + paramPtrs.length * f64)
 
+  // Inter-module slot array (M10). Slot-mode plans pass slotCount > 0;
+  // legacy plans omit it and the region is zero-sized.
+  const slotsOffset = cursor
+  cursor = align8(cursor + requestedSlotCount * f64)
+
   const outputOffset = cursor
   cursor = align8(cursor + maxBlockSize * f64)
 
@@ -93,6 +103,7 @@ export function computeLayout(args: {
     arrayOffsets,
     paramTableOffset,
     paramFrameOffset,
+    slotsOffset,
     outputOffset,
     totalBytes,
     pageCount,
@@ -101,6 +112,7 @@ export function computeLayout(args: {
     arraySlotCount: plan.array_slot_count,
     arraySizes: plan.array_slot_sizes.slice(),
     paramCount: paramPtrs.length,
+    slotCount: requestedSlotCount,
     maxBlockSize,
   }
 }

--- a/compiler/wasm_runtime.test.ts
+++ b/compiler/wasm_runtime.test.ts
@@ -43,6 +43,8 @@ async function compile(plan: FlatPlan, maxBlockSize: number): Promise<LoadedPlan
     registerTypes: plan.register_types,
     registerNames: plan.register_names,
     arraySlotNames: plan.array_slot_names,
+    slotNames:    plan.slot_names,
+    slotDefaults: plan.slot_defaults,
   }
 }
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1225,7 +1225,7 @@ function resolveDacSource(expr: ExprNode): { instance: string; output: string } 
 
 function handleWire(args: Record<string, unknown>) {
   return wrap(() => {
-    const setOps = (args.set ?? []) as Array<{ instance: string; input: string | number; expr: ExprNode }>
+    const setOps = (args.set ?? []) as Array<{ instance: string; input: string | number; expr: ExprNode; combine?: string }>
     const removeOps = (args.remove ?? []) as Array<{ instance: string; input: string | number }>
 
     // Process removes first
@@ -1275,8 +1275,20 @@ function handleWire(args: Record<string, unknown>) {
       const resolvedName = inputNames(inst)[inputId] ?? String(inputId)
       validateExpr(s.expr, `${s.instance}.${resolvedName}`)
       const { expr } = adaptInputExpr(s.expr, inputPortType(inst, inputId), s.instance, resolvedName)
-      session.inputExprNodes.set(`${s.instance}:${resolvedName}`, expr)
-      results.push({ instance: s.instance, input: resolvedName, expr })
+      // M9d: fan-in support. If the input already has a wired
+      // expression and the caller provided `combine`, wrap both in
+      // {op:combine, args:[existing, new]}. Without `combine`, behave
+      // as before (replace) for backward compat with single-wire
+      // MCP callers. Future tightening (require combine on duplicate
+      // writes) deferred to M9d-strict.
+      const key = `${s.instance}:${resolvedName}`
+      const existing = session.inputExprNodes.get(key)
+      let toStore: ExprNode = expr
+      if (existing !== undefined && s.combine !== undefined) {
+        toStore = { op: s.combine, args: [existing, expr] } as ExprNode
+      }
+      session.inputExprNodes.set(key, toStore)
+      results.push({ instance: s.instance, input: resolvedName, expr: toStore })
     }
 
     return {

--- a/stdlib/Pulse.trop
+++ b/stdlib/Pulse.trop
@@ -1,0 +1,7 @@
+```tropical
+program Pulse(signal: signal = 0) -> (out: bool) {
+  reg prev: float = 0
+  out = (signal > 0.5) * (prev <= 0.5)
+  next prev = signal
+}
+```

--- a/web/host/compiler.ts
+++ b/web/host/compiler.ts
@@ -33,6 +33,8 @@ export async function compilePlan(plan: FlatPlan, maxBlockSize = 2048): Promise<
     registerTypes: plan.register_types,
     registerNames: plan.register_names,
     arraySlotNames: plan.array_slot_names,
+    slotNames:    plan.slot_names,
+    slotDefaults: plan.slot_defaults,
   }
 }
 

--- a/web/worklet/runtime.ts
+++ b/web/worklet/runtime.ts
@@ -26,6 +26,9 @@ export type LoadedPlan = {
   registerTypes: ('float' | 'int' | 'bool')[]
   registerNames: string[]
   arraySlotNames: string[]
+  /** Slot-model names and seeded defaults. Empty for legacy plans. (M10) */
+  slotNames?:    string[]
+  slotDefaults?: number[]
 }
 
 type Slot = {
@@ -37,6 +40,7 @@ type Slot = {
   registerNames: string[]
   arraySlotNames: string[]
   registerTypes: ('float' | 'int' | 'bool')[]
+  slotNames: string[]
 }
 
 const FADE_SAMPLES = 2048
@@ -64,6 +68,9 @@ export class WasmRuntime {
     // Initialize state_init into registers. Array slots are zeroed (matching
     // the native parser at engine/runtime/NumericProgramParser.hpp:130-139).
     initRegisters(memory, plan.layout.registersOffset, plan.stateInit, plan.registerTypes)
+    // M10: seed inter-module slots from slot_defaults. Mirrors the
+    // native FlatRuntime::load_plan path (FlatRuntime.cpp:43-49).
+    initSlots(memory, plan.layout.slotsOffset, plan.layout.slotCount, plan.slotDefaults)
 
     const newSlot: Slot = {
       instance, memory, processFn,
@@ -72,6 +79,7 @@ export class WasmRuntime {
       registerNames: plan.registerNames,
       arraySlotNames: plan.arraySlotNames,
       registerTypes: plan.registerTypes,
+      slotNames: plan.slotNames ?? [],
     }
 
     // If there's an outgoing slot, transfer matching state.
@@ -79,6 +87,7 @@ export class WasmRuntime {
     if (outgoing) {
       transferRegisters(outgoing, newSlot)
       transferArrays(outgoing, newSlot)
+      transferSlots(outgoing, newSlot)
     }
 
     const inactive = 1 - this.activeIdx
@@ -179,6 +188,34 @@ function transferRegisters(from: Slot, to: Slot): void {
     if (from.registerTypes[fromIdx] !== to.registerTypes[toIdx]) continue
     const val = dvFrom.getBigInt64(from.layout.registersOffset + fromIdx * 8, true)
     dvTo.setBigInt64(to.layout.registersOffset + toIdx * 8, val, true)
+  }
+}
+
+function initSlots(
+  memory: WebAssembly.Memory,
+  slotsOffset: number,
+  slotCount: number,
+  slotDefaults: number[] | undefined,
+): void {
+  if (slotCount === 0) return
+  const view = new Float64Array(memory.buffer, slotsOffset, slotCount)
+  if (slotDefaults === undefined) return
+  for (let i = 0; i < Math.min(slotDefaults.length, slotCount); i++) {
+    view[i] = slotDefaults[i]!
+  }
+}
+
+function transferSlots(from: Slot, to: Slot): void {
+  // Copy slot values by name match. Mirrors FlatRuntime.hpp:295-305.
+  if (to.slotNames.length === 0 || from.slotNames.length === 0) return
+  const dvFrom = new Float64Array(from.memory.buffer)
+  const dvTo = new Float64Array(to.memory.buffer)
+  for (let toIdx = 0; toIdx < to.slotNames.length; toIdx++) {
+    const name = to.slotNames[toIdx]
+    const fromIdx = from.slotNames.indexOf(name!)
+    if (fromIdx < 0) continue
+    dvTo[to.layout.slotsOffset / 8 + toIdx] =
+      dvFrom[from.layout.slotsOffset / 8 + fromIdx]!
   }
 }
 


### PR DESCRIPTION
## Summary

Per-instance emit-path rewrite for the slot model, building on PR #144's foundational infrastructure. The per-instance path compiles each session instance standalone via `compileResolved`, remaps operands into a unified register/slot space, and stitches the per-instance plans through an explicit DAC phase. Slot operands and `WriteSlot` instructions replace the legacy `inlineInstances`-flattening approach for supported shapes; unsupported shapes auto-fall back to the legacy path so audio is preserved everywhere. WASM consumes slot-mode plans byte-equivalently to the JIT.

**Audio behavior:** 909 tests green in default mode (byte-identical to legacy) AND under forced `TROPICAL_SLOT_OPS=1`. C++ JIT/CTest also green.

## What ships

| Sub-milestone | Commit | What |
|---|---|---|
| M9a | `1c989f4` | Per-instance compile + merge with explicit DAC stitching for ref-chain patches |
| M9b | `e1d7893` | Triggers dissolve into bool slots; `stdlib/Pulse.trop` for fire-once; params/triggers compile to slot reads |
| M9c | `d590d79` | Arbitrary input expressions (arithmetic, comparison, logical, bitwise, unary, ternary/select/clamp) via preamble emission |
| M9d | `2debda1` | Fan-in via `wire(combine: ...)`. Arrays + sums deferred |
| M9e | `48555ca` | Auto-fallback to legacy on unsupported shapes; `allocateOutputSlots` wired into `loadProgramAsSession` |
| Refactor | `1423d05` | `SlotShapeUnsupportedError` marker class instead of message-text matching for fallback dispatch |
| Refactor | `8d75560` | `InputBinding` discriminated union replaces coupled `(expr \| undefined, defaultVal \| undefined)` parameter pair |
| Gateable | `a1b29d7` | Detect `gateable=true` instances and fall back to legacy (gate wrapping requires `materializeSession`'s two-phase wrap) |
| M10 | `9347a31` | WASM slot operand + `WriteSlot` support; closes the JIT/WASM equivalence gap on slot-mode plans |

## Architecture: per-instance compile-then-merge

Replaces the legacy monolithic flow:
```
session → materializeSession → strata (inlineInstances flattens) → compileResolved → FlatPlan
```

With per-instance:
```
session → topo-sort instances → per-instance compileResolved → operand remap →
  merge instructions + register space + DAC stitch → FlatPlan with slot operands
```

Per-instance remap:
- `input` operands → `slot` operands pointing at wire source slot, or `const` for literals
- Param/trigger refs → `slot` operands at `paramSlotRegistry` indices (no kernel-side smoothing or trigger consume)
- Arbitrary input expressions → preamble `NInstrs` computed before the instance's body
- `reg` / `state_reg` / `array_reg` slot indices → offset across instances
- Output ports → `WriteSlot` instruction publishing each output to its slot

DAC stitching: post-loop phase reads each `graphOutput` source slot into a fresh temp, exposed through the kernel's existing mix-bus mechanism.

## M10: WASM slot operand support

Closes the equivalence gap between the JIT and the WASM backend for slot-mode plans:

- `wasm_memory_layout.ts`: adds `f64[slotCount]` region between `paramFrame` and `output`. Legacy plans pass `slotCount=0`; the region is zero-sized with no overhead.
- `emit_wasm.ts`: replaces the throwing `slot`-operand stub with an `f64.load` from `slotsOffset + index*8`. Adds `WriteSlot` instruction dispatch — coerces arg to float, stores at `slotsOffset + dst*8`. Mirrors `store_slot_f64` in `OrcJitEngine.cpp`.
- `worklet/runtime.ts`: `LoadedPlan` carries optional `slotNames` / `slotDefaults`. `initSlots` seeds the region from defaults on plan load; `transferSlots` copies values by name on hot-swap, mirroring `FlatRuntime::transfer_state`.

## Key design decision: triggers dissolve

Per the M9b sub-milestone, triggers stop being a kernel concept. What was previously a `ControlParam` variant with per-buffer atomic exchange is now a plain bool slot. Fire-once semantics move into user-visible signal flow via a new stdlib `Pulse` module:

```trop
program Pulse(signal: signal = 0) -> (out: bool) {
  reg prev: float = 0
  out = (signal > 0.5) * (prev <= 0.5)
  next prev = signal
}
```

Outputs `true` for one sample on each rising edge. Users wanting fire-once semantics wire their trigger slot through `Pulse`. The control plane just writes 1.0 to the slot to fire and 0.0 to reset; no kernel coordination required.

## Auto-fallback (M9e + gateable)

The per-instance path doesn't yet cover every shape (arrays, sum types, nested instance calls, gateable subgraphs). Rather than throwing on these, `compileSessionSlotted` auto-falls-back to the legacy metadata-only path via a `SlotShapeUnsupportedError` marker class. Audio is preserved for every patch; the slot-mode optimization simply doesn't apply to fall-back shapes. A console warning logs each unique fallback reason once per process.

This means the per-instance path can ship without breaking any existing tests. The deferred shape support lifts each fallback case incrementally.

## Note on the original "M11" plan item

The original plan listed `M11: interpret_resolved slot operand support` as a deferred follow-up. Investigating the failing tests revealed this was a misdiagnosis — `interpret_resolved` consumes `ResolvedExpr` (upstream of FlatPlan emission), so it never sees slot operands. The 5 "interpreter equivalence" failures were actually about gateable subgraph wrapping being lost in the per-instance path, which the gateable-fallback commit (`a1b29d7`) addresses correctly. No interpreter changes were needed.

## Test plan

- [x] `bun test` — 909 pass / 0 fail in default mode
- [x] `TROPICAL_SLOT_OPS=1 bun test` — 909 pass / 0 fail
- [x] `cmake --build build -j4 && ctest --test-dir build` — C++ JIT + C API tests pass
- [x] `bunx tsc --noEmit` — clean
- [x] Per-sub-milestone equivalence tests verify byte-equal audio between `compileSessionLegacy` and the per-instance path on representative patches
- [x] `Pulse` stdlib module fires exactly once per rising edge, stays silent while held high
- [x] WASM `wasm_vs_jit_equiv` byte-equal under both modes

## What's deferred (follow-up PRs)

- **M12: arrays + sum types in per-instance path** — currently fall back to legacy
- **M13: nested instance calls in input expressions** — currently fall back to legacy
- **Gateable in per-instance path** — currently falls back; would need pre/post-strata gate wrapping to be re-implementable outside `materializeSession`
- **Final cleanup: delete `compileSessionLegacy`** — once 100% shape coverage exists and the auto-fallback target is no longer needed

## Migration notes (for follow-up MCP docs)

- The `Trigger` TS class and `tropical_param_new_trigger` C API remain functional for the legacy path. MCP callers that use `trigger.fire()` continue to work.
- Under `TROPICAL_SLOT_OPS=1`, callers should wire triggers through `Pulse` for fire-once semantics. The trigger slot can be left high; `Pulse` outputs on the rising edge.
- `set_param(name, value)` continues to work — it writes to the legacy registry; the slot-mode path reads the same value from the slot (M5's hot-swap transfer ensures the values stay in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)