### PR TITLE
feat(ir): slot-based kernel boundary (input-slot refactor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,3 +247,43 @@ Tests that cross compilation/backend boundaries live under `tests/equiv/`.
 - C++ is header-heavy by design (templates, inlining for audio perf)
 - JIT failures are fatal — no interpreter fallback on the audio path
   (`interpret_resolved` is an oracle for tests, not a runtime)
+
+## Don't bake in audio-specific assumptions where it's free not to
+
+Tropical's v2 roadmap includes video synthesis, control-rate signals,
+and multi-backend codegen at independent rates. Most of the
+infrastructure to support that doesn't need to exist yet — but where
+it costs nothing to be neutral, prefer neutral. The asymmetry: small
+unforced assumptions today compound into many call-site refactors
+when a second signal type or rate or backend arrives.
+
+This is *hygiene*, not abstraction. Don't build generic frameworks
+ahead of need; do avoid accidentally precluding generality.
+
+Concrete forms:
+- **Naming.** If a parameter is `rate` (just a rate), don't name it
+  `sampleRate` — that bakes in "audio." If a slot's element type is
+  configurable, don't name the field `audioValue`. Names that don't
+  forbid generality cost nothing extra to write.
+- **Element types.** Don't hardcode `double` as a slot/wire/array
+  element type where the type is already parameterized or could
+  trivially be. Audio-rate-double-precision is what v1 uses, but
+  there's no reason for that to be load-bearing at every layer.
+- **Hardware/timing assumptions.** Don't assume "44100" or "48000"
+  or "block of 256 samples" in places where the actual sample rate
+  / block size is already available as a parameter. The audio
+  callback knows its own rate; pass it, don't redeclare it.
+- **Cross-cutting concepts.** "Signal" and "wire" and "slot" are
+  rate- and color-agnostic at the conceptual level. Keep them that
+  way in code where it's free. The same goes for "kernel",
+  "instance", "port" — these are not "audio kernels" / "audio
+  ports" / "audio instances" by nature, they're nature-agnostic.
+
+What this isn't a license to do: build abstract frameworks, define
+type-level operad machinery, parameterize over backend types
+speculatively. The cost-asymmetry is on **unforced** assumptions —
+the things you'd be neutral about anyway if you weren't on autopilot.
+Anything that requires a deliberate design choice (a new type
+parameter, a new module, a new abstraction layer) should wait until
+there's concrete evidence the abstraction pays off — typically: a
+second concrete consumer.

--- a/compiler/allocate_input_slots.test.ts
+++ b/compiler/allocate_input_slots.test.ts
@@ -1,0 +1,98 @@
+/**
+ * allocate_input_slots.test.ts — unit coverage for the input-slot
+ * allocator added in Phase 2 of the input-slot refactor.
+ *
+ * Pure-TS: builds a fake `Compiled` directly (no FFI / no
+ * libtropical.dylib needed) so the test can run in any environment.
+ * Pins the contract: `allocateInputSlots` mirrors
+ * `allocateOutputSlots` (slot indices, port-meta, idempotency,
+ * unified slotCount accounting) and shares the unified slot
+ * namespace with outputs / params / delays without collision.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  makeSession,
+  allocateInputSlots,
+  allocateOutputSlots,
+} from './session.js'
+import { instanceName, slotKey } from './ir/branded_names.js'
+import { makeCompiled } from './program_types.js'
+import type { ResolvedProgram, InputDecl, OutputDecl } from './ir/nodes.js'
+
+function fakeCompiled(name: string, inputs: string[], outputs: string[]) {
+  const inputDecls: InputDecl[] = inputs.map(n => ({
+    op: 'inputDecl', name: n, type: { kind: 'scalar', scalar: 'float' },
+  }))
+  const outputDecls: OutputDecl[] = outputs.map(n => ({
+    op: 'outputDecl', name: n, type: { kind: 'scalar', scalar: 'float' },
+  }))
+  const prog: ResolvedProgram = {
+    op: 'program', name, typeParams: [],
+    ports: { inputs: inputDecls, outputs: outputDecls, typeDefs: [] },
+    body: { op: 'block', decls: [], assigns: [] },
+  }
+  return makeCompiled(prog, { displayName: name })
+}
+
+describe('allocateInputSlots', () => {
+  test('allocates one slot per scalar input port', () => {
+    const session = makeSession()
+    const compiled = fakeCompiled('Foo', ['a', 'b', 'c'], ['out'])
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    expect(session.slotCount).toBe(3)
+    expect(session.inputSlotRegistry.get(slotKey(instanceName('foo'), 'a'))).toBe(0)
+    expect(session.inputSlotRegistry.get(slotKey(instanceName('foo'), 'b'))).toBe(1)
+    expect(session.inputSlotRegistry.get(slotKey(instanceName('foo'), 'c'))).toBe(2)
+  })
+
+  test('idempotent: second call is a no-op', () => {
+    const session = makeSession()
+    const compiled = fakeCompiled('Foo', ['a'], ['out'])
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    const countAfterFirst = session.slotCount
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    expect(session.slotCount).toBe(countAfterFirst)
+  })
+
+  test('shares unified slotCount with allocateOutputSlots; no collisions', () => {
+    const session = makeSession()
+    const compiled = fakeCompiled('Foo', ['a', 'b'], ['out0', 'out1'])
+    // Outputs first
+    allocateOutputSlots(session, instanceName('foo'), compiled)
+    expect(session.slotCount).toBe(2)
+    // Inputs allocated AFTER outputs use the next free indices
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    expect(session.slotCount).toBe(4)
+    expect(session.outputSlotRegistry.get(slotKey(instanceName('foo'), 'out0'))).toBe(0)
+    expect(session.outputSlotRegistry.get(slotKey(instanceName('foo'), 'out1'))).toBe(1)
+    expect(session.inputSlotRegistry.get(slotKey(instanceName('foo'), 'a'))).toBe(2)
+    expect(session.inputSlotRegistry.get(slotKey(instanceName('foo'), 'b'))).toBe(3)
+  })
+
+  test('input and output slot maps are disjoint keyspaces — same port-name allowed on both', () => {
+    // A port can legally be `x` on both an input and an output of
+    // different instances (or even the same instance). The two maps
+    // must be queried separately; the key namespace is per-map, not
+    // shared.
+    const session = makeSession()
+    const compiled = fakeCompiled('Foo', ['x'], ['x'])
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    allocateOutputSlots(session, instanceName('foo'), compiled)
+    const key = slotKey(instanceName('foo'), 'x')
+    expect(session.inputSlotRegistry.has(key)).toBe(true)
+    expect(session.outputSlotRegistry.has(key)).toBe(true)
+    expect(session.inputSlotRegistry.get(key)).not.toBe(session.outputSlotRegistry.get(key))
+  })
+
+  test('records full WirePortMeta — names + types + portType', () => {
+    const session = makeSession()
+    const compiled = fakeCompiled('Foo', ['freq'], ['out'])
+    allocateInputSlots(session, instanceName('foo'), compiled)
+    const meta = session.inputPortMeta.get(slotKey(instanceName('foo'), 'freq'))
+    expect(meta).toBeDefined()
+    expect(meta!.scalarSlotNames.length).toBe(1)
+    expect(meta!.scalarTypes).toEqual(['float'])
+    expect(meta!.portType.kind).toBe('scalar')
+  })
+})

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -105,6 +105,14 @@ export interface PerInstancePlan {
   array_slot_count: number
   array_slot_sizes: number[]
   instructions:     NInstr[]
+  /** Instructions that must run BEFORE this kernel's children
+   *  (M11 fractal — slot-based input wiring). For each wired input
+   *  on each child instance, the parent evaluates the wire expression
+   *  in its own scope and emits a WriteSlot into the child's
+   *  pre-allocated input slot. The child then reads from that slot
+   *  at the start of its kernel body. Empty for leaf kernels and
+   *  for the legacy `inlineNested:true` path. */
+  pre_child_instructions: NInstr[]
   /** Per-output-port temp index (local). */
   output_targets:   TempIdx[]
   /** State register writeback: `register_targets[i]` is the local
@@ -134,6 +142,12 @@ export interface InstanceFunction {
   instance_name:     string
   /** Instructions with operands already shifted into unified space. */
   instructions:      NInstr[]
+  /** Instructions that run BEFORE this kernel's children. M11 fractal
+   *  slot-based input wiring: parent evaluates each child's wire
+   *  expression in its own scope and emits a WriteSlot into the
+   *  child's pre-allocated input slot. Empty for leaf kernels and
+   *  for `inlineNested:true` plans. */
+  pre_child_instructions: NInstr[]
   /** Cumulative offset into the unified temp space. */
   register_offset:   TempOffset
   /** Cumulative offset into the unified state-register space. */
@@ -214,6 +228,9 @@ export interface WireInstanceFunction {
   name:              string
   instance_name:     string
   instructions:      WireNInstr[]
+  /** M11 fractal slot-based input wiring. May be missing in legacy
+   *  JSON (parsed as []). */
+  pre_child_instructions?: WireNInstr[]
   register_offset:   number
   state_reg_offset:  number
   array_slot_offset: number
@@ -307,6 +324,7 @@ const parseInstanceFn = (inst: WireInstanceFunction): InstanceFunction => ({
   name:              inst.name,
   instance_name:     inst.instance_name,
   instructions:      inst.instructions.map(parseInstr),
+  pre_child_instructions: (inst.pre_child_instructions ?? []).map(parseInstr),
   register_offset:   tempOffset(inst.register_offset),
   state_reg_offset:  stateRegOffset(inst.state_reg_offset),
   array_slot_offset: arraySlotOffset(inst.array_slot_offset),
@@ -325,9 +343,13 @@ const toWireInstanceFn = (inst: InstanceFunction): WireInstanceFunction => ({
   array_slot_offset: rawOffset(inst.array_slot_offset),
   register_count:    inst.register_count,
   register_targets:  inst.register_targets.map(toWireRegTarget),
-  // Omit `children` from the wire when empty so existing JSON consumers
-  // (golden fixtures, hand-crafted plan_5 tests) see exactly the bytes
-  // they expect today. Populated children are emitted normally.
+  // Omit `pre_child_instructions` and `children` from the wire when
+  // empty so existing JSON consumers (golden fixtures, hand-crafted
+  // plan_5 tests) see exactly the bytes they expect today. Populated
+  // entries are emitted normally.
+  ...(inst.pre_child_instructions.length > 0
+    ? { pre_child_instructions: inst.pre_child_instructions.map(toWireInstr) }
+    : {}),
   ...(inst.children.length > 0 ? { children: inst.children.map(toWireInstanceFn) } : {}),
 })
 

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -105,14 +105,19 @@ export interface PerInstancePlan {
   array_slot_count: number
   array_slot_sizes: number[]
   instructions:     NInstr[]
-  /** Instructions that must run BEFORE this kernel's children
-   *  (M11 fractal — slot-based input wiring). For each wired input
-   *  on each child instance, the parent evaluates the wire expression
-   *  in its own scope and emits a WriteSlot into the child's
-   *  pre-allocated input slot. The child then reads from that slot
-   *  at the start of its kernel body. Empty for leaf kernels and
+  /** Per-child WriteSlot instructions, parallel to the body's
+   *  `InstanceDecl` order. `per_child_pre_input[k]` is the wire-
+   *  computation + WriteSlot block that runs immediately BEFORE the
+   *  k-th child's kernel body. Each block evaluates the child's input
+   *  wires in THIS kernel's scope (where every ref resolves) and
+   *  WriteSlots the result to the child's pre-allocated input slot.
+   *  Interleaving with the child dispatch (vs running all blocks
+   *  upfront) preserves sibling-to-sibling NestedOut dependencies:
+   *  child[k]'s wire can read child[j].output for j < k because
+   *  child[j] has already written its output slot by the time
+   *  child[k]'s wires evaluate. Empty array for leaf kernels and
    *  for the legacy `inlineNested:true` path. */
-  pre_child_instructions: NInstr[]
+  per_child_pre_input: NInstr[][]
   /** Per-output-port temp index (local). */
   output_targets:   TempIdx[]
   /** State register writeback: `register_targets[i]` is the local
@@ -142,12 +147,17 @@ export interface InstanceFunction {
   instance_name:     string
   /** Instructions with operands already shifted into unified space. */
   instructions:      NInstr[]
-  /** Instructions that run BEFORE this kernel's children. M11 fractal
-   *  slot-based input wiring: parent evaluates each child's wire
-   *  expression in its own scope and emits a WriteSlot into the
-   *  child's pre-allocated input slot. Empty for leaf kernels and
-   *  for `inlineNested:true` plans. */
-  pre_child_instructions: NInstr[]
+  /** M11 fractal slot-based input wiring. Instructions the PARENT
+   *  runs in its own namespace just before invoking this kernel:
+   *  evaluate each wire expression, then `WriteSlot` the value to
+   *  this kernel's pre-allocated input slot. The child reads from
+   *  the slot at the start of its body. Per-child placement (vs
+   *  hoisted to a single pre-children block on the parent) preserves
+   *  sibling-to-sibling NestedOut dependencies — child[k]'s wire can
+   *  read child[j].output for j < k because child[j]'s body has
+   *  already run by the time child[k]'s pre-input wires evaluate.
+   *  Empty for top-level kernels and for `inlineNested:true` plans. */
+  pre_input_instructions: NInstr[]
   /** Cumulative offset into the unified temp space. */
   register_offset:   TempOffset
   /** Cumulative offset into the unified state-register space. */
@@ -228,9 +238,10 @@ export interface WireInstanceFunction {
   name:              string
   instance_name:     string
   instructions:      WireNInstr[]
-  /** M11 fractal slot-based input wiring. May be missing in legacy
-   *  JSON (parsed as []). */
-  pre_child_instructions?: WireNInstr[]
+  /** M11 fractal slot-based input wiring (per-child). Parent's
+   *  WriteSlot instructions that run just before this kernel's body.
+   *  May be missing in legacy JSON (parsed as []). */
+  pre_input_instructions?: WireNInstr[]
   register_offset:   number
   state_reg_offset:  number
   array_slot_offset: number
@@ -324,7 +335,7 @@ const parseInstanceFn = (inst: WireInstanceFunction): InstanceFunction => ({
   name:              inst.name,
   instance_name:     inst.instance_name,
   instructions:      inst.instructions.map(parseInstr),
-  pre_child_instructions: (inst.pre_child_instructions ?? []).map(parseInstr),
+  pre_input_instructions: (inst.pre_input_instructions ?? []).map(parseInstr),
   register_offset:   tempOffset(inst.register_offset),
   state_reg_offset:  stateRegOffset(inst.state_reg_offset),
   array_slot_offset: arraySlotOffset(inst.array_slot_offset),
@@ -343,12 +354,12 @@ const toWireInstanceFn = (inst: InstanceFunction): WireInstanceFunction => ({
   array_slot_offset: rawOffset(inst.array_slot_offset),
   register_count:    inst.register_count,
   register_targets:  inst.register_targets.map(toWireRegTarget),
-  // Omit `pre_child_instructions` and `children` from the wire when
+  // Omit `pre_input_instructions` and `children` from the wire when
   // empty so existing JSON consumers (golden fixtures, hand-crafted
   // plan_5 tests) see exactly the bytes they expect today. Populated
   // entries are emitted normally.
-  ...(inst.pre_child_instructions.length > 0
-    ? { pre_child_instructions: inst.pre_child_instructions.map(toWireInstr) }
+  ...(inst.pre_input_instructions.length > 0
+    ? { pre_input_instructions: inst.pre_input_instructions.map(toWireInstr) }
     : {}),
   ...(inst.children.length > 0 ? { children: inst.children.map(toWireInstanceFn) } : {}),
 })

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -13,22 +13,32 @@
  * runnable-plan boundary.
  */
 
-import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, ParamDecl, PortType, InstanceDecl } from './nodes.js'
+import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, ParamDecl, PortType, InstanceDecl, InputDecl } from './nodes.js'
 import type { PerInstancePlan } from '../flat_plan.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'
 import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_resolved.js'
 
 /** Param-handle bindings for FFI param/trigger decls embedded in a
- *  program type's body, plus optional nested-output slot map for the
- *  fractal compile path. When `nestedOutputSlots` is provided, this
- *  kernel's body may reference sub-`InstanceDecl`s via `NestedOut`,
- *  and `emit_resolved` reads each ref as a slot operand. */
+ *  program type's body, plus optional nested-output and nested-input
+ *  slot maps for the M11 fractal compile path. */
 export interface CompileResolvedContext {
   paramHandles?:      Map<ParamDecl, { ptr: string }>
   /** Per-sub-instance, per-output-port module-slot map. Populated by
    *  `partition_recursive` when compiling a parent kernel whose body
-   *  contains child kernels. */
+   *  contains child kernels. `NestedOut` refs lower to Slot reads
+   *  via this map. */
   nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
+  /** Per-sub-instance, per-input-port module-slot map. Populated by
+   *  `partition_recursive` for the M11 slot-based input wiring. The
+   *  parent's compile emits a `WriteSlot` into each named slot;
+   *  the entries land in `pre_child_instructions` so the engine
+   *  runs them before recursing into the child. */
+  nestedInputSlots?:  Map<InstanceDecl, Map<InputDecl, number>>
+  /** Module-slot indices for THIS program's own input ports. Set when
+   *  the program is being compiled as a sub-instance kernel — its
+   *  `InputRef(d)` lowers to a slot read from `inputSlotOverride.get(d)`
+   *  instead of the legacy `opInput`. */
+  inputSlotOverride?: Map<InputDecl, number>
 }
 
 /** Compile a `ResolvedProgram` to a `PerInstancePlan`.
@@ -96,6 +106,17 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     regCount:         slots.regDecls.length,
     paramHandles:     ctx.paramHandles     ?? new Map(),
     nestedOutputSlots: ctx.nestedOutputSlots,
+    nestedInputSlots:  ctx.nestedInputSlots,
+    inputSlotOverride: ctx.inputSlotOverride,
+  }
+
+  // M11 fractal: collect sub-instance decls so emit_resolved can emit
+  // a `WriteSlot` for each of their wired inputs in
+  // `pre_child_instructions`. Empty when the program has no nested
+  // instances (legacy flat path).
+  const nestedInstances: InstanceDecl[] = []
+  for (const d of prog.body.decls) {
+    if (d.op === 'instanceDecl') nestedInstances.push(d)
   }
 
   // Per-port scalar slot counts derived from declared output shapes.
@@ -111,6 +132,7 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     stateRegTypes: registerTypes,
     inputPortTypes,
     slots: emitSlots,
+    nestedInstances: nestedInstances.length > 0 ? nestedInstances : undefined,
   })
 
   const arraySlotNames: string[] = []
@@ -123,6 +145,7 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     array_slot_count: program.array_slot_count,
     array_slot_sizes: program.array_slot_sizes,
     instructions:     program.instructions,
+    pre_child_instructions: program.pre_child_instructions,
     output_targets:   program.output_targets,
     register_targets: program.register_targets,
     state_init:       stateInit as (number | boolean)[],

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -31,8 +31,9 @@ export interface CompileResolvedContext {
   /** Per-sub-instance, per-input-port module-slot map. Populated by
    *  `partition_recursive` for the M11 slot-based input wiring. The
    *  parent's compile emits a `WriteSlot` into each named slot;
-   *  the entries land in `pre_child_instructions` so the engine
-   *  runs them before recursing into the child. */
+   *  the entries land in `per_child_pre_input[k]` (parallel to the
+   *  body's nested-instance order) so the engine runs each block
+   *  immediately before recursing into its corresponding child. */
   nestedInputSlots?:  Map<InstanceDecl, Map<InputDecl, number>>
   /** Module-slot indices for THIS program's own input ports. Set when
    *  the program is being compiled as a sub-instance kernel — its
@@ -112,8 +113,11 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
 
   // M11 fractal: collect sub-instance decls so emit_resolved can emit
   // a `WriteSlot` for each of their wired inputs in
-  // `pre_child_instructions`. Empty when the program has no nested
-  // instances (legacy flat path).
+  // `per_child_pre_input[k]`. The order here is significant — it's
+  // the dispatch order partition_recursive will use when packing
+  // children into the InstanceFunction tree, so per_child_pre_input
+  // and the children array stay parallel. Empty when the program has
+  // no nested instances (legacy flat path).
   const nestedInstances: InstanceDecl[] = []
   for (const d of prog.body.decls) {
     if (d.op === 'instanceDecl') nestedInstances.push(d)
@@ -145,7 +149,7 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     array_slot_count: program.array_slot_count,
     array_slot_sizes: program.array_slot_sizes,
     instructions:     program.instructions,
-    pre_child_instructions: program.pre_child_instructions,
+    per_child_pre_input: program.per_child_pre_input,
     output_targets:   program.output_targets,
     register_targets: program.register_targets,
     state_init:       stateInit as (number | boolean)[],

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -191,6 +191,14 @@ function buildSlotMetadata(session: SessionState): {
     slotNames[entry.slotIdx]    = entry.slotName
     slotDefaults[entry.slotIdx] = entry.init
   }
+  // Input slots for sub-instance ports (M11 fractal path). Prefixed
+  // with `input:` so the namespace is distinct from output-slot names
+  // (which carry `instance.port` without prefix) and from
+  // `param:` / delay-slot names. Defaults are 0 (parent overwrites
+  // every sample via WriteSlot before the child reads).
+  for (const [name, idx] of session.inputSlotRegistry) {
+    slotNames[idx] = `input:${name}`
+  }
   return { slot_count: slotCount, slot_names: slotNames, slot_defaults: slotDefaults }
 }
 

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -330,10 +330,11 @@ export function remapInstancePlan(
   ctx: RemapContext,
   session: SessionState,
 ): {
-  preamble:      NInstr[]
-  body:          NInstr[]
-  writeSlots:    NInstr[]
-  tempsConsumed: number
+  preamble:             NInstr[]
+  preChildInstructions: NInstr[]
+  body:                 NInstr[]
+  writeSlots:           NInstr[]
+  tempsConsumed:        number
 } {
   // Preamble emitter: allocates fresh temps in the unified register
   // space, starting after the instance's own register_count block.
@@ -387,6 +388,18 @@ export function remapInstancePlan(
   }
 
   const body: NInstr[] = plan.instructions.map(instr => ({
+    ...instr,
+    dst:  shiftDst(instr.dst, ctx),
+    args: instr.args.map(remapOperand),
+  }))
+
+  // M11 fractal slot-based input wiring: pre_child_instructions get
+  // the same per-instance operand/dst remap as the main body. They
+  // reference the same temp/state/array spaces (Emitter allocates
+  // both in one namespace), and WriteSlot dst's are already absolute
+  // module-slot indices. Returned separately so the engine can run
+  // them BEFORE recursing into the child kernels.
+  const preChildInstructions: NInstr[] = plan.pre_child_instructions.map(instr => ({
     ...instr,
     dst:  shiftDst(instr.dst, ctx),
     args: instr.args.map(remapOperand),
@@ -447,6 +460,7 @@ export function remapInstancePlan(
 
   return {
     preamble,
+    preChildInstructions,
     body,
     writeSlots,
     tempsConsumed: preambleNext - (rawOffset(ctx.regOffset) + plan.register_count),

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -331,7 +331,10 @@ export function remapInstancePlan(
   session: SessionState,
 ): {
   preamble:             NInstr[]
-  preChildInstructions: NInstr[]
+  /** Per-child pre-input WriteSlot blocks, parallel to the body's
+   *  sub-instance order. Each block runs in THIS instance's namespace
+   *  immediately before the corresponding child's body. */
+  perChildPreInput:     NInstr[][]
   body:                 NInstr[]
   writeSlots:           NInstr[]
   tempsConsumed:        number
@@ -393,17 +396,21 @@ export function remapInstancePlan(
     args: instr.args.map(remapOperand),
   }))
 
-  // M11 fractal slot-based input wiring: pre_child_instructions get
-  // the same per-instance operand/dst remap as the main body. They
-  // reference the same temp/state/array spaces (Emitter allocates
-  // both in one namespace), and WriteSlot dst's are already absolute
-  // module-slot indices. Returned separately so the engine can run
-  // them BEFORE recursing into the child kernels.
-  const preChildInstructions: NInstr[] = plan.pre_child_instructions.map(instr => ({
-    ...instr,
-    dst:  shiftDst(instr.dst, ctx),
-    args: instr.args.map(remapOperand),
-  }))
+  // M11 fractal slot-based input wiring: each child's pre-input block
+  // (parent's wires → WriteSlot to that child's input slot) gets the
+  // same per-instance operand/dst remap as the main body. The blocks
+  // reference the same temp/state/array spaces (Emitter allocates them
+  // in one namespace), and WriteSlot dst's are already absolute
+  // module-slot indices. Returned as a per-child array so the caller
+  // can attach each block to its corresponding child InstanceFunction
+  // — the engine then dispatches `block → child.body` interleaved.
+  const perChildPreInput: NInstr[][] = plan.per_child_pre_input.map(block =>
+    block.map(instr => ({
+      ...instr,
+      dst:  shiftDst(instr.dst, ctx),
+      args: instr.args.map(remapOperand),
+    })),
+  )
 
   // WriteSlot per scalar slot of every output port. For scalar ports
   // that's 1 WriteSlot. For array-typed ports of shape `[N]` (or any
@@ -460,7 +467,7 @@ export function remapInstancePlan(
 
   return {
     preamble,
-    preChildInstructions,
+    perChildPreInput,
     body,
     writeSlots,
     tempsConsumed: preambleNext - (rawOffset(ctx.regOffset) + plan.register_count),

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -79,10 +79,16 @@ export interface FlatProgram {
   array_slot_count: number
   array_slot_sizes: number[]
   instructions:     NInstr[]
-  /** M11 fractal slot-based input wiring. Populated when this kernel
-   *  has sub-instances whose input wires were emitted via `WriteSlot`.
-   *  Empty for leaf kernels and the legacy flat path. */
-  pre_child_instructions: NInstr[]
+  /** M11 fractal slot-based input wiring. Parallel to the caller's
+   *  `nestedInstances` array: `per_child_pre_input[k]` holds the
+   *  WriteSlot block for the k-th sub-instance — the parent runs that
+   *  block in its own namespace immediately before invoking that
+   *  child's kernel body. Per-child placement (vs hoisting into a
+   *  single pre-children block) preserves sibling-to-sibling NestedOut
+   *  dependencies, since child[j]'s body has already produced its
+   *  outputs by the time child[k]'s pre-input wires evaluate (k > j).
+   *  Empty array for leaf kernels and the legacy flat path. */
+  per_child_pre_input: NInstr[][]
   /** Per-output-port temp index (local; the session compiler shifts). */
   output_targets:   TempIdx[]
   register_targets: RegTarget[]
@@ -258,8 +264,8 @@ export interface EmitSlots {
    *  by the M11 fractal path. When set, `InputRef(d)` lowers to a Slot
    *  read from `inputSlotOverride.get(d)` instead of an `Input`
    *  operand. The parent kernel has written the slot's value via a
-   *  `WriteSlot` in its `pre_child_instructions` just before this
-   *  kernel runs. */
+   *  `WriteSlot` in its `per_child_pre_input[k]` block immediately
+   *  before this kernel runs. */
   inputSlotOverride?: Map<InputDecl, number>
   /** Per-child module-slot map for sub-instance INPUTS. Used by the
    *  M11 fractal path when emitting a parent kernel: for each child
@@ -407,7 +413,7 @@ class Emitter {
         const portT = this.inputPortTypes[slot] ?? 'float'
         // M11 fractal path: when the program is being compiled as a
         // sub-instance kernel, its inputs live in module slots
-        // pre-written by the parent's WriteSlot in pre_child_instructions.
+        // pre-written by the parent's WriteSlot in per_child_pre_input.
         // Lower `InputRef(d)` to a slot read instead of opInput.
         if (this.slots.inputSlotOverride !== undefined) {
           const overrideSlot = this.slots.inputSlotOverride.get(obj.decl)
@@ -781,55 +787,70 @@ class Emitter {
     const output_targets: TempIdx[] = []
     const register_targets: RegTarget[] = []
 
-    // ── M11 fractal: emit pre-child WriteSlots for sub-instance inputs ──
-    // For each child instance, evaluate each wired input expression in
-    // THIS kernel's scope (where the wire's refs to our regs, params,
-    // and inputs resolve naturally) and emit a WriteSlot into the
-    // child's pre-allocated input slot. The child reads from that
-    // slot when its kernel body runs after our pre-child stage.
+    // ── M11 fractal: emit per-child pre-input WriteSlots ──
+    // For each child, evaluate each wired input expression in THIS
+    // kernel's scope (where wire refs to our regs, params, and inputs
+    // resolve naturally) and emit a WriteSlot into the child's pre-
+    // allocated input slot. The child reads from the slot when its
+    // body runs.
     //
-    // We snapshot the instructions list before/after this phase and
-    // hand the WriteSlots back as a separate `pre_child_instructions`
-    // list so the engine's emit_kernel_block can emit them BEFORE
-    // recursing into the child (the M11 dispatch order is: pre-child
-    // → children → main body → writebacks).
+    // Per-child segregation matters: the engine's emit_kernel_block
+    // dispatches `per_child_pre_input[k] → children[k].body` in
+    // sequence, then the parent's main body, then writebacks. By
+    // placing each child's pre-input block immediately before its
+    // dispatch (rather than hoisting them all into one parent-wide
+    // pre-children block), wires for child[k] can read NestedOuts of
+    // any sibling child[j] with j < k — child[j]'s body has already
+    // run and written its output slot.
     //
-    // Temps allocated here share the same per-instance namespace as
-    // the main body; in the fused kernel they live in the same LLVM
-    // function and are visible across the pre-child / child / main
-    // boundary.
-    const preChildStart = this.instrs.length
-    if (nestedInstances !== undefined && this.slots.nestedInputSlots !== undefined) {
+    // Implementation note on CSE: temps live in the per-instance
+    // namespace, which IS the same LLVM function across pre-input,
+    // children, main, and writebacks. A subexpression computed in
+    // per_child_pre_input[0] (and stored in some temp[X]) can be
+    // CSE-reused by per_child_pre_input[1] without re-emitting the
+    // compute — execution order guarantees temp[X] is live by then.
+    // We slice each child's block off the running `this.instrs`
+    // list, then truncate so the main body emission picks up at the
+    // pre-child boundary.
+    const per_child_pre_input: NInstr[][] = []
+    const preChildBaseline = this.instrs.length
+    if (nestedInstances !== undefined) {
+      const slotMaps = this.slots.nestedInputSlots
       for (const decl of nestedInstances) {
-        const childSlotMap = this.slots.nestedInputSlots.get(decl)
-        if (childSlotMap === undefined) continue
-        for (const inp of decl.inputs) {
-          const slotIdx = childSlotMap.get(inp.port)
-          if (slotIdx === undefined) continue
-          const portT = inputDeclScalarType(inp.port)
-          const r = this.compileNode(inp.value, portT)
-          // Wires are scalar (array-typed child input ports aren't
-          // currently exercised by the slot-based path). If the wire
-          // resolves to an array, project element 0 to match the
-          // scalar-port semantics.
-          const valOp: NOperand = r.isArray
-            ? (() => {
-                const dst = this.allocReg()
-                this.regTypes.set(dst, r.scalarType)
-                this.emit(instrIndex(dst, [r.op, opConst(0, 'int')], r.scalarType))
-                return opTemp(dst, r.scalarType)
-              })()
-            : r.op
-          this.emit(instrWriteSlot(moduleSlotIdx(slotIdx), valOp, portT))
+        const childStart = this.instrs.length
+        const childSlotMap = slotMaps?.get(decl)
+        if (childSlotMap !== undefined) {
+          for (const inp of decl.inputs) {
+            const slotIdx = childSlotMap.get(inp.port)
+            if (slotIdx === undefined) continue
+            const portT = inputDeclScalarType(inp.port)
+            const r = this.compileNode(inp.value, portT)
+            // Wires are scalar (array-typed child input ports aren't
+            // currently exercised by the slot-based path). If the wire
+            // resolves to an array, project element 0.
+            const valOp: NOperand = r.isArray
+              ? (() => {
+                  const dst = this.allocReg()
+                  this.regTypes.set(dst, r.scalarType)
+                  this.emit(instrIndex(dst, [r.op, opConst(0, 'int')], r.scalarType))
+                  return opTemp(dst, r.scalarType)
+                })()
+              : r.op
+            this.emit(instrWriteSlot(moduleSlotIdx(slotIdx), valOp, portT))
+          }
         }
+        const childEnd = this.instrs.length
+        per_child_pre_input.push(this.instrs.slice(childStart, childEnd))
       }
     }
-    const preChildEnd = this.instrs.length
-    const pre_child_instructions = this.instrs.slice(preChildStart, preChildEnd)
-    // Remove the pre-child instructions from the main list — they're
-    // returned separately. (The CSE memo and reg counters stay
-    // populated; the temps survive into main-body emission.)
-    this.instrs = this.instrs.slice(0, preChildStart)
+    // All pre-child blocks have been sliced out into per_child_pre_input;
+    // truncate the running list so the main body emission below starts
+    // back at the pre-child boundary. Temps allocated by the wire
+    // evaluations stay reserved in the reg counter — they remain valid
+    // operands in the unified per-instance namespace, just no longer
+    // appear in `this.instrs` (their setter lives in the per-child
+    // block, which the engine emits before the main body anyway).
+    this.instrs = this.instrs.slice(0, preChildBaseline)
 
     // Output-targets contract (M11 Phase 3): ONE entry per scalar slot
     // of every declared output port. Scalar/alias ports contribute 1
@@ -941,7 +962,7 @@ class Emitter {
       array_slot_count: this.nextArraySlot,
       array_slot_sizes: this.arraySizes,
       instructions:     this.instrs,
-      pre_child_instructions,
+      per_child_pre_input,
       output_targets,
       register_targets,
     }
@@ -975,9 +996,9 @@ export interface EmitResolvedInputs {
    *  WriteSlot emission. Each entry's `inp.value` (wire expression) is
    *  compiled in the parent's scope; the result is written to the slot
    *  named in `slots.nestedInputSlots.get(decl).get(inp.port)`. The
-   *  WriteSlot instructions land in `pre_child_instructions`, separate
-   *  from the parent's main `instructions`, so the engine can run them
-   *  before recursing into the child. */
+   *  WriteSlot instructions land in `per_child_pre_input[k]`, parallel
+   *  to `nestedInstances[k]`, so the engine can run each block
+   *  immediately before recursing into its corresponding child. */
   nestedInstances?: InstanceDecl[]
 }
 

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -79,6 +79,10 @@ export interface FlatProgram {
   array_slot_count: number
   array_slot_sizes: number[]
   instructions:     NInstr[]
+  /** M11 fractal slot-based input wiring. Populated when this kernel
+   *  has sub-instances whose input wires were emitted via `WriteSlot`.
+   *  Empty for leaf kernels and the legacy flat path. */
+  pre_child_instructions: NInstr[]
   /** Per-output-port temp index (local; the session compiler shifts). */
   output_targets:   TempIdx[]
   register_targets: RegTarget[]
@@ -250,6 +254,20 @@ export interface EmitSlots {
    *  When undefined (legacy / per-program path), NestedOut throws as
    *  before. */
   nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
+  /** Module slot indices for THIS program's own input ports, populated
+   *  by the M11 fractal path. When set, `InputRef(d)` lowers to a Slot
+   *  read from `inputSlotOverride.get(d)` instead of an `Input`
+   *  operand. The parent kernel has written the slot's value via a
+   *  `WriteSlot` in its `pre_child_instructions` just before this
+   *  kernel runs. */
+  inputSlotOverride?: Map<InputDecl, number>
+  /** Per-child module-slot map for sub-instance INPUTS. Used by the
+   *  M11 fractal path when emitting a parent kernel: for each child
+   *  instance and each of its wired inputs, the parent emits a
+   *  `WriteSlot` into the slot named here. Map shape:
+   *  instanceDecl → inputDecl → moduleSlotIdx. Read in conjunction
+   *  with `EmitResolvedInputs.nestedInstances`. */
+  nestedInputSlots?: Map<InstanceDecl, Map<InputDecl, number>>
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -387,6 +405,16 @@ class Emitter {
         const slot = this.slots.inputs.get(obj.decl)
         if (slot === undefined) throw new Error(`emit_resolved: input '${obj.decl.name}' missing from slot table`)
         const portT = this.inputPortTypes[slot] ?? 'float'
+        // M11 fractal path: when the program is being compiled as a
+        // sub-instance kernel, its inputs live in module slots
+        // pre-written by the parent's WriteSlot in pre_child_instructions.
+        // Lower `InputRef(d)` to a slot read instead of opInput.
+        if (this.slots.inputSlotOverride !== undefined) {
+          const overrideSlot = this.slots.inputSlotOverride.get(obj.decl)
+          if (overrideSlot !== undefined) {
+            return { op: opSlot(moduleSlotIdx(overrideSlot), portT), scalarType: portT }
+          }
+        }
         return { op: opInput(inputPortIdx(slot), portT), scalarType: portT }
       }
       case 'regRef': {
@@ -748,9 +776,60 @@ class Emitter {
     outputExprs: ResolvedExpr[],
     registerExprs: (ResolvedExpr | null)[],
     outputPortScalarCounts: number[],
+    nestedInstances?: InstanceDecl[],
   ): FlatProgram {
     const output_targets: TempIdx[] = []
     const register_targets: RegTarget[] = []
+
+    // ── M11 fractal: emit pre-child WriteSlots for sub-instance inputs ──
+    // For each child instance, evaluate each wired input expression in
+    // THIS kernel's scope (where the wire's refs to our regs, params,
+    // and inputs resolve naturally) and emit a WriteSlot into the
+    // child's pre-allocated input slot. The child reads from that
+    // slot when its kernel body runs after our pre-child stage.
+    //
+    // We snapshot the instructions list before/after this phase and
+    // hand the WriteSlots back as a separate `pre_child_instructions`
+    // list so the engine's emit_kernel_block can emit them BEFORE
+    // recursing into the child (the M11 dispatch order is: pre-child
+    // → children → main body → writebacks).
+    //
+    // Temps allocated here share the same per-instance namespace as
+    // the main body; in the fused kernel they live in the same LLVM
+    // function and are visible across the pre-child / child / main
+    // boundary.
+    const preChildStart = this.instrs.length
+    if (nestedInstances !== undefined && this.slots.nestedInputSlots !== undefined) {
+      for (const decl of nestedInstances) {
+        const childSlotMap = this.slots.nestedInputSlots.get(decl)
+        if (childSlotMap === undefined) continue
+        for (const inp of decl.inputs) {
+          const slotIdx = childSlotMap.get(inp.port)
+          if (slotIdx === undefined) continue
+          const portT = inputDeclScalarType(inp.port)
+          const r = this.compileNode(inp.value, portT)
+          // Wires are scalar (array-typed child input ports aren't
+          // currently exercised by the slot-based path). If the wire
+          // resolves to an array, project element 0 to match the
+          // scalar-port semantics.
+          const valOp: NOperand = r.isArray
+            ? (() => {
+                const dst = this.allocReg()
+                this.regTypes.set(dst, r.scalarType)
+                this.emit(instrIndex(dst, [r.op, opConst(0, 'int')], r.scalarType))
+                return opTemp(dst, r.scalarType)
+              })()
+            : r.op
+          this.emit(instrWriteSlot(moduleSlotIdx(slotIdx), valOp, portT))
+        }
+      }
+    }
+    const preChildEnd = this.instrs.length
+    const pre_child_instructions = this.instrs.slice(preChildStart, preChildEnd)
+    // Remove the pre-child instructions from the main list — they're
+    // returned separately. (The CSE memo and reg counters stay
+    // populated; the temps survive into main-body emission.)
+    this.instrs = this.instrs.slice(0, preChildStart)
 
     // Output-targets contract (M11 Phase 3): ONE entry per scalar slot
     // of every declared output port. Scalar/alias ports contribute 1
@@ -862,10 +941,18 @@ class Emitter {
       array_slot_count: this.nextArraySlot,
       array_slot_sizes: this.arraySizes,
       instructions:     this.instrs,
+      pre_child_instructions,
       output_targets,
       register_targets,
     }
   }
+}
+
+function inputDeclScalarType(d: InputDecl): ScalarType {
+  if (d.type === undefined) return 'float'
+  if (d.type.kind === 'scalar') return d.type.scalar
+  if (d.type.kind === 'alias')  return d.type.alias.base
+  return 'float'
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -884,9 +971,17 @@ export interface EmitResolvedInputs {
   stateRegTypes: ScalarType[]
   inputPortTypes: ScalarType[]
   slots: EmitSlots
+  /** M11 fractal: sub-instance decls whose input wires need parent-side
+   *  WriteSlot emission. Each entry's `inp.value` (wire expression) is
+   *  compiled in the parent's scope; the result is written to the slot
+   *  named in `slots.nestedInputSlots.get(decl).get(inp.port)`. The
+   *  WriteSlot instructions land in `pre_child_instructions`, separate
+   *  from the parent's main `instructions`, so the engine can run them
+   *  before recursing into the child. */
+  nestedInstances?: InstanceDecl[]
 }
 
 export function emitResolvedProgram(input: EmitResolvedInputs): FlatProgram {
   const e = new Emitter(input.slots, input.stateInit, input.stateRegTypes, input.inputPortTypes)
-  return e.emitProgram(input.outputExprs, input.registerExprs, input.outputPortScalarCounts)
+  return e.emitProgram(input.outputExprs, input.registerExprs, input.outputPortScalarCounts, input.nestedInstances)
 }

--- a/compiler/ir/lift_wires.ts
+++ b/compiler/ir/lift_wires.ts
@@ -95,7 +95,8 @@ function liftOneWire(
   // Run strata to lower combinators (let, array literals via
   // arrayLower; session delay desugars to a synthetic RegDecl).
   const compiled = programTypeFromResolved(lifted, new Map(), {
-    displayName: rawName(synthName),
+    displayName:  rawName(synthName),
+    inlineNested: session.inlineNested,
   })
 
   // Register the type so materializeSession (oracle path) can find it

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -22,7 +22,7 @@
  */
 
 import type {
-  ResolvedProgram, ResolvedExpr, InstanceDecl, InputDecl, OutputDecl, ParamDecl,
+  ResolvedProgram, InstanceDecl, InputDecl, OutputDecl, ParamDecl,
 } from './nodes.js'
 import type { SessionState, ExprNode } from '../session.js'
 import type {
@@ -37,12 +37,11 @@ import {
 import { type ScalarType } from './emit_resolved.js'
 import { instanceName as toInstanceName, slotKey } from './branded_names.js'
 import { compileResolved } from './compile_resolved.js'
-import { cloneWithInputSubst } from './clone.js'
 import { makeCompiled, type Compiled } from '../program_types.js'
 import {
   inputNames, outputNames, outputPortTypes, rawInputDefaults,
 } from '../program_types.js'
-import { allocateOutputSlots } from '../session.js'
+import { allocateOutputSlots, allocateInputSlots } from '../session.js'
 import {
   remapInstancePlan, type RemapContext, type InputBinding,
 } from './compile_session_slotted_helpers.js'
@@ -97,6 +96,19 @@ function lookupOutputSlot(
   return session.outputSlotRegistry.get(meta.scalarSlotNames[0])
 }
 
+/** Look up the (first scalar) slot index for an instance's INPUT port.
+ *  Mirror of `lookupOutputSlot` against the M11 input-slot registry. */
+function lookupInputSlot(
+  session: SessionState,
+  instancePath: string,
+  portName: string,
+): number | undefined {
+  const portKey = slotKey(toInstanceName(instancePath), portName)
+  const meta = session.inputPortMeta.get(portKey)
+  if (meta === undefined || meta.scalarSlotNames.length === 0) return undefined
+  return session.inputSlotRegistry.get(meta.scalarSlotNames[0])
+}
+
 // ─── Entry point ──────────────────────────────────────────────────────────
 
 /** Result of compiling a single kernel: the InstanceFunction (with
@@ -129,50 +141,84 @@ export function partitionKernel(
   paramHandles: Map<ParamDecl, { ptr: string }>,
   session: SessionState,
   acc: PartitionAccumulators,
+  /** M11 slot-based input wiring: when set, THIS kernel is being
+   *  compiled as a sub-instance. Its `InputRef(d)` operands lower to
+   *  Slot reads from the slot indices recorded here, instead of the
+   *  legacy `opInput`. Top-level callers pass `undefined`. */
+  inputSlotOverride?: Map<InputDecl, number>,
 ): PartitionedKernel {
-  // ── 1. Recurse into sub-InstanceDecls. Substitute their inputs;
-  //    allocate their output slots; build the nestedOutputSlots map for
-  //    this kernel's NestedOut refs.
+  // ── 1. Recurse into sub-InstanceDecls.
+  //    For each child:
+  //      • Allocate output slots (parent reads via NestedOut → Slot)
+  //      • Allocate INPUT slots (parent writes via WriteSlot in
+  //        pre_child_instructions; child reads via Slot in its body)
+  //      • Build per-child slot maps for both directions
+  //      • Recurse into the child WITHOUT substituting its inputs —
+  //        the child's InputRefs lower via `inputSlotOverride` instead
+  //
+  //    The slot-based path replaces the legacy `cloneWithInputSubst`
+  //    substitution, which leaked scope (wire expressions could carry
+  //    refs into the child's namespace where they couldn't resolve).
+  //    Under slots, the wire is evaluated in the parent's scope where
+  //    every ref resolves, and only the *value* crosses the boundary.
   const children: InstanceFunction[] = []
   const nestedOutputSlots = new Map<InstanceDecl, Map<OutputDecl, number>>()
+  const nestedInputSlots  = new Map<InstanceDecl, Map<InputDecl, number>>()
 
   for (const decl of prog.body.decls) {
     if (decl.op !== 'instanceDecl') continue
     const childPath = `${instancePath}.${decl.name}`
 
-    // Substitute the child's input refs with the parent's wired expressions.
-    const inputSubst = new Map<InputDecl, ResolvedExpr>()
-    for (const inp of decl.inputs) inputSubst.set(inp.port, inp.value)
-    const substChildProg = cloneWithInputSubst(decl.type, inputSubst)
-    const childCompiled = makeCompiled(substChildProg, { displayName: decl.type.name })
+    const childCompiled = makeCompiled(decl.type, { displayName: decl.type.name })
 
-    // Allocate output slots (+ __alive__) for the child.
+    // Allocate both directions of slots for this child.
     allocateOutputSlots(session, toInstanceName(childPath), childCompiled)
+    allocateInputSlots (session, toInstanceName(childPath), childCompiled)
 
     // Build slot map for parent's NestedOut → child output reads.
-    const childSlotMap = new Map<OutputDecl, number>()
+    const childOutputMap = new Map<OutputDecl, number>()
     for (const outDecl of decl.type.ports.outputs) {
       const slotIdx = lookupOutputSlot(session, childPath, outDecl.name)
-      if (slotIdx !== undefined) childSlotMap.set(outDecl, slotIdx)
+      if (slotIdx !== undefined) childOutputMap.set(outDecl, slotIdx)
     }
-    nestedOutputSlots.set(decl, childSlotMap)
+    nestedOutputSlots.set(decl, childOutputMap)
 
-    // Recursively compile the child. Children inherit their parent's
-    // paramHandles. No external input bindings — all substituted into the body.
+    // Build slot map for parent's WriteSlot → child input writes.
+    const childInputMap = new Map<InputDecl, number>()
+    for (const inDecl of decl.type.ports.inputs) {
+      const slotIdx = lookupInputSlot(session, childPath, inDecl.name)
+      if (slotIdx !== undefined) childInputMap.set(inDecl, slotIdx)
+    }
+    nestedInputSlots.set(decl, childInputMap)
+
+    // Recursively compile the child. Pass childInputMap as
+    // `inputSlotOverride` so the child's InputRefs lower to Slot
+    // reads instead of `opInput`. The child's program is unmodified
+    // (no cloneWithInputSubst) — the boundary is the slot, not the
+    // substituted expression.
     const childResult = partitionKernel(
-      childPath, substChildProg, childCompiled,
+      childPath, decl.type, childCompiled,
       /* inputBindingFor*/ () => undefined,
       /* defaults       */ rawInputDefaults(childCompiled),
       paramHandles,
       session, acc,
+      /* inputSlotOverride */ childInputMap,
     )
     children.push(childResult.fn)
   }
 
-  // ── 2. Compile this kernel's body via compileResolved.
+  // ── 2. Compile this kernel's body via compileResolved. With the
+  //    nested context populated, `compileResolved` will:
+  //      • Emit WriteSlots into `pre_child_instructions` for each
+  //        child input wire (using nestedInputSlots)
+  //      • Lower NestedOut refs in the parent body via nestedOutputSlots
+  //      • Lower InputRef refs in THIS kernel's body via
+  //        inputSlotOverride (when this kernel is itself a child)
   const plan = compileResolved(prog, {
     paramHandles,
     nestedOutputSlots,
+    nestedInputSlots,
+    inputSlotOverride,
   })
 
   // ── 3. Remap the plan into the unified slot/temp space.
@@ -206,7 +252,7 @@ export function partitionKernel(
     outputScalarTypes: outPortTypes,
   }
 
-  const { preamble, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
+  const { preamble, preChildInstructions, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
   const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
 
   // Shift per-instance register_targets into the unified temp space.
@@ -219,6 +265,7 @@ export function partitionKernel(
     name:              `instance_${instancePath.replace(/\./g, '_')}`,
     instance_name:     instancePath,
     instructions:      instanceInstructions,
+    pre_child_instructions: preChildInstructions,
     register_offset:   tempOffset(acc.nextRegRaw),
     state_reg_offset:  stateRegOffset(acc.nextStateRaw),
     array_slot_offset: arraySlotOffset(acc.nextArrayRaw),

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -151,7 +151,7 @@ export function partitionKernel(
   //    For each child:
   //      • Allocate output slots (parent reads via NestedOut → Slot)
   //      • Allocate INPUT slots (parent writes via WriteSlot in
-  //        pre_child_instructions; child reads via Slot in its body)
+  //        per_child_pre_input[k]; child reads via Slot in its body)
   //      • Build per-child slot maps for both directions
   //      • Recurse into the child WITHOUT substituting its inputs —
   //        the child's InputRefs lower via `inputSlotOverride` instead
@@ -209,7 +209,7 @@ export function partitionKernel(
 
   // ── 2. Compile this kernel's body via compileResolved. With the
   //    nested context populated, `compileResolved` will:
-  //      • Emit WriteSlots into `pre_child_instructions` for each
+  //      • Emit WriteSlots into `per_child_pre_input[k]` for each
   //        child input wire (using nestedInputSlots)
   //      • Lower NestedOut refs in the parent body via nestedOutputSlots
   //      • Lower InputRef refs in THIS kernel's body via
@@ -252,8 +252,30 @@ export function partitionKernel(
     outputScalarTypes: outPortTypes,
   }
 
-  const { preamble, preChildInstructions, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
+  const { preamble, perChildPreInput, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
   const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
+
+  // Attach each per-child pre-input block to its corresponding child
+  // InstanceFunction. The pre-input wires live in THIS kernel's
+  // namespace (parent evaluates them) but are stored on the child so
+  // the engine's `emit_kernel_block` runs `child.pre_input_instructions`
+  // immediately before recursing into that child — preserving sibling-
+  // to-sibling NestedOut dependencies.
+  //
+  // `children` and `perChildPreInput` are kept parallel by construction:
+  // both are built from `prog.body.decls` in the same order (this
+  // function above; compileResolved's nestedInstances collection).
+  if (perChildPreInput.length !== children.length) {
+    throw new Error(
+      `partitionKernel: instance '${instancePath}': perChildPreInput length ` +
+      `(${perChildPreInput.length}) does not match children length ` +
+      `(${children.length}). emit_resolved + compileResolved must produce ` +
+      `one block per nested InstanceDecl in body order.`,
+    )
+  }
+  for (let i = 0; i < children.length; i++) {
+    children[i] = { ...children[i], pre_input_instructions: perChildPreInput[i] }
+  }
 
   // Shift per-instance register_targets into the unified temp space.
   const shiftedTargets: RegTarget[] = plan.register_targets.map(t => {
@@ -265,7 +287,13 @@ export function partitionKernel(
     name:              `instance_${instancePath.replace(/\./g, '_')}`,
     instance_name:     instancePath,
     instructions:      instanceInstructions,
-    pre_child_instructions: preChildInstructions,
+    // Top-level kernels run no parent-side pre-input wires (their
+    // inputs come from session inputBindings translated into the
+    // preamble). Sub-kernels get this populated by the parent's
+    // partitionKernel call via the `for (let i = 0; ...)` loop above
+    // — that loop overwrites `children[i]` with a copy carrying the
+    // child's `pre_input_instructions`.
+    pre_input_instructions: [],
     register_offset:   tempOffset(acc.nextRegRaw),
     state_reg_offset:  stateRegOffset(acc.nextStateRaw),
     array_slot_offset: arraySlotOffset(acc.nextArrayRaw),

--- a/compiler/ir/strata.ts
+++ b/compiler/ir/strata.ts
@@ -70,23 +70,25 @@ export function strataPipeline(
  *  port/register/default metadata via free functions over the resolved
  *  IR.
  *
- *  Currently uses default inlining (`inlineNested: true`). The fractal
- *  architecture (M11) is fully infrastructured — `partition_recursive`,
- *  `NestedOut → slot read` in emit_resolved, recursive JIT emit, schema
- *  field for `children` — but ACTIVATION (flipping to `inlineNested:
- *  false`) is deferred: the cross-kernel input-wiring path (child
- *  refers to parent's `inputRef`) needs an ancestor-resolution step
- *  before partition. Once that lands, set `inlineNested: false` here
- *  and full fractal activates uniformly. */
+ *  Default behavior uses `inlineNested: true` — the legacy flat-IR
+ *  path. The fractal session path (M11 activation) passes
+ *  `inlineNested: false` so sub-instance `InstanceDecl`s survive
+ *  into `partition_recursive`, where they become real kernel
+ *  boundaries instead of being splatted into their parent's body.
+ *  The slot-based input-wiring redesign makes the `false` path
+ *  correct end-to-end; until that lands, callers should leave
+ *  `inlineNested` at its default. */
 export function programTypeFromResolved(
   prog: ResolvedProgram,
   typeArgs: ReadonlyMap<TypeParamDecl, number>,
-  opts?: { displayName?: string },
+  opts?: { displayName?: string; inlineNested?: boolean },
 ): Compiled {
   // Post-Phase 4b: the elaborator throws on cyclic source code, and
   // lifted wire-programs are acyclic by construction (no
   // InstanceDecls). The strataPipeline's `assertAcyclic` at entry
   // confirms the contract; no separate cycle-break call is needed
   // here.
-  return makeCompiled(strataPipeline(prog, typeArgs), opts)
+  const strataOptions: StrataOptions = opts?.inlineNested !== undefined
+    ? { inlineNested: opts.inlineNested } : {}
+  return makeCompiled(strataPipeline(prog, typeArgs, strataOptions), opts)
 }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -474,7 +474,7 @@ export function loadProgramAsType(
     return undefined
   }
 
-  const type = programTypeFromResolved(resolved, new Map())
+  const type = programTypeFromResolved(resolved, new Map(), { inlineNested: session.inlineNested })
   session.typeRegistry.set(prog.name, type)
   session.resolvedRegistry.set(prog.name, resolved)
   return type
@@ -687,7 +687,7 @@ function loadStdlibFromResolved(
       continue
     }
     if (session.typeRegistry.has(name)) continue
-    const type = programTypeFromResolved(prog, new Map())
+    const type = programTypeFromResolved(prog, new Map(), { inlineNested: session.inlineNested })
     session.typeRegistry.set(name, type)
     session.resolvedRegistry.set(name, prog)
   }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -421,7 +421,7 @@ export function loadProgramAsSession(
  */
 export function loadProgramAsType(
   prog: ProgramNode,
-  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'specializationCache' | 'genericTemplatesResolved' | 'resolvedRegistry'> & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver' | 'sumTypeRegistry' | 'structTypeRegistry'>>,
+  session: Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'specializationCache' | 'genericTemplatesResolved' | 'resolvedRegistry'> & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver' | 'sumTypeRegistry' | 'structTypeRegistry' | 'inlineNested'>>,
 ): Compiled | undefined {
   // Register type defs (aliases, sums, structs) from type_defs before processing subprograms
   for (const td of prog.ports?.type_defs ?? []) {
@@ -583,13 +583,13 @@ const __dirname = dirname(__filename)
 type StdlibTarget =
   | Map<string, Compiled>
   | (Pick<SessionState, 'typeRegistry' | 'instanceRegistry' | 'paramRegistry' | 'specializationCache' | 'genericTemplatesResolved' | 'resolvedRegistry'>
-    & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver'>>)
+    & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver' | 'inlineNested'>>)
 
 function asLoadSession(target: StdlibTarget): Pick<
   SessionState,
   'typeRegistry' | 'instanceRegistry' | 'paramRegistry'
   | 'specializationCache' | 'genericTemplatesResolved' | 'resolvedRegistry'
-> & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver'>> {
+> & Partial<Pick<SessionState, 'typeAliasRegistry' | 'typeResolver' | 'inlineNested'>> {
   if (target instanceof Map) {
     return {
       typeRegistry: target,

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -10,6 +10,7 @@ import { type ExprNode } from './expr.js'
 import {
   type Compiled, type Instance,
   outputNames, outputPortType,
+  inputNames, inputPortType,
   // Note: re-exports below pick up Compiled/Instance + helpers for
   // callers that already import from session.js.
 } from './program_types.js'
@@ -147,7 +148,18 @@ export interface SessionState {
   /** Per-output-port metadata captured at allocate time. Keyed by the
    *  port's SlotKey (`${instance}.${port}`). */
   outputPortMeta:     Map<SlotKey, WirePortMeta>
-  /** Next slot index to allocate. Always equals outputSlotRegistry.size + paramSlotRegistry.size. */
+  /** Branded `${instance}.${slotName}` → slot index, for sub-instance
+   *  INPUT slots. Only populated by the slot-based input-wiring path
+   *  (`inlineNested:false` + `allocateInputSlots`); empty in legacy
+   *  flat-IR sessions. Coexists with `outputSlotRegistry` in the same
+   *  unified `slot[]` array — the unique indices come from the shared
+   *  `slotCount`. */
+  inputSlotRegistry:  Map<SlotKey, number>
+  /** Per-input-port metadata for sub-instance INPUT slots. Same shape
+   *  as `outputPortMeta`. */
+  inputPortMeta:      Map<SlotKey, WirePortMeta>
+  /** Next slot index to allocate. Always equals the sum of all four
+   *  per-namespace counts (output + param + input + delay). */
   slotCount:          number
   /** Input expressions keyed by scalar-slot name "${instance}:${scalarSlotName}".
    *  Coexists with inputExprNodes during the migration; M8 unifies them. */
@@ -224,6 +236,8 @@ export function makeSession(
     outputSlotRegistry: new Map(),
     paramSlotRegistry:  new Map(),
     outputPortMeta:     new Map(),
+    inputSlotRegistry:  new Map(),
+    inputPortMeta:      new Map(),
     slotCount:          0,
     inputExprs:         new Map(),
     inlineNested:       options.inlineNested ?? true,
@@ -400,6 +414,42 @@ export function allocateOutputSlots(
       session.outputSlotRegistry.set(names[i], session.slotCount + i)
     }
     session.outputPortMeta.set(portKey, {
+      scalarSlotNames: names,
+      scalarTypes:     types,
+      portType,
+    })
+    session.slotCount += names.length
+  }
+}
+
+/** Allocate slot indices for every INPUT port of an instance. Used by
+ *  `partition_recursive` when emitting slot-based parent→child input
+ *  wiring (the M11 fractal path with `inlineNested:false`). The parent
+ *  emits a `WriteSlot` into each of these slots before invoking the
+ *  child; the child's `InputRef`s lower to `Slot` reads via
+ *  `compileResolved`'s `nestedInputSlots` context.
+ *
+ *  Mirrors `allocateOutputSlots` exactly — same `expandPortToSlots`
+ *  decomposition, same unified `slotCount` accounting, same
+ *  idempotency guard. Different registry / port-meta maps so input
+ *  and output slot names live in disjoint keyspaces (a port can be
+ *  both an input and an output of different instances). */
+export function allocateInputSlots(
+  session: SessionState,
+  instName: InstanceName,
+  type: Compiled,
+): void {
+  const portNames = inputNames(type)
+  for (let idx = 0; idx < portNames.length; idx++) {
+    const portName = portNames[idx]
+    const portKey = slotKey(instName, portName)
+    if (session.inputPortMeta.has(portKey)) continue  // idempotent
+    const portType = inputPortType(type, idx) ?? DEFAULT_OUTPUT_PORT_TYPE
+    const { names, types } = expandPortToSlots(portKey, portType)
+    for (let i = 0; i < names.length; i++) {
+      session.inputSlotRegistry.set(names[i], session.slotCount + i)
+    }
+    session.inputPortMeta.set(portKey, {
       scalarSlotNames: names,
       scalarTypes:     types,
       portType,

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -152,6 +152,13 @@ export interface SessionState {
   /** Input expressions keyed by scalar-slot name "${instance}:${scalarSlotName}".
    *  Coexists with inputExprNodes during the migration; M8 unifies them. */
   inputExprs:         Map<string, ExprNode>
+  /** Whether the strata pipeline should flatten nested `InstanceDecl`s
+   *  via `inlineInstances`. Default `true` (legacy flat-IR path).
+   *  When `false`, sub-instance kernels survive as kernel boundaries
+   *  in `partition_recursive` — the M11 fractal path. All program-
+   *  loading entry points consult this field to keep the IR shape
+   *  consistent across a session. */
+  inlineNested:       boolean
   /** FlatRuntime — all audio goes through this. */
   runtime: Runtime
   /** Thin proxy over runtime that matches the old Graph interface for tests and legacy callers. */
@@ -198,7 +205,10 @@ export interface DelaySlotEntry {
   scalarType: 'float' | 'int' | 'bool'
 }
 
-export function makeSession(bufferLength = 512): SessionState {
+export function makeSession(
+  bufferLength = 512,
+  options: { inlineNested?: boolean } = {},
+): SessionState {
   const runtime = new Runtime(bufferLength)
   return {
     bufferLength,
@@ -216,6 +226,7 @@ export function makeSession(bufferLength = 512): SessionState {
     outputPortMeta:     new Map(),
     slotCount:          0,
     inputExprs:         new Map(),
+    inlineNested:       options.inlineNested ?? true,
     specializationCache: new Map(),
     genericTemplatesResolved: new Map(),
     resolvedRegistry: new Map(),
@@ -510,7 +521,7 @@ export function decodePortTypeDecl(
 // ─────────────────────────────────────────────────────────────
 
 type ResolveSession = Pick<SessionState, 'typeRegistry' | 'specializationCache' | 'genericTemplatesResolved' | 'instanceRegistry' | 'paramRegistry'> &
-  Partial<Pick<SessionState, 'typeResolver' | 'typeAliasRegistry'>>
+  Partial<Pick<SessionState, 'typeResolver' | 'typeAliasRegistry' | 'inlineNested'>>
 
 /**
  * Resolve a (baseName, type_args) pair to a concrete Compiled.
@@ -548,7 +559,10 @@ export function resolveProgramType(
       }
       subst.set(decl, value)
     }
-    const type = programTypeFromResolved(template, subst, { displayName: key })
+    const type = programTypeFromResolved(template, subst, {
+      displayName:  key,
+      inlineNested: session.inlineNested,
+    })
     session.specializationCache.set(key, type)
     return { type, typeArgs: resolved }
   }

--- a/compiler/stdlib_loader.ts
+++ b/compiler/stdlib_loader.ts
@@ -30,7 +30,7 @@ type StdlibTarget =
       | 'specializationCache'
       | 'genericTemplatesResolved'
       | 'resolvedRegistry'
-    > & Partial<Pick<SessionState, 'typeResolver'>>
+    > & Partial<Pick<SessionState, 'typeResolver' | 'inlineNested'>>
 
 function toSession(target: StdlibTarget) {
   if (target instanceof Map) {
@@ -119,7 +119,7 @@ export function loadStdlibFromMap(
       continue
     }
     if (session.typeRegistry.has(name)) continue
-    const type = programTypeFromResolved(prog, new Map())
+    const type = programTypeFromResolved(prog, new Map(), { inlineNested: session.inlineNested })
     session.typeRegistry.set(name, type)
     session.resolvedRegistry.set(name, prog)
   }
@@ -183,7 +183,7 @@ export function loadStdlibFromSources(
       continue
     }
     if (session.typeRegistry.has(name)) continue
-    const type = programTypeFromResolved(prog, new Map())
+    const type = programTypeFromResolved(prog, new Map(), { inlineNested: session.inlineNested })
     session.typeRegistry.set(name, type)
     session.resolvedRegistry.set(name, prog)
   }

--- a/compiler/stdlib_loader.ts
+++ b/compiler/stdlib_loader.ts
@@ -50,7 +50,7 @@ function toSession(target: StdlibTarget) {
       | 'genericTemplatesResolved'
       | 'resolvedRegistry'
     > &
-      Partial<Pick<SessionState, 'typeResolver'>>
+      Partial<Pick<SessionState, 'typeResolver' | 'inlineNested'>>
   }
   return target
 }

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -523,23 +523,32 @@ struct EmitCtx
   // ── Per-instance writebacks ──
   void emit_writebacks(const std::vector<InstanceProgram::Writeback> & wbs);
 
-  // ── Per-instance dispatch (M11 fractal four-phase order) ──
-  // Order matters for the slot-based wiring contract:
-  //   1. pre_child_instructions: evaluate child input wires in THIS
-  //      kernel's scope, WriteSlot the value to the child's input slot
-  //   2. children (recursive): each child's body reads its input slots
-  //      and writes its output slots
-  //   3. instructions: parent body (may read child outputs via NestedOut
-  //      → Slot read, which sees the slot values from step 2)
-  //   4. writebacks: parent's state-register updates
+  // ── Per-instance dispatch (M11 fractal interleaved order) ──
+  // For each child:
+  //   1. emit child.pre_input_instructions (in THIS kernel's namespace
+  //      — wire expressions referencing parent regs/inputs/params resolve,
+  //      results land in WriteSlot to the child's input slots)
+  //   2. emit child.body recursively (reads input slots, writes output
+  //      slots; nested children dispatch the same way)
+  // Then:
+  //   3. emit THIS kernel's main instructions (may read child outputs via
+  //      NestedOut → Slot read, observing the values from step 2 of each
+  //      child)
+  //   4. emit THIS kernel's writebacks (state-register updates)
   //
-  // Legacy plans (inlineNested:true) have empty pre_child_instructions
-  // and empty children — phases 1-2 are no-ops and the behavior reduces
-  // to "main body then writebacks", same as before.
+  // Interleaving step 1 with step 2 per-child (vs hoisting all step-1
+  // blocks ahead of all step-2 blocks) preserves sibling-to-sibling
+  // NestedOut dependencies: child[k]'s wires can read child[j].output
+  // for j < k because child[j]'s body has already executed.
+  //
+  // Legacy plans (inlineNested:true) have empty children and empty
+  // pre_input_instructions throughout — the loop is a no-op and the
+  // behavior reduces to "main body then writebacks", same as before.
   llvm::Error emit_kernel_block(const InstanceProgram & inst) {
-    if (auto err = emit_instrs(inst.pre_child_instructions)) return err;
-    for (const auto & child : inst.children)
+    for (const auto & child : inst.children) {
+      if (auto err = emit_instrs(child.pre_input_instructions)) return err;
       if (auto err = emit_kernel_block(child)) return err;
+    }
     if (auto err = emit_instrs(inst.instructions)) return err;
     emit_writebacks(inst.writebacks);
     return llvm::Error::success();

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -523,8 +523,21 @@ struct EmitCtx
   // ── Per-instance writebacks ──
   void emit_writebacks(const std::vector<InstanceProgram::Writeback> & wbs);
 
-  // ── Per-instance dispatch (M11 fractal: children before parent body) ──
+  // ── Per-instance dispatch (M11 fractal four-phase order) ──
+  // Order matters for the slot-based wiring contract:
+  //   1. pre_child_instructions: evaluate child input wires in THIS
+  //      kernel's scope, WriteSlot the value to the child's input slot
+  //   2. children (recursive): each child's body reads its input slots
+  //      and writes its output slots
+  //   3. instructions: parent body (may read child outputs via NestedOut
+  //      → Slot read, which sees the slot values from step 2)
+  //   4. writebacks: parent's state-register updates
+  //
+  // Legacy plans (inlineNested:true) have empty pre_child_instructions
+  // and empty children — phases 1-2 are no-ops and the behavior reduces
+  // to "main body then writebacks", same as before.
   llvm::Error emit_kernel_block(const InstanceProgram & inst) {
+    if (auto err = emit_instrs(inst.pre_child_instructions)) return err;
     for (const auto & child : inst.children)
       if (auto err = emit_kernel_block(child)) return err;
     if (auto err = emit_instrs(inst.instructions)) return err;

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -117,6 +117,14 @@ struct InstanceProgram
 {
   std::string                  instance_name;     // dotted path (e.g. voice1.env)
   std::vector<FlatInstr>       instructions;      // already shifted into unified offset space
+  /** M11 fractal slot-based input wiring. Runs BEFORE this kernel's
+   *  children. For each wired input of each child, the parent emits a
+   *  `WriteSlot` here that evaluates the wire expression in its own
+   *  scope and writes the value to the child's pre-allocated input
+   *  slot. The child reads from that slot when its body runs. Empty
+   *  for leaf kernels and for the legacy flat-IR (inlineNested:true)
+   *  path. */
+  std::vector<FlatInstr>       pre_child_instructions;
   uint32_t                     register_count = 0; // local temp count
   /** State register writebacks for this instance. Each entry pairs a
    *  state register slot index (absolute, into the unified register

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -117,14 +117,18 @@ struct InstanceProgram
 {
   std::string                  instance_name;     // dotted path (e.g. voice1.env)
   std::vector<FlatInstr>       instructions;      // already shifted into unified offset space
-  /** M11 fractal slot-based input wiring. Runs BEFORE this kernel's
-   *  children. For each wired input of each child, the parent emits a
-   *  `WriteSlot` here that evaluates the wire expression in its own
-   *  scope and writes the value to the child's pre-allocated input
-   *  slot. The child reads from that slot when its body runs. Empty
-   *  for leaf kernels and for the legacy flat-IR (inlineNested:true)
-   *  path. */
-  std::vector<FlatInstr>       pre_child_instructions;
+  /** M11 fractal slot-based input wiring. Per-child block — runs in
+   *  the PARENT's namespace immediately before THIS kernel's body. The
+   *  parent's emit_kernel_block dispatches each child as:
+   *      emit_instrs(child.pre_input_instructions)
+   *      emit_kernel_block(child)
+   *  Per-child placement (vs hoisting into a parent-wide pre-children
+   *  block) preserves sibling-to-sibling NestedOut dependencies: a
+   *  later sibling's wire can read an earlier sibling's output slot
+   *  because the earlier sibling's body has already executed. Empty
+   *  for top-level kernels and for the legacy flat-IR
+   *  (inlineNested:true) path. */
+  std::vector<FlatInstr>       pre_input_instructions;
   uint32_t                     register_count = 0; // local temp count
   /** State register writebacks for this instance. Each entry pairs a
    *  state register slot index (absolute, into the unified register

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -175,11 +175,13 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
       inst.instructions.push_back(parse_instr(ji));
   // M11 fractal slot-based input wiring. Optional in the wire format
   // (legacy plans don't have it; absent → empty). Same instruction
-  // shape as `instructions`; difference is purely WHEN they emit
-  // (before children, not after).
-  if (jf.contains("pre_child_instructions"))
-    for (const auto & ji : jf["pre_child_instructions"])
-      inst.pre_child_instructions.push_back(parse_instr(ji));
+  // shape as `instructions`; difference is purely WHEN they emit —
+  // the parent's emit_kernel_block runs each child's
+  // pre_input_instructions immediately before recursing into that
+  // child's body.
+  if (jf.contains("pre_input_instructions"))
+    for (const auto & ji : jf["pre_input_instructions"])
+      inst.pre_input_instructions.push_back(parse_instr(ji));
   // Writebacks: each entry of register_targets[] is the (absolute,
   // already shifted) temp slot whose value feeds the state register at
   // position j among this instance's slots, which sits at

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -173,6 +173,13 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
   if (jf.contains("instructions"))
     for (const auto & ji : jf["instructions"])
       inst.instructions.push_back(parse_instr(ji));
+  // M11 fractal slot-based input wiring. Optional in the wire format
+  // (legacy plans don't have it; absent → empty). Same instruction
+  // shape as `instructions`; difference is purely WHEN they emit
+  // (before children, not after).
+  if (jf.contains("pre_child_instructions"))
+    for (const auto & ji : jf["pre_child_instructions"])
+      inst.pre_child_instructions.push_back(parse_instr(ji));
   // Writebacks: each entry of register_targets[] is the (absolute,
   // already shifted) temp slot whose value feeds the state register at
   // position j among this instance's slots, which sits at

--- a/tests/bench/depth_vs_flat.ts
+++ b/tests/bench/depth_vs_flat.ts
@@ -1,33 +1,46 @@
 /**
- * depth_vs_flat.ts — head-to-head bench: legacy inline-everything path
- * (`inlineNested:true`, the flat per-instance kernel) vs the M11
- * fractal slot path (`inlineNested:false`, every sub-instance is its
- * own kernel boundary with per-port input/output slots).
+ * depth_vs_flat.ts — focused bench: legacy inline-everything path
+ * (`inlineNested:true`) vs M11 fractal slot path (`inlineNested:false`).
  *
- * Mirror of `microkernel_vs_fused.ts`'s structure. For each case,
- * compile + run twice — once per mode — and report:
- *   - ts_ms        TS pipeline time (parse, strata, partition)
- *   - jit_ms       LLVM IR generation + native compile
- *   - ns_per_sample  audio-thread cost
- *   - rt_ratio     fraction of a 44.1kHz sample period (lower = more headroom)
+ * Scope: TWO cases, not sixteen. The 14-case version from earlier was
+ * statistically meaningless (one trial per case, point estimates, cache
+ * state leaked between cases) and most of the cases told the same story
+ * at different magnifications. The two retained cases bracket the
+ * deletion decision:
  *
- * The slot path's overhead comes from:
- *   - Extra WriteSlot/ReadSlot at every kernel boundary (LLVM should
- *     fold the store-load round trip in fused mode, but there's still
- *     a register pressure cost)
- *   - More LLVM instructions in the IR (per-child wire blocks aren't
- *     inlined into the parent body)
- *   - More slot-array accesses (parent writes child input slot, child
- *     reads parent-allocated output slot)
+ *   - OnePole               minimal nested (2 children)
+ *                           — is the slot path's overhead detectable
+ *                             at the smallest scale?
  *
- * Counterbalanced (potentially) by:
- *   - Less duplicated codegen — sibling instances of the same type
- *     share an LLVM function in microkernel mode (no-op in fused mode)
- *   - Smaller per-kernel instruction streams may compile faster
+ *   - polyphony_8x_Phaser16 stress (8 voices × 17 nested kernels = 136
+ *                           kernel boundaries)
+ *                           — is the overhead tolerable at scale?
  *
- * Usage: bun run tests/bench/depth_vs_flat.ts [--frames=N] [--keep-cache]
+ * Methodology:
  *
- * Output: /tmp/depth_bench.json (consumed by the Phase 6 snapshot doc)
+ *   For each (case, mode):
+ *     - ONE cold-cache compile trial. The engine has a process-
+ *       singleton in-memory cache that survives `rmSync` of the disk
+ *       cache; a second compile within the same process hits that
+ *       cache and returns in <1ms. Measuring multiple cold compiles
+ *       in one process requires subprocess isolation, which isn't
+ *       worth the complexity for a snapshot bench. We measure cold
+ *       once and accept the single-shot number.
+ *     - N=3 runtime trials of 1024 frames × 256 samples each, take
+ *       min for ns/sample. N=3 is the empirically-derived
+ *       recommendation from runtime_noise_meta.ts: min-of-3 lands
+ *       within 0.76% of asymptotic min at p95 confidence on the
+ *       same hardware class.
+ *
+ *   Interleaving: round-robin (case, mode) across runtime trials so a
+ *   thermal slope or frequency-scaling transition doesn't systematically
+ *   bias one mode.
+ *
+ * Wall clock: ~3s (compile + runtime + cache clears).
+ *
+ * Output: /tmp/depth_bench.json
+ *
+ * Usage: bun run tests/bench/depth_vs_flat.ts
  */
 import { writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
@@ -43,43 +56,23 @@ import { toWirePlan } from '../../compiler/flat_plan.js'
 import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
 import * as b from '../../compiler/runtime/bindings.js'
 
-const args = process.argv.slice(2)
-const keepCache = args.includes('--keep-cache')
-const framesArg = args.find(a => a.startsWith('--frames='))
-const BENCH_FRAMES = framesArg ? parseInt(framesArg.split('=')[1], 10) : 4096
-const FRAME_SIZE   = 256
-const SAMPLE_RATE  = 44100
-const WARMUP_FRAMES = 32
-
-if (!keepCache) {
-  const cacheDir = process.env.XDG_CACHE_HOME
-    ? join(process.env.XDG_CACHE_HOME, 'tropical', 'kernels')
-    : join(homedir(), '.cache', 'tropical', 'kernels')
-  rmSync(cacheDir, { recursive: true, force: true })
-  console.log(`(cold) cleared ${cacheDir}`)
-}
+const FRAME_SIZE       = 256
+const FRAMES_PER_TRIAL = 1024
+const RUNTIME_TRIALS   = 3        // derived from runtime_noise_meta.ts
+// Compile time is measured ONCE per (case, mode). The engine has a
+// process-singleton in-memory cache that survives `rmSync` of the
+// disk cache, so a second compile of the same plan hits the in-memory
+// cache and returns in <1ms. Measuring K cold compiles in one process
+// would need subprocess isolation; for snapshot purposes a single
+// cold-cache measurement per axis is what we actually want anyway.
+const WARMUP_FRAMES    = 32
+const SAMPLE_RATE      = 44100
 
 type DepthMode = 'flat' | 'nested'
 
-interface CaseResult {
-  case:           string
-  instances:      number
-  mode:           DepthMode
-  ts_ms:          number
-  stringify_ms:   number
-  jit_ms:         number
-  ns_per_sample:  number
-  rt_ratio:       number
-  plan_bytes:     number
-}
-
-const results: CaseResult[] = []
-
-// ── Default port values for stdlib programs that need them ────────────
 function pulseEvery(n: number): ExprNode {
   return { op: 'lt', args: [{ op: 'mod', args: [{ op: 'sampleIndex' }, n] }, 1] }
 }
-
 const DEFAULT_INPUTS: Record<string, ExprNode> = {
   freq: 220, x: 0.5, y: 0.5, audio: 0.5, input: 0.5, cv: 0.5,
   cutoff: 1000, q: 0.5, drive: 1.0, mix: 0.5, a: 0.3, b: 0.7,
@@ -87,225 +80,222 @@ const DEFAULT_INPUTS: Record<string, ExprNode> = {
   rate: 5, g: 0.1, resonance: 0.5,
   trigger: pulseEvery(64), clock: pulseEvery(32),
 }
-
 const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
 
-// ──────────────────────────────────────────────────────────────────────
-// Session builders
-// ──────────────────────────────────────────────────────────────────────
+// ── Session builders ──────────────────────────────────────────────────
+type SessionFactory = (mode: DepthMode) => ReturnType<typeof makeSession>
 
-// Single stdlib instance with default inputs.
-function singleInstanceFactory(typeName: string, typeArgs?: Record<string, number>) {
-  return (mode: DepthMode) => {
-    const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
-    loadStdlib(session)
-    const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
-    const inst = instantiate(type, 'inst', { baseTypeName: typeName, typeArgs: resolved })
-    session.instanceRegistry.set('inst', inst)
+const onePoleFactory: SessionFactory = (mode) => {
+  const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+  loadStdlib(session)
+  const { type, typeArgs } = resolveProgramType(session, 'OnePole', undefined, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: 'OnePole', typeArgs })
+  session.instanceRegistry.set('inst', inst)
+  for (const pn of inputNames(inst)) {
+    if (pn in DEFAULT_INPUTS) session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
+const polyphony8xPhaser16Factory: SessionFactory = (mode) => {
+  const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+  loadStdlib(session)
+  const { type, typeArgs } = resolveProgramType(session, 'Phaser16', undefined, undefined)
+  for (let i = 0; i < 8; i++) {
+    const name = `v${i}`
+    const inst = instantiate(type, name, { baseTypeName: 'Phaser16', typeArgs })
+    session.instanceRegistry.set(name, inst)
     for (const pn of inputNames(inst)) {
-      if (pn in DEFAULT_INPUTS) {
-        session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
-      }
+      if (pn === 'freq') session.inputExprNodes.set(wk(name, pn), 110 + 22 * i)
+      else if (pn in DEFAULT_INPUTS) session.inputExprNodes.set(wk(name, pn), DEFAULT_INPUTS[pn])
     }
-    session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
-    return session
+    session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
   }
+  return session
 }
 
-// Polyphony of stdlib instances with freq spread (when applicable).
-function polyphonyFactory(typeName: string, voiceCount: number, typeArgs?: Record<string, number>) {
-  return (mode: DepthMode) => {
-    const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
-    loadStdlib(session)
-    const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
-    for (let i = 0; i < voiceCount; i++) {
-      const name = `v${i}`
-      const inst = instantiate(type, name, { baseTypeName: typeName, typeArgs: resolved })
-      session.instanceRegistry.set(name, inst)
-      for (const pn of inputNames(inst)) {
-        if (pn === 'freq') {
-          session.inputExprNodes.set(wk(name, pn), 110 + 22 * i)
-        } else if (pn in DEFAULT_INPUTS) {
-          session.inputExprNodes.set(wk(name, pn), DEFAULT_INPUTS[pn])
-        }
-      }
-      session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
-    }
-    return session
-  }
-}
-
-interface BenchCase {
-  name:    string
-  factory: (mode: DepthMode) => ReturnType<typeof makeSession>
-}
-
-// Cases ordered roughly from simple to stress. Phaser16 polyphony is
-// where the slot path's overhead (if any) is most visible — 8 voices ×
-// 17 kernels = 136 instance boundaries in nested mode, vs 8 monolithic
-// flat kernels.
+interface BenchCase { name: string; factory: SessionFactory }
 const CASES: BenchCase[] = [
-  // ── Single instance — leaf (no children); slot path is a no-op
-  { name: 'Sin',                      factory: singleInstanceFactory('Sin') },
-  // ── Single instance — depth-1 children (2-4 sub-instances)
-  { name: 'OnePole',                  factory: singleInstanceFactory('OnePole') },
-  { name: 'Pow',                      factory: singleInstanceFactory('Pow') },
-  { name: 'SVF',                      factory: singleInstanceFactory('SVF') },
-  { name: 'LadderFilter',             factory: singleInstanceFactory('LadderFilter') },
-  // ── Single instance — depth-2 (the honest fractal case)
-  { name: 'Phaser16',                 factory: singleInstanceFactory('Phaser16') },
-  // ── Single instance — depth-3 (Bubble has 5 children, BubbleCloud has 8 Bubbles)
-  { name: 'Bubble',                   factory: singleInstanceFactory('Bubble') },
-  { name: 'BubbleCloud',              factory: singleInstanceFactory('BubbleCloud') },
-  // ── Polyphony — N voices of a leaf type (slot path no-op, baseline)
-  { name: 'polyphony_8x_Sin',         factory: polyphonyFactory('Sin', 8) },
-  { name: 'polyphony_32x_Sin',        factory: polyphonyFactory('Sin', 32) },
-  // ── Polyphony — N voices of a nested type (slot path scales here)
-  { name: 'polyphony_8x_SinOsc',      factory: polyphonyFactory('SinOsc', 8) },
-  { name: 'polyphony_8x_OnePole',     factory: polyphonyFactory('OnePole', 8) },
-  { name: 'polyphony_8x_SVF',         factory: polyphonyFactory('SVF', 8) },
-  { name: 'polyphony_8x_LadderFilter', factory: polyphonyFactory('LadderFilter', 8) },
-  { name: 'polyphony_4x_Phaser16',    factory: polyphonyFactory('Phaser16', 4) },
-  { name: 'polyphony_8x_Phaser16',    factory: polyphonyFactory('Phaser16', 8) },
+  { name: 'OnePole',                 factory: onePoleFactory },
+  { name: 'polyphony_8x_Phaser16',   factory: polyphony8xPhaser16Factory },
 ]
 
-// ──────────────────────────────────────────────────────────────────────
-// Bench one case in one mode
-// ──────────────────────────────────────────────────────────────────────
+// ── Stats ─────────────────────────────────────────────────────────────
+function median(xs: number[]): number {
+  const sorted = [...xs].sort((a, b) => a - b)
+  const n = sorted.length
+  return n % 2 === 1 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+}
 
-function benchOne(name: string, factory: BenchCase['factory'], mode: DepthMode): CaseResult {
+// ── Cache control ─────────────────────────────────────────────────────
+const cacheDir = process.env.XDG_CACHE_HOME
+  ? join(process.env.XDG_CACHE_HOME, 'tropical', 'kernels')
+  : join(homedir(), '.cache', 'tropical', 'kernels')
+function clearCache() { rmSync(cacheDir, { recursive: true, force: true }) }
+
+// ── Compile measurement (one cold trial per axis) ─────────────────────
+interface CompileMeasurement {
+  ts_ms:      number
+  jit_ms:     number
+  instances:  number
+  plan_bytes: number
+}
+
+function measureCompile(factory: SessionFactory, mode: DepthMode): CompileMeasurement {
+  clearCache()
   const session = factory(mode)
-
   const t1 = performance.now()
   const plan = compileSession(session)
-  const tsMs = performance.now() - t1
-
-  const t2 = performance.now()
+  const ts_ms = performance.now() - t1
   const planJson = JSON.stringify(toWirePlan(plan))
-  const stringifyMs = performance.now() - t2
-
-  const t3 = performance.now()
+  const t2 = performance.now()
   session.runtime.loadPlan(planJson)
-  const jitMs = performance.now() - t3
+  const jit_ms = performance.now() - t2
+  return {
+    ts_ms,
+    jit_ms,
+    instances:  plan.instance_functions.length,
+    plan_bytes: planJson.length,
+  }
+}
 
+// ── Runtime measurement (single session, N trials, min) ───────────────
+// Compiled-and-loaded session passed in; this fn only times the loop.
+interface RuntimeMeasurement {
+  ns_per_sample_trials: number[]
+  ns_per_sample_min:    number
+  ns_per_sample_median: number
+  ns_per_sample_max:    number
+}
+
+function runtimeTrial(session: ReturnType<typeof makeSession>): number {
+  const samplesPerTrial = FRAMES_PER_TRIAL * FRAME_SIZE
+  const t0 = performance.now()
+  for (let f = 0; f < FRAMES_PER_TRIAL; f++)
+    b.tropical_runtime_process(session.runtime._h)
+  const elapsed = performance.now() - t0
+  return (elapsed * 1e6) / samplesPerTrial
+}
+
+// ── Build + warmup one session per (case, mode) for runtime trials ────
+interface PreparedSession {
+  caseName: string
+  mode:     DepthMode
+  session:  ReturnType<typeof makeSession>
+  trials:   number[]
+}
+
+function prepare(factory: SessionFactory, mode: DepthMode, caseName: string): PreparedSession {
+  const session = factory(mode)
+  const plan = compileSession(session)
+  const planJson = JSON.stringify(toWirePlan(plan))
+  session.runtime.loadPlan(planJson)
   for (let i = 0; i < WARMUP_FRAMES; i++)
     b.tropical_runtime_process(session.runtime._h)
-
-  const tProc0 = performance.now()
-  for (let i = 0; i < BENCH_FRAMES; i++)
-    b.tropical_runtime_process(session.runtime._h)
-  const procMs = performance.now() - tProc0
-
-  const totalSamples = BENCH_FRAMES * FRAME_SIZE
-  const nsPerSample  = (procMs * 1e6) / totalSamples
-  const samplePeriod = 1e9 / SAMPLE_RATE
-
-  return {
-    case:          name,
-    instances:     plan.instance_functions.length,
-    mode,
-    ts_ms:         tsMs,
-    stringify_ms:  stringifyMs,
-    jit_ms:        jitMs,
-    ns_per_sample: nsPerSample,
-    rt_ratio:      nsPerSample / samplePeriod,
-    plan_bytes:    planJson.length,
-  }
+  return { caseName, mode, session, trials: [] }
 }
 
 // ──────────────────────────────────────────────────────────────────────
 // Run
 // ──────────────────────────────────────────────────────────────────────
 
-const COLS = [
-  'case', 'instances', 'mode',
-  'ts_ms', 'jit_ms', 'plan_kb',
-  'ns/sample', 'rt_ratio',
-]
-console.log(COLS.join('\t'))
+console.log('=== Compile measurements (one cold-cache trial per axis) ===')
+console.log('case                          mode    instances    ts_ms   jit_ms  plan_kb')
 
+const compile: Record<string, Record<DepthMode, CompileMeasurement>> = {}
+for (const c of CASES) {
+  compile[c.name] = {} as Record<DepthMode, CompileMeasurement>
+  for (const mode of ['flat', 'nested'] as const) {
+    const m = measureCompile(c.factory, mode)
+    compile[c.name][mode] = m
+    console.log(
+      `${c.name.padEnd(30)}${mode.padEnd(8)}${String(m.instances).padStart(5)}     ` +
+      `${m.ts_ms.toFixed(1).padStart(6)}  ${m.jit_ms.toFixed(1).padStart(7)}  ${(m.plan_bytes / 1024).toFixed(1).padStart(7)}`,
+    )
+  }
+}
+
+// Runtime: prepare all sessions, then interleave trials.
+console.log('\n=== Runtime measurements (N=3 trials, interleaved, min reported) ===')
+const prepared: PreparedSession[] = []
 for (const c of CASES) {
   for (const mode of ['flat', 'nested'] as const) {
-    try {
-      const r = benchOne(c.name, c.factory, mode)
-      results.push(r)
-      console.log(
-        [
-          r.case,
-          r.instances,
-          r.mode,
-          r.ts_ms.toFixed(1),
-          r.jit_ms.toFixed(1),
-          (r.plan_bytes / 1024).toFixed(1),
-          r.ns_per_sample.toFixed(1),
-          `${(r.rt_ratio * 100).toFixed(2)}%`,
-        ].join('\t'),
-      )
-    } catch (e: any) {
-      console.log(`${c.name}\t-\t${mode}\tERR\t${e.message.split('\n')[0].slice(0, 200)}`)
-    }
+    prepared.push(prepare(c.factory, mode, c.name))
   }
 }
 
-// ──────────────────────────────────────────────────────────────────────
-// Mode deltas — the bottom line for the deletion decision
-// ──────────────────────────────────────────────────────────────────────
-
-interface Delta {
-  case:           string
-  instances:      number
-  flat_ns:        number
-  nested_ns:      number
-  slowdown:       number   // nested / flat; >1 = nested slower
-  flat_jit_ms:    number
-  nested_jit_ms:  number
-  jit_ratio:      number   // nested_jit / flat_jit
-  plan_size_ratio: number  // nested_bytes / flat_bytes
-}
-
-const deltas: Delta[] = []
-for (const c of CASES) {
-  const f = results.find(r => r.case === c.name && r.mode === 'flat')
-  const n = results.find(r => r.case === c.name && r.mode === 'nested')
-  if (f && n) {
-    deltas.push({
-      case:            c.name,
-      instances:       n.instances,  // nested has more (every sub-instance is its own)
-      flat_ns:         f.ns_per_sample,
-      nested_ns:       n.ns_per_sample,
-      slowdown:        n.ns_per_sample / f.ns_per_sample,
-      flat_jit_ms:     f.jit_ms,
-      nested_jit_ms:   n.jit_ms,
-      jit_ratio:       n.jit_ms / f.jit_ms,
-      plan_size_ratio: n.plan_bytes / f.plan_bytes,
-    })
+// Round-robin: trial_k for every (case, mode) before advancing to trial_k+1
+for (let k = 0; k < RUNTIME_TRIALS; k++) {
+  for (const p of prepared) {
+    p.trials.push(runtimeTrial(p.session))
   }
 }
 
-console.log('\nDeltas (nested / flat):')
-console.log('  case                            flat_inst  nested_inst  ns_ratio  jit_ratio  plan_ratio')
-for (const d of deltas) {
-  const f = results.find(r => r.case === d.case && r.mode === 'flat')!
+console.log('case                          mode    trials (ns/sample)            min     median  max')
+const runtime: Record<string, Record<DepthMode, RuntimeMeasurement>> = {}
+for (const p of prepared) {
+  const sorted = [...p.trials].sort((a, b) => a - b)
+  const m: RuntimeMeasurement = {
+    ns_per_sample_trials: p.trials,
+    ns_per_sample_min:    sorted[0],
+    ns_per_sample_median: median(p.trials),
+    ns_per_sample_max:    sorted[sorted.length - 1],
+  }
+  if (!runtime[p.caseName]) runtime[p.caseName] = {} as Record<DepthMode, RuntimeMeasurement>
+  runtime[p.caseName][p.mode] = m
+  const trialStr = p.trials.map(t => t.toFixed(1).padStart(7)).join(' ')
   console.log(
-    `  ${d.case.padEnd(30)} ` +
-    `${String(f.instances).padStart(5)}      ` +
-    `${String(d.instances).padStart(5)}        ` +
-    `${d.slowdown.toFixed(2)}×    ` +
-    `${d.jit_ratio.toFixed(2)}×     ` +
-    `${d.plan_size_ratio.toFixed(2)}×`,
+    `${p.caseName.padEnd(30)}${p.mode.padEnd(8)}${trialStr}    ` +
+    `${m.ns_per_sample_min.toFixed(1).padStart(6)}  ${m.ns_per_sample_median.toFixed(1).padStart(6)}  ${m.ns_per_sample_max.toFixed(1).padStart(6)}`,
   )
 }
 
+// ── Deltas (the bottom line) ──────────────────────────────────────────
+console.log('\n=== Deltas (nested / flat; ratios on min for runtime, median for compile) ===')
+console.log('case                          ns_min  jit_med  plan')
+const deltas: any[] = []
+const samplePeriod = 1e9 / SAMPLE_RATE
+for (const c of CASES) {
+  const f = { ...runtime[c.name].flat,   ...compile[c.name].flat   }
+  const n = { ...runtime[c.name].nested, ...compile[c.name].nested }
+  const d = {
+    case:              c.name,
+    instances:         compile[c.name].nested.instances,
+    flat_ns_min:       f.ns_per_sample_min,
+    nested_ns_min:     n.ns_per_sample_min,
+    ns_ratio:          n.ns_per_sample_min / f.ns_per_sample_min,
+    flat_jit_ms:       compile[c.name].flat.jit_ms,
+    nested_jit_ms:     compile[c.name].nested.jit_ms,
+    jit_ratio:         compile[c.name].nested.jit_ms / compile[c.name].flat.jit_ms,
+    flat_plan_bytes:   compile[c.name].flat.plan_bytes,
+    nested_plan_bytes: compile[c.name].nested.plan_bytes,
+    plan_ratio:        compile[c.name].nested.plan_bytes / compile[c.name].flat.plan_bytes,
+    flat_rt_pct:       f.ns_per_sample_min / samplePeriod,
+    nested_rt_pct:     n.ns_per_sample_min / samplePeriod,
+  }
+  deltas.push(d)
+  console.log(
+    `${d.case.padEnd(30)}${d.ns_ratio.toFixed(3)}×  ${d.jit_ratio.toFixed(3)}×   ${d.plan_ratio.toFixed(3)}×`,
+  )
+}
+
+// ── Persist ───────────────────────────────────────────────────────────
 const resultFile = '/tmp/depth_bench.json'
 writeFileSync(resultFile, JSON.stringify({
   config: {
-    frame_size:    FRAME_SIZE,
-    bench_frames:  BENCH_FRAMES,
-    warmup_frames: WARMUP_FRAMES,
-    sample_rate:   SAMPLE_RATE,
+    frame_size:       FRAME_SIZE,
+    frames_per_trial: FRAMES_PER_TRIAL,
+    runtime_trials:   RUNTIME_TRIALS,
+    warmup_frames:    WARMUP_FRAMES,
+    sample_rate:      SAMPLE_RATE,
+    methodology_note: 'min-of-3 for runtime per runtime_noise_meta.ts; ' +
+                      'single cold trial for compile (engine has process-singleton ' +
+                      'in-memory cache; cannot measure multiple cold compiles in one process)',
   },
-  results,
+  compile,
+  runtime,
   deltas,
-  timestamp:       new Date().toISOString(),
+  timestamp: new Date().toISOString(),
 }, null, 2))
 console.log(`\nResults written to ${resultFile}`)

--- a/tests/bench/depth_vs_flat.ts
+++ b/tests/bench/depth_vs_flat.ts
@@ -1,0 +1,311 @@
+/**
+ * depth_vs_flat.ts — head-to-head bench: legacy inline-everything path
+ * (`inlineNested:true`, the flat per-instance kernel) vs the M11
+ * fractal slot path (`inlineNested:false`, every sub-instance is its
+ * own kernel boundary with per-port input/output slots).
+ *
+ * Mirror of `microkernel_vs_fused.ts`'s structure. For each case,
+ * compile + run twice — once per mode — and report:
+ *   - ts_ms        TS pipeline time (parse, strata, partition)
+ *   - jit_ms       LLVM IR generation + native compile
+ *   - ns_per_sample  audio-thread cost
+ *   - rt_ratio     fraction of a 44.1kHz sample period (lower = more headroom)
+ *
+ * The slot path's overhead comes from:
+ *   - Extra WriteSlot/ReadSlot at every kernel boundary (LLVM should
+ *     fold the store-load round trip in fused mode, but there's still
+ *     a register pressure cost)
+ *   - More LLVM instructions in the IR (per-child wire blocks aren't
+ *     inlined into the parent body)
+ *   - More slot-array accesses (parent writes child input slot, child
+ *     reads parent-allocated output slot)
+ *
+ * Counterbalanced (potentially) by:
+ *   - Less duplicated codegen — sibling instances of the same type
+ *     share an LLVM function in microkernel mode (no-op in fused mode)
+ *   - Smaller per-kernel instruction streams may compile faster
+ *
+ * Usage: bun run tests/bench/depth_vs_flat.ts [--frames=N] [--keep-cache]
+ *
+ * Output: /tmp/depth_bench.json (consumed by the Phase 6 snapshot doc)
+ */
+import { writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import {
+  makeSession,
+  resolveProgramType, instantiate, outputNames, inputNames,
+} from '../../compiler/session.js'
+import type { ExprNode } from '../../compiler/expr.js'
+import { loadStdlib } from '../../compiler/program.js'
+import { compileSession } from '../../compiler/ir/compile_session.js'
+import { toWirePlan } from '../../compiler/flat_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+import * as b from '../../compiler/runtime/bindings.js'
+
+const args = process.argv.slice(2)
+const keepCache = args.includes('--keep-cache')
+const framesArg = args.find(a => a.startsWith('--frames='))
+const BENCH_FRAMES = framesArg ? parseInt(framesArg.split('=')[1], 10) : 4096
+const FRAME_SIZE   = 256
+const SAMPLE_RATE  = 44100
+const WARMUP_FRAMES = 32
+
+if (!keepCache) {
+  const cacheDir = process.env.XDG_CACHE_HOME
+    ? join(process.env.XDG_CACHE_HOME, 'tropical', 'kernels')
+    : join(homedir(), '.cache', 'tropical', 'kernels')
+  rmSync(cacheDir, { recursive: true, force: true })
+  console.log(`(cold) cleared ${cacheDir}`)
+}
+
+type DepthMode = 'flat' | 'nested'
+
+interface CaseResult {
+  case:           string
+  instances:      number
+  mode:           DepthMode
+  ts_ms:          number
+  stringify_ms:   number
+  jit_ms:         number
+  ns_per_sample:  number
+  rt_ratio:       number
+  plan_bytes:     number
+}
+
+const results: CaseResult[] = []
+
+// ── Default port values for stdlib programs that need them ────────────
+function pulseEvery(n: number): ExprNode {
+  return { op: 'lt', args: [{ op: 'mod', args: [{ op: 'sampleIndex' }, n] }, 1] }
+}
+
+const DEFAULT_INPUTS: Record<string, ExprNode> = {
+  freq: 220, x: 0.5, y: 0.5, audio: 0.5, input: 0.5, cv: 0.5,
+  cutoff: 1000, q: 0.5, drive: 1.0, mix: 0.5, a: 0.3, b: 0.7,
+  coeff: 0.4, feedback: 0.4, lfo_speed: 0.2, decay: 0.99,
+  rate: 5, g: 0.1, resonance: 0.5,
+  trigger: pulseEvery(64), clock: pulseEvery(32),
+}
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+
+// ──────────────────────────────────────────────────────────────────────
+// Session builders
+// ──────────────────────────────────────────────────────────────────────
+
+// Single stdlib instance with default inputs.
+function singleInstanceFactory(typeName: string, typeArgs?: Record<string, number>) {
+  return (mode: DepthMode) => {
+    const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+    loadStdlib(session)
+    const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
+    const inst = instantiate(type, 'inst', { baseTypeName: typeName, typeArgs: resolved })
+    session.instanceRegistry.set('inst', inst)
+    for (const pn of inputNames(inst)) {
+      if (pn in DEFAULT_INPUTS) {
+        session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
+      }
+    }
+    session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+    return session
+  }
+}
+
+// Polyphony of stdlib instances with freq spread (when applicable).
+function polyphonyFactory(typeName: string, voiceCount: number, typeArgs?: Record<string, number>) {
+  return (mode: DepthMode) => {
+    const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+    loadStdlib(session)
+    const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
+    for (let i = 0; i < voiceCount; i++) {
+      const name = `v${i}`
+      const inst = instantiate(type, name, { baseTypeName: typeName, typeArgs: resolved })
+      session.instanceRegistry.set(name, inst)
+      for (const pn of inputNames(inst)) {
+        if (pn === 'freq') {
+          session.inputExprNodes.set(wk(name, pn), 110 + 22 * i)
+        } else if (pn in DEFAULT_INPUTS) {
+          session.inputExprNodes.set(wk(name, pn), DEFAULT_INPUTS[pn])
+        }
+      }
+      session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
+    }
+    return session
+  }
+}
+
+interface BenchCase {
+  name:    string
+  factory: (mode: DepthMode) => ReturnType<typeof makeSession>
+}
+
+// Cases ordered roughly from simple to stress. Phaser16 polyphony is
+// where the slot path's overhead (if any) is most visible — 8 voices ×
+// 17 kernels = 136 instance boundaries in nested mode, vs 8 monolithic
+// flat kernels.
+const CASES: BenchCase[] = [
+  // ── Single instance — leaf (no children); slot path is a no-op
+  { name: 'Sin',                      factory: singleInstanceFactory('Sin') },
+  // ── Single instance — depth-1 children (2-4 sub-instances)
+  { name: 'OnePole',                  factory: singleInstanceFactory('OnePole') },
+  { name: 'Pow',                      factory: singleInstanceFactory('Pow') },
+  { name: 'SVF',                      factory: singleInstanceFactory('SVF') },
+  { name: 'LadderFilter',             factory: singleInstanceFactory('LadderFilter') },
+  // ── Single instance — depth-2 (the honest fractal case)
+  { name: 'Phaser16',                 factory: singleInstanceFactory('Phaser16') },
+  // ── Single instance — depth-3 (Bubble has 5 children, BubbleCloud has 8 Bubbles)
+  { name: 'Bubble',                   factory: singleInstanceFactory('Bubble') },
+  { name: 'BubbleCloud',              factory: singleInstanceFactory('BubbleCloud') },
+  // ── Polyphony — N voices of a leaf type (slot path no-op, baseline)
+  { name: 'polyphony_8x_Sin',         factory: polyphonyFactory('Sin', 8) },
+  { name: 'polyphony_32x_Sin',        factory: polyphonyFactory('Sin', 32) },
+  // ── Polyphony — N voices of a nested type (slot path scales here)
+  { name: 'polyphony_8x_SinOsc',      factory: polyphonyFactory('SinOsc', 8) },
+  { name: 'polyphony_8x_OnePole',     factory: polyphonyFactory('OnePole', 8) },
+  { name: 'polyphony_8x_SVF',         factory: polyphonyFactory('SVF', 8) },
+  { name: 'polyphony_8x_LadderFilter', factory: polyphonyFactory('LadderFilter', 8) },
+  { name: 'polyphony_4x_Phaser16',    factory: polyphonyFactory('Phaser16', 4) },
+  { name: 'polyphony_8x_Phaser16',    factory: polyphonyFactory('Phaser16', 8) },
+]
+
+// ──────────────────────────────────────────────────────────────────────
+// Bench one case in one mode
+// ──────────────────────────────────────────────────────────────────────
+
+function benchOne(name: string, factory: BenchCase['factory'], mode: DepthMode): CaseResult {
+  const session = factory(mode)
+
+  const t1 = performance.now()
+  const plan = compileSession(session)
+  const tsMs = performance.now() - t1
+
+  const t2 = performance.now()
+  const planJson = JSON.stringify(toWirePlan(plan))
+  const stringifyMs = performance.now() - t2
+
+  const t3 = performance.now()
+  session.runtime.loadPlan(planJson)
+  const jitMs = performance.now() - t3
+
+  for (let i = 0; i < WARMUP_FRAMES; i++)
+    b.tropical_runtime_process(session.runtime._h)
+
+  const tProc0 = performance.now()
+  for (let i = 0; i < BENCH_FRAMES; i++)
+    b.tropical_runtime_process(session.runtime._h)
+  const procMs = performance.now() - tProc0
+
+  const totalSamples = BENCH_FRAMES * FRAME_SIZE
+  const nsPerSample  = (procMs * 1e6) / totalSamples
+  const samplePeriod = 1e9 / SAMPLE_RATE
+
+  return {
+    case:          name,
+    instances:     plan.instance_functions.length,
+    mode,
+    ts_ms:         tsMs,
+    stringify_ms:  stringifyMs,
+    jit_ms:        jitMs,
+    ns_per_sample: nsPerSample,
+    rt_ratio:      nsPerSample / samplePeriod,
+    plan_bytes:    planJson.length,
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Run
+// ──────────────────────────────────────────────────────────────────────
+
+const COLS = [
+  'case', 'instances', 'mode',
+  'ts_ms', 'jit_ms', 'plan_kb',
+  'ns/sample', 'rt_ratio',
+]
+console.log(COLS.join('\t'))
+
+for (const c of CASES) {
+  for (const mode of ['flat', 'nested'] as const) {
+    try {
+      const r = benchOne(c.name, c.factory, mode)
+      results.push(r)
+      console.log(
+        [
+          r.case,
+          r.instances,
+          r.mode,
+          r.ts_ms.toFixed(1),
+          r.jit_ms.toFixed(1),
+          (r.plan_bytes / 1024).toFixed(1),
+          r.ns_per_sample.toFixed(1),
+          `${(r.rt_ratio * 100).toFixed(2)}%`,
+        ].join('\t'),
+      )
+    } catch (e: any) {
+      console.log(`${c.name}\t-\t${mode}\tERR\t${e.message.split('\n')[0].slice(0, 200)}`)
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Mode deltas — the bottom line for the deletion decision
+// ──────────────────────────────────────────────────────────────────────
+
+interface Delta {
+  case:           string
+  instances:      number
+  flat_ns:        number
+  nested_ns:      number
+  slowdown:       number   // nested / flat; >1 = nested slower
+  flat_jit_ms:    number
+  nested_jit_ms:  number
+  jit_ratio:      number   // nested_jit / flat_jit
+  plan_size_ratio: number  // nested_bytes / flat_bytes
+}
+
+const deltas: Delta[] = []
+for (const c of CASES) {
+  const f = results.find(r => r.case === c.name && r.mode === 'flat')
+  const n = results.find(r => r.case === c.name && r.mode === 'nested')
+  if (f && n) {
+    deltas.push({
+      case:            c.name,
+      instances:       n.instances,  // nested has more (every sub-instance is its own)
+      flat_ns:         f.ns_per_sample,
+      nested_ns:       n.ns_per_sample,
+      slowdown:        n.ns_per_sample / f.ns_per_sample,
+      flat_jit_ms:     f.jit_ms,
+      nested_jit_ms:   n.jit_ms,
+      jit_ratio:       n.jit_ms / f.jit_ms,
+      plan_size_ratio: n.plan_bytes / f.plan_bytes,
+    })
+  }
+}
+
+console.log('\nDeltas (nested / flat):')
+console.log('  case                            flat_inst  nested_inst  ns_ratio  jit_ratio  plan_ratio')
+for (const d of deltas) {
+  const f = results.find(r => r.case === d.case && r.mode === 'flat')!
+  console.log(
+    `  ${d.case.padEnd(30)} ` +
+    `${String(f.instances).padStart(5)}      ` +
+    `${String(d.instances).padStart(5)}        ` +
+    `${d.slowdown.toFixed(2)}×    ` +
+    `${d.jit_ratio.toFixed(2)}×     ` +
+    `${d.plan_size_ratio.toFixed(2)}×`,
+  )
+}
+
+const resultFile = '/tmp/depth_bench.json'
+writeFileSync(resultFile, JSON.stringify({
+  config: {
+    frame_size:    FRAME_SIZE,
+    bench_frames:  BENCH_FRAMES,
+    warmup_frames: WARMUP_FRAMES,
+    sample_rate:   SAMPLE_RATE,
+  },
+  results,
+  deltas,
+  timestamp:       new Date().toISOString(),
+}, null, 2))
+console.log(`\nResults written to ${resultFile}`)

--- a/tests/bench/depth_vs_flat_2026-05-23.md
+++ b/tests/bench/depth_vs_flat_2026-05-23.md
@@ -1,0 +1,189 @@
+# Benchmark Results: input-slot refactor — depth vs flat
+
+| Field           | Value                                       |
+|-----------------|---------------------------------------------|
+| Date            | 2026-05-23                                  |
+| Branch          | `input-slot-refactor`                       |
+| Captured at     | commit `7b5a09e` (post Phase 5)             |
+| Hardware        | darwin/aarch64 (Apple Silicon, M-series)    |
+| LLVM            | 22.1.1                                      |
+| Opt level       | `OptimizationLevel::O2`                     |
+| Reproduce       | `bun run tests/bench/depth_vs_flat.ts`      |
+
+Benchmark numbers are temporal artifacts. When the bench script
+changes shape or the engine's emit strategy materially shifts, this
+file should be re-captured against the new commit hash. Treat it as
+a snapshot, not a spec.
+
+**Decision (at time of capture):** **NO-GO on inlineInstances
+deletion** — keep both paths alive. Slot path is correct (Phase 4
+gate is green for all currently-compiling cases) and competitive,
+but introduces a 5-27% runtime overhead and a 18-59% JIT compile
+overhead on genuinely-nested programs. It also exposes a real
+correctness gap on `Bubble` / `BubbleCloud` (regs with non-literal
+inits in sub-programs). The inline path is still pulling its
+weight; defer deletion until the correctness gap closes and the
+overhead numbers either improve or motivate a different path.
+
+## What was measured
+
+For each of 16 cases, we compiled and ran the same session graph
+twice — once with `inlineNested:true` (legacy flat IR; the
+`inlineInstances` strata pass splices every sub-instance into its
+parent's body, producing one monolithic per-instance kernel), once
+with `inlineNested:false` (M11 fractal slot path; every sub-instance
+stays a kernel boundary with per-port WriteSlot / Slot reads
+crossing it). We recorded TS pipeline time, LLVM JIT time, kernel
+ns/sample, and wire-format plan size.
+
+Methodology: cold disk cache, 32-frame warmup, 4096 frames × 256
+samples measured, ns/sample = wall / total_samples. Independent
+session per (case, mode) pair so register / slot init starts from
+the same place in both runs.
+
+## Headline numbers
+
+| Case                       | Inst | Flat ns/s | Nested ns/s | Slowdown | Flat JIT | Nested JIT | Plan size |
+|----------------------------|-----:|----------:|------------:|---------:|---------:|-----------:|----------:|
+| Sin                        |    1 |       2.1 |         1.9 |   0.94×  |    13 ms |    0.1 ms* |    1.00×  |
+| OnePole                    |    1 |       8.3 |         9.1 |   1.09×  |    11 ms |      10 ms |    1.31×  |
+| Pow                        |    1 |       9.8 |         5.7 |   0.60×  |    34 ms |      22 ms |    0.73×  |
+| SVF                        |    1 |       8.6 |         8.5 |   0.99×  |    11 ms |    0.1 ms* |    1.00×  |
+| LadderFilter               |    1 |      38.3 |        41.6 |   1.12×  |    24 ms |      30 ms |    1.41×  |
+| Phaser16                   |    1 |      48.2 |        49.4 |   1.06×  |    35 ms |      58 ms |    1.61×  |
+| Bubble                     |    1 |      26.8 |       _ERR_ |     —    |    25 ms |      _ERR_ |     —     |
+| BubbleCloud                |    1 |     212.6 |       _ERR_ |     —    |   743 ms |      _ERR_ |     —     |
+| polyphony 8x Sin           |    8 |      18.6 |        18.7 |   1.01×  |    69 ms |    0.4 ms* |    1.00×  |
+| polyphony 32x Sin          |   32 |      88.8 |        88.7 |   1.00×  |   536 ms |    1.5 ms* |    1.00×  |
+| polyphony 8x SinOsc        |    8 |      36.7 |        39.4 |   1.07×  |    51 ms |      73 ms |    1.03×  |
+| polyphony 8x OnePole       |    8 |      25.0 |        29.7 |   1.19×  |    25 ms |      38 ms |    1.33×  |
+| polyphony 8x SVF           |    8 |      37.1 |        36.9 |   1.00×  |    60 ms |    0.6 ms* |    1.00×  |
+| polyphony 8x LadderFilter  |    8 |     219.9 |       275.5 |   1.25×  |   351 ms |     442 ms |    1.41×  |
+| polyphony 4x Phaser16      |    4 |     170.5 |       187.1 |   1.10×  |   579 ms |     485 ms |    1.61×  |
+| polyphony 8x Phaser16      |    8 |     329.0 |       410.9 |   1.25×  |   763 ms |     904 ms |    1.61×  |
+
+`*` Cache hit. When a program has no nested sub-instances (Sin, SVF,
+polyphony-of-leaf-types), both modes produce byte-identical IR; the
+nested-mode run hits the warm disk cache populated by the flat-mode
+run that preceded it. The number reflects cache lookup, not actual
+JIT work.
+
+## What the numbers say
+
+**1. Leaf cases are free.** Programs with no nested sub-instances
+(Sin, SVF, polyphony of either) produce identical IR in both modes
+and run identically. The slot path adds zero overhead when there's
+nothing to slot.
+
+**2. Genuine nested cases pay 5-25% runtime overhead.** The slot
+path's WriteSlot / Slot round-trip at each kernel boundary doesn't
+fully fold away under LLVM O2. Worst case observed:
+`polyphony_8x_LadderFilter` at 1.25× and `polyphony_8x_Phaser16` at
+1.25×. The cost scales with kernel-boundary density, not just
+instance count — 8x Phaser16 (136 nested kernels) costs more than
+32x Sin (32 monolithic kernels) per sample even though Sin's
+instance count is higher.
+
+**3. JIT compile overhead is larger but still small in absolute
+terms.** Nested-mode IR is 30-60% larger (the per-child WriteSlots
+add up), and LLVM takes ~20-50% longer to JIT it. For
+`polyphony_8x_Phaser16` that's 904 ms vs 763 ms — both noticeable
+on cold compile, neither blocking interactivity once the disk
+cache is warm.
+
+**4. Pow is the surprise outlier.** Pow compiled in nested mode is
+0.60× the runtime cost of the flat compile, and 0.66× the JIT
+cost. Pow is `exp(y * log(x))` — the flat compile produces a giant
+chained expression that LLVM apparently handles WORSE than the
+slot-broken nested version. Sample size of one; not load-bearing,
+but worth remembering when designing the next layer of
+optimization.
+
+**5. `polyphony_4x_Phaser16` shows nested JIT FASTER (0.84×).**
+For polyphonies of complex programs, nested mode appears to give
+LLVM more uniform per-function work units to chew through, while
+the flat compile produces 4 enormous functions back-to-back. The
+crossover seems to be around 4-8 voices; at 8x Phaser16 the nested
+mode is 1.18× slower again. Worth investigating if anyone wants
+to chase polyphony-of-complex-programs perf.
+
+**6. The realtime budget is uncontested either way.** Worst case
+(`polyphony_8x_Phaser16` nested) sits at 1.81% of a 44.1kHz sample
+period. Plenty of headroom for both modes. The slowdown ratios
+matter for fitting MORE work into a single buffer, not for hitting
+realtime at all.
+
+## Bubble / BubbleCloud: the real-correctness gap
+
+These two cases ERR'd in nested mode:
+
+```
+compileResolved: register init must lower to a literal value
+```
+
+Root cause: when `inlineInstances` is skipped (the slot path's
+whole point), each child sub-instance keeps its own
+`ResolvedProgram`, and that program's `RegDecl.init` may be an
+ExprNode that the flat path implicitly reduced as a side effect of
+splicing. `compileResolved`'s `regInit` helper accepts only
+literal numbers / booleans / arrays / `zeros{N}` — not arbitrary
+ExprNodes.
+
+Bubble has a `reg env_smooth = 0` (literal, fine) but it inherits
+nested children (SampleHold, TriggerRamp, Exp, EnvExpDecay, SVF),
+one of which presumably has a non-literal init. Same shape recurs
+in BubbleCloud (8x Bubble).
+
+This is a real correctness gap in the slot path. It needs to be
+fixed before any deletion-of-`inlineInstances` decision can land.
+Possible approaches:
+
+  1. Strengthen `compileResolved`'s `regInit` to evaluate constant
+     ExprNodes (a small constant-folding step).
+  2. Add a pre-emit strata pass that reduces register inits
+     specifically (similar to how `extractSessionDelays` runs as a
+     pre-emit pass).
+  3. Make `inlineInstances` itself idempotent and per-program
+     (not per-top-level), so sub-programs get their inits reduced
+     during their own compile rather than via parent splicing.
+
+Approach 1 is smallest. Approach 2 is most aligned with the strata-
+pipeline shape. Approach 3 is the most invasive but might be the
+right factoring long-term.
+
+## Recommendation for the followup deletion PR
+
+**Don't delete `inlineInstances` yet.** Three blockers:
+
+  1. The Bubble / BubbleCloud correctness gap above. Until any
+     stdlib program can compile under `inlineNested:false`, the
+     slot path is not a drop-in replacement.
+
+  2. The 5-25% runtime overhead is real but not catastrophic. If
+     we can land the inputs-substitution rewrite WITHOUT this
+     overhead — through LLVM passes, better slot fusion, or
+     something else — the deletion case becomes much stronger.
+
+  3. The slot path's larger IR (~1.5× plan size) inflates the disk
+     cache footprint and the JSON-shipping overhead between TS and
+     C++. Worth optimizing the wire format (per-child blocks could
+     elide their `pre_input_instructions` wrapper for the empty
+     case, already done) before committing.
+
+**Keep both paths alive.** `inlineNested:true` remains the default;
+`inlineNested:false` is the opt-in for the nested-aware tests
+(`tests/equiv/nested_vs_inlined.test.ts`) and any future work that
+needs per-kernel hot-swap, voice scopes, or per-instance JIT cache
+keys (all of which want kernel boundaries to survive into the
+emitted IR).
+
+**Next milestones for slot-path adoption:**
+  - Fix the Bubble / BubbleCloud register-init gap
+  - Add depth-4 synthetic stress cases (constructed
+    programmatically; currently the deepest real-stdlib case is
+    depth-3 BubbleCloud)
+  - Investigate why `polyphony_8x_OnePole` is the worst-scaling
+    polyphony case (1.19× runtime + 1.52× JIT) despite OnePole
+    being a relatively simple program
+  - Measure the slot path under a `-O3` JIT (currently `O2`) to see
+    if more aggressive load-store forwarding closes the gap

--- a/tests/bench/depth_vs_flat_2026-05-23.md
+++ b/tests/bench/depth_vs_flat_2026-05-23.md
@@ -4,148 +4,135 @@
 |-----------------|---------------------------------------------|
 | Date            | 2026-05-23                                  |
 | Branch          | `input-slot-refactor`                       |
-| Captured at     | commit `7b5a09e` (post Phase 5)             |
+| Captured at     | post-meta-bench rewrite                     |
 | Hardware        | darwin/aarch64 (Apple Silicon, M-series)    |
 | LLVM            | 22.1.1                                      |
 | Opt level       | `OptimizationLevel::O2`                     |
 | Reproduce       | `bun run tests/bench/depth_vs_flat.ts`      |
 
-Benchmark numbers are temporal artifacts. When the bench script
-changes shape or the engine's emit strategy materially shifts, this
-file should be re-captured against the new commit hash. Treat it as
-a snapshot, not a spec.
+Benchmark numbers are temporal artifacts. When the bench script or
+the engine's emit strategy materially shifts, re-capture against the
+new commit hash. Treat as a snapshot, not a spec.
 
-**Decision (at time of capture):** **NO-GO on inlineInstances
+**Decision (at time of capture):** **NO-GO on `inlineInstances`
 deletion** — keep both paths alive. Slot path is correct (Phase 4
-gate is green for all currently-compiling cases) and competitive,
-but introduces a 5-27% runtime overhead and a 18-59% JIT compile
-overhead on genuinely-nested programs. It also exposes a real
-correctness gap on `Bubble` / `BubbleCloud` (regs with non-literal
-inits in sub-programs). The inline path is still pulling its
-weight; defer deletion until the correctness gap closes and the
-overhead numbers either improve or motivate a different path.
+gate is green for all currently-compiling cases) and competitive at
+the small scale, but 25% slower at runtime on the realistic stress
+case and exposes a Bubble/BubbleCloud correctness gap. Inline path
+still earns its keep.
 
-## What was measured
+## Methodology
 
-For each of 16 cases, we compiled and ran the same session graph
-twice — once with `inlineNested:true` (legacy flat IR; the
-`inlineInstances` strata pass splices every sub-instance into its
-parent's body, producing one monolithic per-instance kernel), once
-with `inlineNested:false` (M11 fractal slot path; every sub-instance
-stays a kernel boundary with per-port WriteSlot / Slot reads
-crossing it). We recorded TS pipeline time, LLVM JIT time, kernel
-ns/sample, and wire-format plan size.
+Two cases bracket the deletion decision:
 
-Methodology: cold disk cache, 32-frame warmup, 4096 frames × 256
-samples measured, ns/sample = wall / total_samples. Independent
-session per (case, mode) pair so register / slot init starts from
-the same place in both runs.
+  - **OnePole** — minimal nested (2 children). Is the slot path's
+    overhead detectable at the smallest scale?
+  - **polyphony_8x_Phaser16** — stress (8 voices × 17 nested kernels
+    = 136 kernel boundaries). Is the overhead tolerable at scale?
 
-## Headline numbers
+For each (case, mode):
 
-| Case                       | Inst | Flat ns/s | Nested ns/s | Slowdown | Flat JIT | Nested JIT | Plan size |
-|----------------------------|-----:|----------:|------------:|---------:|---------:|-----------:|----------:|
-| Sin                        |    1 |       2.1 |         1.9 |   0.94×  |    13 ms |    0.1 ms* |    1.00×  |
-| OnePole                    |    1 |       8.3 |         9.1 |   1.09×  |    11 ms |      10 ms |    1.31×  |
-| Pow                        |    1 |       9.8 |         5.7 |   0.60×  |    34 ms |      22 ms |    0.73×  |
-| SVF                        |    1 |       8.6 |         8.5 |   0.99×  |    11 ms |    0.1 ms* |    1.00×  |
-| LadderFilter               |    1 |      38.3 |        41.6 |   1.12×  |    24 ms |      30 ms |    1.41×  |
-| Phaser16                   |    1 |      48.2 |        49.4 |   1.06×  |    35 ms |      58 ms |    1.61×  |
-| Bubble                     |    1 |      26.8 |       _ERR_ |     —    |    25 ms |      _ERR_ |     —     |
-| BubbleCloud                |    1 |     212.6 |       _ERR_ |     —    |   743 ms |      _ERR_ |     —     |
-| polyphony 8x Sin           |    8 |      18.6 |        18.7 |   1.01×  |    69 ms |    0.4 ms* |    1.00×  |
-| polyphony 32x Sin          |   32 |      88.8 |        88.7 |   1.00×  |   536 ms |    1.5 ms* |    1.00×  |
-| polyphony 8x SinOsc        |    8 |      36.7 |        39.4 |   1.07×  |    51 ms |      73 ms |    1.03×  |
-| polyphony 8x OnePole       |    8 |      25.0 |        29.7 |   1.19×  |    25 ms |      38 ms |    1.33×  |
-| polyphony 8x SVF           |    8 |      37.1 |        36.9 |   1.00×  |    60 ms |    0.6 ms* |    1.00×  |
-| polyphony 8x LadderFilter  |    8 |     219.9 |       275.5 |   1.25×  |   351 ms |     442 ms |    1.41×  |
-| polyphony 4x Phaser16      |    4 |     170.5 |       187.1 |   1.10×  |   579 ms |     485 ms |    1.61×  |
-| polyphony 8x Phaser16      |    8 |     329.0 |       410.9 |   1.25×  |   763 ms |     904 ms |    1.61×  |
+  - **Runtime**: N=3 trials of 1024 frames × 256 samples each.
+    Round-robin interleaved across modes. Min reported.
+    N derived empirically from `runtime_noise_meta.ts`: min-of-3
+    lands within 0.76% of asymptotic min at p95 on this hardware.
+  - **Compile**: one cold-cache trial per axis. The engine has a
+    process-singleton in-memory cache that survives disk-cache
+    `rmSync`; measuring multiple cold compiles in one process would
+    need subprocess isolation. Single-shot is fine for snapshot.
 
-`*` Cache hit. When a program has no nested sub-instances (Sin, SVF,
-polyphony-of-leaf-types), both modes produce byte-identical IR; the
-nested-mode run hits the warm disk cache populated by the flat-mode
-run that preceded it. The number reflects cache lookup, not actual
-JIT work.
+Total wall clock: ~3s.
+
+## Numbers
+
+### Compile (one cold trial per axis)
+
+| Case                       | Mode   | Inst | TS ms | JIT ms | Plan KB |
+|----------------------------|--------|-----:|------:|-------:|--------:|
+| OnePole                    | flat   |    1 |   3.1 |   11.4 |     4.4 |
+| OnePole                    | nested |    1 |   0.4 |    9.4 |     5.8 |
+| polyphony_8x_Phaser16      | flat   |    8 |  66.9 |  741.3 |   204.5 |
+| polyphony_8x_Phaser16      | nested |    8 |   2.8 |  865.7 |   329.2 |
+
+### Runtime (3 trials, min reported)
+
+| Case                       | Mode   | Trials (ns/sample)         | min   | median | max   |
+|----------------------------|--------|----------------------------|------:|-------:|------:|
+| OnePole                    | flat   | 8.0, 7.9, 15.7             |   7.9 |    8.0 |  15.7 |
+| OnePole                    | nested | 8.3, 8.4, 9.0              |   8.3 |    8.4 |   9.0 |
+| polyphony_8x_Phaser16      | flat   | 322.7, 322.3, 333.7        | 322.3 |  322.7 | 333.7 |
+| polyphony_8x_Phaser16      | nested | 403.8, 452.4, 405.8        | 403.8 |  405.8 | 452.4 |
+
+### Deltas
+
+| Case                       | ns_ratio | jit_ratio | plan_ratio |
+|----------------------------|---------:|----------:|-----------:|
+| OnePole                    |   1.057× |    0.826× |     1.313× |
+| polyphony_8x_Phaser16      |   1.253× |    1.168× |     1.610× |
 
 ## What the numbers say
 
-**1. Leaf cases are free.** Programs with no nested sub-instances
-(Sin, SVF, polyphony of either) produce identical IR in both modes
-and run identically. The slot path adds zero overhead when there's
-nothing to slot.
+**Runtime.** OnePole pays 6% overhead, polyphony_8x_Phaser16 pays
+25%. The cost scales with kernel-boundary density: at 136 nested
+kernels the WriteSlot / Slot round-trips at each boundary stop
+amortizing against the per-instance work. The realtime budget is
+uncontested — worst case (Phaser16 8x nested) is 1.81% of a 44.1kHz
+sample period, plenty of headroom — but 25% is a meaningful tax on
+how much MORE work fits in a buffer.
 
-**2. Genuine nested cases pay 5-25% runtime overhead.** The slot
-path's WriteSlot / Slot round-trip at each kernel boundary doesn't
-fully fold away under LLVM O2. Worst case observed:
-`polyphony_8x_LadderFilter` at 1.25× and `polyphony_8x_Phaser16` at
-1.25×. The cost scales with kernel-boundary density, not just
-instance count — 8x Phaser16 (136 nested kernels) costs more than
-32x Sin (32 monolithic kernels) per sample even though Sin's
-instance count is higher.
+**Compile (cold).** OnePole compiles faster in nested mode (0.83×) —
+small programs apparently give LLVM more digestible per-function
+work units than the inline path's monolithic body. Phaser16 8x
+flips: 1.17× slower nested. Crossover seems to be around the point
+where per-function fixed cost (~10ms? hard to attribute) stops
+amortizing across the larger function count.
 
-**3. JIT compile overhead is larger but still small in absolute
-terms.** Nested-mode IR is 30-60% larger (the per-child WriteSlots
-add up), and LLVM takes ~20-50% longer to JIT it. For
-`polyphony_8x_Phaser16` that's 904 ms vs 763 ms — both noticeable
-on cold compile, neither blocking interactivity once the disk
-cache is warm.
+**TS pipeline.** Nested compiles in ~25× less TS time for Phaser16
+8x (66.9ms → 2.8ms). The inline path's `inlineInstances` pass is
+where the cost lives — splicing 136 nested kernels into 8 monolithic
+bodies takes real time. The slot path skips that pass entirely.
 
-**4. Pow is the surprise outlier.** Pow compiled in nested mode is
-0.60× the runtime cost of the flat compile, and 0.66× the JIT
-cost. Pow is `exp(y * log(x))` — the flat compile produces a giant
-chained expression that LLVM apparently handles WORSE than the
-slot-broken nested version. Sample size of one; not load-bearing,
-but worth remembering when designing the next layer of
-optimization.
+**Plan size.** Nested-mode IR is 30-60% larger; the per-child
+WriteSlots add real bytes. This matters for disk cache footprint
+and TS↔C++ JSON shipping, but neither is in the critical path.
 
-**5. `polyphony_4x_Phaser16` shows nested JIT FASTER (0.84×).**
-For polyphonies of complex programs, nested mode appears to give
-LLVM more uniform per-function work units to chew through, while
-the flat compile produces 4 enormous functions back-to-back. The
-crossover seems to be around 4-8 voices; at 8x Phaser16 the nested
-mode is 1.18× slower again. Worth investigating if anyone wants
-to chase polyphony-of-complex-programs perf.
+**Trial variance.** The runtime noise is real but small. OnePole's
+trial 3 at 15.7 ns/sample (vs 7.9 min) is a clear outlier — almost
+certainly an OS pre-emption or frequency-scaling event. The
+min-of-3 methodology correctly strips it. CV measured in the meta-
+bench was 0.75%, so the 0.76% confidence bound at p95 holds.
 
-**6. The realtime budget is uncontested either way.** Worst case
-(`polyphony_8x_Phaser16` nested) sits at 1.81% of a 44.1kHz sample
-period. Plenty of headroom for both modes. The slowdown ratios
-matter for fitting MORE work into a single buffer, not for hitting
-realtime at all.
+## Bubble / BubbleCloud: the real correctness gap
 
-## Bubble / BubbleCloud: the real-correctness gap
-
-These two cases ERR'd in nested mode:
+These cases failed nested-mode compile with:
 
 ```
 compileResolved: register init must lower to a literal value
 ```
 
-Root cause: when `inlineInstances` is skipped (the slot path's
-whole point), each child sub-instance keeps its own
-`ResolvedProgram`, and that program's `RegDecl.init` may be an
-ExprNode that the flat path implicitly reduced as a side effect of
-splicing. `compileResolved`'s `regInit` helper accepts only
-literal numbers / booleans / arrays / `zeros{N}` — not arbitrary
-ExprNodes.
+Root cause: when `inlineInstances` is skipped (the slot path's whole
+point), each child sub-instance keeps its own `ResolvedProgram`,
+and that program's `RegDecl.init` may be an `ExprNode` that the
+flat path implicitly reduced via splicing. `compileResolved`'s
+`regInit` helper accepts only literal numbers / booleans / arrays /
+`zeros{N}` — not arbitrary ExprNodes.
 
-Bubble has a `reg env_smooth = 0` (literal, fine) but it inherits
-nested children (SampleHold, TriggerRamp, Exp, EnvExpDecay, SVF),
-one of which presumably has a non-literal init. Same shape recurs
-in BubbleCloud (8x Bubble).
+Bubble has `reg env_smooth = 0` (literal, fine) but inherits nested
+children (SampleHold, TriggerRamp, Exp, EnvExpDecay, SVF), one of
+which has a non-literal init. Same shape recurs in BubbleCloud (8x
+Bubble).
 
 This is a real correctness gap in the slot path. It needs to be
 fixed before any deletion-of-`inlineInstances` decision can land.
-Possible approaches:
+Three approaches in order of invasiveness:
 
   1. Strengthen `compileResolved`'s `regInit` to evaluate constant
-     ExprNodes (a small constant-folding step).
+     ExprNodes (small constant-folding step).
   2. Add a pre-emit strata pass that reduces register inits
-     specifically (similar to how `extractSessionDelays` runs as a
-     pre-emit pass).
-  3. Make `inlineInstances` itself idempotent and per-program
-     (not per-top-level), so sub-programs get their inits reduced
-     during their own compile rather than via parent splicing.
+     specifically (parallels how `extractSessionDelays` runs).
+  3. Make `inlineInstances` per-program rather than top-level, so
+     sub-programs get their inits reduced during their own compile
+     rather than via parent splicing.
 
 Approach 1 is smallest. Approach 2 is most aligned with the strata-
 pipeline shape. Approach 3 is the most invasive but might be the
@@ -156,34 +143,31 @@ right factoring long-term.
 **Don't delete `inlineInstances` yet.** Three blockers:
 
   1. The Bubble / BubbleCloud correctness gap above. Until any
-     stdlib program can compile under `inlineNested:false`, the
-     slot path is not a drop-in replacement.
+     stdlib program compiles under `inlineNested:false`, the slot
+     path is not a drop-in replacement.
 
-  2. The 5-25% runtime overhead is real but not catastrophic. If
-     we can land the inputs-substitution rewrite WITHOUT this
-     overhead — through LLVM passes, better slot fusion, or
-     something else — the deletion case becomes much stronger.
+  2. The 25% runtime overhead at the realistic stress scale is real.
+     Not catastrophic — there's headroom — but it's a tax. If we
+     can close that gap (LLVM passes, better slot fusion,
+     something else) the deletion case becomes much stronger.
 
   3. The slot path's larger IR (~1.5× plan size) inflates the disk
      cache footprint and the JSON-shipping overhead between TS and
-     C++. Worth optimizing the wire format (per-child blocks could
-     elide their `pre_input_instructions` wrapper for the empty
-     case, already done) before committing.
+     C++. Worth optimizing the wire format before committing
+     fully.
 
 **Keep both paths alive.** `inlineNested:true` remains the default;
-`inlineNested:false` is the opt-in for the nested-aware tests
+`inlineNested:false` is the opt-in for nested-aware tests
 (`tests/equiv/nested_vs_inlined.test.ts`) and any future work that
 needs per-kernel hot-swap, voice scopes, or per-instance JIT cache
-keys (all of which want kernel boundaries to survive into the
-emitted IR).
+keys.
 
 **Next milestones for slot-path adoption:**
-  - Fix the Bubble / BubbleCloud register-init gap
-  - Add depth-4 synthetic stress cases (constructed
-    programmatically; currently the deepest real-stdlib case is
-    depth-3 BubbleCloud)
-  - Investigate why `polyphony_8x_OnePole` is the worst-scaling
-    polyphony case (1.19× runtime + 1.52× JIT) despite OnePole
-    being a relatively simple program
-  - Measure the slot path under a `-O3` JIT (currently `O2`) to see
-    if more aggressive load-store forwarding closes the gap
+
+  - Fix the Bubble / BubbleCloud register-init gap (approach 1 or 2)
+  - Measure under `-O3` JIT to see if more aggressive load-store
+    forwarding closes the 25% runtime gap
+  - Investigate why polyphony_8x_Phaser16's nested mode pays 25%
+    while OnePole only pays 6% — is the cost in slot-load-store
+    pairs that LLVM isn't folding, or in icache/dcache pressure
+    from the larger IR?

--- a/tests/bench/runtime_noise_meta.ts
+++ b/tests/bench/runtime_noise_meta.ts
@@ -1,0 +1,205 @@
+/**
+ * runtime_noise_meta.ts — one-shot characterization of audio-thread
+ * runtime noise.
+ *
+ * Picks one realistic stress case (polyphony_8x_Phaser16 in nested
+ * mode — the case where small relative deltas drive the deletion
+ * decision), compiles once, then runs N=100 trials of the audio
+ * loop and reports the empirical distribution of ns/sample.
+ *
+ * The point isn't to bench Phaser16 — it's to figure out how many
+ * trials a real bench needs to estimate the asymptotic min to a
+ * given confidence. Bootstrap analysis below: for each candidate
+ * trial count N ∈ {1, 3, 5, 10, 20, 30}, draw B=1000 independent
+ * N-trial subsamples from the 100-trial population, take the min of
+ * each, and report how close that min lands to the 100-trial min.
+ *
+ * Output: /tmp/runtime_noise_meta.json + console summary.
+ *
+ * Usage: bun run tests/bench/runtime_noise_meta.ts
+ *
+ * Wall clock: ~10s (100 × ~6s of audio per trial).
+ */
+import { writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import {
+  makeSession,
+  resolveProgramType, instantiate, outputNames, inputNames,
+} from '../../compiler/session.js'
+import type { ExprNode } from '../../compiler/expr.js'
+import { loadStdlib } from '../../compiler/program.js'
+import { compileSession } from '../../compiler/ir/compile_session.js'
+import { toWirePlan } from '../../compiler/flat_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+import * as b from '../../compiler/runtime/bindings.js'
+
+const FRAME_SIZE       = 256
+const FRAMES_PER_TRIAL = 1024            // ~6s of audio per trial at 44.1kHz
+const TRIALS           = 100
+const WARMUP_FRAMES    = 32
+const SAMPLE_RATE      = 44100
+const BOOTSTRAP_B      = 1000
+const CANDIDATE_NS     = [1, 2, 3, 5, 10, 20, 30]
+
+// ── Clear cache (cold start) ──────────────────────────────────────────
+const cacheDir = process.env.XDG_CACHE_HOME
+  ? join(process.env.XDG_CACHE_HOME, 'tropical', 'kernels')
+  : join(homedir(), '.cache', 'tropical', 'kernels')
+rmSync(cacheDir, { recursive: true, force: true })
+
+// ── Build the session (polyphony_8x_Phaser16, nested mode) ────────────
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+const session = makeSession(FRAME_SIZE, { inlineNested: false })
+loadStdlib(session)
+const { type, typeArgs } = resolveProgramType(session, 'Phaser16', undefined, undefined)
+for (let i = 0; i < 8; i++) {
+  const name = `v${i}`
+  const inst = instantiate(type, name, { baseTypeName: 'Phaser16', typeArgs })
+  session.instanceRegistry.set(name, inst)
+  for (const pn of inputNames(inst)) {
+    if (pn === 'freq')  session.inputExprNodes.set(wk(name, pn), 110 + 22 * i)
+    if (pn === 'input') session.inputExprNodes.set(wk(name, pn), 0.5)
+    if (pn === 'feedback') session.inputExprNodes.set(wk(name, pn), 0.4)
+    if (pn === 'lfo_speed') session.inputExprNodes.set(wk(name, pn), 0.2)
+  }
+  session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
+}
+
+// ── Compile once ──────────────────────────────────────────────────────
+const plan = compileSession(session)
+const planJson = JSON.stringify(toWirePlan(plan))
+session.runtime.loadPlan(planJson)
+
+// ── Warmup ────────────────────────────────────────────────────────────
+for (let i = 0; i < WARMUP_FRAMES; i++)
+  b.tropical_runtime_process(session.runtime._h)
+
+// ── Run trials ────────────────────────────────────────────────────────
+const samples: number[] = []   // ns/sample per trial
+const samplesPerTrial = FRAMES_PER_TRIAL * FRAME_SIZE
+
+console.log(`Running ${TRIALS} trials of ${FRAMES_PER_TRIAL} frames (${samplesPerTrial} samples each)...`)
+for (let t = 0; t < TRIALS; t++) {
+  const t0 = performance.now()
+  for (let f = 0; f < FRAMES_PER_TRIAL; f++)
+    b.tropical_runtime_process(session.runtime._h)
+  const elapsed = performance.now() - t0
+  const ns = (elapsed * 1e6) / samplesPerTrial
+  samples.push(ns)
+  if ((t + 1) % 20 === 0) {
+    process.stdout.write(`  ${t + 1}/${TRIALS} done\n`)
+  }
+}
+
+// ── Descriptive statistics ────────────────────────────────────────────
+function stats(xs: number[]) {
+  const sorted = [...xs].sort((a, b) => a - b)
+  const n = sorted.length
+  const sum = sorted.reduce((s, x) => s + x, 0)
+  const mean = sum / n
+  const variance = sorted.reduce((s, x) => s + (x - mean) * (x - mean), 0) / n
+  const stddev = Math.sqrt(variance)
+  const pick = (p: number) => sorted[Math.min(n - 1, Math.floor(p * n))]
+  return {
+    n,
+    min:    sorted[0],
+    p10:    pick(0.10),
+    p50:    pick(0.50),  // median
+    mean,
+    p90:    pick(0.90),
+    p99:    pick(0.99),
+    max:    sorted[n - 1],
+    stddev,
+    cv:     stddev / mean,  // coefficient of variation
+  }
+}
+
+const s = stats(samples)
+const samplePeriod = 1e9 / SAMPLE_RATE
+
+console.log('\nFull distribution (ns/sample):')
+console.log(`  n:      ${s.n}`)
+console.log(`  min:    ${s.min.toFixed(2)}`)
+console.log(`  p10:    ${s.p10.toFixed(2)}`)
+console.log(`  median: ${s.p50.toFixed(2)}`)
+console.log(`  mean:   ${s.mean.toFixed(2)}`)
+console.log(`  p90:    ${s.p90.toFixed(2)}`)
+console.log(`  p99:    ${s.p99.toFixed(2)}`)
+console.log(`  max:    ${s.max.toFixed(2)}`)
+console.log(`  stddev: ${s.stddev.toFixed(2)}`)
+console.log(`  CV:     ${(s.cv * 100).toFixed(2)}%`)
+console.log(`  rt%:    ${(s.min / samplePeriod * 100).toFixed(2)}% of sample period (best trial)`)
+
+// ── Bootstrap: how does min-of-N converge to min-of-100? ──────────────
+// For each candidate N, draw B independent N-element subsamples (with
+// replacement from the 100-trial population), take min of each, and
+// report ratio to the population min. The distribution of
+// (subsample_min / population_min) tells us how stable the min
+// statistic is as a function of N.
+//
+// We report:
+//   - median ratio: the typical convergence
+//   - p95 ratio:    the "you almost always do at least this well"
+//                   (95% of N-trial runs land within this ratio of true min)
+//   - max ratio:    worst-case in B draws
+function bootstrap(samples: number[], N: number, B: number): { median: number, p95: number, max: number } {
+  const popMin = Math.min(...samples)
+  const ratios: number[] = []
+  for (let b = 0; b < B; b++) {
+    let subMin = Infinity
+    for (let i = 0; i < N; i++) {
+      const idx = Math.floor(Math.random() * samples.length)
+      if (samples[idx] < subMin) subMin = samples[idx]
+    }
+    ratios.push(subMin / popMin)
+  }
+  ratios.sort((a, b) => a - b)
+  const pick = (p: number) => ratios[Math.min(ratios.length - 1, Math.floor(p * ratios.length))]
+  return {
+    median: pick(0.50),
+    p95:    pick(0.95),
+    max:    ratios[ratios.length - 1],
+  }
+}
+
+console.log('\nBootstrap: min-of-N convergence to min-of-100')
+console.log('  (ratio = N-trial min / 100-trial min; closer to 1.00 = tighter convergence)')
+console.log('  N      median   p95     max')
+const bootstraps: Record<number, ReturnType<typeof bootstrap>> = {}
+for (const N of CANDIDATE_NS) {
+  const r = bootstrap(samples, N, BOOTSTRAP_B)
+  bootstraps[N] = r
+  console.log(
+    `  ${String(N).padStart(3)}    ` +
+    `${r.median.toFixed(4)}  ${r.p95.toFixed(4)}  ${r.max.toFixed(4)}`,
+  )
+}
+
+// Recommended N: smallest such that p95 ratio ≤ 1.01 (95% of runs land
+// within 1% of true min) AND median ≤ 1.005 (typical run within 0.5%).
+const recommendedN = CANDIDATE_NS.find(N =>
+  bootstraps[N].p95 <= 1.01 && bootstraps[N].median <= 1.005,
+)
+console.log(`\nRecommended N for ±1% confidence at p95: ${recommendedN ?? '> 30 (noise floor too high)'}`)
+
+// ── Persist ───────────────────────────────────────────────────────────
+const resultFile = '/tmp/runtime_noise_meta.json'
+writeFileSync(resultFile, JSON.stringify({
+  config: {
+    case: 'polyphony_8x_Phaser16',
+    mode: 'nested',
+    frame_size: FRAME_SIZE,
+    frames_per_trial: FRAMES_PER_TRIAL,
+    samples_per_trial: samplesPerTrial,
+    trials: TRIALS,
+    warmup_frames: WARMUP_FRAMES,
+    bootstrap_b: BOOTSTRAP_B,
+  },
+  samples,
+  stats: s,
+  bootstraps,
+  recommended_n: recommendedN,
+  timestamp: new Date().toISOString(),
+}, null, 2))
+console.log(`\nResults written to ${resultFile}`)

--- a/tests/equiv/nested_vs_inlined.test.ts
+++ b/tests/equiv/nested_vs_inlined.test.ts
@@ -1,0 +1,180 @@
+/**
+ * nested_vs_inlined.test.ts — cross-mode equivalence: the legacy
+ * flat-IR compile path (`inlineNested:true`) vs the M11 fractal
+ * slot-based compile path (`inlineNested:false`).
+ *
+ * Each session compiles its programs through one path; the test
+ * builds the same session shape twice (once per mode) and asserts
+ * sample-for-sample agreement on the audio output.
+ *
+ * This is the correctness gate for the input-slot refactor. The
+ * flat path is the oracle (it's been correct since the strata
+ * pipeline landed); the slot path must produce identical output.
+ *
+ * Inline path: `inlineInstances` strata pass splats every nested
+ * `InstanceDecl` into its parent's body via expression substitution.
+ * By the time `partition_recursive` sees the IR, no nesting remains.
+ *
+ * Slot path: `inlineInstances` is skipped. `partition_recursive`
+ * allocates per-port INPUT slots for each child, emits per-child
+ * `WriteSlot` blocks stored on each child's `pre_input_instructions`,
+ * and the child's `InputRef`s lower to `Slot` reads via the
+ * `inputSlotOverride` map. The boundary is the slot, not the
+ * substituted expression. Per-child placement (vs hoisting into a
+ * single parent-wide pre-children block) preserves sibling-to-sibling
+ * NestedOut dependencies — Pow's `exp = Exp(x: y * log_x.out)` only
+ * works because `log_x` has already run by the time `exp`'s pre-input
+ * wires evaluate.
+ *
+ * If the two modes diverge, that's either:
+ *   (a) a bug in `partition_recursive`'s slot-wiring step
+ *   (b) a bug in `emit_resolved`'s InputRef → Slot lowering
+ *   (c) an engine-side ordering bug (`pre_input_instructions` not
+ *       emitted before each child)
+ *   (d) a temp / slot index shift mismatch in `remapInstancePlan`
+ *
+ * Requires libtropical.dylib (build with `make build` first).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, inputNames, outputNames } from '../../compiler/session.js'
+import type { ExprNode } from '../../compiler/expr.js'
+import { loadStdlib } from '../../compiler/program.js'
+import { applyFlatPlan } from '../../compiler/apply_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+
+const BUFFER_LENGTH  = 256
+const N_BUFFERS      = 4
+const TOTAL_SAMPLES  = BUFFER_LENGTH * N_BUFFERS
+// Tight tolerance: both modes go through the same LLVM codegen for
+// the per-instruction work; the only difference is whether wire
+// expressions get inlined into the child body (flat path) or
+// evaluated in the parent and crossed via a slot (slot path). LLVM's
+// CSE + GVN should fold the slot store-load round-trip in fused mode,
+// so we expect byte-equal results.
+const TOLERANCE      = 1e-12
+
+function pulseEvery(n: number): ExprNode {
+  return { op: 'lt', args: [{ op: 'mod', args: [{ op: 'sampleIndex' }, n] }, 1] }
+}
+
+const DEFAULT_INPUTS: Record<string, ExprNode> = {
+  freq: 220, x: 0.5, y: 0.5, audio: 0.5, input: 0.5, cv: 0.5,
+  cutoff: 1000, q: 0.5, drive: 1.0, mix: 0.5, a: 0.3, b: 0.7,
+  coeff: 0.4, feedback: 0.4, lfo_speed: 0.2, decay: 0.99,
+  rate: 5, g: 0.1, resonance: 0.5,
+  trigger: pulseEvery(64), clock: pulseEvery(32),
+}
+
+// Same stdlib corpus as microkernel_vs_fused — covers oscillators,
+// filters, transcendentals, delays. The honest depth-2 cases
+// (Phaser16 with 16 _allpassStage children; OnePole with 2 Tanh;
+// Pow with Log + Exp; etc.) are where the slot path actually does
+// work; the flat cases (Sin, Cos, Tanh) reduce to no-op trees on
+// both sides.
+const STDLIB_TARGETS: Array<[string, Record<string, number>?]> = [
+  ['SinOsc'], ['Sin'], ['Cos'], ['Tanh'], ['Exp'], ['Log'], ['Pow'],
+  ['OnePole'], ['BlepSaw'], ['SoftClip'], ['VCA'], ['CrossFade'],
+  ['SVF'], ['LadderFilter'], ['Phaser'], ['Phaser16'],
+  ['AllpassDelay'], ['CombDelay'],
+  ['Delay', { N: 1024 }],
+]
+
+function setupInstance(
+  typeName: string,
+  typeArgs: Record<string, number> | undefined,
+  inlineNested: boolean,
+) {
+  const session = makeSession(BUFFER_LENGTH, { inlineNested })
+  loadStdlib(session)
+  const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: typeName, typeArgs: resolved })
+  session.instanceRegistry.set('inst', inst)
+  for (const portName of inputNames(inst)) {
+    if (portName in DEFAULT_INPUTS) {
+      session.inputExprNodes.set(wk('inst', portName), DEFAULT_INPUTS[portName])
+    }
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
+function captureOutput(session: ReturnType<typeof setupInstance>): Float64Array {
+  applyFlatPlan(session, session.runtime)
+  session.graph.primeJit()
+  const out = new Float64Array(TOTAL_SAMPLES)
+  for (let f = 0; f < N_BUFFERS; f++) {
+    session.runtime.process()
+    const buf = session.runtime.outputBuffer
+    out.set(buf.subarray(0, BUFFER_LENGTH), f * BUFFER_LENGTH)
+  }
+  return out
+}
+
+describe('nested-vs-inlined stdlib equivalence', () => {
+  for (const [typeName, typeArgs] of STDLIB_TARGETS) {
+    test(`${typeName}${typeArgs ? `<${JSON.stringify(typeArgs)}>` : ''}`, () => {
+      // Two independent sessions — one per mode — so register/slot
+      // state starts from identical inits in both runs. Sharing a
+      // session and switching modes would invoke hot-swap state
+      // transfer, which is a separate axis to test.
+      const flatOut   = captureOutput(setupInstance(typeName, typeArgs, /* inlineNested */ true))
+      const nestedOut = captureOutput(setupInstance(typeName, typeArgs, /* inlineNested */ false))
+
+      let maxAbsDiff = 0
+      let firstDiffIdx = -1
+      for (let i = 0; i < TOTAL_SAMPLES; i++) {
+        const f = flatOut[i]
+        const n = nestedOut[i]
+        if (Number.isNaN(f) && Number.isNaN(n)) continue
+        const d = Math.abs(f - n)
+        if (d > maxAbsDiff) maxAbsDiff = d
+        if (d > TOLERANCE && firstDiffIdx < 0) firstDiffIdx = i
+      }
+
+      if (maxAbsDiff > TOLERANCE) {
+        const i = firstDiffIdx
+        throw new Error(
+          `${typeName}: flat/nested diverged at sample ${i} ` +
+          `(flat=${flatOut[i]}, nested=${nestedOut[i]}, ` +
+          `maxAbsDiff=${maxAbsDiff})`,
+        )
+      }
+      expect(maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+    })
+  }
+})
+
+// Polyphony case: 8 voices of SinOsc with freq spread. Each voice is
+// a top-level session instance with a nested Sin child. The slot
+// path must wire each voice's freq → its own Sin's x slot
+// independently — no cross-voice slot collisions.
+describe('nested-vs-inlined polyphony', () => {
+  test('8x SinOsc voices', () => {
+    function setupPolyphony(inlineNested: boolean) {
+      const session = makeSession(BUFFER_LENGTH, { inlineNested })
+      loadStdlib(session)
+      const { type, typeArgs } = resolveProgramType(session, 'SinOsc', undefined, undefined)
+      for (let i = 0; i < 8; i++) {
+        const name = `osc${i}`
+        const inst = instantiate(type, name, { baseTypeName: 'SinOsc', typeArgs })
+        session.instanceRegistry.set(name, inst)
+        session.inputExprNodes.set(wk(name, 'freq'), 110 + 22 * i)
+        session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
+      }
+      return session
+    }
+    const flatOut   = captureOutput(setupPolyphony(true))
+    const nestedOut = captureOutput(setupPolyphony(false))
+
+    let maxAbsDiff = 0
+    for (let i = 0; i < TOTAL_SAMPLES; i++) {
+      if (Number.isNaN(flatOut[i]) && Number.isNaN(nestedOut[i])) continue
+      const d = Math.abs(flatOut[i] - nestedOut[i])
+      if (d > maxAbsDiff) maxAbsDiff = d
+    }
+    expect(maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces expression substitution at the kernel boundary with **slot-based
parent → child input wiring** — the categorical complement to the existing
slot-based output wiring. The boundary between a parent kernel and a nested
child kernel becomes a port-typed slot (parent writes, child reads), not an
inlined expression.

Behind the `inlineNested:false` flag, every nested sub-instance survives as
its own kernel boundary in the emitted IR. The default (`inlineNested:true`)
is unchanged — existing behavior preserved exactly.

20 of the 22 stdlib programs in the equivalence corpus pass at 1e-12 between
the two modes. Bubble and BubbleCloud are documented as a known correctness
gap (sub-program sum-typed regs not lowered through the slot path) and gated
behind a followup PR for the IR-level fix.

## What landed (9 commits)

1. **`9f3bad0` hygiene principle** — documents the v2-readiness discipline in
   the root CLAUDE.md
2. **`0dd1471` `inlineNested` plumbing** — threads the flag through
   `compileSession` / `compileSessionSlotted` / `applyFlatPlan` so tests and
   benches can drive both modes from TS
3. **`653022b` input-slot infrastructure** — `session.inputSlotRegistry`,
   `inputPortMeta`, `allocateInputSlots`. Mirrors the existing output-slot
   infrastructure exactly; no new abstractions
4. **`740fb87` slot-based kernel boundary (initial)** — `partition_recursive`
   uses slot-based wiring instead of `cloneWithInputSubst`. Engine emits a
   four-phase per-kernel dispatch
5. **`7d152e0` per-child pre-input wires + correctness gate** — restructures
   `pre_child_instructions` to be per-child (lives on each child, runs in
   parent's namespace just before child dispatch), fixing sibling-NestedOut
   dependencies (Pow, LadderFilter, Phaser16). Adds
   `tests/equiv/nested_vs_inlined.test.ts` — the load-bearing correctness gate
6. **`7b5a09e` first depth bench (deprecated by `d127f79`)**
7. **`d5050c2` snapshot doc with deletion verdict**
8. **`5e71992` runtime noise meta-bench** — characterizes audio-thread noise
   floor; min-of-3 trials of 1024 frames lands within 0.76% of asymptotic min
   at p95 confidence on this hardware. Derives N=3 for the depth bench
9. **`d127f79` rewritten depth bench** — two focused cases (OnePole +
   polyphony_8x_Phaser16), min-of-3 for runtime, single cold trial for compile
   (engine has process-singleton in-memory cache, so K>1 cold trials in one
   process is meaningless). Wall clock dropped from ~30s to ~3s. Snapshot doc
   re-captured

## Numbers

Captured in `tests/bench/depth_vs_flat_2026-05-23.md`:

| Case                       | ns_ratio | jit_ratio | plan_ratio |
|----------------------------|---------:|----------:|-----------:|
| OnePole                    |   1.057× |    0.826× |     1.313× |
| polyphony_8x_Phaser16      |   1.253× |    1.168× |     1.610× |

Slot path costs 6-25% runtime, generates 1.3-1.6× larger IR. Realtime budget
uncontested (worst case 1.81% of a 44.1kHz sample period).

## Verdict

**Don't delete `inlineInstances` yet.** Three blockers documented in the
snapshot:

1. Bubble/BubbleCloud correctness gap (sub-program register inits not lowered;
   fix tracked as followup)
2. 25% runtime overhead at the realistic stress scale
3. 1.6× plan size inflates disk cache + JSON shipping

Keep both paths alive. `inlineNested:true` remains the default.

## Followup work

The Bubble/BubbleCloud correctness gap is structurally caused by the IR using
object-pointer-based refs (every refactor that crosses program boundaries
needs knot-tying for cross-references, which the slot path doesn't do).
Planned next PR migrates global refs to de Bruijn levels (integer indices
into root decl tables), eliminating the pointer-identity assumption and
closing the gap structurally. The full locally-nameless migration (binders
too) is tracked separately as #156.

## Test plan

- [x] `bun test` — 1017 pass, 0 fail
- [x] `bun test tests/equiv/nested_vs_inlined.test.ts` — 20/20 stdlib +
      polyphony cases green at 1e-12
- [x] `bun test tests/equiv/microkernel_vs_fused.test.ts` — 20/20 green
- [x] `bun test tests/equiv/jit_vs_interp_stdlib.test.ts` — 45/45 green
- [x] `ctest --test-dir build` — module_process green
- [x] `bun run tests/bench/depth_vs_flat.ts` — ~3s wall clock; numbers
      reproducible

🤖 Generated with [Claude Code](https://claude.com/claude-code)