### PR TITLE
refactor(types): brand wire and slot keys

### DIFF
--- a/compiler/active_set.test.ts
+++ b/compiler/active_set.test.ts
@@ -24,6 +24,9 @@ import { instantiate } from './program_types.js'
 import { compileSession } from './ir/compile_session.js'
 import { toWirePlan } from './flat_plan.js'
 import { Runtime } from './runtime/runtime.js'
+import { wireKey, portRef, instanceName, portName } from './ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 describe('active-set plan shape', () => {
   test('every session instance contributes one InstanceFunction', () => {
@@ -35,9 +38,9 @@ describe('active-set plan shape', () => {
     s.instanceRegistry.set('lp', instantiate(onePole, 'lp'))
     allocateOutputSlots(s, 'osc', sinOsc)
     allocateOutputSlots(s, 'lp', onePole)
-    s.inputExprNodes.set('osc:freq', 220)
-    s.inputExprNodes.set('lp:input', { op: 'ref', instance: 'osc', output: 'sine' })
-    s.inputExprNodes.set('lp:g', 0.1)
+    s.inputExprNodes.set(wk("osc", "freq"), 220)
+    s.inputExprNodes.set(wk("lp", "input"), { op: 'ref', instance: 'osc', output: 'sine' })
+    s.inputExprNodes.set(wk("lp", "g"), 0.1)
     s.graphOutputs.push({ instance: 'lp', output: 'out' })
 
     const plan = compileSession(s)
@@ -61,7 +64,7 @@ describe('active-set plan shape', () => {
     for (let i = 0; i < 4; i++) {
       s.instanceRegistry.set(`v${i}`, instantiate(sinOsc, `v${i}`))
       allocateOutputSlots(s, `v${i}`, sinOsc)
-      s.inputExprNodes.set(`v${i}:freq`, 110 * (i + 1))
+      s.inputExprNodes.set(wk(`v${i}`, `freq`), 110 * (i + 1))
       s.graphOutputs.push({ instance: `v${i}`, output: 'sine' })
     }
     const plan = compileSession(s)
@@ -91,7 +94,7 @@ describe('active-set audio invariance', () => {
       if (aliveExpr !== undefined) inst.aliveInput = aliveExpr
       s.instanceRegistry.set('osc', inst)
       allocateOutputSlots(s, 'osc', sinOsc)
-      s.inputExprNodes.set('osc:freq', 440)
+      s.inputExprNodes.set(wk("osc", "freq"), 440)
       s.graphOutputs.push({ instance: 'osc', output: 'sine' })
       return s
     }
@@ -124,7 +127,7 @@ describe('active-set audio invariance', () => {
     inst.aliveInput = false  // never alive
     s.instanceRegistry.set('osc', inst)
     allocateOutputSlots(s, 'osc', sinOsc)
-    s.inputExprNodes.set('osc:freq', 440)
+    s.inputExprNodes.set(wk("osc", "freq"), 440)
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
     const rt = new Runtime(64)
@@ -180,7 +183,7 @@ describe('active-set audio invariance', () => {
         inst.aliveInput = i < nAlive
         s.instanceRegistry.set(`v${i}`, inst)
         allocateOutputSlots(s, `v${i}`, sinOsc)
-        s.inputExprNodes.set(`v${i}:freq`, 110 * (i + 1))
+        s.inputExprNodes.set(wk(`v${i}`, `freq`), 110 * (i + 1))
         s.graphOutputs.push({ instance: `v${i}`, output: 'sine' })
       }
       return s

--- a/compiler/apply_plan.test.ts
+++ b/compiler/apply_plan.test.ts
@@ -11,6 +11,9 @@ import { loadStdlib as loadBuiltins, loadProgramAsType } from './program'
 import type { ProgramNode, ProgramFile } from './program'
 import { applySessionWiring, applyFlatPlan } from './apply_plan'
 import { Runtime } from './runtime/runtime'
+import { wireKey, portRef, instanceName, portName } from './ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 /** Minimal test oscillator — naive saw + sin, phase accumulator. */
 const TEST_OSC: ProgramNode = {
@@ -72,9 +75,9 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     applySessionWiring(session)
@@ -112,9 +115,9 @@ describe('applySessionWiring', () => {
       osc1: { program: 'TestOsc' },
       amp1: { program: 'VCA' },
     })
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     applySessionWiring(session)
@@ -136,16 +139,16 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
     applySessionWiring(session)
     session.graph.primeJit()
     session.graph.process()
     expect(peak(session.graph.outputBuffer)).toBeGreaterThan(0)
 
-    session.inputExprNodes.delete('amp1:audio')
+    session.inputExprNodes.delete(wk("amp1", "audio"))
     applySessionWiring(session)
     session.graph.primeJit()
     session.graph.process()
@@ -162,9 +165,9 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
     applySessionWiring(session)
     session.graph.primeJit()
@@ -172,7 +175,7 @@ describe('applySessionWiring', () => {
     const buf1 = new Float64Array(session.graph.outputBuffer)
     expect(peak(buf1)).toBeGreaterThan(0)
 
-    session.inputExprNodes.set('osc2:freq', 880)
+    session.inputExprNodes.set(wk("osc2", "freq"), 880)
     session.graphOutputs = [{ instance: 'osc2', output: 'saw' }]
     applySessionWiring(session)
     session.graph.primeJit()
@@ -196,13 +199,13 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('osc2:freq', 880)
-    session.inputExprNodes.set('amp1:audio', {
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("osc2", "freq"), 880)
+    session.inputExprNodes.set(wk("amp1", "audio"), {
       op: 'add',
       args: [{ op: 'ref', instance: 'osc1', output: 'saw' }, { op: 'ref', instance: 'osc2', output: 'saw' }],
     } as ExprNode)
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     applySessionWiring(session)
@@ -221,17 +224,17 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('osc2:freq', 880)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("osc2", "freq"), 880)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
     applySessionWiring(session)
     session.graph.primeJit()
     session.graph.process()
     const buf1 = new Float64Array(session.graph.outputBuffer)
 
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc2', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc2', output: 'saw' })
     applySessionWiring(session)
     session.graph.primeJit()
     session.graph.process()
@@ -255,12 +258,12 @@ describe('applySessionWiring', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', {
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), {
       op: 'mul',
       args: [{ op: 'ref', instance: 'osc1', output: 'saw' }, 0.5],
     } as ExprNode)
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     applySessionWiring(session)
@@ -282,9 +285,9 @@ describe('applyFlatPlan', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     const rt = new Runtime(256)
@@ -307,8 +310,8 @@ describe('applyFlatPlan', () => {
       Clock1: { program: 'Clock' },
     })
 
-    session.inputExprNodes.set('Clock1:freq', 1.0)
-    session.inputExprNodes.set('Clock1:ratios_in', [1.0])
+    session.inputExprNodes.set(wk("Clock1", "freq"), 1.0)
+    session.inputExprNodes.set(wk("Clock1", "ratios_in"), [1.0])
     session.graphOutputs.push({ instance: 'Clock1', output: 'output' })
 
     const rt = new Runtime(256)
@@ -327,9 +330,9 @@ describe('applyFlatPlan', () => {
       osc1: { program: 'TestOsc' },
       amp1: { program: 'VCA' },
     })
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     const rt = new Runtime(256)
@@ -359,9 +362,9 @@ describe('applyFlatPlan', () => {
       amp1: { program: 'VCA' },
     })
 
-    session.inputExprNodes.set('osc1:freq', 440)
-    session.inputExprNodes.set('amp1:audio', { op: 'ref', instance: 'osc1', output: 'saw' })
-    session.inputExprNodes.set('amp1:cv', 1.0)
+    session.inputExprNodes.set(wk("osc1", "freq"), 440)
+    session.inputExprNodes.set(wk("amp1", "audio"), { op: 'ref', instance: 'osc1', output: 'saw' })
+    session.inputExprNodes.set(wk("amp1", "cv"), 1.0)
     session.graphOutputs.push({ instance: 'amp1', output: 'out' })
 
     const rt = new Runtime(256)
@@ -370,7 +373,7 @@ describe('applyFlatPlan', () => {
     for (let i = 0; i < 10; i++) rt.process()
     const buf1 = new Float64Array(rt.outputBuffer)
 
-    session.inputExprNodes.set('amp1:cv', 0.5)
+    session.inputExprNodes.set(wk("amp1", "cv"), 0.5)
     applyFlatPlan(session, rt)
     rt.process()
     const buf2 = rt.outputBuffer

--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -9,6 +9,7 @@
 import type { ExprNode } from './session'
 import type { ExprOpNodeStrict } from './expr.js'
 import { mapChildren } from './walk.js'
+import { parseWireKey } from './ir/branded_names.js'
 
 // ─────────────────────────────────────────────────────────────
 // Errors
@@ -117,12 +118,12 @@ export function buildDependencyGraph(
   for (const name of nameSet) graph.set(name, new Set())
 
   for (const [key, expr] of inputExprNodes) {
-    const instanceName = key.split(':')[0]
-    if (!nameSet.has(instanceName)) continue
+    const { instance } = parseWireKey(key)
+    if (!nameSet.has(instance)) continue
     const refs = exprDependencies(expr)
-    const deps = graph.get(instanceName)!
+    const deps = graph.get(instance)!
     for (const ref of refs) {
-      if (nameSet.has(ref) && ref !== instanceName) {
+      if (nameSet.has(ref) && ref !== instance) {
         // Skip edges to cycle-breaking modules — their outputs are
         // previous-sample register reads, not combinational dependencies.
         if (cycleBreakers?.has(ref)) continue

--- a/compiler/ir/branded_names.test.ts
+++ b/compiler/ir/branded_names.test.ts
@@ -2,8 +2,9 @@ import { describe, test, expect } from 'bun:test'
 import {
   instanceName, portName, rawName,
   childInstance, instancePathParts, isTopLevel, parentOf, leafOf,
-  portRef, portRefEq, portRefKey, parsePortRefKey,
+  portRef, portRefEq, wireKey, parseWireKey, slotKey,
   type InstanceName, type PortName, type PortRef,
+  type WireKey, type SlotKey,
 } from './branded_names.js'
 
 describe('InstanceName / PortName constructors', () => {
@@ -102,33 +103,65 @@ describe('PortRef', () => {
     expect(portRefEq(a, d)).toBe(false)
   })
 
-  test('portRefKey serializes to canonical form', () => {
+  test('wireKey serializes to canonical form', () => {
     const r = portRef(instanceName('voice1'), portName('freq'))
-    expect(portRefKey(r)).toBe('voice1:freq')
+    expect(wireKey(r)).toBe('voice1:freq')
   })
 
-  test('portRefKey handles nested instance paths', () => {
+  test('wireKey handles nested instance paths', () => {
     const r = portRef(instanceName('voice1.env'), portName('alive'))
-    expect(portRefKey(r)).toBe('voice1.env:alive')
+    expect(wireKey(r)).toBe('voice1.env:alive')
   })
 
-  test('parsePortRefKey is inverse of portRefKey', () => {
+  test('parseWireKey is inverse of wireKey', () => {
     const r = portRef(instanceName('voice1.env'), portName('alive'))
-    const k = portRefKey(r)
-    const back = parsePortRefKey(k)
+    const k = wireKey(r)
+    const back = parseWireKey(k)
     expect(portRefEq(r, back)).toBe(true)
   })
 
-  test('parsePortRefKey throws on missing separator', () => {
-    expect(() => parsePortRefKey('voice1')).toThrow(/missing ':'/)
+  test('parseWireKey throws on missing separator', () => {
+    expect(() => parseWireKey('voice1')).toThrow(/missing ':'/)
   })
 
-  test('parsePortRefKey splits on first colon only', () => {
+  test('parseWireKey splits on first colon only', () => {
     // contrived but: instance names can contain dots, but not colons.
     // ports also cannot contain colons. so the first colon is canonical.
-    const back = parsePortRefKey('voice1:in')
+    const back = parseWireKey('voice1:in')
     expect(rawName(back.instance)).toBe('voice1')
     expect(rawName(back.port)).toBe('in')
+  })
+
+  test('parseWireKey accepts raw string at JSON deser boundary', () => {
+    // The parser is the entry-point for untrusted/serialized data; it
+    // takes `WireKey | string`. Passing a raw string should work.
+    const raw: string = 'instA:portB'
+    const back = parseWireKey(raw)
+    expect(rawName(back.instance)).toBe('instA')
+    expect(rawName(back.port)).toBe('portB')
+  })
+})
+
+describe('SlotKey', () => {
+  test('slotKey serializes (instance, slotName) with dot separator', () => {
+    expect(slotKey(instanceName('lp1'), 'out')).toBe('lp1.out')
+  })
+
+  test('slotKey allows brackets in slotName (array elements)', () => {
+    expect(slotKey(instanceName('seq'), 'values[3]')).toBe('seq.values[3]')
+  })
+
+  test('slotKey allows synthetic slot names like __alive__', () => {
+    expect(slotKey(instanceName('a'), '__alive__')).toBe('a.__alive__')
+  })
+
+  test('slotKey allows dotted instance paths (nesting + slot dot are both present)', () => {
+    // voice1.env.out — two dots, second one is the slot separator.
+    expect(slotKey(instanceName('voice1.env'), 'out')).toBe('voice1.env.out')
+  })
+
+  test('slotKey rejects empty slotName', () => {
+    expect(() => slotKey(instanceName('a'), '')).toThrow(/empty/)
   })
 })
 

--- a/compiler/ir/branded_names.ts
+++ b/compiler/ir/branded_names.ts
@@ -42,6 +42,19 @@ export type InstanceName = BrandedName<'InstanceName'>
  *  dots are not allowed (ports are not nested). */
 export type PortName = BrandedName<'PortName'>
 
+/** Canonical key into `session.inputExprNodes` — identifies a wire by
+ *  the consumer (instance, input port) pair. Serialized as
+ *  `${instance}:${port}` for use as a Map key. Constructed only via
+ *  `wireKey(portRef)`; parsed only via `parseWireKey(key)`. */
+export type WireKey = BrandedName<'WireKey'>
+
+/** Canonical key into `session.outputSlotRegistry` and
+ *  `session.outputPortMeta` — identifies one allocated slot by the
+ *  (instance, slotName) pair. Slot names may be plain port names
+ *  ("out"), array elements ("out[0]"), or synthetic ("__alive__").
+ *  Serialized as `${instance}.${slotName}`; never parsed back. */
+export type SlotKey = BrandedName<'SlotKey'>
+
 // ─── Constructors ───────────────────────────────────────────────────────────
 
 const construct = <B extends string>(name: B, s: string, allowDots: boolean): BrandedName<B> => {
@@ -123,16 +136,22 @@ export const portRef = (inst: InstanceName, port: PortName): PortRef => ({
 export const portRefEq = (a: PortRef, b: PortRef): boolean =>
   a.instance === b.instance && a.port === b.port
 
-/** Canonical string form for use as a Map key or in JSON. Uses `:` as
- *  the instance/port separator (distinct from `.` which separates
- *  nesting levels in the instance path). */
-export const portRefKey = (r: PortRef): string => `${r.instance}:${r.port}`
+/** Canonical wire-key serialization. Uses `:` as the instance/port
+ *  separator (distinct from `.` which separates nesting levels in
+ *  the instance path). The return is a branded `WireKey`; consumers
+ *  that store wire keys (e.g. `Map<WireKey, ExprNode>`) reject raw
+ *  strings at the type level. */
+export const wireKey = (r: PortRef): WireKey =>
+  `${r.instance}:${r.port}` as WireKey
 
-/** Inverse of `portRefKey`. Throws on malformed input. */
-export const parsePortRefKey = (key: string): PortRef => {
+/** Inverse of `wireKey`. Accepts a raw string for use at JSON ingest
+ *  / deserialization boundaries. Returns the structured `PortRef`;
+ *  the brand only travels with the serialized form, so the parser
+ *  always returns the inner structure. */
+export const parseWireKey = (key: WireKey | string): PortRef => {
   const idx = key.indexOf(':')
   if (idx < 0) {
-    throw new Error(`parsePortRefKey: malformed key '${key}' — missing ':'`)
+    throw new Error(`parseWireKey: malformed key '${key}' — missing ':'`)
   }
   const instPart = key.slice(0, idx)
   const portPart = key.slice(idx + 1)
@@ -140,4 +159,18 @@ export const parsePortRefKey = (key: string): PortRef => {
     instance: instanceName(instPart),
     port:     portName(portPart),
   }
+}
+
+// ─── SlotKey ────────────────────────────────────────────────────────────────
+
+/** Canonical slot-key serialization. Used as the key into
+ *  `session.outputSlotRegistry` and `session.outputPortMeta`. The
+ *  `slotName` is allowed to contain brackets (`out[0]`) and synthetic
+ *  prefixes (`__alive__`); only the instance portion is validated
+ *  through `InstanceName`'s discipline. */
+export const slotKey = (inst: InstanceName, slotName: string): SlotKey => {
+  if (typeof slotName !== 'string' || slotName.length === 0) {
+    throw new Error(`slotKey: empty or non-string slotName`)
+  }
+  return `${inst}.${slotName}` as SlotKey
 }

--- a/compiler/ir/compile_session.test.ts
+++ b/compiler/ir/compile_session.test.ts
@@ -12,6 +12,9 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, resolveProgramType, instantiate, outputNames } from '../session.js'
 import { loadStdlib } from '../program.js'
 import { compileSession } from './compile_session.js'
+import { wireKey, portRef, instanceName, portName } from './branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 function singleInstanceSession(typeName: string) {
   const session = makeSession()
@@ -72,8 +75,8 @@ describe('compileSession — two-instance refs', () => {
     session.instanceRegistry.set('osc', sinInst)
     session.instanceRegistry.set('amp', vcaInst)
 
-    session.inputExprNodes.set('amp:audio', { op: 'ref', instance: 'osc', output: 'out' })
-    session.inputExprNodes.set('amp:cv', 0.5)
+    session.inputExprNodes.set(wk("amp", "audio"), { op: 'ref', instance: 'osc', output: 'out' })
+    session.inputExprNodes.set(wk("amp", "cv"), 0.5)
 
     session.graphOutputs.push({ instance: 'amp', output: 'out' })
 

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -33,7 +33,10 @@
  */
 
 import { allocateOutputSlots, type SessionState } from '../session.js'
-import { instanceName as toInstanceName } from './branded_names.js'
+import {
+  instanceName as toInstanceName, portName as toPortName,
+  portRef, wireKey,
+} from './branded_names.js'
 import type { FlatPlan, InstanceFunction, SchedulerFunction } from '../flat_plan.js'
 import type { NInstr, NOperand } from './emit_resolved.js'
 import { instrWriteSlot, opConst } from './emit_resolved.js'
@@ -87,8 +90,10 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
       /* prog           */ compiled.prog,
       /* compiled       */ compiled,
       /* aliveInput     */ inst.aliveInput,
-      /* inputBindingFor*/ (portName) => {
-        const expr = session.inputExprNodes.get(`${instName}:${portName}`)
+      /* inputBindingFor*/ (portNameStr) => {
+        const expr = session.inputExprNodes.get(
+          wireKey(portRef(toInstanceName(instName), toPortName(portNameStr))),
+        )
         if (expr !== undefined) return { kind: 'wired', expr }
         return undefined
       },

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -33,6 +33,7 @@
  */
 
 import { allocateOutputSlots, type SessionState } from '../session.js'
+import { instanceName as toInstanceName } from './branded_names.js'
 import type { FlatPlan, InstanceFunction, SchedulerFunction } from '../flat_plan.js'
 import type { NInstr, NOperand } from './emit_resolved.js'
 import { instrWriteSlot, opConst } from './emit_resolved.js'
@@ -59,7 +60,7 @@ function compileSessionSlottedPerInstance(session: SessionState): FlatPlan {
   // pre-allocated. `add_instance` / `loadProgramAsSession` already do
   // this eagerly; tests sometimes poke `instanceRegistry` directly.
   for (const [name, inst] of session.instanceRegistry) {
-    if (inst.compiled !== undefined) allocateOutputSlots(session, name, inst.compiled)
+    if (inst.compiled !== undefined) allocateOutputSlots(session, toInstanceName(name), inst.compiled)
   }
 
   const order = computeInstanceTopoOrder(session)

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -53,6 +53,7 @@ import {
   ZERO_TEMP_OFFSET,
 } from './slot_indices.js'
 import { topologicalSort } from '../compiler.js'
+import { parseWireKey } from './branded_names.js'
 
 /** Raised when a session uses a shape the per-instance compile path
  *  doesn't yet support. Marker class for diagnostics. */
@@ -274,9 +275,8 @@ export function computeInstanceTopoOrder(session: SessionState): string[] {
     deps.set(name, new Set())
   }
   for (const [key, expr] of session.inputExprNodes) {
-    const colon = key.indexOf(':')
-    if (colon < 0) continue
-    const consumer = key.slice(0, colon)
+    let consumer
+    try { consumer = parseWireKey(key).instance } catch { continue }
     const producers = deps.get(consumer)
     if (producers === undefined) continue
     collectInstanceRefs(expr, producers)

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -53,7 +53,10 @@ import {
   ZERO_TEMP_OFFSET,
 } from './slot_indices.js'
 import { topologicalSort } from '../compiler.js'
-import { parseWireKey } from './branded_names.js'
+import {
+  parseWireKey, slotKey,
+  instanceName as toInstanceName,
+} from './branded_names.js'
 
 /** Raised when a session uses a shape the per-instance compile path
  *  doesn't yet support. Marker class for diagnostics. */
@@ -115,7 +118,7 @@ export function translateNode(
 
   // ── refs and params (leaves) ──
   if (op === 'ref' && typeof obj.instance === 'string' && typeof obj.output === 'string') {
-    const key = `${obj.instance}.${obj.output}`
+    const key = slotKey(toInstanceName(obj.instance), obj.output)
     const slotIdxRaw = session.outputSlotRegistry.get(key)
     if (slotIdxRaw === undefined) {
       throw new SlotShapeUnsupportedError(
@@ -423,7 +426,7 @@ export function remapInstancePlan(
   let targetIdx = 0
   for (let portI = 0; portI < ctx.outputPortNames.length; portI++) {
     const portName = ctx.outputPortNames[portI]
-    const portKey  = `${ctx.instanceName}.${portName}`
+    const portKey  = slotKey(toInstanceName(ctx.instanceName), portName)
     const meta = session.outputPortMeta.get(portKey)
     if (meta === undefined) {
       throw new Error(
@@ -498,7 +501,7 @@ export function emitDacStitch(
 
   for (let i = 0; i < session.graphOutputs.length; i++) {
     const go = session.graphOutputs[i]
-    const key = `${go.instance}.${go.output}`
+    const key = slotKey(toInstanceName(go.instance), go.output)
     const slotIdxRaw = session.outputSlotRegistry.get(key)
     if (slotIdxRaw === undefined) {
       throw new SlotShapeUnsupportedError(

--- a/compiler/ir/lift_wires.ts
+++ b/compiler/ir/lift_wires.ts
@@ -103,7 +103,7 @@ function liftOneWire(
     baseTypeName: rawName(synthName),
   })
   session.instanceRegistry.set(rawName(synthName), inst)
-  allocateOutputSlots(session, rawName(synthName), compiled)
+  allocateOutputSlots(session, synthName, compiled)
 
   // Wire each free ref to its corresponding input on the lifted
   // instance. The input naming convention matches `liftWireToProgram`:

--- a/compiler/ir/lift_wires.ts
+++ b/compiler/ir/lift_wires.ts
@@ -29,7 +29,10 @@
 
 import type { SessionState, ExprNode } from '../session.js'
 import { freeRefs, liftWireToProgram } from './wire_program.js'
-import { instanceName, rawName, type PortRef } from './branded_names.js'
+import {
+  instanceName, rawName, type PortRef, type WireKey,
+  wireKey as toWireKey, portRef, portName as toPortName,
+} from './branded_names.js'
 import { programTypeFromResolved } from './strata.js'
 import { instantiate } from '../program_types.js'
 import { allocateOutputSlots } from '../session.js'
@@ -115,10 +118,10 @@ function liftOneWire(
   )
   for (const ref of refList) {
     const inputName = `${rawName(ref.instance).replace(/\./g, '_')}__${rawName(ref.port)}`
-    const wireKey = `${rawName(synthName)}:${inputName}`
+    const key = toWireKey(portRef(synthName, toPortName(inputName)))
     // Forward the original ref expression unchanged — this is now a
     // simple `{op:'ref',...}` wire that translateNode handles.
-    session.inputExprNodes.set(wireKey, {
+    session.inputExprNodes.set(key, {
       op: 'ref',
       instance: rawName(ref.instance),
       output: rawName(ref.port),
@@ -138,7 +141,7 @@ function liftOneWire(
 export function liftWiresToInstances(session: SessionState): void {
   // Capture wires before mutation; we'll modify the map as we go but
   // never want to re-lift a wire we just inserted.
-  const toLift: Array<{ key: string; expr: ExprNode }> = []
+  const toLift: Array<{ key: WireKey; expr: ExprNode }> = []
   for (const [key, expr] of session.inputExprNodes) {
     if (needsWireLift(expr)) toLift.push({ key, expr })
   }

--- a/compiler/ir/lowering/extract_session_delays.test.ts
+++ b/compiler/ir/lowering/extract_session_delays.test.ts
@@ -6,12 +6,17 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, setWireExpr } from '../../session.js'
 import { extractSessionDelays } from './extract_session_delays.js'
+import { portRef, instanceName, portName } from '../branded_names.js'
+
+/** Local sugar: build a PortRef from raw strings — keeps test
+ *  expectations readable without bypassing the branded constructors. */
+const pr = (i: string, p: string) => portRef(instanceName(i), portName(p))
 
 describe('extractSessionDelays', () => {
   test('hoists a top-level delay wire to a sessionSlot read', () => {
     const session = makeSession()
     const baseSlotCount = session.slotCount
-    setWireExpr(session, 'a:in', {
+    setWireExpr(session, pr('a', 'in'), {
       op: 'ref', instance: 'b', output: 'out',
     })
 
@@ -36,7 +41,7 @@ describe('extractSessionDelays', () => {
 
   test('honors explicit init and id on the delay wrap', () => {
     const session = makeSession()
-    setWireExpr(session, 'osc:phase',
+    setWireExpr(session, pr('osc', 'phase'),
       { op: 'ref', instance: 'src', output: 'y' },
       { init: 0.5, id: 'feedback-tap' },
     )
@@ -65,7 +70,7 @@ describe('extractSessionDelays', () => {
 
   test('idempotent: re-running finds no delays to extract', () => {
     const session = makeSession()
-    setWireExpr(session, 'a:in', {
+    setWireExpr(session, pr('a', 'in'), {
       op: 'ref', instance: 'b', output: 'out',
     })
     extractSessionDelays(session)
@@ -82,8 +87,8 @@ describe('extractSessionDelays', () => {
   test('handles multiple delays in allocation order', () => {
     const session = makeSession()
     const baseSlot = session.slotCount
-    setWireExpr(session, 'a:in', { op: 'ref', instance: 'b', output: 'out' })
-    setWireExpr(session, 'b:in', { op: 'ref', instance: 'a', output: 'out' })
+    setWireExpr(session, pr('a', 'in'), { op: 'ref', instance: 'b', output: 'out' })
+    setWireExpr(session, pr('b', 'in'), { op: 'ref', instance: 'a', output: 'out' })
 
     extractSessionDelays(session)
 

--- a/compiler/ir/lowering/extract_session_delays.test.ts
+++ b/compiler/ir/lowering/extract_session_delays.test.ts
@@ -6,7 +6,9 @@
 import { describe, test, expect } from 'bun:test'
 import { makeSession, setWireExpr } from '../../session.js'
 import { extractSessionDelays } from './extract_session_delays.js'
-import { portRef, instanceName, portName } from '../branded_names.js'
+import { portRef, instanceName, portName, wireKey } from '../branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 /** Local sugar: build a PortRef from raw strings — keeps test
  *  expectations readable without bypassing the branded constructors. */
@@ -33,7 +35,7 @@ describe('extractSessionDelays', () => {
     })
 
     // Wire is rewritten to a sessionSlot read pointing at the new slot.
-    expect(session.inputExprNodes.get('a:in')).toEqual({
+    expect(session.inputExprNodes.get(wk("a", "in"))).toEqual({
       op: 'sessionSlot', index: baseSlotCount,
     })
     expect(session.slotCount).toBe(baseSlotCount + 1)
@@ -58,11 +60,11 @@ describe('extractSessionDelays', () => {
     const session = makeSession()
     // Direct write, bypassing setWireExpr — simulates a legacy
     // patch ingest path.
-    session.inputExprNodes.set('a:gain', { op: 'param', name: 'gain' })
+    session.inputExprNodes.set(wk("a", "gain"), { op: 'param', name: 'gain' })
 
-    const before = session.inputExprNodes.get('a:gain')
+    const before = session.inputExprNodes.get(wk("a", "gain"))
     extractSessionDelays(session)
-    const after = session.inputExprNodes.get('a:gain')
+    const after = session.inputExprNodes.get(wk("a", "gain"))
 
     expect(after).toEqual(before!)
     expect(session.delaySlotRegistry).toHaveLength(0)

--- a/compiler/ir/lowering/session_cycle_check.test.ts
+++ b/compiler/ir/lowering/session_cycle_check.test.ts
@@ -7,6 +7,9 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, setWireExpr, type ExprNode } from '../../session.js'
 import { extractSessionDelays } from './extract_session_delays.js'
 import { assertSessionAcyclic, SessionCycleViolation } from './session_cycle_check.js'
+import { portRef, instanceName, portName } from '../branded_names.js'
+
+const pr = (i: string, p: string) => portRef(instanceName(i), portName(p))
 
 function makeInstance(session: ReturnType<typeof makeSession>, name: string): void {
   // We don't need a real Compiled here — assertSessionAcyclic only
@@ -27,8 +30,8 @@ describe('assertSessionAcyclic', () => {
     const session = makeSession()
     makeInstance(session, 'a')
     makeInstance(session, 'b')
-    setWireExpr(session, 'a:in', { op: 'ref', instance: 'b', output: 'out' })
-    setWireExpr(session, 'b:in', { op: 'ref', instance: 'a', output: 'out' })
+    setWireExpr(session, pr('a', 'in'), { op: 'ref', instance: 'b', output: 'out' })
+    setWireExpr(session, pr('b', 'in'), { op: 'ref', instance: 'a', output: 'out' })
     extractSessionDelays(session)
     expect(() => assertSessionAcyclic(session)).not.toThrow()
   })

--- a/compiler/ir/lowering/session_cycle_check.test.ts
+++ b/compiler/ir/lowering/session_cycle_check.test.ts
@@ -7,7 +7,9 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, setWireExpr, type ExprNode } from '../../session.js'
 import { extractSessionDelays } from './extract_session_delays.js'
 import { assertSessionAcyclic, SessionCycleViolation } from './session_cycle_check.js'
-import { portRef, instanceName, portName } from '../branded_names.js'
+import { portRef, instanceName, portName, wireKey } from '../branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 const pr = (i: string, p: string) => portRef(instanceName(i), portName(p))
 
@@ -42,15 +44,15 @@ describe('assertSessionAcyclic', () => {
     makeInstance(session, 'b')
     // Bypass setWireExpr — write directly, simulating a programmatic
     // session that doesn't honor the auto-delay convention.
-    session.inputExprNodes.set('a:in', { op: 'ref', instance: 'b', output: 'out' })
-    session.inputExprNodes.set('b:in', { op: 'ref', instance: 'a', output: 'out' })
+    session.inputExprNodes.set(wk("a", "in"), { op: 'ref', instance: 'b', output: 'out' })
+    session.inputExprNodes.set(wk("b", "in"), { op: 'ref', instance: 'a', output: 'out' })
     expect(() => assertSessionAcyclic(session)).toThrow(SessionCycleViolation)
   })
 
   test('rejects a self-cycle (single instance with self-edge)', () => {
     const session = makeSession()
     makeInstance(session, 'a')
-    session.inputExprNodes.set('a:in', { op: 'ref', instance: 'a', output: 'out' })
+    session.inputExprNodes.set(wk("a", "in"), { op: 'ref', instance: 'a', output: 'out' })
     expect(() => assertSessionAcyclic(session)).toThrow(SessionCycleViolation)
   })
 
@@ -65,8 +67,8 @@ describe('assertSessionAcyclic', () => {
         1,
       ],
     }
-    session.inputExprNodes.set('a:in', expr)
-    session.inputExprNodes.set('b:in', { op: 'ref', instance: 'a', output: 'out' })
+    session.inputExprNodes.set(wk("a", "in"), expr)
+    session.inputExprNodes.set(wk("b", "in"), { op: 'ref', instance: 'a', output: 'out' })
     expect(() => assertSessionAcyclic(session)).toThrow(SessionCycleViolation)
   })
 
@@ -74,8 +76,8 @@ describe('assertSessionAcyclic', () => {
     const session = makeSession()
     makeInstance(session, 'a')
     makeInstance(session, 'b')
-    session.inputExprNodes.set('a:in', { op: 'ref', instance: 'b', output: 'out' })
-    session.inputExprNodes.set('b:in', { op: 'ref', instance: 'a', output: 'out' })
+    session.inputExprNodes.set(wk("a", "in"), { op: 'ref', instance: 'b', output: 'out' })
+    session.inputExprNodes.set(wk("b", "in"), { op: 'ref', instance: 'a', output: 'out' })
     try {
       assertSessionAcyclic(session)
       throw new Error('expected SessionCycleViolation')

--- a/compiler/ir/lowering/session_cycle_check.ts
+++ b/compiler/ir/lowering/session_cycle_check.ts
@@ -18,6 +18,7 @@
 
 import type { SessionState, ExprNode } from '../../session.js'
 import { tarjanSCC } from '../../compiler.js'
+import { parseWireKey } from '../branded_names.js'
 
 export class SessionCycleViolation extends Error {
   constructor(public readonly cycles: ReadonlyArray<ReadonlyArray<string>>) {
@@ -72,9 +73,8 @@ export function assertSessionAcyclic(session: SessionState): void {
     deps.set(name, new Set())
   }
   for (const [key, expr] of session.inputExprNodes) {
-    const colon = key.indexOf(':')
-    if (colon < 0) continue
-    const consumer = key.slice(0, colon)
+    let consumer
+    try { consumer = parseWireKey(key).instance } catch { continue }
     const producers = deps.get(consumer)
     if (producers === undefined) continue
     collectInstanceRefs(expr, producers)

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -67,6 +67,7 @@ import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
 import { specializeProgram } from './specialize.js'
 import { cloneResolvedProgram } from './clone.js'
+import { parseWireKey } from './branded_names.js'
 
 /** Run the session-to-ResolvedProgram materialization end-to-end. */
 export function materializeSessionToResolvedIR(session: SessionState): ResolvedProgram {
@@ -248,10 +249,10 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
   }
 
   for (const [key, expr] of session.inputExprNodes) {
-    const colon = key.indexOf(':')
-    if (colon < 0) continue
-    const instName = key.slice(0, colon)
-    const inputName = key.slice(colon + 1)
+    let ref
+    try { ref = parseWireKey(key) } catch { continue }
+    const instName = ref.instance
+    const inputName = ref.port
     const instDecl = ctx.instanceDecls.get(instName)
     if (instDecl === undefined) continue
     const port = instDecl.type.ports.inputs.find(p => p.name === inputName)

--- a/compiler/ir/n_write_slot_expansion.test.ts
+++ b/compiler/ir/n_write_slot_expansion.test.ts
@@ -13,6 +13,9 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession } from '../session.js'
 import { loadProgramAsType } from '../program.js'
 import { compileSession } from './compile_session.js'
+import { slotKey, instanceName } from './branded_names.js'
+
+const sk = (i: string, n: string) => slotKey(instanceName(i), n)
 
 describe('Phase 3 — N-WriteSlot expansion for array output ports', () => {
   test('an instance with array_out: float[3] emits 3 WriteSlots', () => {
@@ -47,7 +50,7 @@ describe('Phase 3 — N-WriteSlot expansion for array output ports', () => {
     } as Parameters<typeof loadJSON>[0], session)
 
     // Confirm slot allocation expanded to 3 for the array port.
-    const aMeta = session.outputPortMeta.get('a.arr')
+    const aMeta = session.outputPortMeta.get(sk("a", "arr"))
     expect(aMeta).toBeDefined()
     expect(aMeta!.scalarSlotNames).toEqual(['a.arr[0]', 'a.arr[1]', 'a.arr[2]'])
 

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -41,6 +41,7 @@ import {
   tempOffset, stateRegOffset, arraySlotOffset,
 } from './slot_indices.js'
 import { type ScalarType, instrWriteSlot, opConst } from './emit_resolved.js'
+import { instanceName as toInstanceName } from './branded_names.js'
 import { compileResolved } from './compile_resolved.js'
 import { cloneWithInputSubst } from './clone.js'
 import { makeCompiled, type Compiled } from '../program_types.js'
@@ -157,7 +158,7 @@ export function partitionKernel(
     const childCompiled = makeCompiled(substChildProg, { displayName: decl.type.name })
 
     // Allocate output slots (+ __alive__) for the child.
-    allocateOutputSlots(session, childPath, childCompiled)
+    allocateOutputSlots(session, toInstanceName(childPath), childCompiled)
 
     // Build slot map for parent's NestedOut → child output reads.
     const childSlotMap = new Map<OutputDecl, number>()

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -41,7 +41,7 @@ import {
   tempOffset, stateRegOffset, arraySlotOffset,
 } from './slot_indices.js'
 import { type ScalarType, instrWriteSlot, opConst } from './emit_resolved.js'
-import { instanceName as toInstanceName } from './branded_names.js'
+import { instanceName as toInstanceName, slotKey } from './branded_names.js'
 import { compileResolved } from './compile_resolved.js'
 import { cloneWithInputSubst } from './clone.js'
 import { makeCompiled, type Compiled } from '../program_types.js'
@@ -101,7 +101,7 @@ function lookupOutputSlot(
   instancePath: string,
   portName: string,
 ): number | undefined {
-  const portKey = `${instancePath}.${portName}`
+  const portKey = slotKey(toInstanceName(instancePath), portName)
   const meta = session.outputPortMeta.get(portKey)
   if (meta === undefined || meta.scalarSlotNames.length === 0) return undefined
   return session.outputSlotRegistry.get(meta.scalarSlotNames[0])
@@ -222,7 +222,7 @@ export function partitionKernel(
   const { preamble, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
   const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
 
-  const aliveSlotRaw = session.outputSlotRegistry.get(`${instancePath}.__alive__`)
+  const aliveSlotRaw = session.outputSlotRegistry.get(slotKey(toInstanceName(instancePath), '__alive__'))
   if (aliveSlotRaw === undefined) {
     throw new Error(
       `partitionKernel: '${instancePath}' has no __alive__ slot — allocateOutputSlots should have reserved it`,

--- a/compiler/ir/wire_program.test.ts
+++ b/compiler/ir/wire_program.test.ts
@@ -5,7 +5,7 @@ import type {
 } from './nodes.js'
 import { freeRefs, liftWireToProgram } from './wire_program.js'
 import {
-  instanceName, portName, portRef, portRefKey, rawName,
+  instanceName, portName, portRef, rawName,
   type InstanceName,
 } from './branded_names.js'
 import { strataPipeline } from './strata.js'

--- a/compiler/ir/wire_program.ts
+++ b/compiler/ir/wire_program.ts
@@ -40,11 +40,11 @@ import type {
   ResolvedBlock,
 } from './nodes.js'
 import {
-  type InstanceName, type PortName, type PortRef,
+  type InstanceName, type PortName, type PortRef, type WireKey,
   instanceName as makeInstanceName,
   portName as makePortName,
   portRef as makePortRef,
-  portRefKey, rawName,
+  wireKey, rawName,
 } from './branded_names.js'
 
 // ─── Op sets ────────────────────────────────────────────────────────────────
@@ -101,7 +101,7 @@ export function freeRefs(expr: ExprNode): ReadonlySet<PortRef> {
         )
       }
       const ref = makePortRef(makeInstanceName(instStr), makePortName(outVal))
-      const key = portRefKey(ref)
+      const key = wireKey(ref)
       if (!byKey.has(key)) byKey.set(key, ref)
       return
     }
@@ -126,8 +126,8 @@ export function freeRefs(expr: ExprNode): ReadonlySet<PortRef> {
 // ─── Lift to ResolvedProgram ───────────────────────────────────────────────
 
 interface TranslateContext {
-  /** Map from canonical PortRef key to the InputDecl that represents it. */
-  readonly refToInput: ReadonlyMap<string, InputDecl>
+  /** Map from canonical wire key to the InputDecl that represents it. */
+  readonly refToInput: ReadonlyMap<WireKey, InputDecl>
   /** Param/Trigger decls accumulated during translation. Keyed by param
    *  name. Mutated as the translator encounters new refs. */
   readonly paramDecls: Map<string, ParamDecl>
@@ -158,11 +158,11 @@ export function liftWireToProgram(
   // Sort refs by canonical key so input ordering is deterministic
   // across calls (the same wire produces the same program shape).
   const sortedRefs = Array.from(freeRefSet).sort((a, b) =>
-    portRefKey(a).localeCompare(portRefKey(b)),
+    wireKey(a).localeCompare(wireKey(b)),
   )
 
   const inputDecls: InputDecl[] = []
-  const refToInput = new Map<string, InputDecl>()
+  const refToInput = new Map<WireKey, InputDecl>()
   for (const ref of sortedRefs) {
     // Name the input deterministically from the ref. Double-underscore
     // separator avoids collisions with user port names (which can't
@@ -171,7 +171,7 @@ export function liftWireToProgram(
     const inputName = `${rawName(ref.instance).replace(/\./g, '_')}__${rawName(ref.port)}`
     const decl: InputDecl = { op: 'inputDecl', name: inputName }
     inputDecls.push(decl)
-    refToInput.set(portRefKey(ref), decl)
+    refToInput.set(wireKey(ref), decl)
   }
 
   const outputDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
@@ -231,13 +231,13 @@ function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
     const instStr = obj.instance as string
     const outStr = obj.output as string
     const ref = makePortRef(makeInstanceName(instStr), makePortName(outStr))
-    const inputDecl = ctx.refToInput.get(portRefKey(ref))
+    const inputDecl = ctx.refToInput.get(wireKey(ref))
     if (inputDecl === undefined) {
       // Should not happen: freeRefs collected this ref. Either the
       // caller passed a stale freeRefSet, or the expression mutated
       // between scanning and lifting.
       throw new Error(
-        `liftWireToProgram: ref ${portRefKey(ref)} not in freeRefSet — ` +
+        `liftWireToProgram: ref ${wireKey(ref)} not in freeRefSet — ` +
         `pass the same set returned by freeRefs(expr)`,
       )
     }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -23,6 +23,7 @@ import {
 import { exprDependencies, reachableInstances, buildDependencyGraph, topologicalSort } from './compiler.js'
 import type { RawTypeArgs } from './specialize.js'
 import { Float, portTypeEqual } from './ir/port_type.js'
+import { wireKey, parseWireKey, portRef, instanceName as toInstanceName, portName as toPortName, rawName } from './ir/branded_names.js'
 import { raiseProgram } from './parse/raise.js'
 import { elaborate, type ExternalProgramResolver } from './ir/elaborator.js'
 import { programTypeFromResolved } from './ir/strata.js'
@@ -822,12 +823,18 @@ export function exportSessionAsProgram(
   const inputKeys = Object.keys(inputs)
   const exposedKeys = new Set<string>()   // "instance:port" keys being exposed as inputs
   for (const [inputName, target] of Object.entries(inputs)) {
-    const [instName, portName] = target.split(':')
-    if (!portName) throw new Error(`export: input '${inputName}' target must be "instance:port", got '${target}'.`)
+    let ref
+    try {
+      ref = parseWireKey(target)
+    } catch {
+      throw new Error(`export: input '${inputName}' target must be "instance:port", got '${target}'.`)
+    }
+    const instName = ref.instance
+    const portNameStr = ref.port
     const inst = session.instanceRegistry.get(instName)
     if (!inst) throw new Error(`export: input '${inputName}' references unknown instance '${instName}'.`)
-    if (!inputNames(inst).includes(portName))
-      throw new Error(`export: instance '${instName}' has no input '${portName}'. Available: ${inputNames(inst).join(', ')}`)
+    if (!inputNames(inst).includes(portNameStr))
+      throw new Error(`export: instance '${instName}' has no input '${portNameStr}'. Available: ${inputNames(inst).join(', ')}`)
     exposedKeys.add(target)
   }
 
@@ -917,9 +924,9 @@ export function exportSessionAsProgram(
 
   const inputEntries: Array<string | ProgramPortSpec> = inputKeys.map(inputName => {
     const target = inputs[inputName]
-    const [instName, portName] = target.split(':')
-    const inst = session.instanceRegistry.get(instName)!
-    const idx = inputIndex(inst, portName)
+    const ref = parseWireKey(target)
+    const inst = session.instanceRegistry.get(ref.instance)!
+    const idx = inputIndex(inst, ref.port)
     const pt = inputPortType(inst, idx)
     const dflt = inputDefaults[inputName]
     const entry: ProgramPortSpec = { name: inputName }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -382,13 +382,16 @@ export function loadProgramAsSession(
     // Slot model: allocate output slots for the instance, parallel to
     // what MCP add_instance does. Required for the per-instance
     // compile path (M9a+) to find each output's slot index.
-    allocateOutputSlots(session, instance.name, type)
+    allocateOutputSlots(session, toInstanceName(instance.name), type)
 
     // Populate wiring from instance inputs
     if (inst.inputs) {
       for (const [input, expr] of Object.entries(inst.inputs)) {
         validateExpr(expr, `${inst.name}.${input}`)
-        session.inputExprNodes.set(`${inst.name}:${input}`, expr)
+        session.inputExprNodes.set(
+          wireKey(portRef(toInstanceName(inst.name), toPortName(input))),
+          expr,
+        )
       }
     }
   }
@@ -397,7 +400,7 @@ export function loadProgramAsSession(
   for (const [name, inst] of session.instanceRegistry) {
     const defaults = rawInputDefaults(inst)
     for (const [inputName, value] of Object.entries(defaults)) {
-      const key = `${name}:${inputName}`
+      const key = wireKey(portRef(toInstanceName(name), toPortName(inputName)))
       if (!session.inputExprNodes.has(key)) {
         session.inputExprNodes.set(key, value)
       }
@@ -543,13 +546,16 @@ export function mergeProgramIntoSession(
     // Slot model: allocate output slots for the instance, parallel to
     // what MCP add_instance does. Required for the per-instance
     // compile path (M9a+) to find each output's slot index.
-    allocateOutputSlots(session, instance.name, type)
+    allocateOutputSlots(session, toInstanceName(instance.name), type)
 
     // Populate wiring from instance inputs
     if (inst.inputs) {
       for (const [input, expr] of Object.entries(inst.inputs)) {
         validateExpr(expr, `${inst.name}.${input}`)
-        session.inputExprNodes.set(`${inst.name}:${input}`, expr)
+        session.inputExprNodes.set(
+          wireKey(portRef(toInstanceName(inst.name), toPortName(input))),
+          expr,
+        )
       }
     }
   }
@@ -558,7 +564,7 @@ export function mergeProgramIntoSession(
   for (const [name, inst] of session.instanceRegistry) {
     const defaults = rawInputDefaults(inst)
     for (const [inputName, value] of Object.entries(defaults)) {
-      const key = `${name}:${inputName}`
+      const key = wireKey(portRef(toInstanceName(name), toPortName(inputName)))
       if (!session.inputExprNodes.has(key)) {
         session.inputExprNodes.set(key, value)
       }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -23,7 +23,11 @@ import {
 import { exprDependencies, reachableInstances, buildDependencyGraph, topologicalSort } from './compiler.js'
 import type { RawTypeArgs } from './specialize.js'
 import { Float, portTypeEqual } from './ir/port_type.js'
-import { wireKey, parseWireKey, portRef, instanceName as toInstanceName, portName as toPortName, rawName } from './ir/branded_names.js'
+import {
+  wireKey, parseWireKey, portRef, rawName,
+  instanceName as toInstanceName, portName as toPortName,
+  type WireKey,
+} from './ir/branded_names.js'
 import { raiseProgram } from './parse/raise.js'
 import { elaborate, type ExternalProgramResolver } from './ir/elaborator.js'
 import { programTypeFromResolved } from './ir/strata.js'
@@ -745,7 +749,7 @@ export function saveProgramFromSession(
     // Merge wiring for this instance
     const inputs: Record<string, ExprNode> = {}
     for (const portName of inputNames(inst)) {
-      const key = `${name}:${portName}`
+      const key = wireKey(portRef(toInstanceName(name), toPortName(portName)))
       const expr = session.inputExprNodes.get(key)
       if (expr !== undefined) inputs[portName] = expr
     }
@@ -825,9 +829,11 @@ export function exportSessionAsProgram(
     rootExprs.push(refExpr)
   }
 
-  // Validate input mappings
+  // Validate input mappings. exposedKeys collects validated wire
+  // keys (brand re-applied after parse — the input strings came from
+  // user JSON, so they're untrusted until parseWireKey accepts them).
   const inputKeys = Object.keys(inputs)
-  const exposedKeys = new Set<string>()   // "instance:port" keys being exposed as inputs
+  const exposedKeys = new Set<WireKey>()
   for (const [inputName, target] of Object.entries(inputs)) {
     let ref
     try {
@@ -841,7 +847,7 @@ export function exportSessionAsProgram(
     if (!inst) throw new Error(`export: input '${inputName}' references unknown instance '${instName}'.`)
     if (!inputNames(inst).includes(portNameStr))
       throw new Error(`export: instance '${instName}' has no input '${portNameStr}'. Available: ${inputNames(inst).join(', ')}`)
-    exposedKeys.add(target)
+    exposedKeys.add(wireKey(ref))
   }
 
   // Walk backward from outputs to find all needed instances
@@ -919,10 +925,12 @@ export function exportSessionAsProgram(
     }
   }
 
-  // Collect per-port defaults from current wiring of exposed ports
+  // Collect per-port defaults from current wiring of exposed ports.
+  // Targets were already validated at the start of this function; re-
+  // parse to recover the brand for the Map lookup.
   const inputDefaults: Record<string, ExprNode> = {}
   for (const [inputName, target] of Object.entries(inputs)) {
-    const currentExpr = session.inputExprNodes.get(target)
+    const currentExpr = session.inputExprNodes.get(wireKey(parseWireKey(target)))
     if (currentExpr !== undefined) {
       inputDefaults[inputName] = rewriteRefs(currentExpr)
     }
@@ -982,7 +990,7 @@ export function exportSessionAsProgram(
     // and ref→nested_out for sibling instances
     const instInputs: Record<string, ExprNode> = {}
     for (const portName of inputNames(inst)) {
-      const key = `${instName}:${portName}`
+      const key = wireKey(portRef(toInstanceName(instName), toPortName(portName)))
       if (exposedKeys.has(key)) {
         const inputName = Object.entries(inputs).find(([_, t]) => t === key)![0]
         instInputs[portName] = { op: 'input', name: inputName }

--- a/compiler/render.test.ts
+++ b/compiler/render.test.ts
@@ -28,6 +28,9 @@ import {
   dominantFrequency,
   writeWav,
 } from './test_utils/audio'
+import { wireKey, portRef, instanceName, portName } from './ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -120,7 +123,7 @@ describe('renderFrames / buffer backend', () => {
 
     renderFrames(session.runtime, 8)
 
-    session.inputExprNodes.set('osc:freq', 440)
+    session.inputExprNodes.set(wk("osc", "freq"), 440)
     applySessionWiring(session)
 
     const samples = renderFrames(session.runtime, 174)

--- a/compiler/runtime/m9b_param_slot_equiv.test.ts
+++ b/compiler/runtime/m9b_param_slot_equiv.test.ts
@@ -24,6 +24,9 @@ import { instantiate } from '../program_types.ts'
 import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
 import { toWirePlan } from '../flat_plan.ts'
 import { Param, Trigger } from './param.ts'
+import { wireKey, portRef, instanceName, portName } from '../ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 let prevEnv: string | undefined
 beforeEach(() => {
@@ -45,7 +48,7 @@ describe('M9b: params as slot reads in per-instance path', () => {
     // Declare a 'cutoff' param at the session level and wire it
     s.paramRegistry.set('cutoff', new Param(880, 0))   // unsmoothed (time_const=0)
     const paramSlotIdx = allocateParamSlot(s, 'cutoff')
-    s.inputExprNodes.set('osc:freq', { op: 'param', name: 'cutoff' })
+    s.inputExprNodes.set(wk("osc", "freq"), { op: 'param', name: 'cutoff' })
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
     const plan = compileSessionSlotted(s)
@@ -75,7 +78,7 @@ describe('M9b: params as slot reads in per-instance path', () => {
     allocateOutputSlots(sParam, 'osc', sin)
     sParam.paramRegistry.set('freq', new Param(FREQ, 0))
     const slotIdx = allocateParamSlot(sParam, 'freq')
-    sParam.inputExprNodes.set('osc:freq', { op: 'param', name: 'freq' })
+    sParam.inputExprNodes.set(wk("osc", "freq"), { op: 'param', name: 'freq' })
     sParam.graphOutputs.push({ instance: 'osc', output: 'sine' })
     const planParam = compileSessionSlotted(sParam)
 
@@ -85,7 +88,7 @@ describe('M9b: params as slot reads in per-instance path', () => {
     const sin2 = sLit.typeRegistry.get('SinOsc')!
     sLit.instanceRegistry.set('osc', instantiate(sin2, 'osc'))
     allocateOutputSlots(sLit, 'osc', sin2)
-    sLit.inputExprNodes.set('osc:freq', FREQ)
+    sLit.inputExprNodes.set(wk("osc", "freq"), FREQ)
     sLit.graphOutputs.push({ instance: 'osc', output: 'sine' })
     const planLit = compileSessionSlotted(sLit)
 
@@ -117,7 +120,7 @@ describe('M9b: params as slot reads in per-instance path', () => {
     allocateOutputSlots(s, 'osc', sin)
     s.paramRegistry.set('f', new Param(110, 0))
     allocateParamSlot(s, 'f')
-    s.inputExprNodes.set('osc:freq', { op: 'param', name: 'f' })
+    s.inputExprNodes.set(wk("osc", "freq"), { op: 'param', name: 'f' })
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
     const plan = compileSessionSlotted(s)
@@ -154,7 +157,7 @@ describe('M9b: triggers as slot reads', () => {
     s.triggerRegistry.set('go', new Trigger())
     const trigSlot = allocateParamSlot(s, 'go')
     // Wire trigger into freq — odd but exercises the compile path
-    s.inputExprNodes.set('osc:freq', { op: 'triggerParamExpr', name: 'go' })
+    s.inputExprNodes.set(wk("osc", "freq"), { op: 'triggerParamExpr', name: 'go' })
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
     const plan = compileSessionSlotted(s)

--- a/compiler/runtime/pulse_stdlib.test.ts
+++ b/compiler/runtime/pulse_stdlib.test.ts
@@ -14,6 +14,9 @@ import { loadStdlib } from '../program.ts'
 import { instantiate } from '../program_types.ts'
 import { compileSessionSlotted } from '../ir/compile_session_slotted.ts'
 import { toWirePlan } from '../flat_plan.ts'
+import { wireKey, portRef, instanceName, portName } from '../ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 describe('M9b: Pulse stdlib emits rising-edge pulses', () => {
   test('Pulse fires exactly once per low-to-high transition', () => {
@@ -31,7 +34,7 @@ describe('M9b: Pulse stdlib emits rising-edge pulses', () => {
     // uses allocateParamSlot + paramRegistry lookup.
     s.paramRegistry.set('fire', { value: 0 } as any)
     allocateParamSlot(s, 'fire')
-    s.inputExprNodes.set('p:signal', { op: 'param', name: 'fire' })
+    s.inputExprNodes.set(wk("p", "signal"), { op: 'param', name: 'fire' })
     s.graphOutputs.push({ instance: 'p', output: 'out' })
 
     process.env.TROPICAL_SLOT_OPS = '1'

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -131,16 +131,23 @@ export interface SessionState {
   graphOutputs: Array<{ instance: string; output: string }>
   paramRegistry: Map<string, Param>
   triggerRegistry: Map<string, Trigger>
-  /** Canonical input wiring: key is `${instance}:${input}`, value is the ExprNode for round-trip save. */
-  inputExprNodes: Map<string, ExprNode>  // key: `${instance}:${input}`
+  /** Canonical input wiring: key is the branded `${instance}:${port}`
+   *  wire identity, value is the ExprNode for round-trip save. Only
+   *  `setWireExpr` (via `wireKey(portRef(...))`) may construct keys;
+   *  raw strings are rejected at the type level. */
+  inputExprNodes: Map<WireKey, ExprNode>
 
   // ── Slot model state (populated by M3+; empty in legacy path) ───────────
-  /** "${instance}.${scalarSlotName}" → slot index in the shared slot[] array. */
-  outputSlotRegistry: Map<string, number>
-  /** Param/trigger name → slot index. Same flat slot[] as outputs. */
+  /** Branded `${instance}.${slotName}` → slot index in the shared
+   *  slot[] array. Constructed only via `slotKey(instName, slotName)`. */
+  outputSlotRegistry: Map<SlotKey, number>
+  /** Param/trigger name → slot index. Same flat slot[] as outputs.
+   *  Param names are plain strings (no instance context to brand
+   *  against). */
   paramSlotRegistry:  Map<string, number>
-  /** Per-output-port metadata captured at allocate time. */
-  outputPortMeta:     Map<string, WirePortMeta>  // key: "${instance}.${port}"
+  /** Per-output-port metadata captured at allocate time. Keyed by the
+   *  port's SlotKey (`${instance}.${port}`). */
+  outputPortMeta:     Map<SlotKey, WirePortMeta>
   /** Next slot index to allocate. Always equals outputSlotRegistry.size + paramSlotRegistry.size. */
   slotCount:          number
   /** Input expressions keyed by scalar-slot name "${instance}:${scalarSlotName}".

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -28,6 +28,11 @@ import {
 import type { PortType as IRPortType, ScalarKind as IRScalarKind } from './ir/nodes.js'
 import { programTypeFromResolved } from './ir/strata.js'
 import type { TypeParamDecl } from './ir/nodes.js'
+import {
+  type PortRef, type WireKey, type SlotKey,
+  type InstanceName,
+  wireKey, slotKey,
+} from './ir/branded_names.js'
 
 // ─────────────────────────────────────────────────────────────
 // JSON schema types
@@ -101,8 +106,9 @@ export type TypeDefJSON = StructTypeDefJSON | SumTypeDefJSON | AliasTypeDefJSON
  *  After strata, sums/structs/products/units are gone — only scalar,
  *  alias, and array remain. */
 export interface WirePortMeta {
-  /** "${instance}.${port}[0]" / etc. — one entry per scalar slot. */
-  scalarSlotNames: string[]
+  /** Branded SlotKey per scalar slot — `${instance}.${port}` for
+   *  scalar ports, `${instance}.${port}[0]` etc. for array elements. */
+  scalarSlotNames: SlotKey[]
   /** One ScalarKind per slot; length === scalarSlotNames.length. */
   scalarTypes:     IRScalarKind[]
   /** The original IR PortType, retained for combine typecheck. */
@@ -260,15 +266,18 @@ export interface WireExprOpts {
 }
 
 /** Wrap a raw wire expression in a session-level unit delay and store
- *  it in `session.inputExprNodes` under `key`. Every MCP wire-setting
- *  tool routes through this helper. */
+ *  it in `session.inputExprNodes` at the consumer port `ref`. Every
+ *  MCP wire-setting tool routes through this helper. Callers must
+ *  construct the `PortRef` via `portRef(instanceName, portName)` —
+ *  the brand on `WireKey` makes raw-string keys impossible. */
 export function setWireExpr(
   session: SessionState,
-  key:     string,
+  ref:     PortRef,
   rawExpr: ExprNode,
   opts:    WireExprOpts = {},
 ): void {
-  const id = opts.id ?? `__autodelay:${key}`
+  const key = wireKey(ref)
+  const id  = opts.id ?? `__autodelay:${key}`
   session.inputExprNodes.set(key, wrapInUnitDelay(rawExpr, opts.init ?? 0, id))
 }
 
@@ -309,9 +318,9 @@ function wrapInUnitDelay(expr: ExprNode, init: number, id: string): ExprNode {
  *  Uses the IR (post-strata) PortType. Sum/struct/product/unit don't
  *  appear here because strata lowered them all. */
 export function expandPortToSlots(
-  baseName: string,
+  baseName: SlotKey,
   type: IRPortType,
-): { names: string[]; types: IRScalarKind[] } {
+): { names: SlotKey[]; types: IRScalarKind[] } {
   switch (type.kind) {
     case 'scalar':
       return { names: [baseName], types: [type.scalar] }
@@ -340,10 +349,13 @@ export function expandPortToSlots(
         }
         total *= dim
       }
-      const names: string[] = []
+      const names: SlotKey[] = []
       const types: IRScalarKind[] = []
       for (let i = 0; i < total; i++) {
-        names.push(`${baseName}[${i}]`)
+        // `${baseName}[i]` preserves the SlotKey shape — the baseName
+        // is already `inst.port`, and `inst.port[0]` is a valid SlotKey
+        // (slotKey's slotName parameter explicitly allows brackets).
+        names.push(`${baseName}[${i}]` as SlotKey)
         types.push(elemKind)
       }
       return { names, types }
@@ -365,13 +377,13 @@ const DEFAULT_OUTPUT_PORT_TYPE: IRPortType = { kind: 'scalar', scalar: 'float' }
  *  after LLVM folds the conditional. Idempotent. */
 export function allocateOutputSlots(
   session: SessionState,
-  instanceName: string,
+  instName: InstanceName,
   type: Compiled,
 ): void {
   const portNames = outputNames(type)
   for (let idx = 0; idx < portNames.length; idx++) {
     const portName = portNames[idx]
-    const portKey = `${instanceName}.${portName}`
+    const portKey = slotKey(instName, portName)
     if (session.outputPortMeta.has(portKey)) continue  // idempotent
     const portType = outputPortType(type, idx) ?? DEFAULT_OUTPUT_PORT_TYPE
     const { names, types } = expandPortToSlots(portKey, portType)
@@ -386,7 +398,7 @@ export function allocateOutputSlots(
     session.slotCount += names.length
   }
 
-  const aliveKey = `${instanceName}.__alive__`
+  const aliveKey = slotKey(instName, '__alive__')
   if (!session.outputSlotRegistry.has(aliveKey)) {
     session.outputSlotRegistry.set(aliveKey, session.slotCount)
     session.slotCount += 1

--- a/compiler/session_slots.test.ts
+++ b/compiler/session_slots.test.ts
@@ -13,6 +13,9 @@ import {
 import { loadStdlib, loadProgramAsSession } from './program.ts'
 import { Float, Int, Bool } from './ir/port_type.ts'
 import { ArrayType } from './ir/port_type.ts'
+import { slotKey, instanceName } from './ir/branded_names.js'
+
+const sk = (i: string, n: string) => slotKey(instanceName(i), n)
 
 describe('expandPortToSlots', () => {
   test('scalar port → 1 slot, original name', () => {
@@ -58,10 +61,10 @@ describe('session slot allocation', () => {
     allocateOutputSlots(s, 'lp1', onePole)
     // OnePole has one output 'out' (scalar float); plus the
     // auto-allocated `__alive__` slot (active-set runtime).
-    expect(s.outputSlotRegistry.get('lp1.out')).toBe(0)
-    expect(s.outputSlotRegistry.get('lp1.__alive__')).toBe(1)
+    expect(s.outputSlotRegistry.get(sk("lp1", "out"))).toBe(0)
+    expect(s.outputSlotRegistry.get(sk("lp1", "__alive__"))).toBe(1)
     expect(s.slotCount).toBe(2)
-    const meta = s.outputPortMeta.get('lp1.out')!
+    const meta = s.outputPortMeta.get(sk("lp1", "out"))!
     expect(meta.scalarSlotNames).toEqual(['lp1.out'])
     expect(meta.scalarTypes).toEqual(['float'])
   })
@@ -81,10 +84,10 @@ describe('session slot allocation', () => {
     const onePole = s.typeRegistry.get('OnePole')!
     allocateOutputSlots(s, 'lp1', onePole)
     allocateOutputSlots(s, 'lp2', onePole)
-    expect(s.outputSlotRegistry.get('lp1.out')).toBe(0)
-    expect(s.outputSlotRegistry.get('lp1.__alive__')).toBe(1)
-    expect(s.outputSlotRegistry.get('lp2.out')).toBe(2)
-    expect(s.outputSlotRegistry.get('lp2.__alive__')).toBe(3)
+    expect(s.outputSlotRegistry.get(sk("lp1", "out"))).toBe(0)
+    expect(s.outputSlotRegistry.get(sk("lp1", "__alive__"))).toBe(1)
+    expect(s.outputSlotRegistry.get(sk("lp2", "out"))).toBe(2)
+    expect(s.outputSlotRegistry.get(sk("lp2", "__alive__"))).toBe(3)
     expect(s.slotCount).toBe(4)
   })
 
@@ -106,11 +109,11 @@ describe('session slot allocation', () => {
     allocateOutputSlots(s, 'lp1', onePole)            // slots 0 (out) + 1 (__alive__)
     const p = allocateParamSlot(s, 'cutoff')          // slot 2
     allocateOutputSlots(s, 'lp2', onePole)            // slots 3 (out) + 4 (__alive__)
-    expect(s.outputSlotRegistry.get('lp1.out')).toBe(0)
-    expect(s.outputSlotRegistry.get('lp1.__alive__')).toBe(1)
+    expect(s.outputSlotRegistry.get(sk("lp1", "out"))).toBe(0)
+    expect(s.outputSlotRegistry.get(sk("lp1", "__alive__"))).toBe(1)
     expect(p).toBe(2)
-    expect(s.outputSlotRegistry.get('lp2.out')).toBe(3)
-    expect(s.outputSlotRegistry.get('lp2.__alive__')).toBe(4)
+    expect(s.outputSlotRegistry.get(sk("lp2", "out"))).toBe(3)
+    expect(s.outputSlotRegistry.get(sk("lp2", "__alive__"))).toBe(4)
     expect(s.slotCount).toBe(5)
   })
 
@@ -150,8 +153,8 @@ describe('session slot allocation', () => {
       slotsCache: undefined,
     }
     allocateOutputSlots(s, 'fp1', fakePortless as any)
-    expect(s.outputSlotRegistry.get(`fp1.${onePole.prog.ports.outputs[0].name}`)).toBe(0)
-    expect(s.outputSlotRegistry.get('fp1.__alive__')).toBe(1)
+    expect(s.outputSlotRegistry.get(sk(`fp1`, onePole.prog.ports.outputs[0].name))).toBe(0)
+    expect(s.outputSlotRegistry.get(sk("fp1", "__alive__"))).toBe(1)
     expect(s.slotCount).toBe(2)
   })
 })

--- a/compiler/transcendentals.test.ts
+++ b/compiler/transcendentals.test.ts
@@ -15,6 +15,9 @@ import { describe, test, expect } from 'bun:test'
 import { makeSession, resolveProgramType, instantiate } from './session'
 import { loadStdlib } from './program'
 import { interpretSession } from './interpret_resolved'
+import { wireKey, portRef, instanceName, portName } from './ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 // One shared session for the whole suite — cuts ~400× repeated stdlib
 // loads down to one. evalProgram resets the per-call state (instance
@@ -42,7 +45,7 @@ function evalProgram(
   const { type } = resolveProgramType(sharedSession, programName, undefined, undefined)
   const inst = instantiate(type, 'it', { baseTypeName: programName })
   sharedSession.instanceRegistry.set('it', inst)
-  for (const [k, v] of Object.entries(inputs)) sharedSession.inputExprNodes.set(`it:${k}`, v)
+  for (const [k, v] of Object.entries(inputs)) sharedSession.inputExprNodes.set(wk(`it`, k), v)
   sharedSession.graphOutputs.push({ instance: 'it', output: outputName })
   const buf = interpretSession(sharedSession, 1)
   return buf[0] * 20.0   // undo interpretSession's /20 audio mix scaling

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -41,7 +41,11 @@ import { checkArrayConnection } from '../compiler/array_wiring.js'
 import { validateExpr }         from '../compiler/expr.js'
 import { exprDependencies }     from '../compiler/compiler.js'
 import { portTypeToString } from '../compiler/ir/port_type.js'
-import { parseWireKey } from '../compiler/ir/branded_names.js'
+import {
+  parseWireKey, portRef, wireKey,
+  instanceName as toInstanceName,
+  portName as toPortName,
+} from '../compiler/ir/branded_names.js'
 import type { PortType } from '../compiler/ir/nodes.js'
 
 const portTypeOrNull = (t: PortType | undefined): string | null =>
@@ -762,7 +766,7 @@ function handleAddInstance(
     // Slot model (M3, additive): populate the output slot registry
     // alongside the legacy instanceRegistry. Nothing consumes these
     // yet; M4 wires them into the new compile path.
-    allocateOutputSlots(session, instanceName, type)
+    allocateOutputSlots(session, toInstanceName(instanceName), type)
     return instanceSummary(instanceName)
   })
 }
@@ -804,7 +808,7 @@ function handleReplicate(
       const { type, typeArgs: resolved } = resolveProgramTypeOrFail(programName, typeArgs, 'program')
       const inst = instantiate(type, name, { baseTypeName: programName, typeArgs: resolved })
       session.instanceRegistry.set(name, inst)
-      allocateOutputSlots(session, name, type)
+      allocateOutputSlots(session, toInstanceName(name), type)
       created.push(instanceSummary(name))
     }
     return { created }
@@ -847,7 +851,7 @@ function handleWireChain(args: Record<string, unknown>) {
       const firstInst  = insts[0]
       const inputName  = resolveInputName(firstInst, inputPort)
       const { expr }   = adaptInputExpr(initialExpr, inputPortType(firstInst, inputNames(firstInst).indexOf(inputName)), firstName, inputName)
-      setWireExpr(session, `${firstName}:${inputName}`, expr)
+      setWireExpr(session, portRef(toInstanceName(firstName), toPortName(inputName)), expr)
     }
 
     // Wire instances[i].output → instances[i+1].input
@@ -861,7 +865,7 @@ function handleWireChain(args: Record<string, unknown>) {
       const inName   = resolveInputName(dstInst, inputPort)
       const refExpr  = { op: 'ref' as const, instance: srcName, output: outName }
       const { expr } = adaptInputExpr(refExpr, inputPortType(dstInst, inputNames(dstInst).indexOf(inName)), dstName, inName)
-      setWireExpr(session, `${dstName}:${inName}`, expr)
+      setWireExpr(session, portRef(toInstanceName(dstName), toPortName(inName)), expr)
       linked.push(`${srcName}.${outName} → ${dstName}.${inName}`)
     }
 
@@ -893,7 +897,7 @@ function handleWireZip(args: Record<string, unknown>) {
       const inName   = resolveInputName(dstInst, dst.input)
       const refExpr  = { op: 'ref' as const, instance: src.instance, output: outName }
       const { expr } = adaptInputExpr(refExpr, inputPortType(dstInst, inputNames(dstInst).indexOf(inName)), dst.instance, inName)
-      setWireExpr(session, `${dst.instance}:${inName}`, expr)
+      setWireExpr(session, portRef(toInstanceName(dst.instance), toPortName(inName)), expr)
       linked.push(`${src.instance}.${outName} → ${dst.instance}.${inName}`)
     }
 
@@ -931,7 +935,7 @@ function handleFanOut(args: Record<string, unknown>) {
       const dstInst = requireInstance(dst.instance, 'targets[].instance')
       const inName   = resolveInputName(dstInst, dst.input)
       const { expr } = adaptInputExpr(sourceExpr, inputPortType(dstInst, inputNames(dstInst).indexOf(inName)), dst.instance, inName)
-      setWireExpr(session, `${dst.instance}:${inName}`, expr)
+      setWireExpr(session, portRef(toInstanceName(dst.instance), toPortName(inName)), expr)
       linked.push(`${sourceLabel} → ${dst.instance}.${inName}`)
     }
 
@@ -967,7 +971,7 @@ function handleFanIn(args: Record<string, unknown>) {
 
     const inName   = resolveInputName(dstInst, target.input)
     const { expr } = adaptInputExpr(sumExpr, inputPortType(dstInst, inputNames(dstInst).indexOf(inName)), target.instance, inName)
-    setWireExpr(session, `${target.instance}:${inName}`, expr)
+    setWireExpr(session, portRef(toInstanceName(target.instance), toPortName(inName)), expr)
 
     return { mixed: sources.length, target: `${target.instance}.${inName}`, ...wire() }
   })
@@ -995,7 +999,7 @@ function handleFeedback(args: Record<string, unknown>) {
     const refExpr: ExprNode = { op: 'ref' as const, instance: from.instance, output: outName }
     validateExpr(refExpr, `${to.instance}.${inName}`)
     const { expr } = adaptInputExpr(refExpr, inputPortType(dstInst, inputNames(dstInst).indexOf(inName)), to.instance, inName)
-    setWireExpr(session, `${to.instance}:${inName}`, expr, { init, id: delayId })
+    setWireExpr(session, portRef(toInstanceName(to.instance), toPortName(inName)), expr, { init, id: delayId })
 
     return {
       feedback: `${from.instance}.${outName} →[delay init=${init}]→ ${to.instance}.${inName}`,
@@ -1294,13 +1298,13 @@ function handleWire(args: Record<string, unknown>) {
       // single outer delay (applied by `setWireExpr`) rather than a
       // nested-delay-inside-delay shape that would give the existing
       // source two samples of latency.
-      const key = `${s.instance}:${resolvedName}`
-      const existing = session.inputExprNodes.get(key)
+      const ref = portRef(toInstanceName(s.instance), toPortName(resolvedName))
+      const existing = session.inputExprNodes.get(wireKey(ref))
       let toStore: ExprNode = expr
       if (existing !== undefined && s.combine !== undefined) {
         toStore = { op: s.combine, args: [unwrapDelay(existing), expr] } as ExprNode
       }
-      setWireExpr(session, key, toStore)
+      setWireExpr(session, ref, toStore)
       results.push({ instance: s.instance, input: resolvedName, expr: toStore })
     }
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -41,6 +41,7 @@ import { checkArrayConnection } from '../compiler/array_wiring.js'
 import { validateExpr }         from '../compiler/expr.js'
 import { exprDependencies }     from '../compiler/compiler.js'
 import { portTypeToString } from '../compiler/ir/port_type.js'
+import { parseWireKey } from '../compiler/ir/branded_names.js'
 import type { PortType } from '../compiler/ir/nodes.js'
 
 const portTypeOrNull = (t: PortType | undefined): string | null =>
@@ -1317,11 +1318,9 @@ function handleListWiring(filterInstance?: string) {
   return wrap(() => {
     const results: Array<{ instance: string; input: string; expr: string }> = []
     for (const [key, node] of session.inputExprNodes) {
-      const colonIdx = key.indexOf(':')
-      const inst  = key.slice(0, colonIdx)
-      const input = key.slice(colonIdx + 1)
-      if (filterInstance && inst !== filterInstance) continue
-      results.push({ instance: inst, input, expr: prettyExpr(node, session.instanceRegistry) })
+      const { instance, port } = parseWireKey(key)
+      if (filterInstance && instance !== filterInstance) continue
+      results.push({ instance, input: port, expr: prettyExpr(node, session.instanceRegistry) })
     }
     return results
   })

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1138,14 +1138,18 @@ function handleGetInfo(instanceName: string) {
       name: instanceName,
       program: inst.baseTypeName,
       type_args: inst.typeArgs ?? null,
-      inputs:  inputNames(inst).map((n, i) => ({
-        name: n, index: i,
-        type: inputPortType(inst, i) ?? null,
-        expr: session.inputExprNodes.get(`${instanceName}:${n}`) ?? null,
-        pretty: session.inputExprNodes.has(`${instanceName}:${n}`)
-          ? prettyExpr(session.inputExprNodes.get(`${instanceName}:${n}`)!, session.instanceRegistry)
-          : null,
-      })),
+      inputs:  inputNames(inst).map((n, i) => {
+        const key = wireKey(portRef(toInstanceName(instanceName), toPortName(n)))
+        const expr = session.inputExprNodes.get(key)
+        return {
+          name: n, index: i,
+          type: inputPortType(inst, i) ?? null,
+          expr: expr ?? null,
+          pretty: expr !== undefined
+            ? prettyExpr(expr, session.instanceRegistry)
+            : null,
+        }
+      }),
       outputs: outputNames(inst).map((n, i) => ({
         name: n, index: i,
         type: outputPortType(inst, i) ?? null,
@@ -1253,7 +1257,7 @@ function handleWire(args: Record<string, unknown>) {
       const inst = requireInstance(r.instance, 'remove[].instance')
       const inputId = resolveInputIdx(inst, r.input)
       const resolvedName = inputNames(inst)[inputId] ?? String(inputId)
-      session.inputExprNodes.delete(`${r.instance}:${resolvedName}`)
+      session.inputExprNodes.delete(wireKey(portRef(toInstanceName(r.instance), toPortName(resolvedName))))
     }
 
     // Process sets

--- a/tests/bench/compile.ts
+++ b/tests/bench/compile.ts
@@ -5,6 +5,9 @@ import { makeSession, SessionState, instantiate, outputNames } from '../../compi
 import { loadStdlib as loadBuiltins } from '../../compiler/program.js'
 import { compileSession } from '../../compiler/ir/compile_session'
 import { toWirePlan } from '../../compiler/flat_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 const session: SessionState = makeSession()
 loadBuiltins(session)
@@ -33,7 +36,7 @@ for (const [typeName, instanceName] of modules) {
 }
 
 // Set the input that triggers wire()
-session.inputExprNodes.set('Clock1:freq', 2.1667)
+session.inputExprNodes.set(wk("Clock1", "freq"), 2.1667)
 
 // Test individual modules to find which is slow
 for (const [typeName, instanceName] of modules) {

--- a/tests/equiv/jit_vs_interp_stdlib.test.ts
+++ b/tests/equiv/jit_vs_interp_stdlib.test.ts
@@ -41,6 +41,9 @@ import { applyFlatPlan } from '../../compiler/apply_plan.js'
 import { interpretSession } from '../../compiler/interpret_resolved'
 import { EDGE_FIXTURES } from '../fixtures/equiv/edge_cases.js'
 import { loadProgramAsType } from '../../compiler/program.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
 // 256 * 4 = 1024 samples per fixture — large enough to expose
 // state-transfer drift and 4-buffer continuity, small enough to keep
@@ -96,7 +99,7 @@ function setupStdlibInstance(
   session.instanceRegistry.set('inst', inst)
   for (const portName of inputNames(inst)) {
     if (portName in DEFAULT_INPUTS) {
-      session.inputExprNodes.set(`inst:${portName}`, DEFAULT_INPUTS[portName])
+      session.inputExprNodes.set(wk(`inst`, portName), DEFAULT_INPUTS[portName])
     }
   }
   session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
@@ -172,7 +175,7 @@ describe('JIT ↔ interpreter equivalence — edge cases (Phase D P0.1)', () => 
       session.instanceRegistry.set('inst', inst)
       if (fixture.inputs) {
         for (const [k, v] of Object.entries(fixture.inputs)) {
-          session.inputExprNodes.set(`inst:${k}`, v)
+          session.inputExprNodes.set(wk(`inst`, k), v)
         }
       }
       const outName = fixture.output ?? outputNames(inst)[0]
@@ -288,7 +291,7 @@ describe('JIT state transfer across loadPlan (Phase D P0.1)', () => {
     // Plan B: same SinOsc, but modulate the freq input. Crucially, the
     // SinOsc's phase register should carry over from plan A — we are
     // exercising the FlatRuntime's name-keyed state-transfer path.
-    session.inputExprNodes.set('inst:freq', 220)  // halved
+    session.inputExprNodes.set(wk("inst", "freq"), 220)  // halved
     applyFlatPlan(session, session.runtime)
     session.graph.process()
     const afterRewire = new Float64Array(session.graph.outputBuffer)
@@ -322,8 +325,7 @@ describe('JIT state transfer across loadPlan (Phase D P0.1)', () => {
     // Plan B: change the input gain (mul by 0.5). Phaser's allpass
     // chain registers should transfer; the post-rewire output peak
     // should be ~half the pre-rewire output peak after the crossfade.
-    session.inputExprNodes.set(
-      'inst:input',
+    session.inputExprNodes.set(wk("inst", "input"),
       { op: 'mul', args: [0.5, 0.5] },
     )
     applyFlatPlan(session, session.runtime)


### PR DESCRIPTION
## Summary

Lands the cleanup the post-PR-#150 audit flagged as highest-leverage: the stringly-typed wire and slot keys that flowed ad-hoc through ~10 production sites and ~85 test sites. After this PR, both Map containers are branded at the type level:

```
SessionState.inputExprNodes:     Map<WireKey, ExprNode>
SessionState.outputSlotRegistry: Map<SlotKey, number>
SessionState.outputPortMeta:     Map<SlotKey, WirePortMeta>
```

Every construction goes through `wireKey(portRef(instanceName(i), portName(p)))` or `slotKey(instanceName(i), slotName)`; every parse goes through `parseWireKey(key) → PortRef`. Raw strings can't reach the Maps in production code — the TypeScript checker rejects them. Tests use the same constructors via tiny local sugar (`wk(i, p)`, `sk(i, n)`).

### Phase breakdown

| Phase | Commit | What |
|-------|--------|------|
| 1 | `3141270` | Add `WireKey` and `SlotKey` brands; rename `portRefKey` → `wireKey` and `parsePortRefKey` → `parseWireKey`; brand return types; 5 new unit tests pin slot-key serialization edge cases. |
| 2 | `5b3b3b2` | Migrate 6 production parse sites (compiler.ts, program.ts ×2, materialize_session.ts, session_cycle_check.ts, compile_session_slotted_helpers.ts, mcp/server.ts) to `parseWireKey`. Caught one shadowed-name bug along the way. |
| 3 | `a8aa3f6` | Migrate production construction sites. `setWireExpr` signature changes to `(session, ref: PortRef, expr, opts?)` — the PortRef is the gate. `allocateOutputSlots` takes `InstanceName`; `expandPortToSlots` takes/returns `SlotKey`. |
| 4 | `4f9a0e3` | Flip the Map container types and migrate the 85 test-side sites. A throwaway transform script handled the mechanical work; one multi-line import in render.test.ts needed manual cleanup. |

### What this fixes

The audit (post PR #150) found these specific failure modes:

- `compiler.ts:120` doing `key.split(':')[0]` with no validation
- `program.ts:825,920` parsing input targets ad-hoc
- `materialize_session.ts:250-254`, `session_cycle_check.ts:74-77`, `compile_session_slotted_helpers.ts:276-279` all using `indexOf(':')` + slice with no helper
- `mcp/server.ts:1316-1328` (`handleListWiring`) doing the same slice pattern

All routed through `parseWireKey` now. The brand on `setWireExpr`'s `PortRef` parameter means every MCP wire tool constructs its key through the validated helper — the auto-delay refactor's "single edit point" claim is now structurally enforced.

### What's intentionally not included

- **Test files in tsconfig.** `@types/bun` isn't installed; adding it surfaces ~70 pre-existing `bun:test` resolution errors unrelated to this work. Including tests in the typecheck pass is a small follow-up (add `@types/bun` to devDeps, drop the `exclude` line). Test-side brand discipline is currently enforced by code review rather than tsc.
- **`paramSlotRegistry` branding.** Param names are bare strings (no instance context); branding adds ceremony for marginal benefit. Left as `Map<string, number>`.
- **C++ opaque handle types** flagged by the audit. koffi already handles type confusion at the FFI boundary; branding adds ceremony.

## Test plan

- [x] `bun test` — 968 pass, 8 skip, 0 fail across 976 tests
- [x] `bunx tsc --noEmit` — clean on production code
- [x] `bun test compiler/ir/lowering/` — 11 pass (new branded-helper tests + migrated lowering tests)
- [x] Equivalence suites in `tests/equiv/` all green — backend semantics unchanged
- [x] No production behavior change; brand erases at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)