### PR TITLE
M11: operadic infrastructure (Phases 0-5)

### DIFF
--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -108,7 +108,8 @@ export interface PerInstancePlan {
 export interface InstanceFunction {
   /** Mangled symbol name (informational). */
   name:              string
-  /** Session instance name (e.g., `voice7`). */
+  /** Session instance name (e.g., `voice7`). May be a dotted path
+   *  (`voice7.env`) for nested kernels in the fractal architecture. */
   instance_name:     string
   /** Instructions with operands already shifted into unified space. */
   instructions:      NInstr[]
@@ -125,6 +126,11 @@ export interface InstanceFunction {
   register_targets:  RegTarget[]
   /** Slot driving the dispatch conditional. */
   alive_slot_index:  ModuleSlotIdx
+  /** Nested kernels (M11 fractal architecture). Sub-InstanceDecls
+   *  within this program's body become child kernels, emitted inside
+   *  this kernel's alive-conditional block. Empty for leaf kernels and
+   *  for legacy/non-fractal compiles. */
+  children:          InstanceFunction[]
 }
 
 // ─── SchedulerFunction: the top-level per-sample driver ─────────────────────
@@ -185,6 +191,8 @@ export interface WireInstanceFunction {
   register_count:    number
   register_targets:  number[]
   alive_slot_index:  number
+  /** Nested kernels. May be missing in legacy JSON (parsed as []). */
+  children?:         WireInstanceFunction[]
 }
 
 export interface WireSchedulerFunction {
@@ -258,6 +266,37 @@ const parseInstr = (i: WireNInstr): NInstr => ({
 const parseRegTargetFromWire = (n: number): RegTarget =>
   n < 0 ? ArrayManagedTarget : TempTarget(tempIdx(n))
 
+/** Recursive parse of an InstanceFunction wire structure. */
+const parseInstanceFn = (inst: WireInstanceFunction): InstanceFunction => ({
+  name:              inst.name,
+  instance_name:     inst.instance_name,
+  instructions:      inst.instructions.map(parseInstr),
+  register_offset:   tempOffset(inst.register_offset),
+  state_reg_offset:  stateRegOffset(inst.state_reg_offset),
+  array_slot_offset: arraySlotOffset(inst.array_slot_offset),
+  register_count:    inst.register_count,
+  register_targets:  inst.register_targets.map(parseRegTargetFromWire),
+  alive_slot_index:  moduleSlotIdx(inst.alive_slot_index),
+  children:          (inst.children ?? []).map(parseInstanceFn),
+})
+
+/** Recursive serialize of an InstanceFunction to wire structure. */
+const toWireInstanceFn = (inst: InstanceFunction): WireInstanceFunction => ({
+  name:              inst.name,
+  instance_name:     inst.instance_name,
+  instructions:      inst.instructions.map(toWireInstr),
+  register_offset:   rawOffset(inst.register_offset),
+  state_reg_offset:  rawOffset(inst.state_reg_offset),
+  array_slot_offset: rawOffset(inst.array_slot_offset),
+  register_count:    inst.register_count,
+  register_targets:  inst.register_targets.map(toWireRegTarget),
+  alive_slot_index:  rawIdx(inst.alive_slot_index),
+  // Omit `children` from the wire when empty so existing JSON consumers
+  // (golden fixtures, hand-crafted plan_5 tests) see exactly the bytes
+  // they expect today. Populated children are emitted normally.
+  ...(inst.children.length > 0 ? { children: inst.children.map(toWireInstanceFn) } : {}),
+})
+
 /** Parse a wire-format plan (as read from disk JSON or constructed
  *  by hand in legacy tests) into the branded internal `FlatPlan`.
  *  Inverse of `toWirePlan`. */
@@ -275,17 +314,7 @@ export function parseWirePlan(wire: WireFlatPlan): FlatPlan {
     slot_count:       wire.slot_count,
     slot_names:       wire.slot_names,
     slot_defaults:    wire.slot_defaults,
-    instance_functions: wire.instance_functions.map(inst => ({
-      name:              inst.name,
-      instance_name:     inst.instance_name,
-      instructions:      inst.instructions.map(parseInstr),
-      register_offset:   tempOffset(inst.register_offset),
-      state_reg_offset:  stateRegOffset(inst.state_reg_offset),
-      array_slot_offset: arraySlotOffset(inst.array_slot_offset),
-      register_count:    inst.register_count,
-      register_targets:  inst.register_targets.map(parseRegTargetFromWire),
-      alive_slot_index:  moduleSlotIdx(inst.alive_slot_index),
-    })),
+    instance_functions: wire.instance_functions.map(parseInstanceFn),
     scheduler_function: {
       preamble:       wire.scheduler_function.preamble.map(parseInstr),
       postamble:      wire.scheduler_function.postamble.map(parseInstr),
@@ -313,17 +342,7 @@ export function toWirePlan(plan: FlatPlan): WireFlatPlan {
     slot_count:       plan.slot_count,
     slot_names:       plan.slot_names,
     slot_defaults:    plan.slot_defaults,
-    instance_functions: plan.instance_functions.map(inst => ({
-      name:              inst.name,
-      instance_name:     inst.instance_name,
-      instructions:      inst.instructions.map(toWireInstr),
-      register_offset:   rawOffset(inst.register_offset),
-      state_reg_offset:  rawOffset(inst.state_reg_offset),
-      array_slot_offset: rawOffset(inst.array_slot_offset),
-      register_count:    inst.register_count,
-      register_targets:  inst.register_targets.map(toWireRegTarget),
-      alive_slot_index:  rawIdx(inst.alive_slot_index),
-    })),
+    instance_functions: plan.instance_functions.map(toWireInstanceFn),
     scheduler_function: {
       preamble:       plan.scheduler_function.preamble.map(toWireInstr),
       postamble:      plan.scheduler_function.postamble.map(toWireInstr),

--- a/compiler/ir/array_lower.ts
+++ b/compiler/ir/array_lower.ts
@@ -120,7 +120,11 @@ function declNeedsLowering(decl: BodyDecl): boolean {
     case 'regDecl':      return exprNeedsLowering(decl.init)
     case 'delayDecl':    return exprNeedsLowering(decl.update) || exprNeedsLowering(decl.init)
     case 'paramDecl':    return false
-    case 'instanceDecl': return decl.inputs.some(i => exprNeedsLowering(i.value))
+    case 'instanceDecl':
+      // M11 fractal: also check sub-program for surviving combinators.
+      // Sub-program bodies are lowered recursively when arrayLower fires.
+      return decl.inputs.some(i => exprNeedsLowering(i.value))
+        || progNeedsLowering(decl.type)
     case 'programDecl':  return false
   }
 }
@@ -213,13 +217,25 @@ function lowerDeclInPlace(decl: BodyDecl, subst: SubstMap, memo: Memo): void {
     case 'programDecl':
       return
     case 'instanceDecl': {
-      // After inlineInstances, no `instanceDecl` should reach arrayLower.
-      // Defensive: if one does (e.g., arrayLower called outside the
-      // strata pipeline), lower its input expressions in place.
+      // M11 fractal: InstanceDecls survive through strata. Lower this
+      // instance's input expressions AND recursively lower the sub-
+      // program's body (its own `let`/`fold`/combinators must be
+      // lowered here — arrayLower only sees the top-level program of
+      // each call, and the per-type strata that constructed this
+      // sub-program lowered ITS top-level but not its grand-children).
       for (const i of decl.inputs) {
         const value = lowerExpr(i.value, subst, memo)
         if (value !== i.value) i.value = value
       }
+      // Recurse into the sub-program's body. The clone-then-lower
+      // discipline still holds because cloneResolvedProgram deep-clones
+      // through InstanceDecl.type, so `decl.type` is a fresh tree we
+      // can mutate.
+      const subEmpty: SubstMap = EMPTY_SUBST
+      for (const subDecl of decl.type.body.decls) {
+        lowerDeclInPlace(subDecl, subEmpty, memo)
+      }
+      decl.type.body.assigns = decl.type.body.assigns.map(a => lowerAssign(a, subEmpty, memo))
       return
     }
   }

--- a/compiler/ir/branded_names.test.ts
+++ b/compiler/ir/branded_names.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  instanceName, portName, rawName,
+  childInstance, instancePathParts, isTopLevel, parentOf, leafOf,
+  portRef, portRefEq, portRefKey, parsePortRefKey,
+  type InstanceName, type PortName, type PortRef,
+} from './branded_names.js'
+
+describe('InstanceName / PortName constructors', () => {
+  test('round-trip through rawName', () => {
+    const n = instanceName('voice1')
+    expect(rawName(n)).toBe('voice1')
+  })
+
+  test('reject empty string', () => {
+    expect(() => instanceName('')).toThrow(/empty string/)
+    expect(() => portName('')).toThrow(/empty string/)
+  })
+
+  test('PortName rejects dots', () => {
+    expect(() => portName('foo.bar')).toThrow(/dots are not allowed/)
+  })
+
+  test('InstanceName allows dots (nested paths)', () => {
+    const n = instanceName('voice1.env')
+    expect(rawName(n)).toBe('voice1.env')
+  })
+})
+
+describe('InstanceName path operations', () => {
+  test('childInstance composes nested paths', () => {
+    const parent = instanceName('voice1')
+    const child = childInstance(parent, 'env')
+    expect(rawName(child)).toBe('voice1.env')
+  })
+
+  test('childInstance composes deeply nested paths', () => {
+    const root = instanceName('voice1')
+    const mid  = childInstance(root, 'filter')
+    const leaf = childInstance(mid, 'pole1')
+    expect(rawName(leaf)).toBe('voice1.filter.pole1')
+  })
+
+  test('childInstance rejects child names with dots', () => {
+    const parent = instanceName('voice1')
+    expect(() => childInstance(parent, 'env.sub')).toThrow(/must not contain dots/)
+  })
+
+  test('childInstance rejects empty child', () => {
+    const parent = instanceName('voice1')
+    expect(() => childInstance(parent, '')).toThrow(/cannot be empty/)
+  })
+
+  test('instancePathParts splits on dots', () => {
+    expect(instancePathParts(instanceName('voice1'))).toEqual(['voice1'])
+    expect(instancePathParts(instanceName('voice1.env'))).toEqual(['voice1', 'env'])
+    expect(instancePathParts(instanceName('a.b.c'))).toEqual(['a', 'b', 'c'])
+  })
+
+  test('isTopLevel is true iff no dots', () => {
+    expect(isTopLevel(instanceName('voice1'))).toBe(true)
+    expect(isTopLevel(instanceName('voice1.env'))).toBe(false)
+    expect(isTopLevel(instanceName('a.b.c'))).toBe(false)
+  })
+
+  test('parentOf returns undefined for top-level', () => {
+    expect(parentOf(instanceName('voice1'))).toBeUndefined()
+  })
+
+  test('parentOf strips the last segment', () => {
+    expect(rawName(parentOf(instanceName('voice1.env'))!)).toBe('voice1')
+    expect(rawName(parentOf(instanceName('a.b.c'))!)).toBe('a.b')
+  })
+
+  test('leafOf returns the last segment', () => {
+    expect(leafOf(instanceName('voice1'))).toBe('voice1')
+    expect(leafOf(instanceName('voice1.env'))).toBe('env')
+    expect(leafOf(instanceName('a.b.c'))).toBe('c')
+  })
+
+  test('childInstance + parentOf round-trip', () => {
+    const parent = instanceName('voice1')
+    const child = childInstance(parent, 'env')
+    expect(parentOf(child)).toBe(parent)
+  })
+})
+
+describe('PortRef', () => {
+  test('portRef constructs a typed pair', () => {
+    const r: PortRef = portRef(instanceName('voice1'), portName('out'))
+    expect(rawName(r.instance)).toBe('voice1')
+    expect(rawName(r.port)).toBe('out')
+  })
+
+  test('portRefEq compares structurally', () => {
+    const a = portRef(instanceName('v'), portName('out'))
+    const b = portRef(instanceName('v'), portName('out'))
+    const c = portRef(instanceName('v'), portName('in'))
+    const d = portRef(instanceName('w'), portName('out'))
+    expect(portRefEq(a, b)).toBe(true)
+    expect(portRefEq(a, c)).toBe(false)
+    expect(portRefEq(a, d)).toBe(false)
+  })
+
+  test('portRefKey serializes to canonical form', () => {
+    const r = portRef(instanceName('voice1'), portName('freq'))
+    expect(portRefKey(r)).toBe('voice1:freq')
+  })
+
+  test('portRefKey handles nested instance paths', () => {
+    const r = portRef(instanceName('voice1.env'), portName('alive'))
+    expect(portRefKey(r)).toBe('voice1.env:alive')
+  })
+
+  test('parsePortRefKey is inverse of portRefKey', () => {
+    const r = portRef(instanceName('voice1.env'), portName('alive'))
+    const k = portRefKey(r)
+    const back = parsePortRefKey(k)
+    expect(portRefEq(r, back)).toBe(true)
+  })
+
+  test('parsePortRefKey throws on missing separator', () => {
+    expect(() => parsePortRefKey('voice1')).toThrow(/missing ':'/)
+  })
+
+  test('parsePortRefKey splits on first colon only', () => {
+    // contrived but: instance names can contain dots, but not colons.
+    // ports also cannot contain colons. so the first colon is canonical.
+    const back = parsePortRefKey('voice1:in')
+    expect(rawName(back.instance)).toBe('voice1')
+    expect(rawName(back.port)).toBe('in')
+  })
+})
+
+describe('type-system discipline (compile-only smoke)', () => {
+  // These checks are mostly that the types compile in the expected
+  // ways. Any line that compiles is a positive test; any line that
+  // would have to be commented out to compile demonstrates the brand.
+
+  test('InstanceName and PortName are not assignable to each other', () => {
+    const inst = instanceName('voice1')
+    const port = portName('out')
+    // @ts-expect-error — PortName is not InstanceName
+    const _bad1: InstanceName = port
+    // @ts-expect-error — InstanceName is not PortName
+    const _bad2: PortName = inst
+    void _bad1; void _bad2
+  })
+
+  test('raw strings are not assignable to branded names', () => {
+    // @ts-expect-error — raw string must be branded first
+    const _bad: InstanceName = 'voice1'
+    void _bad
+  })
+})

--- a/compiler/ir/branded_names.ts
+++ b/compiler/ir/branded_names.ts
@@ -1,0 +1,143 @@
+/**
+ * branded_names.ts — phantom-typed identifiers for the IR vocabulary.
+ *
+ * The IR has two kinds of string identifiers that get confused if they
+ * share a type:
+ *
+ *   - `InstanceName` — names an instance in the session graph. May be a
+ *     dotted path (`voice1.env.lp`) when sub-instances are addressable at
+ *     depth. Used for hot-swap state matching, slot naming, and the MCP
+ *     surface.
+ *   - `PortName` — names an input or output port of an instance.
+ *
+ * Both are runtime-`string`. The brand is a phantom type the compiler
+ * enforces at boundaries. Calling `instanceName(s)` is the single place a
+ * raw `string` gets lifted into the typed world; after that, the type
+ * system tracks which strings are which.
+ *
+ * Sibling to `slot_indices.ts`: same parse-don't-validate discipline,
+ * different namespace (names are strings, not arithmetic-able).
+ *
+ * Discipline:
+ * - Only this module produces values of the branded types.
+ * - At the MCP boundary, raw user input gets branded via
+ *   `instanceName` / `portName` before flowing inward.
+ * - At the JSON-serialization boundary, `rawName` documents the exit.
+ * - Direct casts (`s as InstanceName`) should be rare and reviewed.
+ */
+
+declare const __nameBrand: unique symbol
+
+/** Phantom-tag a string. Erased at runtime. */
+export type BrandedName<B extends string> = string & { readonly [__nameBrand]: B }
+
+// ─── Name brands ────────────────────────────────────────────────────────────
+
+/** Name of an instance in the session graph. May be a dotted path
+ *  (`voice1.env`) for nested instances; the dot separator is reserved
+ *  for nesting and must not appear in a single-level instance name. */
+export type InstanceName = BrandedName<'InstanceName'>
+
+/** Name of an input or output port on an instance. Single-level —
+ *  dots are not allowed (ports are not nested). */
+export type PortName = BrandedName<'PortName'>
+
+// ─── Constructors ───────────────────────────────────────────────────────────
+
+const construct = <B extends string>(name: B, s: string, allowDots: boolean): BrandedName<B> => {
+  if (typeof s !== 'string') {
+    throw new Error(`${name}: expected string, got ${typeof s}`)
+  }
+  if (s.length === 0) {
+    throw new Error(`${name}: empty string is not a valid name`)
+  }
+  if (!allowDots && s.includes('.')) {
+    throw new Error(`${name}: dots are not allowed in '${s}' (dots reserved for nested paths)`)
+  }
+  return s as BrandedName<B>
+}
+
+export const instanceName = (s: string): InstanceName =>
+  construct('InstanceName', s, /* allowDots */ true)
+
+export const portName = (s: string): PortName =>
+  construct('PortName', s, /* allowDots */ false)
+
+/** Identity at the serialization boundary. Documents "leaving the
+ *  typed world; raw string from here." */
+export const rawName = <B extends string>(n: BrandedName<B>): string => n
+
+// ─── Path operations on InstanceName ────────────────────────────────────────
+
+/** Compose a child instance under a parent. `child(parent, "env")` →
+ *  `"parent.env"`. The parent may itself be a nested path. */
+export const childInstance = (parent: InstanceName, child: string): InstanceName => {
+  if (child.includes('.')) {
+    throw new Error(`childInstance: child name '${child}' must not contain dots`)
+  }
+  if (child.length === 0) {
+    throw new Error(`childInstance: child name cannot be empty`)
+  }
+  return `${parent}.${child}` as InstanceName
+}
+
+/** Split a nested InstanceName into its path components. `["voice1",
+ *  "env"]` for `"voice1.env"`; `["voice1"]` for `"voice1"`. */
+export const instancePathParts = (name: InstanceName): string[] => name.split('.')
+
+/** True if this is a top-level (non-nested) instance name. */
+export const isTopLevel = (name: InstanceName): boolean => !name.includes('.')
+
+/** The parent of a nested name, or undefined if top-level.
+ *  `parentOf("voice1.env")` → `"voice1"`; `parentOf("voice1")` → undefined. */
+export const parentOf = (name: InstanceName): InstanceName | undefined => {
+  const idx = name.lastIndexOf('.')
+  if (idx < 0) return undefined
+  return name.slice(0, idx) as InstanceName
+}
+
+/** The leaf segment of a nested name. `leafOf("voice1.env")` → `"env"`;
+ *  `leafOf("voice1")` → `"voice1"`. Returns a plain string, not a
+ *  PortName — the leaf of an instance path is itself an instance label,
+ *  not a port. */
+export const leafOf = (name: InstanceName): string => {
+  const idx = name.lastIndexOf('.')
+  return idx < 0 ? name : name.slice(idx + 1)
+}
+
+// ─── PortRef — instance + port pair ─────────────────────────────────────────
+
+/** A reference to a specific port on a specific instance. Replaces ad-hoc
+ *  string keys like `${instance}:${port}`. */
+export interface PortRef {
+  readonly instance: InstanceName
+  readonly port:     PortName
+}
+
+export const portRef = (inst: InstanceName, port: PortName): PortRef => ({
+  instance: inst,
+  port,
+})
+
+/** Structural equality on PortRefs. */
+export const portRefEq = (a: PortRef, b: PortRef): boolean =>
+  a.instance === b.instance && a.port === b.port
+
+/** Canonical string form for use as a Map key or in JSON. Uses `:` as
+ *  the instance/port separator (distinct from `.` which separates
+ *  nesting levels in the instance path). */
+export const portRefKey = (r: PortRef): string => `${r.instance}:${r.port}`
+
+/** Inverse of `portRefKey`. Throws on malformed input. */
+export const parsePortRefKey = (key: string): PortRef => {
+  const idx = key.indexOf(':')
+  if (idx < 0) {
+    throw new Error(`parsePortRefKey: malformed key '${key}' — missing ':'`)
+  }
+  const instPart = key.slice(0, idx)
+  const portPart = key.slice(idx + 1)
+  return {
+    instance: instanceName(instPart),
+    port:     portName(portPart),
+  }
+}

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -13,7 +13,7 @@
  * runnable-plan boundary.
  */
 
-import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl, ParamDecl } from './nodes.js'
+import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl, ParamDecl, PortType } from './nodes.js'
 import type { PerInstancePlan } from '../flat_plan.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'
 import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_resolved.js'
@@ -97,8 +97,14 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     paramHandles: ctx.paramHandles ?? new Map(),
   }
 
+  // Per-port scalar slot counts derived from declared output shapes.
+  // Scalar/alias = 1; array = product of shape dims. Drives the
+  // output_targets expansion in emit_resolved.
+  const outputPortScalarCounts = prog.ports.outputs.map(outputPortScalarCount)
+
   const program = emitResolvedProgram({
     outputExprs,
+    outputPortScalarCounts,
     registerExprs,
     stateInit,
     stateRegTypes: registerTypes,
@@ -150,6 +156,28 @@ function regInit(d: RegDecl): number | boolean | number[] {
 
 function delayScalarType(_d: DelayDecl): ScalarType {
   return 'float'
+}
+
+/** Total scalar slot count for an output port's declared shape. Scalar
+ *  and alias ports count as 1; array ports as the product of their
+ *  shape dimensions. Used to drive `output_targets` expansion. */
+function outputPortScalarCount(decl: OutputDecl): number {
+  const t: PortType | undefined = decl.type
+  if (t === undefined) return 1
+  if (t.kind === 'scalar') return 1
+  if (t.kind === 'alias')  return 1
+  // array
+  let total = 1
+  for (const dim of t.shape) {
+    if (typeof dim !== 'number') {
+      throw new Error(
+        `compileResolved: output port '${decl.name}' has unresolved ` +
+        `type-param dimension; ensure specialize ran first`,
+      )
+    }
+    total *= dim
+  }
+  return total
 }
 
 function delayInit(d: DelayDecl): number {

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -13,27 +13,39 @@
  * runnable-plan boundary.
  */
 
-import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl, ParamDecl, PortType } from './nodes.js'
+import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, DelayDecl, ParamDecl, PortType, InstanceDecl } from './nodes.js'
 import type { PerInstancePlan } from '../flat_plan.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'
 import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_resolved.js'
 
 /** Param-handle bindings for FFI param/trigger decls embedded in a
- *  program type's body. */
+ *  program type's body, plus optional nested-output slot map for the
+ *  fractal compile path. When `nestedOutputSlots` is provided, this
+ *  kernel's body may reference sub-`InstanceDecl`s via `NestedOut`,
+ *  and `emit_resolved` reads each ref as a slot operand. */
 export interface CompileResolvedContext {
-  paramHandles?: Map<ParamDecl, { ptr: string }>
+  paramHandles?:      Map<ParamDecl, { ptr: string }>
+  /** Per-sub-instance, per-output-port module-slot map. Populated by
+   *  `partition_recursive` when compiling a parent kernel whose body
+   *  contains child kernels. */
+  nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
 }
 
-/** Compile a post-strata `ResolvedProgram` to a `PerInstancePlan`. */
+/** Compile a `ResolvedProgram` to a `PerInstancePlan`.
+ *
+ *  Accepts both flat (no `InstanceDecl`s in body) and fractal (sub-
+ *  `InstanceDecl`s preserved) shapes. In the fractal case, the caller
+ *  must pass `nestedOutputSlots` so that `NestedOut` refs resolve to
+ *  slot reads; the sub-`InstanceDecl`s themselves are NOT compiled
+ *  here — they're sibling kernels emitted by the partitioner. */
 export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedContext = {}): PerInstancePlan {
   const slots = buildSlotMaps(prog)
 
-  if (slots.instanceDecls.length > 0) {
-    throw new Error(
-      `compileResolved: program '${prog.name}' has ${slots.instanceDecls.length} surviving instanceDecl entries; ` +
-      `compileResolved expects post-strata (post-inlineInstances) input.`,
-    )
-  }
+  // Fractal: surviving InstanceDecls are sibling kernels (handled by
+  // partition_recursive). The body's NestedOut refs resolve via
+  // `ctx.nestedOutputSlots`. If the caller didn't provide a slot map
+  // for a nested-bodied program, that's a contract error — let
+  // emit_resolved's terminal check throw a descriptive message.
 
   // ── Output expressions ──
   const outputExprByDecl = new Map<OutputDecl, ResolvedExpr>()
@@ -90,11 +102,12 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
   })
 
   const emitSlots: EmitSlots = {
-    inputs:       slots.inputs,
-    regs:         slots.regs,
-    delays:       slots.delays,
-    regCount:     slots.regDecls.length,
-    paramHandles: ctx.paramHandles ?? new Map(),
+    inputs:           slots.inputs,
+    regs:             slots.regs,
+    delays:           slots.delays,
+    regCount:         slots.regDecls.length,
+    paramHandles:     ctx.paramHandles     ?? new Map(),
+    nestedOutputSlots: ctx.nestedOutputSlots,
   }
 
   // Per-port scalar slot counts derived from declared output shapes.

--- a/compiler/ir/compile_session.ts
+++ b/compiler/ir/compile_session.ts
@@ -1,16 +1,26 @@
 /**
  * compile_session.ts — JIT-side session emit boundary.
  *
- * Delegates to `compileSessionSlotted`, the per-instance compile path
- * that produces `tropical_plan_5`. After PR-C (active-set runtime),
- * this is the only path; the legacy single-kernel materialize-then-
- * inline path is retired.
+ * Two-phase compile:
+ *   1. `liftWiresToInstances` — wire pre-process. Wires whose expressions
+ *      contain forms `translateNode` doesn't handle (array literals,
+ *      session-level `delay()`) are extracted into anonymous
+ *      `__wire_${i}` instances at session pre-compile time. The lifted
+ *      programs go through the full strata pipeline so combinators
+ *      lower correctly. After this pass, every wire is a simple
+ *      `translateNode`-compatible form.
+ *   2. `compileSessionSlotted` — produces the `tropical_plan_5` FlatPlan
+ *      via the per-instance compile path.
  */
 
 import type { SessionState } from '../session.js'
 import type { FlatPlan } from '../flat_plan'
+import { liftWiresToInstances } from './lift_wires.js'
 
 export function compileSession(session: SessionState): FlatPlan {
+  // Pre-compile: hoist complex wires to anonymous programs.
+  liftWiresToInstances(session)
+
   // Lazy import to avoid a circular dependency (compile_session_slotted's
   // helpers import session.js types).
   const { compileSessionSlotted } = require('./compile_session_slotted.js') as

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -33,26 +33,20 @@
  */
 
 import { allocateOutputSlots, type SessionState } from '../session.js'
-import type { FlatPlan, InstanceFunction, SchedulerFunction, RegTarget } from '../flat_plan.js'
-import { TempTarget, ArrayManagedTarget } from '../flat_plan.js'
-import type { NInstr, ScalarType, NOperand } from './emit_resolved.js'
+import type { FlatPlan, InstanceFunction, SchedulerFunction } from '../flat_plan.js'
+import type { NInstr, NOperand } from './emit_resolved.js'
 import { instrWriteSlot, opConst } from './emit_resolved.js'
-import { compileResolved } from './compile_resolved.js'
 import {
-  computeInstanceTopoOrder, remapInstancePlan, emitDacStitch,
-  type RemapContext, type PreambleEmitter,
+  computeInstanceTopoOrder, emitDacStitch,
+  type PreambleEmitter,
   translateAliveExpr,
 } from './compile_session_slotted_helpers.js'
 import {
-  type TempIdx, type ModuleSlotIdx,
-  tempIdx, moduleSlotIdx,
-  tempOffset, stateRegOffset, arraySlotOffset,
+  type ModuleSlotIdx,
+  tempIdx, moduleSlotIdx, tempOffset,
   rawOffset,
 } from './slot_indices.js'
-import {
-  inputNames, outputNames, outputPortTypes,
-  rawInputDefaults,
-} from '../program_types.js'
+import { partitionKernel, makeAccumulators } from './partition_recursive.js'
 
 /** Compile the session into a `tropical_plan_5` `FlatPlan`. */
 export function compileSessionSlotted(session: SessionState): FlatPlan {
@@ -69,25 +63,13 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
 
   const order = computeInstanceTopoOrder(session)
 
-  // ── Unified accumulators across all instance functions + scheduler ───
-  // Plain counts (number) for things that are just "how many in this
-  // namespace"; the offsets we hand to RemapContext are branded so
-  // cross-namespace arithmetic can't compile.
-  const allRegisterNames:   string[]            = []
-  const allRegisterTypes:   ScalarType[]        = []
-  const allStateInit:       (number | boolean)[] = []
-  const allArraySlotSizes:  number[]            = []
-  const allArraySlotNames:  string[]            = []
-
-  let nextRegRaw    = 0
-  let nextStateRaw  = 0
-  let nextArrayRaw  = 0
-
+  // Recursive partition: for each top-level session instance, walk its
+  // ResolvedProgram tree and emit a kernel per InstanceDecl at every
+  // level. Slot allocations, register/state/array offsets, alive
+  // preamble operands are all threaded through `acc`.
+  const acc = makeAccumulators()
   const instanceFunctions: InstanceFunction[] = []
-  const schedulerPreamble: NInstr[] = []
 
-  // First pass: compile each instance, building instance_functions
-  // entries and accumulating unified state.
   for (const instName of order) {
     const inst = session.instanceRegistry.get(instName)
     if (inst === undefined) continue
@@ -98,78 +80,44 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       )
     }
 
-    const plan = compileResolved(compiled.prog, { paramHandles: new Map() })
-
-    const inPortNames  = inputNames(compiled)
-    const outPortNames = outputNames(compiled)
-    const outPortTypes = outputPortTypes(compiled).map(scalarOf)
-    const defaults     = rawInputDefaults(compiled)
-
-    const ctx: RemapContext = {
-      instanceName: instName,
-      regOffset:       tempOffset(nextRegRaw),
-      stateRegOffset:  stateRegOffset(nextStateRaw),
-      arraySlotOffset: arraySlotOffset(nextArrayRaw),
-      inputBindingFor: (portName) => {
+    const { fn } = partitionKernel(
+      /* instancePath   */ instName,
+      /* prog           */ compiled.prog,
+      /* compiled       */ compiled,
+      /* aliveInput     */ inst.aliveInput,
+      /* inputBindingFor*/ (portName) => {
         const expr = session.inputExprNodes.get(`${instName}:${portName}`)
         if (expr !== undefined) return { kind: 'wired', expr }
-        const d = defaults[portName]
-        const value = (typeof d === 'number' || typeof d === 'boolean') ? d : 0
-        return { kind: 'literal', value }
+        return undefined
       },
-      outputSlotFor: (portName) => moduleSlotIdx(requireOutputSlot(session, instName, portName)),
-      inputPortNames:    inPortNames,
-      outputPortNames:   outPortNames,
-      outputScalarTypes: outPortTypes,
-    }
-
-    const { preamble, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
-    const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
-
-    const aliveSlot = moduleSlotIdx(
-      requireOutputSlot(session, instName, '__alive__'),
+      /* defaults       */ (() => {
+        // rawInputDefaults is imported from program_types.js — but we
+        // need the Compiled here. Use lazy access via property.
+        const out: Record<string, import('../session.js').ExprNode> = {}
+        for (const d of compiled.prog.ports.inputs) {
+          if (d.default !== undefined) {
+            const init = d.default
+            if (typeof init === 'number' || typeof init === 'boolean') {
+              out[d.name] = init
+            }
+          }
+        }
+        return out
+      })(),
+      /* paramHandles   */ new Map(),
+      session,
+      acc,
     )
-
-    // Shift per-instance register_targets into the unified temp
-    // space. ArrayManagedTarget passes through structurally — no
-    // arithmetic can corrupt it, exactly the property the `-1`
-    // sentinel didn't provide.
-    const shiftedTargets: RegTarget[] = plan.register_targets.map(t => {
-      if (t.kind === 'arrayManaged') return ArrayManagedTarget
-      return TempTarget(tempIdx(t.slot + nextRegRaw))
-    })
-
-    instanceFunctions.push({
-      name:              `instance_${instName}`,
-      instance_name:     instName,
-      instructions:      instanceInstructions,
-      register_offset:   tempOffset(nextRegRaw),
-      state_reg_offset:  stateRegOffset(nextStateRaw),
-      array_slot_offset: arraySlotOffset(nextArrayRaw),
-      register_count:    plan.register_count + tempsConsumed,
-      register_targets:  shiftedTargets,
-      alive_slot_index:  aliveSlot,
-      children:          [],
-    })
-
-    // Accumulate unified state. These arrays mirror per-instance
-    // contributions in instance order; their indices line up with
-    // (state_reg_offset + i), (array_slot_offset + i), etc.
-    for (const n of plan.register_names) allRegisterNames.push(`${instName}.${n}`)
-    allRegisterTypes.push(...plan.register_types)
-    for (const v of plan.state_init) allStateInit.push(v as number | boolean)
-    allArraySlotSizes.push(...plan.array_slot_sizes)
-    for (const n of plan.array_slot_names) allArraySlotNames.push(`${instName}.${n}`)
-
-    nextRegRaw   += plan.register_count + tempsConsumed
-    nextStateRaw += plan.state_init.length
-    nextArrayRaw += plan.array_slot_count
+    instanceFunctions.push(fn)
   }
 
-  // Second pass: emit alive WriteSlots into the scheduler preamble.
-  // Writing every sample lets GVN forward the constant 1.0 in the
-  // default case so the dispatch conditional folds to inline.
-  let preambleNextTempRaw = nextRegRaw
+  // ── Scheduler preamble: emit alive WriteSlots for every kernel in
+  //    the tree. Writing every sample lets GVN forward the constant 1.0
+  //    in the default case so the dispatch conditional folds to inline.
+  //    Done in a second pass so nested kernels' alive emissions are
+  //    included; acc.alivePreambleOps was populated during partition.
+  const schedulerPreamble: NInstr[] = []
+  let preambleNextTempRaw = acc.nextRegRaw
   const aliveEmitter: PreambleEmitter = {
     instrs: schedulerPreamble,
     allocTemp: () => {
@@ -179,20 +127,14 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
     },
   }
 
-  for (const instName of order) {
-    const inst = session.instanceRegistry.get(instName)
-    if (inst === undefined) continue
-    const aliveSlotRaw = session.outputSlotRegistry.get(`${instName}.__alive__`)
-    if (aliveSlotRaw === undefined) continue
-    const aliveSlot = moduleSlotIdx(aliveSlotRaw)
-
-    const aliveOperand: NOperand = inst.aliveInput === undefined
+  for (const op of acc.alivePreambleOps) {
+    const aliveOperand: NOperand = op.expr === undefined
       ? opConst(1, 'float')
       : translateAliveExpr(
-          inst.aliveInput, session, aliveEmitter,
-          `${instName}.__alive__`,
+          op.expr, session, aliveEmitter,
+          `__alive__@${rawOffset(op.aliveSlot)}`,
         )
-    schedulerPreamble.push(instrWriteSlot(aliveSlot, aliveOperand, 'float'))
+    schedulerPreamble.push(instrWriteSlot(op.aliveSlot, aliveOperand, 'float'))
   }
 
   // DAC stitching reads each graphOutput slot AFTER all instances
@@ -210,30 +152,17 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
   return {
     schema: 'tropical_plan_5',
     config: { sampleRate: 44100 },
-    state_init:        allStateInit,
-    register_names:    allRegisterNames,
-    register_types:    allRegisterTypes,
-    array_slot_names:  allArraySlotNames,
-    array_slot_count:  nextArrayRaw,
-    array_slot_sizes:  allArraySlotSizes,
+    state_init:        acc.stateInit,
+    register_names:    acc.registerNames,
+    register_types:    acc.registerTypes,
+    array_slot_names:  acc.arraySlotNames,
+    array_slot_count:  acc.nextArrayRaw,
+    array_slot_sizes:  acc.arraySlotSizes,
     register_count:    dacEndRaw,
     instance_functions: instanceFunctions,
     scheduler_function: schedulerFunction,
     ...buildSlotMetadata(session),
   }
-}
-
-/** Look up an instance's output slot, throwing with a clear message
- *  if it's missing. Centralised so error wording stays consistent. */
-function requireOutputSlot(session: SessionState, instName: string, portName: string): number {
-  const key = `${instName}.${portName}`
-  const idx = session.outputSlotRegistry.get(key)
-  if (idx === undefined) {
-    throw new Error(
-      `compileSessionSlotted: output slot for '${key}' not allocated.`,
-    )
-  }
-  return idx
 }
 
 /** Compute slot allocation metadata from the session registries. */
@@ -257,18 +186,6 @@ function buildSlotMetadata(session: SessionState): {
   return { slot_count: slotCount, slot_names: slotNames, slot_defaults: slotDefaults }
 }
 
-/** Reduce a PortType to a ScalarType for emission. */
-function scalarOf(
-  t: { kind?: string; scalar?: ScalarType; alias?: { base: ScalarType }; element?: ScalarType | { base: ScalarType } } | undefined,
-): ScalarType {
-  if (t === undefined) return 'float'
-  if (t.kind === 'scalar' && t.scalar !== undefined) return t.scalar
-  if (t.kind === 'alias' && t.alias !== undefined) return t.alias.base
-  if (t.kind === 'array' && t.element !== undefined) {
-    return typeof t.element === 'string' ? (t.element as ScalarType) : t.element.base
-  }
-  return 'float'
-}
 
 /** @deprecated Slot mode is the only mode. */
 export function slotModeEnabled(_session?: SessionState, _opt?: boolean): boolean {

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -149,6 +149,7 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       register_count:    plan.register_count + tempsConsumed,
       register_targets:  shiftedTargets,
       alive_slot_index:  aliveSlot,
+      children:          [],
     })
 
     // Accumulate unified state. These arrays mirror per-instance

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -396,23 +396,57 @@ export function remapInstancePlan(
     args: instr.args.map(remapOperand),
   }))
 
-  // WriteSlot per output port to publish each computed value into
-  // the instance's allocated output slot. `plan.output_targets[i]`
-  // is a local temp index; shift into the unified space.
+  // WriteSlot per scalar slot of every output port. For scalar ports
+  // that's 1 WriteSlot. For array-typed ports of shape `[N]` (or any
+  // shape; `expandPortToSlots` flattens row-major) that's N WriteSlots,
+  // one per element. `plan.output_targets` is sized to match (one entry
+  // per scalar slot in port-major order — see emit_resolved.ts's
+  // emitProgram for the producer side).
+  //
+  // The session's `outputPortMeta` is the authoritative per-port shape
+  // record (scalar slot names + types, allocated once in
+  // `allocateOutputSlots`). We iterate it in port order and consume
+  // output_targets monotonically.
   const writeSlots: NInstr[] = []
-  for (let i = 0; i < ctx.outputPortNames.length; i++) {
-    const portName = ctx.outputPortNames[i]
-    const slotIdx  = ctx.outputSlotFor(portName)
-    const localTemp = plan.output_targets[i]
-    if (localTemp === undefined) {
+  let targetIdx = 0
+  for (let portI = 0; portI < ctx.outputPortNames.length; portI++) {
+    const portName = ctx.outputPortNames[portI]
+    const portKey  = `${ctx.instanceName}.${portName}`
+    const meta = session.outputPortMeta.get(portKey)
+    if (meta === undefined) {
       throw new Error(
-        `compileSessionSlotted: instance '${ctx.instanceName}' missing output_targets[${i}] ` +
-        `for port '${portName}'.`,
+        `compileSessionSlotted: instance '${ctx.instanceName}' port '${portName}' ` +
+        `missing outputPortMeta entry (allocateOutputSlots should have run).`,
       )
     }
-    const scalarType = ctx.outputScalarTypes[i]
-    const absTemp = shiftTemp(localTemp, ctx.regOffset)
-    writeSlots.push(instrWriteSlot(slotIdx, opTemp(absTemp, scalarType), scalarType))
+    for (let scalarI = 0; scalarI < meta.scalarSlotNames.length; scalarI++) {
+      const scalarSlotName = meta.scalarSlotNames[scalarI]
+      const slotIdxRaw = session.outputSlotRegistry.get(scalarSlotName)
+      if (slotIdxRaw === undefined) {
+        throw new Error(
+          `compileSessionSlotted: scalar slot '${scalarSlotName}' not in outputSlotRegistry.`,
+        )
+      }
+      const slotIdx = moduleSlotIdx(slotIdxRaw)
+      const localTemp = plan.output_targets[targetIdx]
+      if (localTemp === undefined) {
+        throw new Error(
+          `compileSessionSlotted: instance '${ctx.instanceName}' missing output_targets[${targetIdx}] ` +
+          `for scalar slot '${scalarSlotName}' (port '${portName}', element ${scalarI}).`,
+        )
+      }
+      const scalarType = meta.scalarTypes[scalarI]
+      const absTemp = shiftTemp(localTemp, ctx.regOffset)
+      writeSlots.push(instrWriteSlot(slotIdx, opTemp(absTemp, scalarType), scalarType))
+      targetIdx++
+    }
+  }
+  if (targetIdx !== plan.output_targets.length) {
+    throw new Error(
+      `compileSessionSlotted: instance '${ctx.instanceName}' has ${plan.output_targets.length} ` +
+      `output_targets but only ${targetIdx} were consumed by scalar slot expansion. ` +
+      `This indicates a port-shape / emit mismatch.`,
+    )
   }
 
   return {

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -711,22 +711,67 @@ class Emitter {
   }
 
   // ── Top-level emit driver ──
-  emitProgram(outputExprs: ResolvedExpr[], registerExprs: (ResolvedExpr | null)[]): FlatProgram {
+  emitProgram(
+    outputExprs: ResolvedExpr[],
+    registerExprs: (ResolvedExpr | null)[],
+    outputPortScalarCounts: number[],
+  ): FlatProgram {
     const output_targets: TempIdx[] = []
     const register_targets: RegTarget[] = []
 
-    for (const expr of outputExprs) {
+    // Output-targets contract (M11 Phase 3): ONE entry per scalar slot
+    // of every declared output port. Scalar/alias ports contribute 1
+    // entry; array ports of total scalar count N contribute N entries
+    // in row-major order matching `expandPortToSlots`'s naming.
+    //
+    // The number of targets per port is determined by the DECLARED port
+    // shape (`outputPortScalarCounts`), not by the runtime shape of the
+    // computed expression. Backward-compat case: when a scalar-declared
+    // port receives an array-shaped expression, we project to element 0
+    // (the historical behavior for under-specified types).
+    if (outputPortScalarCounts.length !== outputExprs.length) {
+      throw new Error(
+        `emitProgram: outputPortScalarCounts.length (${outputPortScalarCounts.length}) ` +
+        `must match outputExprs.length (${outputExprs.length})`,
+      )
+    }
+    for (let portI = 0; portI < outputExprs.length; portI++) {
+      const expr = outputExprs[portI]
+      const declaredCount = outputPortScalarCounts[portI]
       const r = this.compileNode(expr, 'float')
-      if (r.isArray) {
+
+      if (declaredCount === 1) {
+        // Scalar port. If the expression is array-shaped, take [0]
+        // (backward-compat); otherwise emit a single scalar copy.
         const dst = this.allocReg()
-        this.regTypes.set(dst, 'float')
-        this.emit(instrIndex(dst, [r.op, opConst(0, 'int')], 'float'))
+        if (r.isArray) {
+          this.regTypes.set(dst, r.scalarType)
+          this.emit(instrIndex(dst, [r.op, opConst(0, 'int')], r.scalarType))
+        } else {
+          this.regTypes.set(dst, r.scalarType)
+          this.emit(instrScalar('Add', dst, [r.op, opConst(0, r.scalarType)], r.scalarType))
+        }
         output_targets.push(dst)
       } else {
-        const dst = this.allocReg()
-        this.regTypes.set(dst, r.scalarType)
-        this.emit(instrScalar('Add', dst, [r.op, opConst(0, r.scalarType)], r.scalarType))
-        output_targets.push(dst)
+        // Array port. Expression must be array-shaped of matching size.
+        if (!r.isArray) {
+          throw new Error(
+            `emitProgram: output port ${portI} declared as array of scalar count ` +
+            `${declaredCount}, but expression is scalar`,
+          )
+        }
+        if (r.size !== declaredCount) {
+          throw new Error(
+            `emitProgram: output port ${portI} declared as array of scalar count ` +
+            `${declaredCount}, but expression has size ${r.size}`,
+          )
+        }
+        for (let elemI = 0; elemI < declaredCount; elemI++) {
+          const dst = this.allocReg()
+          this.regTypes.set(dst, r.scalarType)
+          this.emit(instrIndex(dst, [r.op, opConst(elemI, 'int')], r.scalarType))
+          output_targets.push(dst)
+        }
       }
     }
 
@@ -796,6 +841,11 @@ class Emitter {
 
 export interface EmitResolvedInputs {
   outputExprs: ResolvedExpr[]
+  /** One entry per output port: total scalar slot count derived from
+   *  the port's declared shape (1 for scalar/alias; product of shape
+   *  dims for arrays). Determines how many `output_targets` the emit
+   *  produces per port. */
+  outputPortScalarCounts: number[]
   registerExprs: (ResolvedExpr | null)[]
   stateInit: (number | boolean | number[])[]
   stateRegTypes: ScalarType[]
@@ -805,5 +855,5 @@ export interface EmitResolvedInputs {
 
 export function emitResolvedProgram(input: EmitResolvedInputs): FlatProgram {
   const e = new Emitter(input.slots, input.stateInit, input.stateRegTypes, input.inputPortTypes)
-  return e.emitProgram(input.outputExprs, input.registerExprs)
+  return e.emitProgram(input.outputExprs, input.registerExprs, input.outputPortScalarCounts)
 }

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -32,12 +32,12 @@
 
 import type {
   ResolvedExpr, ResolvedExprOp,
-  RegDecl, DelayDecl, InputDecl, InstanceDecl, ParamDecl,
+  RegDecl, DelayDecl, InputDecl, InstanceDecl, OutputDecl, ParamDecl,
 } from './nodes.js'
 import {
   type TempIdx, type StateRegIdx, type ArraySlotIdx, type ModuleSlotIdx,
   type InputPortIdx,
-  tempIdx, arraySlotIdx, stateRegIdx, inputPortIdx,
+  tempIdx, arraySlotIdx, stateRegIdx, inputPortIdx, moduleSlotIdx,
   rawIdx,
 } from './slot_indices.js'
 import type { RegTarget } from '../flat_plan.js'
@@ -250,6 +250,14 @@ export interface EmitSlots {
   regCount: number
   /** FFI handle metadata per param/trigger decl. */
   paramHandles: Map<ParamDecl, { ptr: string }>
+  /** Module slot indices for sub-instance outputs that this kernel's
+   *  body references via `NestedOut`. Populated by `partition_recursive`
+   *  for fractal kernels — each child kernel's outputs occupy slots in
+   *  the shared module-slot array, and the parent reads them via slot
+   *  operands. Map shape: instanceDecl → outputDecl → moduleSlotIdx.
+   *  When undefined (legacy / per-program path), NestedOut throws as
+   *  before. */
+  nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -413,6 +421,44 @@ class Emitter {
       }
       case 'sampleRate':  return { op: opRate, scalarType: 'float' }
       case 'sampleIndex': return { op: opTick, scalarType: 'int' }
+      case 'nestedOut': {
+        // Fractal compile: a NestedOut references a sub-instance's
+        // output, which lives in a module slot allocated by
+        // partition_recursive. Read it as `slot[index]`. The scalar
+        // type comes from the output port's declared type.
+        if (this.slots.nestedOutputSlots === undefined) {
+          throw new Error(
+            `emit_resolved: NestedOut to '${obj.instance.name}.${obj.output.name}' ` +
+            `requires nestedOutputSlots — pass them via EmitSlots when invoking emit ` +
+            `on a fractal kernel.`,
+          )
+        }
+        const perInst = this.slots.nestedOutputSlots.get(obj.instance)
+        if (perInst === undefined) {
+          throw new Error(
+            `emit_resolved: NestedOut to instance '${obj.instance.name}' — ` +
+            `no slot map entry. partition_recursive should record every child ` +
+            `instance before emitting the parent kernel.`,
+          )
+        }
+        const slotRaw = perInst.get(obj.output)
+        if (slotRaw === undefined) {
+          throw new Error(
+            `emit_resolved: NestedOut to '${obj.instance.name}.${obj.output.name}' — ` +
+            `output port not in slot map.`,
+          )
+        }
+        // Determine the scalar type from the output port's declared type.
+        const outType = obj.output.type
+        const scalarType: ScalarType = outType === undefined
+          ? 'float'
+          : outType.kind === 'scalar'
+            ? outType.scalar
+            : outType.kind === 'alias'
+              ? (outType.alias.base as ScalarType)
+              : 'float'   // array — element 0; full array NestedOut not yet supported
+        return { op: opSlot(moduleSlotIdx(slotRaw), scalarType), scalarType }
+      }
     }
     return null
   }
@@ -545,8 +591,10 @@ class Emitter {
       case 'chain': case 'map2': case 'zipWith':
       case 'let':
       case 'tag': case 'match':
-      case 'typeParamRef': case 'bindingRef': case 'nestedOut':
+      case 'typeParamRef': case 'bindingRef':
         throw new Error(`emit_resolved: '${obj.op}' should have been lowered before emit`)
+      // 'nestedOut' is handled in tryTerminal (fractal compile slot read);
+      // it should never reach this exhaustiveness check.
     }
 
     const _exhaustive: never = obj as never

--- a/compiler/ir/identity_elim.test.ts
+++ b/compiler/ir/identity_elim.test.ts
@@ -1,0 +1,341 @@
+import { describe, test, expect } from 'bun:test'
+import type {
+  ResolvedProgram, InstanceDecl, InputDecl, OutputDecl,
+  ResolvedExpr, NestedOut, BinaryOp, RegDecl,
+} from './nodes.js'
+import { identityElim } from './identity_elim.js'
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+/** Build a trivial identity program: takes one input `in_p`, has one
+ *  output `out`, body assigns `out = inputRef(in_p)`. */
+function identityProgram(name = 'IdProg'): ResolvedProgram {
+  const inDecl: InputDecl  = { op: 'inputDecl',  name: 'in_p' }
+  const outDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
+  return {
+    op: 'program',
+    name,
+    typeParams: [],
+    ports: { inputs: [inDecl], outputs: [outDecl], typeDefs: [] },
+    body: {
+      op: 'block',
+      decls: [],
+      assigns: [{
+        op: 'outputAssign',
+        target: outDecl,
+        expr: { op: 'inputRef', decl: inDecl },
+      }],
+    },
+  }
+}
+
+/** Build a non-identity program: body assigns `out = inputRef(p) + 1`. */
+function nonIdentityProgram(name = 'NonIdProg'): ResolvedProgram {
+  const inDecl: InputDecl  = { op: 'inputDecl',  name: 'in_p' }
+  const outDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
+  return {
+    op: 'program',
+    name,
+    typeParams: [],
+    ports: { inputs: [inDecl], outputs: [outDecl], typeDefs: [] },
+    body: {
+      op: 'block',
+      decls: [],
+      assigns: [{
+        op: 'outputAssign',
+        target: outDecl,
+        expr: { op: 'add', args: [{ op: 'inputRef', decl: inDecl }, 1] },
+      }],
+    },
+  }
+}
+
+/** Build an InstanceDecl wrapping a program and wiring one input. */
+function makeInstance(
+  prog: ResolvedProgram,
+  instName: string,
+  wireValue: ResolvedExpr,
+): InstanceDecl {
+  return {
+    op: 'instanceDecl',
+    name: instName,
+    type: prog,
+    typeArgs: [],
+    inputs: [{ port: prog.ports.inputs[0], value: wireValue }],
+  }
+}
+
+// ─── No-op cases ──────────────────────────────────────────────────────────
+
+describe('identityElim — no-op cases', () => {
+  test('empty program returns same shape', () => {
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'empty', typeParams: [],
+      ports: { inputs: [], outputs: [], typeDefs: [] },
+      body: { op: 'block', decls: [], assigns: [] },
+    }
+    const after = identityElim(prog)
+    expect(after.body.decls).toEqual([])
+    expect(after.body.assigns).toEqual([])
+  })
+
+  test('returns input identity when no identity decls present', () => {
+    const inDecl: InputDecl  = { op: 'inputDecl',  name: 'x' }
+    const outDecl: OutputDecl = { op: 'outputDecl', name: 'y' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'p', typeParams: [],
+      ports: { inputs: [inDecl], outputs: [outDecl], typeDefs: [] },
+      body: {
+        op: 'block', decls: [],
+        assigns: [{
+          op: 'outputAssign',
+          target: outDecl,
+          expr: { op: 'inputRef', decl: inDecl },
+        }],
+      },
+    }
+    // Even though THIS program body looks like an identity, the pass
+    // only eliminates *InstanceDecls* whose body is identity — it
+    // doesn't change the top-level program's I/O behavior.
+    const after = identityElim(prog)
+    expect(after).toBe(prog)   // identity preserved when no work
+  })
+
+  test('non-identity InstanceDecl is preserved', () => {
+    const idProg = nonIdentityProgram()
+    const inst = makeInstance(idProg, 'i1', 42)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+        }],
+      },
+    }
+    const after = identityElim(prog)
+    expect(after.body.decls.length).toBe(1)   // not eliminated
+  })
+})
+
+// ─── Elimination ──────────────────────────────────────────────────────────
+
+describe('identityElim — elimination', () => {
+  test('single identity InstanceDecl eliminated; NestedOut rewritten', () => {
+    const idProg = identityProgram()
+    const inst = makeInstance(idProg, 'i1', 42)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+        }],
+      },
+    }
+    const after = identityElim(prog)
+    // The InstanceDecl is gone.
+    expect(after.body.decls).toEqual([])
+    // The outputAssign now reads the constant 42 directly.
+    expect(after.body.assigns.length).toBe(1)
+    const oa = after.body.assigns[0]
+    expect(oa.op).toBe('outputAssign')
+    expect((oa as { expr: ResolvedExpr }).expr).toBe(42)
+  })
+
+  test('rewrite is recursive — chained identities collapse', () => {
+    // Build: outerOut <- inst2.out  where  inst2.in_p = nestedOut(inst1.out)  where  inst1.in_p = 7
+    const idProg = identityProgram()
+    const inst1 = makeInstance(idProg, 'i1', 7)
+    const inst2 = makeInstance(
+      idProg,
+      'i2',
+      { op: 'nestedOut', instance: inst1, output: idProg.ports.outputs[0] },
+    )
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst1, inst2],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'nestedOut', instance: inst2, output: idProg.ports.outputs[0] },
+        }],
+      },
+    }
+    const after = identityElim(prog)
+    expect(after.body.decls).toEqual([])
+    expect((after.body.assigns[0] as { expr: ResolvedExpr }).expr).toBe(7)
+  })
+
+  test('NestedOut deep inside a binary expression is rewritten', () => {
+    const idProg = identityProgram()
+    const inst = makeInstance(idProg, 'i1', 3.14)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const nestedRef: NestedOut = {
+      op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0],
+    }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'mul', args: [nestedRef, 2] },
+        }],
+      },
+    }
+    const after = identityElim(prog)
+    expect(after.body.decls).toEqual([])
+    const expr = (after.body.assigns[0] as { expr: ResolvedExpr }).expr as BinaryOp
+    expect(expr.op).toBe('mul')
+    expect(expr.args[0]).toBe(3.14)
+    expect(expr.args[1]).toBe(2)
+  })
+
+  test('identity at one level + non-identity sibling: only identity eliminated', () => {
+    const idProg = identityProgram()
+    const nonIdProg = nonIdentityProgram()
+    const idInst = makeInstance(idProg, 'id1', 5)
+    const nonIdInst = makeInstance(nonIdProg, 'non1', 10)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [idInst, nonIdInst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: {
+            op: 'add',
+            args: [
+              { op: 'nestedOut', instance: idInst,    output: idProg.ports.outputs[0] },
+              { op: 'nestedOut', instance: nonIdInst, output: nonIdProg.ports.outputs[0] },
+            ],
+          },
+        }],
+      },
+    }
+    const after = identityElim(prog)
+    // Identity gone, non-identity remains. The pass clones the program
+    // before mutating, so surviving InstanceDecls are fresh objects
+    // (different identity from the input `nonIdInst`) but they're
+    // shared with the rest of the cloned program — NestedOut refs in
+    // expressions point at the same surviving object.
+    expect(after.body.decls.length).toBe(1)
+    expect(after.body.decls[0].op).toBe('instanceDecl')
+    const survivor = after.body.decls[0] as InstanceDecl
+    expect(survivor.name).toBe('non1')
+    const expr = (after.body.assigns[0] as { expr: ResolvedExpr }).expr as BinaryOp
+    expect(expr.args[0]).toBe(5)
+    expect((expr.args[1] as NestedOut).op).toBe('nestedOut')
+    // The rhs NestedOut MUST reference the surviving instance (not the
+    // dangling original). This is the consistency invariant the
+    // clone-then-mutate approach preserves.
+    expect((expr.args[1] as NestedOut).instance).toBe(survivor)
+  })
+
+  test('substitution into RegDecl init / update fields', () => {
+    const idProg = identityProgram()
+    const inst = makeInstance(idProg, 'i1', 100)
+    const reg: RegDecl = {
+      op: 'regDecl',
+      name: 'r',
+      init: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+    }
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst, reg],
+        assigns: [
+          {
+            op: 'outputAssign',
+            target: outerOut,
+            expr: { op: 'regRef', decl: reg },
+          },
+          {
+            op: 'nextUpdate',
+            target: reg,
+            expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+          },
+        ],
+      },
+    }
+    const after = identityElim(prog)
+    expect(after.body.decls.length).toBe(1)   // only the RegDecl
+    expect(after.body.decls[0].op).toBe('regDecl')
+    const newReg = after.body.decls[0] as RegDecl
+    expect(newReg.init).toBe(100)              // substituted from nestedOut → 100
+    const nextAssign = after.body.assigns.find(a => a.op === 'nextUpdate')!
+    expect((nextAssign as { expr: ResolvedExpr }).expr).toBe(100)
+  })
+})
+
+// ─── Properties ───────────────────────────────────────────────────────────
+
+describe('identityElim — properties', () => {
+  test('idempotent: applying twice gives the same result as once', () => {
+    const idProg = identityProgram()
+    const inst = makeInstance(idProg, 'i1', 99)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+        }],
+      },
+    }
+    const once = identityElim(prog)
+    const twice = identityElim(once)
+    expect(JSON.stringify(twice)).toEqual(JSON.stringify(once))
+  })
+
+  test('does not mutate input program', () => {
+    const idProg = identityProgram()
+    const inst = makeInstance(idProg, 'i1', 99)
+    const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
+    const prog: ResolvedProgram = {
+      op: 'program', name: 'outer', typeParams: [],
+      ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
+      body: {
+        op: 'block',
+        decls: [inst],
+        assigns: [{
+          op: 'outputAssign',
+          target: outerOut,
+          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+        }],
+      },
+    }
+    const snapshot = JSON.stringify(prog)
+    identityElim(prog)
+    expect(JSON.stringify(prog)).toBe(snapshot)
+  })
+})

--- a/compiler/ir/identity_elim.ts
+++ b/compiler/ir/identity_elim.ts
@@ -1,0 +1,316 @@
+/**
+ * identity_elim.ts — categorical identity-law rewrite as a strata pass.
+ *
+ * The identity law in the cartesian-with-trace category of signal-flow
+ * graphs:
+ *
+ *   id_T ∘ f = f = f ∘ id_T
+ *
+ * Operational realization: an `InstanceDecl` whose body is the identity
+ * morphism on its input — `out = inputRef(p)` for some input port `p` —
+ * is a no-op kernel. Composing it with any consumer is equivalent to the
+ * consumer alone. We rewrite by inlining: every `NestedOut(I, o)` ref to
+ * the identity instance's output `o` becomes the expression that was
+ * wired into `p` at the consumer site, and the `InstanceDecl` is dropped
+ * from the body.
+ *
+ * Under the fractal architecture (M11 Phase 4+, `inlineInstances`
+ * retired), trivial wires lifted by `liftWireToProgram` would survive
+ * as identity `InstanceDecl`s — one kernel per trivial wire — bloating
+ * slot space and adding pointless read/write instructions per sample.
+ * `identityElim` recognizes and eliminates them, returning the wire to
+ * a direct slot-read on the consumer side. The pass is the structural
+ * analogue of compiler peephole optimizations, but it isn't a peephole:
+ * it's a categorical equation made operational, exactly parallel to the
+ * other strata passes (each one mechanizes some category-theoretic law
+ * about the IR).
+ *
+ * Implementation discipline: we never mutate the input. When work needs
+ * to be done, we deep-clone via `cloneResolvedProgram` and mutate the
+ * clone freely. This keeps the rewrite local — surviving `InstanceDecl`
+ * objects preserve their identity inside the clone, so cross-decl
+ * `NestedOut` refs stay consistent without an explicit rename pass.
+ *
+ * Pure, idempotent, meaning-preserving. Runs at every level of the
+ * strata pipeline because the pipeline itself recurses through nested
+ * programs.
+ */
+
+import type {
+  ResolvedProgram, ResolvedExpr, ResolvedExprOp,
+  InstanceDecl, InputDecl, OutputDecl,
+  Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith, Let, Tag, Match,
+} from './nodes.js'
+import { cloneResolvedProgram } from './clone.js'
+
+// ─── Detection ─────────────────────────────────────────────────────────────
+
+/** An identity `InstanceDecl` carries enough information to rewire its
+ *  consumers. For each output port we record the resolved expression
+ *  that would substitute for `NestedOut(I, output)`. */
+interface IdentityDeclRewrite {
+  readonly inst: InstanceDecl
+  /** For each of the instance's outputs, the expression to substitute
+   *  for `NestedOut(I, output)`. */
+  readonly outputSub: ReadonlyMap<OutputDecl, ResolvedExpr>
+}
+
+/** Recognize whether an InstanceDecl's program body is the identity
+ *  morphism. A program is identity when its body has no decls (no
+ *  state, no nested instances), and every output is assigned exactly
+ *  one `inputRef` (each output forwards a specific input). */
+function detectIdentity(inst: InstanceDecl): IdentityDeclRewrite | null {
+  const prog = inst.type
+
+  // No state, no nested instances, no parameters in the body.
+  if (prog.body.decls.length > 0) return null
+
+  // Build input → wired-expression map from this InstanceDecl's inputs.
+  const inputToWire = new Map<InputDecl, ResolvedExpr>()
+  for (const i of inst.inputs) inputToWire.set(i.port, i.value)
+
+  const outputSub = new Map<OutputDecl, ResolvedExpr>()
+  for (const o of prog.ports.outputs) {
+    // Find the (single) outputAssign for this output.
+    const assigns = prog.body.assigns.filter(
+      a => a.op === 'outputAssign' && a.target === o,
+    )
+    if (assigns.length !== 1) return null   // missing or duplicated
+
+    const expr = (assigns[0] as { expr: ResolvedExpr }).expr
+    // Identity case: expr is exactly `inputRef(p)` for some input port p.
+    if (typeof expr !== 'object' || expr === null || Array.isArray(expr)) return null
+    if (expr.op !== 'inputRef') return null
+
+    const inputDecl = expr.decl
+    const wired = inputToWire.get(inputDecl)
+    if (wired === undefined) {
+      // The instance must have a wire for every required input; if not,
+      // we don't have enough information to inline. Defensive — should
+      // not happen in well-formed IR.
+      return null
+    }
+    outputSub.set(o, wired)
+  }
+
+  // Must have at least one output to be a meaningful identity.
+  if (outputSub.size === 0) return null
+
+  return { inst, outputSub }
+}
+
+// ─── Substitution ─────────────────────────────────────────────────────────
+
+type SubstMap = ReadonlyMap<InstanceDecl, ReadonlyMap<OutputDecl, ResolvedExpr>>
+
+function substExpr(
+  e: ResolvedExpr,
+  subst: SubstMap,
+  memo: WeakMap<object, ResolvedExpr>,
+): ResolvedExpr {
+  if (typeof e === 'number' || typeof e === 'boolean') return e
+  if (Array.isArray(e)) {
+    const cached = memo.get(e)
+    if (cached !== undefined) return cached
+    const out = e.map(x => substExpr(x, subst, memo))
+    memo.set(e, out)
+    return out
+  }
+  const cached = memo.get(e)
+  if (cached !== undefined) return cached
+  const out = substOpNode(e, subst, memo)
+  memo.set(e, out)
+  return out
+}
+
+function substOpNode(
+  node: ResolvedExprOp,
+  subst: SubstMap,
+  memo: WeakMap<object, ResolvedExpr>,
+): ResolvedExpr {
+  const recur = (x: ResolvedExpr) => substExpr(x, subst, memo)
+
+  switch (node.op) {
+    case 'nestedOut': {
+      const perInstance = subst.get(node.instance)
+      if (perInstance === undefined) return node
+      const v = perInstance.get(node.output)
+      if (v === undefined) return node
+      // The replacement expression may itself contain nestedOut refs to
+      // OTHER identity instances; walk recursively so chains collapse.
+      return recur(v)
+    }
+    case 'inputRef':
+    case 'regRef':
+    case 'delayRef':
+    case 'paramRef':
+    case 'typeParamRef':
+    case 'bindingRef':
+    case 'sampleRate':
+    case 'sampleIndex':
+      return node
+
+    // Binary
+    case 'add': case 'sub': case 'mul': case 'div': case 'mod':
+    case 'lt':  case 'lte': case 'gt':  case 'gte': case 'eq':  case 'neq':
+    case 'and': case 'or':
+    case 'bitAnd': case 'bitOr': case 'bitXor': case 'lshift': case 'rshift':
+    case 'floorDiv': case 'ldexp':
+      return { op: node.op, args: [recur(node.args[0]), recur(node.args[1])] }
+
+    // Unary
+    case 'neg': case 'not': case 'bitNot':
+    case 'sqrt': case 'abs': case 'floor': case 'ceil': case 'round':
+    case 'floatExponent': case 'toInt': case 'toBool': case 'toFloat':
+      return { op: node.op, args: [recur(node.args[0])] }
+
+    // Ternary
+    case 'clamp':
+      return { op: 'clamp', args: [recur(node.args[0]), recur(node.args[1]), recur(node.args[2])] }
+    case 'select':
+      return { op: 'select', args: [recur(node.args[0]), recur(node.args[1]), recur(node.args[2])] }
+    case 'arraySet':
+      return { op: 'arraySet', args: [recur(node.args[0]), recur(node.args[1]), recur(node.args[2])] }
+    case 'index':
+      return { op: 'index', args: [recur(node.args[0]), recur(node.args[1])] }
+    case 'zeros':
+      return { op: 'zeros', count: recur(node.count) }
+
+    case 'fold': {
+      const fresh: Fold = {
+        op: 'fold',
+        over: recur(node.over),
+        init: recur(node.init),
+        acc:  node.acc,
+        elem: node.elem,
+        body: recur(node.body),
+      }
+      return fresh
+    }
+    case 'scan': {
+      const fresh: Scan = {
+        op: 'scan',
+        over: recur(node.over),
+        init: recur(node.init),
+        acc:  node.acc,
+        elem: node.elem,
+        body: recur(node.body),
+      }
+      return fresh
+    }
+    case 'generate': {
+      const fresh: Generate = { op: 'generate', count: recur(node.count), iter: node.iter, body: recur(node.body) }
+      return fresh
+    }
+    case 'iterate': {
+      const fresh: Iterate = { op: 'iterate', count: recur(node.count), init: recur(node.init), iter: node.iter, body: recur(node.body) }
+      return fresh
+    }
+    case 'chain': {
+      const fresh: Chain = { op: 'chain', count: recur(node.count), init: recur(node.init), iter: node.iter, body: recur(node.body) }
+      return fresh
+    }
+    case 'map2': {
+      const fresh: Map2 = { op: 'map2', over: recur(node.over), elem: node.elem, body: recur(node.body) }
+      return fresh
+    }
+    case 'zipWith': {
+      const fresh: ZipWith = { op: 'zipWith', a: recur(node.a), b: recur(node.b), x: node.x, y: node.y, body: recur(node.body) }
+      return fresh
+    }
+    case 'let': {
+      const fresh: Let = {
+        op: 'let',
+        binders: node.binders.map(b => ({ binder: b.binder, value: recur(b.value) })),
+        in: recur(node.in),
+      }
+      return fresh
+    }
+    case 'tag': {
+      const fresh: Tag = {
+        op: 'tag',
+        variant: node.variant,
+        payload: node.payload.map(p => ({ field: p.field, value: recur(p.value) })),
+      }
+      return fresh
+    }
+    case 'match': {
+      const fresh: Match = {
+        op: 'match',
+        type: node.type,
+        scrutinee: recur(node.scrutinee),
+        arms: node.arms.map(arm => ({
+          variant: arm.variant,
+          binders: arm.binders,
+          body: recur(arm.body),
+        })),
+      }
+      return fresh
+    }
+  }
+}
+
+// ─── Pass entry point ─────────────────────────────────────────────────────
+
+/** Eliminate identity InstanceDecls from a `ResolvedProgram`. Idempotent
+ *  — applying twice produces the same result as applying once. Does not
+ *  mutate the input program. */
+export function identityElim(prog: ResolvedProgram): ResolvedProgram {
+  // Fast path: detect any identities on the input WITHOUT cloning. If
+  // none, return the original program unchanged.
+  const anyIdentity = prog.body.decls.some(
+    d => d.op === 'instanceDecl' && detectIdentity(d) !== null,
+  )
+  if (!anyIdentity) return prog
+
+  // Clone the program so we can mutate freely. Cloning rewrites all
+  // internal references to the cloned decl objects, which means
+  // identityElim's mutations are local and consistent without a
+  // separate rename pass.
+  const cloned = cloneResolvedProgram(prog)
+
+  // Re-detect identities on the clone (fresh InstanceDecl objects).
+  const identities: IdentityDeclRewrite[] = []
+  for (const decl of cloned.body.decls) {
+    if (decl.op !== 'instanceDecl') continue
+    const id = detectIdentity(decl)
+    if (id !== null) identities.push(id)
+  }
+  // Defensive — if the clone disagreed with the input, something is wrong.
+  if (identities.length === 0) return cloned
+
+  const subst = new Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>()
+  for (const id of identities) {
+    subst.set(id.inst, new Map(id.outputSub))
+  }
+  const eliminated = new Set<InstanceDecl>(identities.map(id => id.inst))
+  const memo = new WeakMap<object, ResolvedExpr>()
+
+  // Mutate the clone in place. Surviving InstanceDecls keep their
+  // identity; references in expressions stay consistent.
+  for (const decl of cloned.body.decls) {
+    if (decl.op === 'instanceDecl') {
+      if (eliminated.has(decl)) continue   // dropping it; no need to rewrite
+      // Surviving instance: rewrite its input wiring expressions in place.
+      for (const i of decl.inputs) {
+        i.value = substExpr(i.value, subst, memo)
+      }
+    } else if (decl.op === 'regDecl') {
+      decl.init = substExpr(decl.init, subst, memo)
+    } else if (decl.op === 'delayDecl') {
+      decl.init   = substExpr(decl.init,   subst, memo)
+      decl.update = substExpr(decl.update, subst, memo)
+    }
+    // ParamDecl, ProgramDecl — no expressions to rewrite; leave alone.
+  }
+  for (const a of cloned.body.assigns) {
+    a.expr = substExpr(a.expr, subst, memo)
+  }
+
+  // Drop eliminated InstanceDecls from the body.
+  cloned.body.decls = cloned.body.decls.filter(
+    d => !(d.op === 'instanceDecl' && eliminated.has(d)),
+  )
+
+  return cloned
+}

--- a/compiler/ir/lift_wires.ts
+++ b/compiler/ir/lift_wires.ts
@@ -1,0 +1,148 @@
+/**
+ * lift_wires.ts — pre-compile pass that lifts complex wire expressions
+ * to anonymous program instances.
+ *
+ * Phase 5 of M11 fractal compilation. Wires whose expression contains
+ * forms that `translateNode` doesn't support (array literals, session-
+ * level `delay()`) are extracted into anonymous programs at session
+ * pre-compile time. The lifted program goes through the full strata
+ * pipeline — `arrayLower` handles array literals, `traceCycles` /
+ * `delay()` synthesis handles session delays — and the existing
+ * per-instance compile path then treats the lifted instance like any
+ * other.
+ *
+ * After this pass:
+ *   - `session.inputExprNodes` entries contain only "simple" wires that
+ *     `translateNode` can handle (refs, params, triggers, sentinels,
+ *     scalar arithmetic).
+ *   - `session.instanceRegistry` has one extra `__wire_${i}` instance
+ *     per lifted wire.
+ *   - Each lifted instance's free refs are wired in `inputExprNodes`
+ *     so the existing compile path resolves them via slot reads.
+ *
+ * Idempotent on already-lifted sessions: re-running finds no
+ * complex wires and is a no-op.
+ */
+
+import type { SessionState, ExprNode } from '../session.js'
+import { freeRefs, liftWireToProgram } from './wire_program.js'
+import { instanceName, rawName, type PortRef } from './branded_names.js'
+import { programTypeFromResolved } from './strata.js'
+import { instantiate } from '../program_types.js'
+import { allocateOutputSlots } from '../session.js'
+
+// ─── Detection: which wires need to be lifted? ────────────────────────────
+
+/** Returns true if any subtree of `expr` contains a form that
+ *  `translateNode` in `compile_session_slotted_helpers.ts` rejects. The
+ *  positive list of rejections (in M11 terms): array literals (bare or
+ *  `{op:'array'}` / `{op:'arrayLiteral'}`) and session-level
+ *  `{op:'delay'}`. Other shapes are conservatively assumed to be OK
+ *  for `translateNode`. */
+export function needsWireLift(expr: ExprNode): boolean {
+  if (Array.isArray(expr)) return true   // bare array literal
+  if (typeof expr !== 'object' || expr === null) return false
+  const obj = expr as Record<string, unknown>
+  const op = obj.op
+  if (op === 'array' || op === 'arrayLiteral') return true
+  if (op === 'delay') return true
+  // Recurse into known child-shapes.
+  if (Array.isArray(obj.args)) {
+    for (const a of obj.args as ExprNode[]) if (needsWireLift(a)) return true
+  }
+  if (Array.isArray(obj.items)) {
+    for (const a of obj.items as ExprNode[]) if (needsWireLift(a)) return true
+  }
+  return false
+}
+
+// ─── Lift one wire ────────────────────────────────────────────────────────
+
+/** Returns the synthesized name for the lifted wire-instance. The
+ *  counter is per-session, stored on `session.nameCounters` under a
+ *  reserved key so the existing nextName mechanism doesn't collide. */
+function nextWireName(session: SessionState): string {
+  const key = '__wire'
+  const n = (session.nameCounters.get(key) ?? 0) + 1
+  session.nameCounters.set(key, n)
+  return `__wire_${n}`
+}
+
+/** Lift a single wire's `ExprNode` to an anonymous program instance.
+ *  Mutates `session` — registers the instance and wires its free refs
+ *  back to their original sources. Returns the replacement `ExprNode`:
+ *  `{op:'ref', instance: '__wire_N', output: 'out'}`. */
+function liftOneWire(
+  session: SessionState,
+  expr: ExprNode,
+  context: string,
+): ExprNode {
+  const refs = freeRefs(expr)
+  const synthName = instanceName(nextWireName(session))
+
+  // Build the synthetic ResolvedProgram. The wire-program lift
+  // accepts free refs and a synthesized name; output port is 'out'.
+  const lifted = liftWireToProgram(expr, refs, synthName)
+
+  // Run strata to lower combinators (let, array literals via
+  // arrayLower; session delay via traceCycles).
+  const compiled = programTypeFromResolved(lifted, new Map(), {
+    displayName: rawName(synthName),
+  })
+
+  // Register the type so materializeSession (oracle path) can find it
+  // by name, then instantiate and allocate output slots.
+  session.typeRegistry.set(rawName(synthName), compiled)
+  session.resolvedRegistry.set(rawName(synthName), lifted)
+  const inst = instantiate(compiled, rawName(synthName), {
+    baseTypeName: rawName(synthName),
+  })
+  session.instanceRegistry.set(rawName(synthName), inst)
+  allocateOutputSlots(session, rawName(synthName), compiled)
+
+  // Wire each free ref to its corresponding input on the lifted
+  // instance. The input naming convention matches `liftWireToProgram`:
+  // `${instance.replace('.','_')}__${port}`.
+  const refList = Array.from(refs).sort((a, b) =>
+    `${rawName(a.instance)}:${rawName(a.port)}`.localeCompare(
+      `${rawName(b.instance)}:${rawName(b.port)}`,
+    ),
+  )
+  for (const ref of refList) {
+    const inputName = `${rawName(ref.instance).replace(/\./g, '_')}__${rawName(ref.port)}`
+    const wireKey = `${rawName(synthName)}:${inputName}`
+    // Forward the original ref expression unchanged — this is now a
+    // simple `{op:'ref',...}` wire that translateNode handles.
+    session.inputExprNodes.set(wireKey, {
+      op: 'ref',
+      instance: rawName(ref.instance),
+      output: rawName(ref.port),
+    })
+  }
+
+  void context
+  return { op: 'ref', instance: rawName(synthName), output: 'out' }
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────
+
+/** Walk `session.inputExprNodes`. For every wire whose expression
+ *  contains a form `translateNode` doesn't handle, lift it to an
+ *  anonymous `__wire_${i}` program instance. After this pass, every
+ *  remaining wire is `translateNode`-compatible. */
+export function liftWiresToInstances(session: SessionState): void {
+  // Capture wires before mutation; we'll modify the map as we go but
+  // never want to re-lift a wire we just inserted.
+  const toLift: Array<{ key: string; expr: ExprNode }> = []
+  for (const [key, expr] of session.inputExprNodes) {
+    if (needsWireLift(expr)) toLift.push({ key, expr })
+  }
+
+  for (const { key, expr } of toLift) {
+    const replacement = liftOneWire(session, expr, key)
+    session.inputExprNodes.set(key, replacement)
+  }
+}
+
+// Re-exports for callers
+export type { PortRef }

--- a/compiler/ir/n_write_slot_expansion.test.ts
+++ b/compiler/ir/n_write_slot_expansion.test.ts
@@ -1,0 +1,94 @@
+/**
+ * n_write_slot_expansion.test.ts — Phase 3 structural witness.
+ *
+ * Verifies that array-typed instance OUTPUT ports compile to N
+ * WriteSlots (one per scalar element) rather than 1 WriteSlot per port.
+ *
+ * The actual end-to-end stdlib tests (Clock equivalence, BubbleCloud
+ * round-trip) are still blocked on Phase 5's array-input handling.
+ * This test isolates the output-side fix.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession } from '../session.js'
+import { loadProgramAsType } from '../program.js'
+import { compileSession } from './compile_session.js'
+
+describe('Phase 3 — N-WriteSlot expansion for array output ports', () => {
+  test('an instance with array_out: float[3] emits 3 WriteSlots', () => {
+    const session = makeSession(64)
+
+    // Register a type with BOTH an array-typed output (for WriteSlot
+    // expansion) and a scalar output (for the DAC wire). DAC stitch
+    // for array-typed graphOutputs is out of M11 Phase 3 scope.
+    loadProgramAsType({
+      op: 'program',
+      name: 'ArrayOut',
+      ports: {
+        outputs: [
+          { name: 'arr',    type: { element: 'float', shape: [3] } },
+          { name: 'single', type: 'float' },
+        ],
+      },
+      body: { op: 'block', assigns: [
+        { op: 'outputAssign', name: 'arr',    expr: [10, 20, 30] },
+        { op: 'outputAssign', name: 'single', expr: 0.5 },
+      ]},
+    } as Parameters<typeof loadProgramAsType>[0], session)
+
+    const { loadJSON } = require('../session.js') as typeof import('../session.js')
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'patch',
+      body: { op: 'block', decls: [
+        { op: 'instanceDecl', name: 'a', program: 'ArrayOut', inputs: {} },
+      ]},
+      audio_outputs: [{ instance: 'a', output: 'single' }],
+    } as Parameters<typeof loadJSON>[0], session)
+
+    // Confirm slot allocation expanded to 3 for the array port.
+    const aMeta = session.outputPortMeta.get('a.arr')
+    expect(aMeta).toBeDefined()
+    expect(aMeta!.scalarSlotNames).toEqual(['a.arr[0]', 'a.arr[1]', 'a.arr[2]'])
+
+    // Compile and inspect.
+    const plan = compileSession(session)
+    expect(plan.instance_functions.length).toBe(1)
+    const instFn = plan.instance_functions[0]
+
+    // Count WriteSlot instructions in the instance body. Expected:
+    //   3 for arr[0], arr[1], arr[2]
+    // + 1 for single
+    // = 4
+    const writeSlots = instFn.instructions.filter(i => i.tag === 'WriteSlot')
+    expect(writeSlots.length).toBe(4)
+  })
+
+  test('scalar output port still emits 1 WriteSlot', () => {
+    const session = makeSession(64)
+
+    loadProgramAsType({
+      op: 'program',
+      name: 'ScalarOut',
+      ports: { outputs: [{ name: 's', type: 'float' }] },
+      body: { op: 'block', assigns: [
+        { op: 'outputAssign', name: 's', expr: 5 },
+      ]},
+    } as Parameters<typeof loadProgramAsType>[0], session)
+
+    const { loadJSON } = require('../session.js') as typeof import('../session.js')
+    loadJSON({
+      schema: 'tropical_program_2',
+      name: 'patch',
+      body: { op: 'block', decls: [
+        { op: 'instanceDecl', name: 'a', program: 'ScalarOut', inputs: {} },
+      ]},
+      audio_outputs: [{ instance: 'a', output: 's' }],
+    } as Parameters<typeof loadJSON>[0], session)
+
+    const plan = compileSession(session)
+    const writeSlots = plan.instance_functions[0].instructions.filter(i => i.tag === 'WriteSlot')
+    // 1 for the scalar output (alive comes from scheduler preamble).
+    expect(writeSlots.length).toBe(1)
+  })
+})

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -1,0 +1,278 @@
+/**
+ * partition_recursive.ts — recursive partitioner for fractal compilation.
+ *
+ * Walks a `ResolvedProgram` whose body may contain nested `InstanceDecl`s
+ * and produces a tree of `InstanceFunction`s — one per `InstanceDecl` at
+ * every level of nesting. Each kernel:
+ *
+ *   - has its own alive slot (full-path name: `voice1.env.__alive__`)
+ *   - has its own state-reg / temp / array-slot offsets in the unified
+ *     namespaces (no per-kernel isolation; just bookkeeping)
+ *   - has its own output slots (full-path: `voice1.env.out` etc.)
+ *   - emits WriteSlots for each scalar slot of every output port
+ *
+ * Children's inputs are substituted into their bodies at partition time
+ * via `cloneWithInputSubst` — by the time `compileResolved` runs on a
+ * child, no `InputRef` survives in the body. The substituted child
+ * compiles as a self-contained kernel.
+ *
+ * Cross-kernel reads in the parent's body (`NestedOut(child, output)`)
+ * resolve to slot reads via `compileResolved`'s `nestedOutputSlots`
+ * context — populated here as we allocate child output slots before
+ * compiling the parent.
+ *
+ * No engine-side change needed: `OrcJitEngine.cpp::emit_kernel_block`
+ * already recursively emits child basic blocks inside the parent's
+ * alive-conditional.
+ */
+
+import type {
+  ResolvedProgram, ResolvedExpr, InstanceDecl, InputDecl, OutputDecl, ParamDecl,
+} from './nodes.js'
+import type { SessionState, ExprNode } from '../session.js'
+import type {
+  InstanceFunction, RegTarget,
+} from '../flat_plan.js'
+import { TempTarget, ArrayManagedTarget } from '../flat_plan.js'
+import type { NInstr } from './emit_resolved.js'
+import {
+  type TempIdx, type ModuleSlotIdx,
+  tempIdx, moduleSlotIdx,
+  tempOffset, stateRegOffset, arraySlotOffset,
+} from './slot_indices.js'
+import { type ScalarType, instrWriteSlot, opConst } from './emit_resolved.js'
+import { compileResolved } from './compile_resolved.js'
+import { cloneWithInputSubst } from './clone.js'
+import { makeCompiled, type Compiled } from '../program_types.js'
+import {
+  inputNames, outputNames, outputPortTypes, rawInputDefaults,
+} from '../program_types.js'
+import { allocateOutputSlots } from '../session.js'
+import {
+  remapInstancePlan, type RemapContext, type InputBinding,
+} from './compile_session_slotted_helpers.js'
+
+// ─── Accumulator ──────────────────────────────────────────────────────────
+
+/** Mutable state threaded through the recursion. The unified slot
+ *  namespaces accumulate as kernels are emitted; the order matches
+ *  depth-first walk of the kernel tree (children before parent). */
+export interface PartitionAccumulators {
+  nextRegRaw:        number
+  nextStateRaw:      number
+  nextArrayRaw:      number
+  registerNames:     string[]
+  registerTypes:     ScalarType[]
+  stateInit:         (number | boolean)[]
+  arraySlotSizes:    number[]
+  arraySlotNames:    string[]
+  /** Alive-slot preamble emissions, one per kernel. Filled as we walk
+   *  the tree; appended to the scheduler preamble at the end. */
+  alivePreambleOps:  Array<{ aliveSlot: ModuleSlotIdx; expr: ExprNode | undefined }>
+}
+
+export function makeAccumulators(): PartitionAccumulators {
+  return {
+    nextRegRaw:        0,
+    nextStateRaw:      0,
+    nextArrayRaw:      0,
+    registerNames:     [],
+    registerTypes:     [],
+    stateInit:         [],
+    arraySlotSizes:    [],
+    arraySlotNames:    [],
+    alivePreambleOps:  [],
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const scalarOf = (t: ReturnType<typeof outputPortTypes>[number]): ScalarType => {
+  if (t === undefined) return 'float'
+  if (t.kind === 'scalar') return t.scalar
+  if (t.kind === 'alias')  return t.alias.base as ScalarType
+  return 'float'
+}
+
+/** Look up the (first scalar) slot index for an instance's output port. */
+function lookupOutputSlot(
+  session: SessionState,
+  instancePath: string,
+  portName: string,
+): number | undefined {
+  const portKey = `${instancePath}.${portName}`
+  const meta = session.outputPortMeta.get(portKey)
+  if (meta === undefined || meta.scalarSlotNames.length === 0) return undefined
+  return session.outputSlotRegistry.get(meta.scalarSlotNames[0])
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────
+
+/** Result of compiling a single kernel: the InstanceFunction (with
+ *  nested children populated) plus the slot map describing this
+ *  kernel's outputs so the caller can wire NestedOut refs in the
+ *  parent's body. */
+export interface PartitionedKernel {
+  fn: InstanceFunction
+  /** Per output-port slot index of this kernel's outputs. Used by the
+   *  parent's `nestedOutputSlots` map when compiling the parent. */
+  outputSlots: Map<OutputDecl, number>
+}
+
+/** Partition a single kernel (recursively). Mutates `session` (slot
+ *  allocations) and `acc` (offset accumulators + alive preamble ops).
+ *
+ *  `inputBindingFor` provides the binding for each input port of THIS
+ *  kernel. For top-level session instances, it consults
+ *  `session.inputExprNodes`. For nested kernels, all input ports have
+ *  been substituted out by `cloneWithInputSubst`, so this function is
+ *  unused (no `opInput` operands survive). Pass `() => undefined` for
+ *  nested calls; the defaults-fallback handles unused declared inputs.
+ */
+export function partitionKernel(
+  instancePath: string,
+  prog: ResolvedProgram,
+  compiled: Compiled,
+  aliveInput: ExprNode | undefined,
+  inputBindingFor: (portName: string) => InputBinding | undefined,
+  defaults: Record<string, ExprNode>,
+  paramHandles: Map<ParamDecl, { ptr: string }>,
+  session: SessionState,
+  acc: PartitionAccumulators,
+): PartitionedKernel {
+  // ── 1. Recurse into sub-InstanceDecls. Substitute their inputs;
+  //    allocate their output slots; build the nestedOutputSlots map for
+  //    this kernel's NestedOut refs.
+  const children: InstanceFunction[] = []
+  const nestedOutputSlots = new Map<InstanceDecl, Map<OutputDecl, number>>()
+
+  for (const decl of prog.body.decls) {
+    if (decl.op !== 'instanceDecl') continue
+    const childPath = `${instancePath}.${decl.name}`
+
+    // Substitute the child's input refs with the parent's wired expressions.
+    const inputSubst = new Map<InputDecl, ResolvedExpr>()
+    for (const inp of decl.inputs) inputSubst.set(inp.port, inp.value)
+    const substChildProg = cloneWithInputSubst(decl.type, inputSubst)
+    const childCompiled = makeCompiled(substChildProg, { displayName: decl.type.name })
+
+    // Allocate output slots (+ __alive__) for the child.
+    allocateOutputSlots(session, childPath, childCompiled)
+
+    // Build slot map for parent's NestedOut → child output reads.
+    const childSlotMap = new Map<OutputDecl, number>()
+    for (const outDecl of decl.type.ports.outputs) {
+      const slotIdx = lookupOutputSlot(session, childPath, outDecl.name)
+      if (slotIdx !== undefined) childSlotMap.set(outDecl, slotIdx)
+    }
+    nestedOutputSlots.set(decl, childSlotMap)
+
+    // Recursively compile the child. Children inherit their parent's
+    // paramHandles. AliveInput is undefined for nested (default 1.0).
+    // No external input bindings — all substituted into the body.
+    const childResult = partitionKernel(
+      childPath, substChildProg, childCompiled,
+      /* aliveInput     */ undefined,
+      /* inputBindingFor*/ () => undefined,
+      /* defaults       */ rawInputDefaults(childCompiled),
+      paramHandles,
+      session, acc,
+    )
+    children.push(childResult.fn)
+  }
+
+  // ── 2. Compile this kernel's body via compileResolved.
+  const plan = compileResolved(prog, {
+    paramHandles,
+    nestedOutputSlots,
+  })
+
+  // ── 3. Remap the plan into the unified slot/temp space.
+  const inPortNames  = inputNames(compiled)
+  const outPortNames = outputNames(compiled)
+  const outPortTypes = outputPortTypes(compiled).map(scalarOf)
+
+  const ctx: RemapContext = {
+    instanceName: instancePath,
+    regOffset:       tempOffset(acc.nextRegRaw),
+    stateRegOffset:  stateRegOffset(acc.nextStateRaw),
+    arraySlotOffset: arraySlotOffset(acc.nextArrayRaw),
+    inputBindingFor: (portName: string) => {
+      const binding = inputBindingFor(portName)
+      if (binding !== undefined) return binding
+      const d = defaults[portName]
+      const value = (typeof d === 'number' || typeof d === 'boolean') ? d : 0
+      return { kind: 'literal', value }
+    },
+    outputSlotFor: (portName: string) => {
+      const slot = lookupOutputSlot(session, instancePath, portName)
+      if (slot === undefined) {
+        throw new Error(
+          `partitionKernel: instance '${instancePath}' port '${portName}' has no allocated slot`,
+        )
+      }
+      return moduleSlotIdx(slot)
+    },
+    inputPortNames:    inPortNames,
+    outputPortNames:   outPortNames,
+    outputScalarTypes: outPortTypes,
+  }
+
+  const { preamble, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
+  const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
+
+  const aliveSlotRaw = session.outputSlotRegistry.get(`${instancePath}.__alive__`)
+  if (aliveSlotRaw === undefined) {
+    throw new Error(
+      `partitionKernel: '${instancePath}' has no __alive__ slot — allocateOutputSlots should have reserved it`,
+    )
+  }
+  const aliveSlot = moduleSlotIdx(aliveSlotRaw)
+
+  // Record this kernel's alive expression so the caller can build the
+  // scheduler preamble (which writes 1.0 or the alive expr each sample,
+  // letting GVN fold the default-alive case).
+  acc.alivePreambleOps.push({ aliveSlot, expr: aliveInput })
+
+  // Shift per-instance register_targets into the unified temp space.
+  const shiftedTargets: RegTarget[] = plan.register_targets.map(t => {
+    if (t.kind === 'arrayManaged') return ArrayManagedTarget
+    return TempTarget(tempIdx(t.slot + acc.nextRegRaw))
+  })
+
+  const fn: InstanceFunction = {
+    name:              `instance_${instancePath.replace(/\./g, '_')}`,
+    instance_name:     instancePath,
+    instructions:      instanceInstructions,
+    register_offset:   tempOffset(acc.nextRegRaw),
+    state_reg_offset:  stateRegOffset(acc.nextStateRaw),
+    array_slot_offset: arraySlotOffset(acc.nextArrayRaw),
+    register_count:    plan.register_count + tempsConsumed,
+    register_targets:  shiftedTargets,
+    alive_slot_index:  aliveSlot,
+    children,
+  }
+
+  // ── 4. Update accumulators (THIS kernel's contribution to the unified
+  //    namespaces). Note: children's accumulator updates already happened
+  //    via the recursive calls above, so we just add this kernel's own.
+  for (const n of plan.register_names) acc.registerNames.push(`${instancePath}.${n}`)
+  acc.registerTypes.push(...plan.register_types)
+  for (const v of plan.state_init) acc.stateInit.push(v as number | boolean)
+  acc.arraySlotSizes.push(...plan.array_slot_sizes)
+  for (const n of plan.array_slot_names) acc.arraySlotNames.push(`${instancePath}.${n}`)
+
+  acc.nextRegRaw   += plan.register_count + tempsConsumed
+  acc.nextStateRaw += plan.state_init.length
+  acc.nextArrayRaw += plan.array_slot_count
+
+  // ── 5. Build the parent-visible output slot map (one entry per
+  //    output port; for array ports this is the first scalar slot).
+  const outputSlots = new Map<OutputDecl, number>()
+  for (const outDecl of prog.ports.outputs) {
+    const slot = lookupOutputSlot(session, instancePath, outDecl.name)
+    if (slot !== undefined) outputSlots.set(outDecl, slot)
+  }
+
+  return { fn, outputSlots }
+}

--- a/compiler/ir/strata.ts
+++ b/compiler/ir/strata.ts
@@ -28,14 +28,25 @@ import { inlineInstances } from './inline_instances.js'
 import { arrayLower } from './array_lower.js'
 import { identityElim } from './identity_elim.js'
 
+export interface StrataOptions {
+  /** Whether to flatten nested `InstanceDecl`s via `inlineInstances`.
+   *  Default `true` (legacy / per-program-emit behavior). The fractal
+   *  session path passes `false` so sub-instances survive as kernel
+   *  boundaries — every `InstanceDecl` at every level becomes its own
+   *  kernel in `partition_recursive`. */
+  inlineNested?: boolean
+}
+
 export function strataPipeline(
   prog: ResolvedProgram,
   typeArgs: ReadonlyMap<TypeParamDecl, number> = new Map(),
+  options: StrataOptions = {},
 ): ResolvedProgram {
+  const { inlineNested = true } = options
   const specialized = specializeProgram(prog, typeArgs)
   const summed = sumLower(specialized)
   const cyclic = traceCycles(summed)
-  const inlined = inlineInstances(cyclic)
+  const inlined = inlineNested ? inlineInstances(cyclic) : cyclic
   const arrayed = arrayLower(inlined)
   return identityElim(arrayed)
 }

--- a/compiler/ir/strata.ts
+++ b/compiler/ir/strata.ts
@@ -3,9 +3,18 @@
  *
  * Composes the strata passes in order:
  *
- *   specialize → sumLower → traceCycles → inlineInstances → arrayLower
+ *   specialize → sumLower → traceCycles → inlineInstances
+ *              → arrayLower → identityElim
  *
- * After arrayLower, the result is a post-strata `ResolvedProgram`
+ * `identityElim` (M11 Phase 2) is the categorical identity-law rewrite:
+ * it eliminates `InstanceDecl`s whose program body is the identity
+ * morphism. Today (pre-Phase-4) it rarely fires at the per-program
+ * level — `inlineInstances` runs first and absorbs trivial sub-instances.
+ * Once Phase 4 retires `inlineInstances` from the session-level
+ * pipeline, `identityElim` catches the trivial wire-programs that would
+ * otherwise survive as no-op kernels.
+ *
+ * After identityElim, the result is a post-strata `ResolvedProgram`
  * consumed by either `compileResolved` (the JIT path) or
  * `interpret_resolved.ts` (the independent oracle).
  */
@@ -17,6 +26,7 @@ import { sumLower } from './sum_lower.js'
 import { traceCycles } from './trace_cycles.js'
 import { inlineInstances } from './inline_instances.js'
 import { arrayLower } from './array_lower.js'
+import { identityElim } from './identity_elim.js'
 
 export function strataPipeline(
   prog: ResolvedProgram,
@@ -26,7 +36,8 @@ export function strataPipeline(
   const summed = sumLower(specialized)
   const cyclic = traceCycles(summed)
   const inlined = inlineInstances(cyclic)
-  return arrayLower(inlined)
+  const arrayed = arrayLower(inlined)
+  return identityElim(arrayed)
 }
 
 /** Run the full strata pipeline + wrap the post-strata `ResolvedProgram`

--- a/compiler/ir/strata.ts
+++ b/compiler/ir/strata.ts
@@ -51,12 +51,19 @@ export function strataPipeline(
   return identityElim(arrayed)
 }
 
-/** Run the full strata pipeline + wrap the post-strata `ResolvedProgram`
+/** Run the full strata pipeline + wrap the resulting `ResolvedProgram`
  *  in a `Compiled` record. Helpers in `program_types.ts` expose
  *  port/register/default metadata via free functions over the resolved
- *  IR — no slot-indexed flattening upfront. The optional `displayName`
- *  rebrands the wrapped name for the specialization cache (e.g.
- *  `Type<N=8>`) without mutating `prog.name`. */
+ *  IR.
+ *
+ *  Currently uses default inlining (`inlineNested: true`). The fractal
+ *  architecture (M11) is fully infrastructured — `partition_recursive`,
+ *  `NestedOut → slot read` in emit_resolved, recursive JIT emit, schema
+ *  field for `children` — but ACTIVATION (flipping to `inlineNested:
+ *  false`) is deferred: the cross-kernel input-wiring path (child
+ *  refers to parent's `inputRef`) needs an ancestor-resolution step
+ *  before partition. Once that lands, set `inlineNested: false` here
+ *  and full fractal activates uniformly. */
 export function programTypeFromResolved(
   prog: ResolvedProgram,
   typeArgs: ReadonlyMap<TypeParamDecl, number>,

--- a/compiler/ir/trace_cycles.test.ts
+++ b/compiler/ir/trace_cycles.test.ts
@@ -775,11 +775,18 @@ describe('Phase A — cycle topologies (TDD plan)', () => {
   // Test 6 — (D) Session-level feedback via session-level delay
   // ──────────────────────────────────────────────────────────
   test.skip('(D) session-level delay() between two instances: denotation matches flattened reference', () => {
-    // Skipped under the active-set runtime: explicit session-level
-    // `delay()` in wiring is being superseded by the slot
-    // architecture's intrinsic unit-delay-on-back-edge. translateNode
-    // doesn't yet emit a synthetic state register for `op: 'delay'`;
-    // tracked as a follow-up.
+    // Phase 5 of M11 lifts `delay()` wire expressions to anonymous
+    // programs whose body contains the delay. But this hides the
+    // session-level delay from traceCycles: the lift turns a 1-sample
+    // delay into a 2-sample delay (one from the lifted body's delay,
+    // one from traceCycles inserting a synthetic delay for the cycle
+    // it now sees with no explicit delay at the session edge).
+    //
+    // Correct handling requires lifting that PRESERVES the delay at
+    // the session-edge level — either by leaving `delay()` at the
+    // session level and only lifting its arg, or by teaching
+    // traceCycles to detect existing delays inside lifted wire bodies.
+    // Tracked as a Phase 5 follow-up.
     // Two Inner instances feeding each other through an explicit
     // delay() expression. The session-level delay() short-circuits the
     // cycle so traceCycles sees no SCC.

--- a/compiler/ir/wire_program.test.ts
+++ b/compiler/ir/wire_program.test.ts
@@ -1,0 +1,355 @@
+import { describe, test, expect } from 'bun:test'
+import type { ExprNode } from '../expr.js'
+import type {
+  ResolvedExpr, InputRef, ParamDecl, DelayDecl, OutputAssign,
+} from './nodes.js'
+import { freeRefs, liftWireToProgram } from './wire_program.js'
+import {
+  instanceName, portName, portRef, portRefKey, rawName,
+  type InstanceName,
+} from './branded_names.js'
+import { strataPipeline } from './strata.js'
+
+// ─── Helper: pretty key-set for assertions ───────────────────────────────
+
+const keysOf = (refs: ReadonlySet<{ instance: InstanceName; port: { toString(): string } }>) =>
+  Array.from(refs).map(r => `${rawName(r.instance)}:${r.port}`).sort()
+
+// ─── freeRefs ────────────────────────────────────────────────────────────
+
+describe('freeRefs — leaves', () => {
+  test('returns empty set for bare number', () => {
+    expect(keysOf(freeRefs(42))).toEqual([])
+  })
+
+  test('returns empty set for bare boolean', () => {
+    expect(keysOf(freeRefs(true))).toEqual([])
+  })
+
+  test('returns empty set for inline array of literals', () => {
+    expect(keysOf(freeRefs([1, 2, 3]))).toEqual([])
+  })
+
+  test('returns empty set for sampleRate / sampleIndex', () => {
+    expect(keysOf(freeRefs({ op: 'sampleRate' }))).toEqual([])
+    expect(keysOf(freeRefs({ op: 'sampleIndex' }))).toEqual([])
+  })
+
+  test('returns empty set for param / trigger refs (not free refs)', () => {
+    expect(keysOf(freeRefs({ op: 'param', name: 'cutoff' }))).toEqual([])
+    expect(keysOf(freeRefs({ op: 'trigger', name: 'fire' }))).toEqual([])
+  })
+})
+
+describe('freeRefs — refs', () => {
+  test('collects a single ref', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 'out' }
+    expect(keysOf(freeRefs(e))).toEqual(['a:out'])
+  })
+
+  test('deduplicates identical refs', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'ref', instance: 'a', output: 'out' },
+        { op: 'ref', instance: 'a', output: 'out' },
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['a:out'])
+  })
+
+  test('collects multiple distinct refs', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'ref', instance: 'a', output: 'x' },
+        { op: 'ref', instance: 'b', output: 'y' },
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['a:x', 'b:y'])
+  })
+
+  test('descends through nested binary ops', () => {
+    // (a.x * b.y) + c.z
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'mul', args: [
+          { op: 'ref', instance: 'a', output: 'x' },
+          { op: 'ref', instance: 'b', output: 'y' },
+        ] },
+        { op: 'ref', instance: 'c', output: 'z' },
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['a:x', 'b:y', 'c:z'])
+  })
+
+  test('descends through unary / ternary ops', () => {
+    const e: ExprNode = {
+      op: 'select',
+      args: [
+        { op: 'gt', args: [
+          { op: 'ref', instance: 'env', output: 'out' },
+          0.5,
+        ] },
+        { op: 'neg', args: [{ op: 'ref', instance: 'osc', output: 'out' }] },
+        { op: 'ref', instance: 'noise', output: 'out' },
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['env:out', 'noise:out', 'osc:out'])
+  })
+
+  test('descends into inline array literals (`{op: array, items}`)', () => {
+    const e: ExprNode = {
+      op: 'array',
+      items: [
+        { op: 'ref', instance: 'a', output: 'x' },
+        { op: 'ref', instance: 'b', output: 'y' },
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['a:x', 'b:y'])
+  })
+
+  test('descends into bare-array (literal form) entries', () => {
+    const e: ExprNode = [
+      { op: 'ref', instance: 'a', output: 'x' },
+      { op: 'ref', instance: 'b', output: 'y' },
+    ]
+    expect(keysOf(freeRefs(e))).toEqual(['a:x', 'b:y'])
+  })
+
+  test('descends into delay() args', () => {
+    const e: ExprNode = {
+      op: 'delay',
+      args: [{ op: 'ref', instance: 'b', output: 'y' }],
+      init: 0,
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['b:y'])
+  })
+
+  test('descends into index(arr, i)', () => {
+    const e: ExprNode = {
+      op: 'index',
+      args: [
+        { op: 'ref', instance: 'clock', output: 'ratios_out' },
+        2,
+      ],
+    }
+    expect(keysOf(freeRefs(e))).toEqual(['clock:ratios_out'])
+  })
+
+  test('throws on numeric output (wire form must be string)', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 0 }
+    expect(() => freeRefs(e)).toThrow(/output must be a string port name/)
+  })
+})
+
+// ─── liftWireToProgram — structural ──────────────────────────────────────
+
+describe('liftWireToProgram — structure', () => {
+  test('literal-only wire produces a zero-input program', () => {
+    const e: ExprNode = 42
+    const refs = freeRefs(e)
+    const prog = liftWireToProgram(e, refs, instanceName('__wire_0'))
+    expect(prog.op).toBe('program')
+    expect(prog.name).toBe('__wire_0')
+    expect(prog.typeParams).toEqual([])
+    expect(prog.ports.inputs).toEqual([])
+    expect(prog.ports.outputs.length).toBe(1)
+    expect(prog.ports.outputs[0].name).toBe('out')
+  })
+
+  test('single-ref wire produces one input port', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 'out' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('__wire_1'))
+    expect(prog.ports.inputs.length).toBe(1)
+    expect(prog.ports.inputs[0].name).toBe('a__out')
+  })
+
+  test('two-ref wire produces two inputs in sorted order', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'ref', instance: 'z', output: 'foo' },
+        { op: 'ref', instance: 'a', output: 'bar' },
+      ],
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('__wire_2'))
+    expect(prog.ports.inputs.map(d => d.name)).toEqual(['a__bar', 'z__foo'])
+  })
+
+  test('nested instance names (dotted) get safe input names', () => {
+    const e: ExprNode = { op: 'ref', instance: 'voice1.env', output: 'out' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('__wire_3'))
+    expect(prog.ports.inputs[0].name).toBe('voice1_env__out')
+  })
+
+  test('output port is named "out"', () => {
+    const e: ExprNode = 0
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    expect(prog.ports.outputs[0].name).toBe('out')
+  })
+
+  test('body has exactly one outputAssign', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 'out' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    expect(prog.body.assigns.length).toBe(1)
+    const assign = prog.body.assigns[0] as OutputAssign
+    expect(assign.op).toBe('outputAssign')
+    expect(assign.target).toBe(prog.ports.outputs[0])
+  })
+
+  test('ref translation: target is the inputRef pointing at the matching input decl', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 'out' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const assign = prog.body.assigns[0] as OutputAssign
+    const expr = assign.expr as InputRef
+    expect(expr.op).toBe('inputRef')
+    expect(expr.decl).toBe(prog.ports.inputs[0])
+  })
+
+  test('binary op translates with both args translated', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'ref', instance: 'a', output: 'out' },
+        2.5,
+      ],
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const assign = prog.body.assigns[0] as OutputAssign
+    const expr = assign.expr as { op: 'add'; args: [ResolvedExpr, ResolvedExpr] }
+    expect(expr.op).toBe('add')
+    expect((expr.args[0] as InputRef).op).toBe('inputRef')
+    expect(expr.args[1]).toBe(2.5)
+  })
+
+  test('delay() produces a synthetic DelayDecl in the body', () => {
+    const e: ExprNode = {
+      op: 'delay',
+      args: [{ op: 'ref', instance: 'b', output: 'y' }],
+      init: 0.5,
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const delays = prog.body.decls.filter(d => d.op === 'delayDecl') as DelayDecl[]
+    expect(delays.length).toBe(1)
+    expect(delays[0].name).toBe('__sd0')
+    expect(delays[0].init).toBe(0.5)
+    const assign = prog.body.assigns[0] as OutputAssign
+    expect((assign.expr as { op: string }).op).toBe('delayRef')
+  })
+
+  test('param ref produces a private ParamDecl', () => {
+    const e: ExprNode = { op: 'param', name: 'cutoff' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const params = prog.body.decls.filter(d => d.op === 'paramDecl') as ParamDecl[]
+    expect(params.length).toBe(1)
+    expect(params[0].name).toBe('cutoff')
+    expect(params[0].kind).toBe('param')
+  })
+
+  test('trigger ref produces a private ParamDecl with kind=trigger', () => {
+    const e: ExprNode = { op: 'trigger', name: 'fire' }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const params = prog.body.decls.filter(d => d.op === 'paramDecl') as ParamDecl[]
+    expect(params.length).toBe(1)
+    expect(params[0].kind).toBe('trigger')
+  })
+
+  test('repeated param ref reuses one ParamDecl', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'param', name: 'k' },
+        { op: 'param', name: 'k' },
+      ],
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const params = prog.body.decls.filter(d => d.op === 'paramDecl') as ParamDecl[]
+    expect(params.length).toBe(1)
+  })
+
+  test('inline array literal translates to bare array of ResolvedExprs', () => {
+    const e: ExprNode = { op: 'array', items: [1, 2, 3] }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const assign = prog.body.assigns[0] as OutputAssign
+    expect(assign.expr).toEqual([1, 2, 3])
+  })
+
+  test('bare-array literal translates to bare ResolvedExpr array', () => {
+    const e: ExprNode = [1, 2, 3]
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('w'))
+    const assign = prog.body.assigns[0] as OutputAssign
+    expect(assign.expr).toEqual([1, 2, 3])
+  })
+})
+
+// ─── liftWireToProgram — error paths ─────────────────────────────────────
+
+describe('liftWireToProgram — errors', () => {
+  test('rejects unknown op', () => {
+    const e: ExprNode = { op: 'fold' as any, over: 0, init: 0, acc: 'a', elem: 'e', body: 0 }
+    expect(() => liftWireToProgram(e, freeRefs(e), instanceName('w'))).toThrow(
+      /unhandled wire-form op 'fold'/,
+    )
+  })
+
+  test('rejects ref absent from freeRefSet (caller error)', () => {
+    const e: ExprNode = { op: 'ref', instance: 'a', output: 'out' }
+    const emptySet = new Set<ReturnType<typeof portRef>>()
+    expect(() => liftWireToProgram(e, emptySet, instanceName('w'))).toThrow(
+      /not in freeRefSet/,
+    )
+  })
+
+  test('rejects param/trigger name collision (same name, different kind)', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'param', name: 'shared' },
+        { op: 'trigger', name: 'shared' },
+      ],
+    }
+    expect(() => liftWireToProgram(e, freeRefs(e), instanceName('w'))).toThrow(
+      /name collision on 'shared'/,
+    )
+  })
+})
+
+// ─── Round-trip with strata pipeline ─────────────────────────────────────
+
+describe('liftWireToProgram — strata round-trip', () => {
+  test('lifted program passes through strataPipeline cleanly', () => {
+    const e: ExprNode = {
+      op: 'add',
+      args: [
+        { op: 'mul', args: [
+          { op: 'ref', instance: 'a', output: 'out' },
+          2,
+        ] },
+        { op: 'ref', instance: 'b', output: 'y' },
+      ],
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('__wire_round_trip'))
+    // strataPipeline should be a no-op or near-no-op on a wire program:
+    // no instances to inline, no sum types, no array combinators.
+    const after = strataPipeline(prog)
+    expect(after.op).toBe('program')
+    expect(after.name).toBe('__wire_round_trip')
+    expect(after.ports.inputs.length).toBe(2)
+    expect(after.ports.outputs.length).toBe(1)
+    expect(after.ports.outputs[0].name).toBe('out')
+  })
+
+  test('lifted program with delay passes through strata cleanly', () => {
+    const e: ExprNode = {
+      op: 'delay',
+      args: [{ op: 'ref', instance: 'b', output: 'y' }],
+      init: 0,
+    }
+    const prog = liftWireToProgram(e, freeRefs(e), instanceName('__wire_delay'))
+    const after = strataPipeline(prog)
+    const delays = after.body.decls.filter(d => d.op === 'delayDecl')
+    expect(delays.length).toBe(1)
+  })
+})

--- a/compiler/ir/wire_program.ts
+++ b/compiler/ir/wire_program.ts
@@ -1,0 +1,320 @@
+/**
+ * wire_program.ts — lift a wire ExprNode to a ResolvedProgram.
+ *
+ * A wire is a `ref(instance, output)` and a transformation expression
+ * that turns one or more such refs into a value consumed by a downstream
+ * instance. Today wires are handled by a parallel mini-compiler
+ * (`translateNode` in `compile_session_slotted_helpers.ts`) that knows
+ * only a subset of expression shapes. Under the fractal architecture
+ * (M11 Phase 5), wires lift to anonymous programs and flow through the
+ * same per-program path as user-authored types.
+ *
+ * The lift is precise: given an `ExprNode` `e` with free refs `r₁..rₖ`,
+ * we synthesize a program shape-identical to one a user could have
+ * written:
+ *
+ *   program __wire_${i}(r₁_out, ..., rₖ_out) -> (out) {
+ *     out = <translated e>
+ *   }
+ *
+ * Every site in the input expression that referenced `r_j` becomes a
+ * read of the corresponding `InputDecl`. Params and triggers become
+ * private `ParamDecl`s in the lifted program's body (the param-name
+ * unification with the surrounding session happens at runtime via the
+ * FFI handle, not at the IR level). Session-level `delay()` becomes a
+ * private synthetic `DelayDecl` — once the session-level strata pipeline
+ * runs `traceCycles` over the inter-instance graph, all inter-program
+ * cycles are explicit, so wire-internal delay is uniform with delay
+ * anywhere else.
+ *
+ * Both exports are pure, total, and stateless. No engine, no FFI, no
+ * session. They are the foundational lift; Phase 4's partitioner and
+ * Phase 5's materializer consume them.
+ */
+
+import type { ExprNode } from '../expr.js'
+import type {
+  ResolvedProgram, ResolvedExpr,
+  InputDecl, OutputDecl, ParamDecl, DelayDecl,
+  BodyDecl,
+  ResolvedBlock,
+} from './nodes.js'
+import {
+  type InstanceName, type PortName, type PortRef,
+  instanceName as makeInstanceName,
+  portName as makePortName,
+  portRef as makePortRef,
+  portRefKey, rawName,
+} from './branded_names.js'
+
+// ─── Op sets ────────────────────────────────────────────────────────────────
+// Mirror the sets in `materialize_session.ts:translateExpr`. Keep these in
+// sync if either changes; the two should agree on which ops a wire-form
+// expression may carry.
+
+const BINARY_OPS: ReadonlySet<string> = new Set([
+  'add', 'sub', 'mul', 'div', 'mod',
+  'lt', 'lte', 'gt', 'gte', 'eq', 'neq',
+  'and', 'or',
+  'bitAnd', 'bitOr', 'bitXor', 'lshift', 'rshift',
+  'floorDiv', 'ldexp',
+])
+
+const UNARY_OPS: ReadonlySet<string> = new Set([
+  'neg', 'not', 'bitNot',
+  'sqrt', 'abs', 'floor', 'ceil', 'round',
+  'floatExponent', 'toInt', 'toBool', 'toFloat',
+])
+
+const TERNARY_OPS: ReadonlySet<string> = new Set(['clamp', 'select', 'arraySet'])
+
+// ─── Free-variable scan ────────────────────────────────────────────────────
+
+/** Walk an `ExprNode` tree and collect every reference to an instance
+ *  output. Returns deduplicated `PortRef`s; the iteration order matches
+ *  first-encounter order in the tree. */
+export function freeRefs(expr: ExprNode): ReadonlySet<PortRef> {
+  const byKey = new Map<string, PortRef>()
+
+  const walk = (e: ExprNode): void => {
+    if (typeof e === 'number' || typeof e === 'boolean') return
+    if (Array.isArray(e)) {
+      for (const item of e) walk(item)
+      return
+    }
+    if (typeof e !== 'object' || e === null) return
+
+    const obj = e as Record<string, unknown>
+    const op = obj.op
+
+    if (op === 'ref') {
+      const instStr = obj.instance
+      const outVal = obj.output
+      if (typeof instStr !== 'string') {
+        throw new Error(`freeRefs: ref node missing string 'instance' field`)
+      }
+      if (typeof outVal !== 'string') {
+        // Numeric output indices are post-elaboration; wire-form is string.
+        throw new Error(
+          `freeRefs: ref(${instStr}, ${String(outVal)}) — output must be a ` +
+          `string port name in wire-form, got ${typeof outVal}`,
+        )
+      }
+      const ref = makePortRef(makeInstanceName(instStr), makePortName(outVal))
+      const key = portRefKey(ref)
+      if (!byKey.has(key)) byKey.set(key, ref)
+      return
+    }
+
+    // Generic structural recursion. Wire-form ops carry children at
+    // `args` (positional) and/or `items` (inline array literals). Other
+    // shapes (let, fold, match, etc.) don't appear in wire expressions
+    // and aren't recursed into — `liftWireToProgram` will reject them
+    // at translate time anyway.
+    if (Array.isArray(obj.args)) {
+      for (const a of obj.args as ExprNode[]) walk(a)
+    }
+    if (Array.isArray(obj.items)) {
+      for (const a of obj.items as ExprNode[]) walk(a)
+    }
+  }
+
+  walk(expr)
+  return new Set(byKey.values())
+}
+
+// ─── Lift to ResolvedProgram ───────────────────────────────────────────────
+
+interface TranslateContext {
+  /** Map from canonical PortRef key to the InputDecl that represents it. */
+  readonly refToInput: ReadonlyMap<string, InputDecl>
+  /** Param/Trigger decls accumulated during translation. Keyed by param
+   *  name. Mutated as the translator encounters new refs. */
+  readonly paramDecls: Map<string, ParamDecl>
+  /** Synthetic DelayDecls created from `delay()` expressions. */
+  readonly syntheticDelays: DelayDecl[]
+}
+
+/** Lift a wire `ExprNode` to a `ResolvedProgram` with the given synthesized
+ *  name. The synthesized program has:
+ *
+ *  - one `InputDecl` per `PortRef` in `freeRefSet` (deterministic order:
+ *    sorted by canonical `instance:port` key)
+ *  - one `OutputDecl` named `out`
+ *  - one `outputAssign` binding `out` to the translated expression
+ *  - inline `ParamDecl`s for any `param`/`trigger` refs in the expression
+ *  - inline `DelayDecl`s for any `delay()` calls in the expression
+ *
+ *  Pure, total. Output is shape-identical to a user-authored single-decl
+ *  program; the per-program strata pipeline accepts it without
+ *  modification. */
+export function liftWireToProgram(
+  expr: ExprNode,
+  freeRefSet: ReadonlySet<PortRef>,
+  synthName: InstanceName,
+): ResolvedProgram {
+  // Sort refs by canonical key so input ordering is deterministic
+  // across calls (the same wire produces the same program shape).
+  const sortedRefs = Array.from(freeRefSet).sort((a, b) =>
+    portRefKey(a).localeCompare(portRefKey(b)),
+  )
+
+  const inputDecls: InputDecl[] = []
+  const refToInput = new Map<string, InputDecl>()
+  for (const ref of sortedRefs) {
+    // Name the input deterministically from the ref. Double-underscore
+    // separator avoids collisions with user port names (which can't
+    // contain `__` since dots aren't allowed in PortName and `__` is
+    // a stable, distinctive infix).
+    const inputName = `${rawName(ref.instance).replace(/\./g, '_')}__${rawName(ref.port)}`
+    const decl: InputDecl = { op: 'inputDecl', name: inputName }
+    inputDecls.push(decl)
+    refToInput.set(portRefKey(ref), decl)
+  }
+
+  const outputDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
+
+  const ctx: TranslateContext = {
+    refToInput,
+    paramDecls: new Map(),
+    syntheticDelays: [],
+  }
+
+  const translated = translateExpr(expr, ctx)
+
+  const bodyDecls: BodyDecl[] = [
+    ...ctx.paramDecls.values(),
+    ...ctx.syntheticDelays,
+  ]
+
+  const body: ResolvedBlock = {
+    op: 'block',
+    decls: bodyDecls,
+    assigns: [{ op: 'outputAssign', target: outputDecl, expr: translated }],
+  }
+
+  return {
+    op: 'program',
+    name: rawName(synthName),
+    typeParams: [],
+    ports: {
+      inputs:   inputDecls,
+      outputs:  [outputDecl],
+      typeDefs: [],
+    },
+    body,
+  }
+}
+
+// ─── Internal: ExprNode → ResolvedExpr ─────────────────────────────────────
+
+function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
+  if (typeof expr === 'number')  return expr
+  if (typeof expr === 'boolean') return expr
+  if (Array.isArray(expr)) {
+    return expr.map(e => translateExpr(e, ctx)) as ResolvedExpr
+  }
+  if (typeof expr !== 'object' || expr === null) {
+    throw new Error(`liftWireToProgram: invalid expr value: ${JSON.stringify(expr)}`)
+  }
+
+  const obj = expr as Record<string, unknown>
+  const op = obj.op
+  if (typeof op !== 'string') {
+    throw new Error(`liftWireToProgram: expression missing op tag`)
+  }
+
+  // ── Refs to instance outputs → inputRefs on the lifted program ──
+  if (op === 'ref') {
+    const instStr = obj.instance as string
+    const outStr = obj.output as string
+    const ref = makePortRef(makeInstanceName(instStr), makePortName(outStr))
+    const inputDecl = ctx.refToInput.get(portRefKey(ref))
+    if (inputDecl === undefined) {
+      // Should not happen: freeRefs collected this ref. Either the
+      // caller passed a stale freeRefSet, or the expression mutated
+      // between scanning and lifting.
+      throw new Error(
+        `liftWireToProgram: ref ${portRefKey(ref)} not in freeRefSet — ` +
+        `pass the same set returned by freeRefs(expr)`,
+      )
+    }
+    return { op: 'inputRef', decl: inputDecl }
+  }
+
+  // ── Param/trigger refs → inline ParamDecls in the lifted program ──
+  if (op === 'param' || op === 'paramExpr') {
+    return paramOrTriggerRef(obj.name as string, 'param', ctx)
+  }
+  if (op === 'trigger' || op === 'triggerParamExpr') {
+    return paramOrTriggerRef(obj.name as string, 'trigger', ctx)
+  }
+
+  // ── Sentinels ──
+  if (op === 'sampleRate')  return { op: 'sampleRate' }
+  if (op === 'sampleIndex') return { op: 'sampleIndex' }
+
+  // ── Binary / unary / ternary ──
+  if (BINARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0], args[1]] } as ResolvedExpr
+  }
+  if (UNARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0]] } as ResolvedExpr
+  }
+  if (TERNARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0], args[1], args[2]] } as ResolvedExpr
+  }
+
+  // ── Index ──
+  if (op === 'index') {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op: 'index', args: [args[0], args[1]] }
+  }
+
+  // ── Inline array literal ──
+  if (op === 'array') {
+    const items = (obj.items as ExprNode[]).map(item => translateExpr(item, ctx))
+    return items as ResolvedExpr
+  }
+
+  // ── Session-level delay → synthetic DelayDecl + delayRef ──
+  if (op === 'delay') {
+    const argsArr = obj.args as ExprNode[]
+    if (!Array.isArray(argsArr) || argsArr.length !== 1) {
+      throw new Error(`liftWireToProgram: delay requires args: [expr], got ${JSON.stringify(argsArr)}`)
+    }
+    const update = translateExpr(argsArr[0], ctx)
+    const init = typeof obj.init === 'number' ? obj.init : 0
+    const decl: DelayDecl = {
+      op: 'delayDecl',
+      name: `__sd${ctx.syntheticDelays.length}`,
+      update,
+      init,
+    }
+    ctx.syntheticDelays.push(decl)
+    return { op: 'delayRef', decl }
+  }
+
+  throw new Error(`liftWireToProgram: unhandled wire-form op '${op}'`)
+}
+
+function paramOrTriggerRef(
+  name: string,
+  kind: 'param' | 'trigger',
+  ctx: TranslateContext,
+): ResolvedExpr {
+  let decl = ctx.paramDecls.get(name)
+  if (decl === undefined) {
+    decl = { op: 'paramDecl', name, kind }
+    ctx.paramDecls.set(name, decl)
+  } else if (decl.kind !== kind) {
+    throw new Error(
+      `liftWireToProgram: param/trigger name collision on '${name}' ` +
+      `(declared as '${decl.kind}', ref demands '${kind}')`,
+    )
+  }
+  return { op: 'paramRef', decl }
+}

--- a/compiler/sequencer.test.ts
+++ b/compiler/sequencer.test.ts
@@ -24,10 +24,14 @@ describe('stdlib Sequencer<N>', () => {
     expect(inputPortType(type, 1)).toEqual(ArrayType(Float, [8]))
   })
 
-  test.skip('Sequencer<4> flattens end-to-end with an arrayPack input', () => {
-    // Skipped under the active-set runtime: array-shaped input
-    // expressions (`values: [110, 220, ...]` and Clock's `ratios_in:
-    // [1]`) are not yet supported by the per-instance compile path's
-    // translateNode. Tracked as a follow-up.
+  test.skip('Sequencer<4> compiles end-to-end with an arrayPack input', () => {
+    // Phase 5 of M11 wire-lift handles the WIRE SIDE: the array literal
+    // [110, 220, ...] is lifted to a __wire_N program whose body is
+    // `out = arrayPack(...)`. But Sequencer's BODY does
+    // `index(InputRef(values), step)` — array-typed instance INPUTS
+    // still aren't materialized as array_reg operands by the per-
+    // instance compile path. emit_resolved throws "non-array operand"
+    // on the body-side index. Body-side array-input materialization
+    // is a separate follow-up to Phase 5.
   })
 })

--- a/design/operadic_ir.md
+++ b/design/operadic_ir.md
@@ -1,0 +1,542 @@
+# Operadic IR for Tropical
+
+## How this document came to exist
+
+This document captures architectural commitments that emerged from an
+extended design conversation. The conversation began with a specific
+technical problem — cross-kernel input wiring under M11's fractal
+architecture — and traced backward to find the implicit categorical
+foundations that had never been written down. The result was a
+recasting of tropical's IR as a typed operad. The existing CLAUDE.md
+tagline ("cartesian category of typed signal-flow graphs with a
+guarded trace") gestures at this framing but never makes it explicit;
+this document is that explicitness.
+
+The journey through the conversation, in compressed form: a specific
+cross-kernel wiring problem → recognition of the slotified-memory
+unification → arrival at operadic encapsulation as the structural
+principle → realization that the language *is* the operad → exploration
+of cycle-handling options as different operadic realizations →
+identification of Wave Digital Filters as the no-compromise structural
+option for analog circuit modeling → understanding that multiple
+realizations can coexist behind operadic interfaces → glimpse of
+tropical as a polymorphic operadic DSL spanning multiple computational
+paradigms.
+
+What follows is the architectural picture in declarative form: what
+tropical IS, categorically, and what design choices follow from that
+commitment.
+
+## The shape of the domain
+
+Tropical models signal flow through bounded, port-typed devices
+arranged hierarchically. Eurorack modules patch into other modules
+through audio and CV jacks. Synthesizers expose MIDI input and audio
+output but encapsulate their internals (LFOs, oscillators, filters)
+behind a single interface. Microcontrollers expose their GPIO pins
+but hide their internal computation. At every level, devices interact
+through explicit port boundaries and never through internal state.
+
+This is the structural fact about the domain — not a design choice we
+make about the IR, but a property of what we're modeling. The IR's job
+is to faithfully represent this domain's compositional structure. The
+categorical name for this kind of compositional structure is a **typed
+(colored) operad** — specifically, a colored PROP for handling
+multi-input/multi-output operations and parallel composition.
+
+## Tropical is a typed colored PROP
+
+A typed (colored) operad consists of:
+
+- A set of **colors** (port types: scalars, arrays, sums)
+- A set of **operations**, each with a typed input signature and a
+  typed output signature
+- A **composition** rule that lets you plug operations into other
+  operations' compatible ports
+- A **tensor product** (in the PROP variant) that lets operations run
+  in parallel
+
+In tropical:
+
+- *Colors* = post-strata port types (`float`, `int`, `bool`, fixed-shape
+  arrays of these)
+- *Operations* = primitive operations (`add`, `mul`, `sin`, `delay`, ...)
+  plus user-defined programs
+- *Composition* = wiring (output of one operation feeds input of another)
+- *Tensor* = parallel placement (operations running side-by-side)
+
+Each `ResolvedProgram` in tropical's IR is, viewed correctly, an
+operation in this operad. Its `body` is a finite tree representation
+of that operation expressed as a composition of sub-operations. The
+tree's leaves are primitive operations (or sub-program references);
+the tree's internal nodes are operadic plug points.
+
+This recasting is not a reimplementation — it's an articulation of
+what the IR has always been. The mathematical structure was always
+there; we just hadn't named it.
+
+## Encapsulation is structural, not a discipline
+
+Operadic composition has one rule about what's visible across the
+boundary of an operation: **only the port signature**. An operation's
+internal definition is categorically opaque from outside. When you
+compose two operations, you don't peer into either of them; you only
+see how they fit together at their ports.
+
+This isn't a discipline we impose to keep the IR clean. It's a
+structural property of operadic composition. Any IR that violates it —
+for example, by letting a sub-operation's body reference the
+*enclosing* operation's input ports directly — has stepped outside the
+operadic category. That's exactly what we saw with the
+`cloneWithInputSubst` scope-leak during the M11 fractal-activation
+attempt: an attempt to substitute the parent's wired expression into
+the child's body produced references that crossed the operadic
+boundary. The error wasn't a bug in the substitution; it was an
+attempt to do something categorically invalid.
+
+The correct architecture: child operations only see their own input
+ports. Cross-program communication happens at the *parent's* level —
+the parent's body computes the wired expression in the parent's scope
+and writes the result to the child's input port slot. The child reads
+its input port slot in its body. Each operation works inside its own
+categorically-closed world.
+
+## Pre- and post-trace operads
+
+Tropical's IR has two distinct operadic shapes connected by a known
+transformation:
+
+**Pre-trace operad**: a traced colored PROP. Operations can be composed
+cyclically — feedback paths in source code translate directly to cyclic
+plug patterns in this operad. The trace operator is implicit in cyclic
+structure: a cycle through operations means "trace this composition."
+This is the user-facing operad.
+
+**Post-trace operad**: a plain colored PROP (no trace operator) with
+`delay` promoted to a first-class primitive in the operadic signature.
+Every composition is acyclic. Cycles from the pre-trace operad have
+become compositions through `delay`. This is the runtime-facing operad.
+
+The transformation `T: pre-trace → post-trace` is a **functor in the
+category of operads (Op)**. It is the entire categorical content of
+compilation. Within tropical's strata pipeline:
+
+- `specialize` — substitution in a polymorphic operad
+- `sumLower` — coproduct elimination
+- `traceCycles` — **the functor T**, mapping cyclic operadic
+  compositions to delay-broken acyclic ones
+- `arrayLower` — combinator unrolling
+- `identityElim` — categorical identity law
+
+`traceCycles` is the load-bearing pass. The others are normalization.
+This is the categorical reading of compilation: each strata pass is a
+named operad morphism; the whole pipeline is a composition of operad
+morphisms.
+
+## The trace functor is not unique
+
+Here is where a key design decision lives: **the functor T is not
+uniquely determined by the categorical structure.** Given a cyclic
+composition, there are infinitely many delay-broken realizations of
+it, differing in where the unit delays sit. Each realization is a
+valid trace functor; each produces a slightly different concrete
+behavior under discrete-time evaluation.
+
+The categorically precise statement: there is an *equivalence class*
+of post-trace realizations that all denote the same morphism in the
+continuous-time TSMC, but which are not equal as concrete morphisms
+in the discrete-time DAG operad. `traceCycles` picks a representative
+of that equivalence class. The choice is a language design decision,
+not a categorical theorem.
+
+The cycle-handling options:
+
+### A. Strict acyclic (no implicit cycles)
+
+The operad has no trace operator. Users must use explicit `delay`
+primitives to express feedback. The compiler never inserts delays.
+The user always knows where the unit-delay sample shift sits.
+
+Verbose source; predictable semantics. This is what Haskell-pure-FP
+does: separate effects (state) from pure computation.
+
+### B. Universal unit delay between operations
+
+Every wire between operations carries an implicit unit delay. The
+post-trace operad is one whose composition operator implicitly
+inserts a delay. Trivial implementation; no cycle-breaking algorithm
+needed.
+
+Cost: latency accumulates through pipeline depth (a 4-stage filter
+chain has 4 samples of delay). This is what VCV Rack and Pure Data
+approximate at coarse-grained module boundaries.
+
+### C. Explicit feedback operator (Faustian)
+
+Users mark feedback points syntactically (`feedback (fb => ...)` or
+`~`). The pre-trace operad has the trace operator as a first-class
+syntactic construct; the compiler mechanically rewrites each
+`feedback` to a `delay` insertion. Implicit cycles outside `feedback`
+are a type error.
+
+Categorically clean: the user explicitly specifies the trace, the
+compiler trivially realizes it.
+
+### D. Implicit cycle-breaking with documented convention
+
+The compiler auto-breaks cycles using a documented rule (e.g.,
+Tarjan's natural back-edge selection). Users can override via explicit
+`delay` annotations. Convenient; relies on users reading documentation
+to predict behavior.
+
+Current tropical sits here, but undocumented. This is the position
+that motivated the architectural conversation.
+
+### E. Iterative fixed-point per sample
+
+The trace operator is realized as iterative evaluation: within each
+sample, the cyclic composition is evaluated N times, with each
+iteration using the previous iteration's slot values as the next
+iteration's inputs. As N grows, this converges to the actual
+categorical fixed point.
+
+Crucially: this realization is more categorically faithful than
+delay-substitution, which is just N=1 iteration. The IR keeps cycles;
+no `traceCycles` pass is required. Cost: N× compute per sample in
+cyclic regions.
+
+### F. Wave Digital Filters / structural mapping
+
+Operations are wave-domain adaptors; reactive elements (capacitors,
+inductors) provide intrinsic delays. The analog-to-digital mapping is
+one-to-one structurally; cycles in the source circuit become acyclic
+dataflow in the wave domain without any compiler-side cycle breaking.
+Stability is guaranteed by construction.
+
+Constraint: requires modeling in circuit-topology terms (not block-
+diagram or transfer-function terms).
+
+### G. Physics-aware per-cycle integration
+
+The compiler analyzes each cycle's transfer characteristics and
+chooses a discretization scheme (forward Euler, backward Euler,
+trapezoidal/bilinear) per cycle. This is what serious analog modeling
+does (Zavalishin's ZDF, others).
+
+---
+
+Each of these is a valid choice of trace functor. The categorical
+structure doesn't pick one for us; the language designer does. The
+categorically cleanest options for general-purpose use are A, C, and E.
+F is the no-compromise option for analog modeling specifically.
+
+## Wave Digital Filters in depth
+
+WDF deserves special attention because it's the only option in the
+cycle-handling spectrum that's structurally lossless — the only one
+where the analog-to-digital mapping is a true functor between operads.
+
+### The wave variable transformation
+
+Instead of tracking node voltages `v` and currents `i`, track:
+
+```
+a = v + R·i   (incident wave)
+b = v - R·i   (reflected wave)
+```
+
+The wave variables are a change of basis — `v` and `i` can be
+recovered from `a` and `b` and vice versa. The free parameter `R`
+(port resistance) is chosen per port.
+
+### Circuit elements in the wave basis
+
+Under this transformation, circuit elements become simple wave-domain
+operations:
+
+- **Resistor with port-matched** R: `b = 0` (perfect absorption)
+- **Capacitor** (bilinear discretized): `b[n] = a[n-1]` (unit delay)
+- **Inductor**: `b[n] = -a[n-1]` (unit delay with sign flip)
+- **Voltage source**: `b = 2V - a`
+- **Current source**: `b = a + 2R·I`
+
+Series, parallel, and three-port junctions become *scattering matrices*
+— small fixed matrices computed at compile time from the port
+resistances.
+
+### Why cycle-breaking dissolves
+
+Every closed analog loop must pass through at least one energy-storing
+element (capacitor or inductor) — otherwise it would be a short
+circuit. In the wave basis, those elements provide intrinsic unit
+delays. So analog cycles become acyclic wave-domain compositions
+naturally — the delays are placed exactly where the circuit puts the
+energy-storing elements, never at arbitrary back-edges.
+
+### The functor
+
+WDF is what you get when you constrain the analog-to-digital map to be
+a true functor of operads. There is a unique (up to port-resistance
+choice) such functor for tree-structured passive circuits. The math
+forces the answer; no language design choice is needed.
+
+### The stability guarantee
+
+WDF preserves "pseudo-power" (the wave-domain analog of `v · i`) under
+composition. If the original analog circuit is passive (energy-
+dissipating), the WDF model is provably stable. This is unique to WDF
+— no other discretization scheme has this constructive stability
+guarantee.
+
+### The limitations
+
+The limitations are real:
+
+- **Tree-structured topologies only** in pure WDF; non-tree topologies
+  require R-type adaptors (manageable but adds machinery).
+- **Nonlinear elements** (diodes, transistors, soft clippers) require
+  local iteration at the nonlinear element. Handled, but not free.
+- **The user must think in circuit-topology terms**, not block-diagram
+  terms. This is a serious modeling constraint.
+
+For tropical's design: WDF is one realization of certain operations
+(filters, distortion stages, analog emulations). It's not a candidate
+for the default cycle-handling strategy because it requires too-specific
+modeling. It IS a candidate for a per-operation realization choice —
+operations defined as WDF blocks live in tropical's operad with the
+same port semantics as standard operations, but with WDF realization
+internally.
+
+## Multi-realization architecture
+
+The deepest implication of operadic encapsulation: **the realization
+of an operation can vary while preserving its operadic identity**. Two
+operations with the same port signature and the same I/O behavior are
+*the same operation* in the operad's view, regardless of how they're
+implemented internally.
+
+This is the Yoneda-ish principle: an operation is fully characterized
+by its observable port behavior. An operation realized as a WDF
+subnetwork, an operation realized as a standard tropical kernel, and
+an operation realized via FFI to a hand-written C++ function are the
+same operation if they have the same signature and behavior. They can
+be substituted for each other in any operadic composition.
+
+This makes tropical's identity the operadic interface, not the
+implementation. The implementation is a *realization* — a specific way
+to evaluate the operadic operation in a runtime. Multiple realizations
+are first-class. The compiler routes each operation to its appropriate
+realization compiler.
+
+Concrete realization candidates:
+
+- **Standard tropical** — the current compilation through strata.
+  Generic signal-flow.
+- **Iterative fixed-point** — for cycles where no-extra-latency
+  matters; runtime iterates N times per sample.
+- **Wave Digital Filters** — for analog circuit modeling; exact
+  topology mapping, stability guarantees.
+- **FFI / native** — escape hatch for performance-critical hand-
+  written kernels.
+- **Neural network inference** — for learned approximations of analog
+  circuits.
+- **State machine / event-driven** — for sequencers, MIDI parsers,
+  anything that isn't time-step driven.
+
+Each realization has:
+
+- A signature interpretation (what kind of values flow through its
+  ports)
+- Adapters at the boundary if the internal representation differs from
+  the operadic port type
+- A compiler that maps its realization-specific IR to the runtime's
+  slot model
+- Possibly its own intermediate IR
+
+The runtime is uniform: it executes kernels that read input slots, do
+their thing, write output slots. The kernels' internal mechanics are
+realization-specific; the slot model glues them together.
+
+## The continuous-discrete semantic hierarchy
+
+Tropical's compilation pipeline implicitly crosses three semantic
+levels:
+
+1. **Continuous-time semantics** — what the user "means" when they
+   write a feedback loop or a filter. The mathematical referent is a
+   continuous-time signal flow model: time is real-valued, signals are
+   continuous functions.
+
+2. **Discrete-time semantics with chosen delay placement** — what
+   compiles. Time is sample-indexed; signals are sample sequences;
+   feedback is broken by unit-delay primitives (or solved iteratively,
+   or handled wave-domain — depending on the realization chosen). Each
+   cycle-handling option from earlier represents a different choice of
+   discrete-time semantics.
+
+3. **Finite-precision arithmetic** — what runs. Floating-point
+   representation; rounding; accumulator behavior. Lossy approximation
+   of the discrete-time semantics.
+
+Each level introduces choices and lossy approximations. Each level can
+be made categorically rigorous. The functors between levels are the
+discretization and quantization steps.
+
+Most DSL implementations collapse all three levels and call it a day.
+Being explicit about which level is the source of truth, and which
+discretization choices the compiler makes, is part of language design
+clarity. Tropical's current compilation pipeline collapses level 1 to
+level 2 silently (via implicit `traceCycles`). Making this collapse
+visible — either by requiring explicit feedback markers, or by exposing
+the realization choice per operation — is part of the operadic vision.
+
+## Memory model: slotified, port-bordered, hierarchically named
+
+Under the operadic framing, memory has one role: holding the
+persistent state that supports the trace operator. Different memory
+namespaces (state registers, module slots, array storage, temps) were
+historical implementation artifacts, not categorical distinctions.
+
+The architectural commitment: **one slot namespace, port-typed and
+hierarchically named**. Every persistent state — register, delay,
+input port, output port, inter-program communication channel — lives
+in one global slot array. Ownership is per-operation:
+
+- **Internal slots** (regs, delays, intermediate state) — owned by an
+  operation, visible only within its body.
+- **Input port slots** — owned by an operation, *written* by its
+  immediate parent, *read* by its own body.
+- **Output port slots** — owned by an operation, *written* by its own
+  body, *read* by its parent or siblings.
+
+Each operation's slots occupy a contiguous range in the global
+namespace. Names follow the operadic plug path: `voice1.env.cutoff` is
+"the `cutoff` state of the `env` operation plugged into `voice1`'s
+`env` slot." Hot-swap matches by full path; replacing an operation's
+internals preserves the slot range; the surrounding operations see no
+change.
+
+Per-sample scratch state (intermediate temps within a kernel's body)
+is JIT-internal — never named in the IR. LLVM's `mem2reg` + GVN
+promote slot operations that have register-like access patterns to SSA
+values automatically.
+
+Cross-operation communication is via slot writes from parent to child
+input port slots and slot reads from sibling output port slots. The
+encapsulation is structural: an operation's body has no language-level
+mechanism to reference slots outside its own range (plus its immediate
+sub-operations' port slots). Slot allocation enforces this; emit-level
+operand resolution honors it.
+
+## The category Op and what compilation is
+
+`Op` — the category of typed operads with operadic morphisms (functors
+that preserve colors, operations, and composition) — is the
+metacategory in which tropical's compilation lives. The pipeline is a
+sequence of morphisms in `Op`:
+
+```
+Surface Operad (typed, traced, primitives = base set)
+  │  specialize   — substitute type params
+  ▼
+Monomorphic Surface Operad
+  │  sumLower     — replace coproduct operations
+  ▼
+Sum-Free Operad
+  │  traceCycles  — choose a trace functor; insert delay primitive
+  ▼
+Choice-of-Trace Operad
+  │  arrayLower   — unroll combinators
+  ▼
+Scalar DAG Operad
+  │  identityElim — categorical identity law
+  ▼
+Normal-Form Operad
+  │  operationalize — assign slots; convert operadic plugs
+  ▼              to slot writes
+Slot-Operational Operad (runtime ready)
+```
+
+Each pass is a named morphism. Each preserves the categorical content
+modulo the specified rewrites. The total compilation is the composition
+of these morphisms. Equivalence tests (`jit_vs_interp`, `wasm_vs_jit`,
+etc.) are claims that two paths through this composition produce the
+same final operad — that two compositions of morphisms agree.
+
+This framing makes the compilation pipeline self-documenting at the
+type level. Each pass has a categorical signature; the IR shapes
+between passes are precisely the intermediate operads.
+
+## Design implications
+
+What this framing tells us about tropical's design choices:
+
+**1. The IR types should make operadic structure explicit.** A
+`ResolvedProgram` is not "a program with a body of declarations"; it's
+an operation in the operad with a body expressing its definition as a
+composition. The naming, the type structure, and the pass signatures
+should reflect this.
+
+**2. Encapsulation is structural, not a discipline.** The IR should
+make boundary-violating operations literally inexpressible. The current
+`cloneWithInputSubst`-style substitution that produces scope leaks is
+categorically invalid and should be impossible to write under the
+right IR types.
+
+**3. The cycle-handling convention is a language design choice that
+should be visible.** Whichever option (A through G) tropical adopts,
+the choice should be explicit — in source-language syntax, in
+documentation, and in the IR types. Users should never have to guess
+where the compiler placed a delay.
+
+**4. Multi-realization is the long-term vision.** The IR carries a
+realization tag per operation. v1 has one realization (standard
+tropical compilation through strata). Future versions add realizations
+(iterative, WDF, FFI, etc.) without changing the language's identity.
+The operadic interface is the stable contract.
+
+**5. Memory unification (slotified) is the foundational refactor.** It
+is the precondition for the rest of the vision. The four-namespace
+memory model is an obstacle; one slot namespace with hierarchical
+naming and structural enforcement of ownership is the destination.
+
+**6. The compilation pipeline is a composition of operad morphisms.**
+Strata passes can be reorganized, replaced, or added by composing
+additional morphisms in `Op`. The framework is generative — new
+compilation strategies are new morphism compositions.
+
+## What remains free for the language designer
+
+The categorical structure doesn't pick everything. Several decisions
+are genuinely free:
+
+- **The choice of cycle-handling realization** (the trace functor's
+  instantiation). Multiple valid options; tropical picks one as default
+  per language version.
+- **The set of primitive operations** (the operadic generators). Add
+  or remove primitives; the operadic framework adapts.
+- **The level of language exposure for realizations**. Does the user
+  select per-operation realization, or does the compiler default
+  everything? Both are valid.
+- **The discretization scheme for `delay`**. Forward Euler is the
+  standard but trapezoidal/bilinear or specialized schemes are equally
+  valid alternatives.
+- **The numerical precision and accumulator behavior**. Floats vs
+  fixed-point; saturation vs wrap. Implementation choices that don't
+  affect operadic structure.
+
+These are language design choices. Tropical commits to specific
+positions; future tropical versions can re-decide.
+
+## Closing note
+
+Operads are not a clever lens through which to view tropical. They are
+the structural fact about what tropical *is*. The domain — signal flow
+through bounded port-typed devices — is operadic; the IR is an
+operadic presentation; the compilation pipeline is a composition of
+operad morphisms.
+
+Making this explicit — in IR types, in language design, in
+documentation — is the architectural commitment. Everything else
+(cycle handling, slotified memory, multi-realization, specific
+implementations) is the working out of details under this commitment.

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <string>
+#include <functional>
 #include <unordered_map>
 
 #if defined(__APPLE__)
@@ -1217,16 +1218,19 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
   // For each instance:
   //   alive_v = load slots[alive_slot_index]
   //   if (alive_v > 0.5) {
+  //     for each child: emit_kernel_block(child)   // recursive
   //     <instance body instructions>
   //     <instance writebacks>
   //   }
   //
-  // For default-alive instances the preamble wrote `1.0` to the
-  // alive slot; LLVM's GVN forwards the store-to-load, folds the
-  // compare to `true`, and jump-threading eliminates the branch —
-  // the body inlines unconditionally and matches a unified kernel
-  // byte-for-byte (per the active-set spike findings).
-  for (const auto & inst : program.instance_functions)
+  // Children run BEFORE the parent's own body so the parent can read
+  // its children's freshly-written slot values (M11 fractal). For
+  // default-alive instances the preamble wrote `1.0` to the alive slot;
+  // LLVM's GVN forwards the store-to-load, folds the compare to
+  // `true`, and jump-threading eliminates the branch — nested
+  // default-alive folds away the same way the flat case does.
+  std::function<llvm::Error(const tropical_jit::InstanceProgram &)> emit_kernel_block =
+    [&](const tropical_jit::InstanceProgram & inst) -> llvm::Error
   {
     llvm::Value * alive_v = load_slot_f64(inst.alive_slot_index);
     llvm::Value * alive_b = builder.CreateFCmpOGT(
@@ -1239,11 +1243,22 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
     builder.CreateCondBr(alive_b, body_bb, merge_bb);
 
     builder.SetInsertPoint(body_bb);
-    if (auto err = emit_instrs(inst.instructions)) return std::move(err);
+    // Recursive: emit child kernels inside the parent's alive-body.
+    for (const auto & child : inst.children)
+    {
+      if (auto err = emit_kernel_block(child)) return err;
+    }
+    if (auto err = emit_instrs(inst.instructions)) return err;
     emit_writebacks(inst.writebacks);
     builder.CreateBr(merge_bb);
 
     builder.SetInsertPoint(merge_bb);
+    return llvm::Error::success();
+  };
+
+  for (const auto & inst : program.instance_functions)
+  {
+    if (auto err = emit_kernel_block(inst)) return std::move(err);
   }
 
   // ── Scheduler postamble: DAC stitch reads. Runs AFTER all

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -111,12 +111,13 @@ struct FlatInstr
 };
 
 // Per-instance kernel slice. Each session instance contributes one of
-// these to the multi-function plan. The compiler emits one `alwaysinline`
-// LLVM function per `InstanceProgram`, plus a scheduler that wraps each
-// call in `if (slots[alive_slot_index] > 0.5) call ...`.
+// these to the multi-function plan. The compiler emits nested
+// alive-conditional basic blocks inside one LLVM function — `children`
+// are emitted recursively inside the parent's body block (M11 fractal
+// architecture).
 struct InstanceProgram
 {
-  std::string                  instance_name;     // session instance name
+  std::string                  instance_name;     // dotted path (e.g. voice1.env)
   std::vector<FlatInstr>       instructions;      // already shifted into unified offset space
   uint32_t                     register_count = 0; // local temp count
   uint32_t                     alive_slot_index = 0; // slot driving the dispatch conditional
@@ -130,6 +131,9 @@ struct InstanceProgram
     int32_t  temp_slot;    // index into the unified temp array (-1 = skip)
   };
   std::vector<Writeback>       writebacks;
+  /** Nested child kernels. Emitted recursively inside this kernel's
+   *  alive-conditional body block. Empty for leaf kernels. */
+  std::vector<InstanceProgram> children;
 };
 
 // Top-level driver: runs once per sample. Preamble fires before any

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -147,11 +147,48 @@ struct ParsedPlan5
   std::vector<double>      slot_defaults;
 };
 
-/** Parse a tropical_plan_5 JSON object. The C++ side only supports
- *  schema "tropical_plan_5"; the TS compiler emits this shape
- *  exclusively. Hand-crafted single-program plans should construct
- *  the new shape (with one entry in `instance_functions[]` whose
- *  `alive_slot_index` points at a slot defaulting to 1.0). */
+/** Parse a single `InstanceProgram` from JSON, recursing into nested
+ *  `children`. Each child kernel's writebacks resolve against its own
+ *  `state_reg_offset` — nested kernels are independent in the unified
+ *  state-register space, just like top-level ones. */
+inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json & jf)
+{
+  tropical_jit::InstanceProgram inst;
+  inst.instance_name    = jf.value("instance_name", std::string{});
+  inst.register_count   = jf.value("register_count", 0u);
+  inst.alive_slot_index = jf.at("alive_slot_index").get<uint32_t>();
+  if (jf.contains("instructions"))
+    for (const auto & ji : jf["instructions"])
+      inst.instructions.push_back(parse_instr(ji));
+  // Writebacks: each entry of register_targets[] is the (absolute,
+  // already shifted) temp slot whose value feeds the state register at
+  // position j among this instance's slots, which sits at
+  // `state_reg_offset + j` in the unified state array.
+  const uint32_t state_reg_offset = jf.value("state_reg_offset", 0u);
+  if (jf.contains("register_targets"))
+  {
+    const auto & rts = jf["register_targets"];
+    for (uint32_t j = 0; j < rts.size(); ++j)
+    {
+      inst.writebacks.push_back({
+        state_reg_offset + j,
+        rts[j].get<int32_t>()
+      });
+    }
+  }
+  // Recurse into nested children (M11 fractal architecture). Absent or
+  // empty `children` array means a leaf kernel.
+  if (jf.contains("children"))
+    for (const auto & jc : jf["children"])
+      inst.children.push_back(parse_instance_program(jc));
+  return inst;
+}
+
+/** Parse a tropical_plan_5 JSON object. The C++ side supports nested
+ *  `instance_functions` (M11 fractal architecture): each function may
+ *  have `children: InstanceFunction[]` that emit recursively inside the
+ *  parent's alive-conditional. Legacy plans without nested children
+ *  parse as leaf-only kernels. */
 inline ParsedPlan5 parse_plan5(const nlohmann::json & plan)
 {
   ParsedPlan5 result;
@@ -201,33 +238,7 @@ inline ParsedPlan5 parse_plan5(const nlohmann::json & plan)
   if (plan.contains("instance_functions"))
   {
     for (const auto & jf : plan["instance_functions"])
-    {
-      tropical_jit::InstanceProgram inst;
-      inst.instance_name = jf.value("instance_name", std::string{});
-      inst.register_count = jf.value("register_count", 0u);
-      inst.alive_slot_index = jf.at("alive_slot_index").get<uint32_t>();
-      if (jf.contains("instructions"))
-        for (const auto & ji : jf["instructions"])
-          inst.instructions.push_back(parse_instr(ji));
-      // Writebacks: each entry of register_targets[] is the
-      // (absolute, already shifted) temp slot whose value feeds the
-      // state register at position j among this instance's slots,
-      // which sits at `state_reg_offset + j` in the unified state
-      // array.
-      const uint32_t state_reg_offset = jf.value("state_reg_offset", 0u);
-      if (jf.contains("register_targets"))
-      {
-        const auto & rts = jf["register_targets"];
-        for (uint32_t j = 0; j < rts.size(); ++j)
-        {
-          inst.writebacks.push_back({
-            state_reg_offset + j,
-            rts[j].get<int32_t>()
-          });
-        }
-      }
-      prog.instance_functions.push_back(std::move(inst));
-    }
+      prog.instance_functions.push_back(parse_instance_program(jf));
   }
 
   // ── scheduler_function ──


### PR DESCRIPTION
## Summary

Lands the operadic infrastructure for tropical's IR. Phases 0-5 of the original M11 plan (`~/.claude/plans/let-s-perform-a-comprehensive-reactive-waterfall.md`). The infrastructure is in place to support full fractal compilation; activation is deferred to a follow-up effort that will also land the foundational refactors discussed in the architectural conversation captured in `design/operadic_ir.md`.

10 commits across 6 phases. 940 TS pass / 8 skip / 0 fail. `bunx tsc --noEmit` clean. C++ ctest passes.

## Phases

- **Phase 0** — `compiler/ir/branded_names.ts`. `InstanceName`, `PortName`, `PortRef` branded vocabulary. Foundational types consumed by later phases.
- **Phase 1** — `compiler/ir/wire_program.ts`. `freeRefs` and `liftWireToProgram` pure functions. Lifts a wire `ExprNode` to a `ResolvedProgram` with a synthesized name.
- **Phase 2** — `compiler/ir/identity_elim.ts`. Categorical identity-law strata pass wired in after `arrayLower`. Eliminates trivial identity `InstanceDecl`s by inlining and substituting.
- **Phase 3** — N-WriteSlot expansion for array output ports. `emit_resolved` produces one target per scalar slot; `compile_session_slotted` iterates `outputPortMeta` to emit N WriteSlots per array port.
- **Phase 4** — Fractal infrastructure. Parameterized `strataPipeline` (`inlineNested?`), `children: InstanceFunction[]` in plan_5 (TS + C++), recursive `emit_kernel_block` in `OrcJitEngine.cpp`, recursive JSON parser, `NestedOut` as slot-read terminal, `partition_recursive.ts`, refactored `compile_session_slotted.ts`. Activation deferred (gated on cross-kernel input wiring resolution; see `design/operadic_ir.md` for the architectural rationale).
- **Phase 5** — `compiler/ir/lift_wires.ts`. Pre-compile pass that lifts wires containing array literals or session-level `delay()` into anonymous `__wire_N` programs going through the full strata pipeline.

## What's deferred

- **Phase 6** (nested-witness test driver) and **Phase 7** (cleanup, goldens, docs) are not in this PR. They depend on Phase 4 activation, which is gated on the cross-kernel input wiring problem (subject of architectural discussion).
- The user-facing M11 test gates (array literal inputs to Sequencer / Clock, session-level `delay()` between instances, the 3 `KNOWN_UNSUPPORTED` migration patches) remain blocked. The resolution path is documented in `design/operadic_ir.md` and discussed in the related planning notes.

## Design context

`design/operadic_ir.md` (also added in this PR) is a substantial new architectural document capturing the operadic framing for tropical's IR: typed colored PROP, structural encapsulation, the pre/post-trace operadic distinction, the spectrum of cycle-handling realizations, Wave Digital Filters in depth, multi-realization architecture, the continuous-discrete semantic hierarchy as finitization functors along multiple axes, slotified memory, and the category `Op` as the metacategory of compilation. It complements `design/architecture.md` (current system) by describing what the system is aiming for structurally.

The architectural commitments in `operadic_ir.md` shape the deferred follow-up work; the Phase 4 activation will land alongside slotified memory, structural encapsulation, and the cycle-handling convention choice as a coherent next PR.

## Test plan

- [x] `bun test` — 940 pass / 8 skip / 0 fail / 40160 expect()
- [x] `bunx tsc --noEmit` — clean
- [x] `make build` — builds
- [x] `ctest --test-dir build` — C++ JIT tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)