### PR TITLE
Migrate global IR refs to de Bruijn levels; close Bubble/BubbleCloud nested gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,14 @@ bun test --exclude compiler/apply_plan.test.ts        # pure-TS subset (no nativ
 `build/libtropical.dylib` via koffi. Run `make build` first or use the
 exclude form above.
 
+**If equivalence tests fail unexpectedly, clear the JIT cache first.**
+`rm -rf ~/.cache/tropical/kernels` — the LLVM-IR cache is keyed by an MD5
+of the serialized plan plus the dylib's build-id, but a fix that changes
+*runtime* behavior without changing the emitted plan (e.g., the engine
+emits an existing instruction field that the parser previously ignored)
+can leave stale kernels in place. Clearing the cache is cheap; chasing
+a phantom regression is not.
+
 ## Ideological backbone
 
 If you want a single sentence to hang the whole codebase off:

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -145,6 +145,18 @@ export interface InstanceFunction {
   /** Session instance name (e.g., `voice7`). May be a dotted path
    *  (`voice7.env`) for nested kernels in the fractal architecture. */
   instance_name:     string
+  /** Instructions that run at the START of this kernel's block —
+   *  before children dispatch, before main body. Holds the temp-
+   *  compute instructions produced by translating session-wired
+   *  input expressions (e.g., `trigger: pulseEvery(64)`) into
+   *  temps that the child pre_input WriteSlots reference. Splitting
+   *  this out of `instructions` matters: children get dispatched
+   *  before `instructions` in the engine's emit_kernel_block, so any
+   *  temp a child's pre_input references MUST exist before children
+   *  start. Pre-Phase-3 (Bubble fix), this was concatenated into
+   *  `instructions` and Bubble's per-child trigger writes wrote
+   *  zeros. */
+  preamble_instructions: NInstr[]
   /** Instructions with operands already shifted into unified space. */
   instructions:      NInstr[]
   /** M11 fractal slot-based input wiring. Instructions the PARENT
@@ -238,6 +250,12 @@ export interface WireInstanceFunction {
   name:              string
   instance_name:     string
   instructions:      WireNInstr[]
+  /** Preamble — runs at the start of this kernel's block, before
+   *  children dispatch. Used for translating session-wired input
+   *  expressions into temps that child pre_input WriteSlots
+   *  reference. Optional in the wire format (legacy plans had this
+   *  bundled inside `instructions`; parsed as [] when missing). */
+  preamble_instructions?: WireNInstr[]
   /** M11 fractal slot-based input wiring (per-child). Parent's
    *  WriteSlot instructions that run just before this kernel's body.
    *  May be missing in legacy JSON (parsed as []). */
@@ -335,6 +353,7 @@ const parseInstanceFn = (inst: WireInstanceFunction): InstanceFunction => ({
   name:              inst.name,
   instance_name:     inst.instance_name,
   instructions:      inst.instructions.map(parseInstr),
+  preamble_instructions:  (inst.preamble_instructions  ?? []).map(parseInstr),
   pre_input_instructions: (inst.pre_input_instructions ?? []).map(parseInstr),
   register_offset:   tempOffset(inst.register_offset),
   state_reg_offset:  stateRegOffset(inst.state_reg_offset),
@@ -354,10 +373,13 @@ const toWireInstanceFn = (inst: InstanceFunction): WireInstanceFunction => ({
   array_slot_offset: rawOffset(inst.array_slot_offset),
   register_count:    inst.register_count,
   register_targets:  inst.register_targets.map(toWireRegTarget),
-  // Omit `pre_input_instructions` and `children` from the wire when
-  // empty so existing JSON consumers (golden fixtures, hand-crafted
-  // plan_5 tests) see exactly the bytes they expect today. Populated
-  // entries are emitted normally.
+  // Omit `preamble_instructions`, `pre_input_instructions`, and
+  // `children` from the wire when empty so existing JSON consumers
+  // (golden fixtures, hand-crafted plan_5 tests) see exactly the bytes
+  // they expect today. Populated entries are emitted normally.
+  ...(inst.preamble_instructions.length > 0
+    ? { preamble_instructions: inst.preamble_instructions.map(toWireInstr) }
+    : {}),
   ...(inst.pre_input_instructions.length > 0
     ? { pre_input_instructions: inst.pre_input_instructions.map(toWireInstr) }
     : {}),

--- a/compiler/interpret_resolved.ts
+++ b/compiler/interpret_resolved.ts
@@ -30,19 +30,24 @@ type Value = number | boolean | number[]
 interface InterpretEnv {
   sampleRate: number
   sampleIndex: number
-  /** Decl-identity-keyed state. Reads see the *current* sample's state;
-   *  next-sample state is computed into a shadow map and atomically
-   *  swapped at sample end. Post-Phase-0a: former DelayDecls live here
-   *  too — the env has one state map for all stateful decls. */
-  regs:    Map<RegDecl, Value>
+  /** The program being interpreted; needed to resolve indices back to
+   *  decl objects for the (rare) sites that still need decl-level
+   *  metadata (e.g., reg name in error messages, paramDecl.value
+   *  fallback). */
+  prog:    ResolvedProgram
+  /** Position-indexed state arrays. Reads see the *current* sample's
+   *  state; next-sample state is computed into a shadow array and
+   *  atomically swapped at sample end. Post-Phase-0a: former
+   *  DelayDecls live here too. */
+  regs:    Value[]
   /** Top-level synthetic program has no inputs (audio inputs are a host
    *  concern, not in the model today), but lifted-from-instance inner
    *  inputRefs have already been substituted by `inlineInstances`, so
    *  this only fires on the rare case of a literal inputRef surviving
    *  to the top level — which would be a strata bug, not a runtime
    *  case. Keep the slot for completeness. */
-  inputs:  Map<InputDecl, Value>
-  params:  Map<ParamDecl, number>
+  inputs:  Value[]
+  params:  number[]
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -106,17 +111,26 @@ function evalOpNode(node: ResolvedExprOp, env: InterpretEnv): Value {
   switch (node.op) {
     // ── References ─────────────────────────────────────────
     case 'inputRef':
-      return env.inputs.get(node.decl) ?? 0
-    case 'regRef':
-      return env.regs.get(node.decl) ?? regInitValue(node.decl)
-    case 'paramRef':
-      return env.params.get(node.decl) ?? node.decl.value ?? 0
+      return env.inputs[node.idx] ?? 0
+    case 'regRef': {
+      const cached = env.regs[node.idx]
+      if (cached !== undefined) return cached
+      return regInitValue(env.prog.regs[node.idx])
+    }
+    case 'paramRef': {
+      const cached = env.params[node.idx]
+      if (cached !== undefined) return cached
+      return env.prog.params[node.idx]?.value ?? 0
+    }
     case 'typeParamRef':
-      throw new Error(`interpret: typeParamRef '${node.decl.name}' should have been substituted by specialize`)
+      throw new Error(`interpret: typeParamRef idx=${node.idx} should have been substituted by specialize`)
     case 'bindingRef':
       throw new Error(`interpret: bindingRef '${node.decl.name}' should have been substituted by array_lower`)
-    case 'nestedOut':
-      throw new Error(`interpret: nestedOut '${node.instance.name}.${node.output.name}' should have been inlined`)
+    case 'nestedOut': {
+      const inst = env.prog.instances[node.instance]
+      const outName = inst?.type.ports.outputs[node.output]?.name ?? `#${node.output}`
+      throw new Error(`interpret: nestedOut '${inst?.name ?? `#${node.instance}`}.${outName}' should have been inlined`)
+    }
 
     // ── Sentinels ──────────────────────────────────────────
     case 'sampleRate':  return env.sampleRate
@@ -282,34 +296,28 @@ export function interpretSession(
 ): Float64Array {
   const prog = materializeSessionToResolvedIR(session)
 
-  // Build initial state from decl init values.
+  // Position-indexed state arrays, parallel to prog.regs / prog.params /
+  // prog.ports.inputs. Indices in refs are direct positions in these
+  // arrays.
   const env: InterpretEnv = {
     sampleRate: 44100,
     sampleIndex: 0,
-    regs:    new Map(),
-    inputs:  new Map(),
-    params:  new Map(),
-  }
-  for (const d of prog.body.decls) {
-    if (d.op === 'regDecl') env.regs.set(d, regInitValue(d))
-    else if (d.op === 'paramDecl') {
-      const v = params?.get(d.name) ?? d.value ?? 0
-      env.params.set(d, v)
-    }
+    prog,
+    regs:   prog.regs.map(d => regInitValue(d)),
+    inputs: prog.ports.inputs.map(_ => 0 as Value),
+    params: prog.params.map(d => params?.get(d.name) ?? d.value ?? 0),
   }
 
-  // Find audio outputs: the OutputDecls in `ports.outputs` whose names
-  // are `${instance}.${output}` (synthesized by `compile_session.ts`
-  // step 3). Their outputAssigns drive the audio mix.
-  const outputAssignByDecl = new Map<typeof prog.ports.outputs[number], ResolvedExpr>()
+  // Find audio outputs: outputAssigns whose target is an OutputIdx
+  // (not the dac sentinel). The synthesized session program puts each
+  // session-level output as an outputAssign per port.
+  const outputExprByIdx = new Map<number, ResolvedExpr>()
   for (const a of prog.body.assigns) {
     if (a.op !== 'outputAssign') continue
-    if (!('op' in a.target)) continue
-    if (a.target.op !== 'outputDecl') continue
-    outputAssignByDecl.set(a.target, a.expr)
+    if (typeof a.target === 'number') outputExprByIdx.set(a.target, a.expr)
   }
-  const outputExprs: ResolvedExpr[] = prog.ports.outputs.map(out => {
-    const expr = outputAssignByDecl.get(out)
+  const outputExprs: ResolvedExpr[] = prog.ports.outputs.map((out, i) => {
+    const expr = outputExprByIdx.get(i)
     if (expr === undefined) throw new Error(`interpret: output '${out.name}' has no outputAssign`)
     return expr
   })
@@ -319,11 +327,8 @@ export function interpretSession(
   // semantics); a defined expression means "compute next value each
   // sample" (former delay or accumulator semantics). NextUpdate body-
   // assigns are gone (folded into the decl by the elaborator).
-  const regUpdateByDecl = new Map<RegDecl, ResolvedExpr | null>()
-  for (const d of prog.body.decls) {
-    if (d.op !== 'regDecl') continue
-    regUpdateByDecl.set(d, d.update ?? null)
-  }
+  // Indexed by reg position to parallel env.regs.
+  const regUpdates: (ResolvedExpr | null)[] = prog.regs.map(d => d.update ?? null)
 
   const output = new Float64Array(nSamples)
 
@@ -338,14 +343,14 @@ export function interpretSession(
     }
 
     // 2. Evaluate register updates against the current state.
-    const newRegs = new Map<RegDecl, Value>()
-    for (const [d, update] of regUpdateByDecl) {
-      if (update === null) newRegs.set(d, env.regs.get(d) ?? regInitValue(d))
-      else newRegs.set(d, evalExpr(update, env))
+    const newRegs: Value[] = new Array(env.regs.length)
+    for (let i = 0; i < regUpdates.length; i++) {
+      const update = regUpdates[i]
+      newRegs[i] = update === null ? env.regs[i] : evalExpr(update, env)
     }
 
     // 3. Atomic writeback.
-    for (const [d, v] of newRegs) env.regs.set(d, v)
+    for (let i = 0; i < newRegs.length; i++) env.regs[i] = newRegs[i]
 
     // 4. Mix + scale (matches the C++ runtime's /20 gain compensation).
     output[s] = mixed / 20.0

--- a/compiler/ir/acyclic.test.ts
+++ b/compiler/ir/acyclic.test.ts
@@ -21,6 +21,8 @@ import { parseProgram } from '../parse/declarations.js'
 import { elaborate } from './elaborator.js'
 import { assertAcyclic, findInstanceCycles, AcyclicityViolation } from './acyclic.js'
 import type { ResolvedProgram, InstanceDecl, OutputDecl, InputDecl } from './nodes.js'
+import { inputIdx, outputIdx, instanceIdx } from './nodes.js'
+import { mkProgram } from './decl_tables.js'
 
 function elab(src: string): ResolvedProgram {
   return elaborate(parseProgram(src))
@@ -52,16 +54,18 @@ describe('assertAcyclic / findInstanceCycles', () => {
     // and we want to test the assertion in isolation.
     const innerIn: InputDecl  = { op: 'inputDecl', name: 'in_' }
     const innerOut: OutputDecl = { op: 'outputDecl', name: 'out_' }
-    const innerProg: ResolvedProgram = {
-      op: 'program', name: 'Inner', typeParams: [],
+    const innerProg = mkProgram({
+      name: 'Inner', typeParams: [],
       ports: { inputs: [innerIn], outputs: [innerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [],
-        assigns: [{ op: 'outputAssign', target: innerOut, expr: { op: 'inputRef', decl: innerIn } }],
+        assigns: [{ op: 'outputAssign', target: outputIdx(0), expr: { op: 'inputRef', idx: inputIdx(0) } }],
       },
-    }
-    // Build two instances of Inner that reference each other.
+    })
+    // Build two instances of Inner that reference each other. Inputs
+    // are positional indices into the target's ports.inputs; NestedOut
+    // carries InstanceIdx (in this program) + OutputIdx (in target).
     const a: InstanceDecl = {
       op: 'instanceDecl', name: 'a', type: innerProg,
       typeArgs: [], inputs: [],
@@ -70,14 +74,14 @@ describe('assertAcyclic / findInstanceCycles', () => {
       op: 'instanceDecl', name: 'b', type: innerProg,
       typeArgs: [], inputs: [],
     }
-    // Now wire them cyclically: a.in_ = b.out_, b.in_ = a.out_.
-    a.inputs.push({ port: innerIn, value: { op: 'nestedOut', instance: b, output: innerOut } })
-    b.inputs.push({ port: innerIn, value: { op: 'nestedOut', instance: a, output: innerOut } })
-    const cyclic: ResolvedProgram = {
-      op: 'program', name: 'Cyclic', typeParams: [],
+    // a is body.decls[0] → InstanceIdx 0; b is [1] → InstanceIdx 1.
+    a.inputs.push({ port: inputIdx(0), value: { op: 'nestedOut', instance: instanceIdx(1), output: outputIdx(0) } })
+    b.inputs.push({ port: inputIdx(0), value: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) } })
+    const cyclic = mkProgram({
+      name: 'Cyclic', typeParams: [],
       ports: { inputs: [], outputs: [], typeDefs: [] },
       body: { op: 'block', decls: [a, b], assigns: [] },
-    }
+    })
     const cycles = findInstanceCycles(cyclic)
     expect(cycles.length).toBe(1)
     expect(new Set(cycles[0].map(i => i.name))).toEqual(new Set(['a', 'b']))
@@ -87,25 +91,26 @@ describe('assertAcyclic / findInstanceCycles', () => {
   test('a self-loop SCC (single instance with self-edge) is detected', () => {
     const innerIn: InputDecl  = { op: 'inputDecl', name: 'in_' }
     const innerOut: OutputDecl = { op: 'outputDecl', name: 'out_' }
-    const innerProg: ResolvedProgram = {
-      op: 'program', name: 'Inner', typeParams: [],
+    const innerProg = mkProgram({
+      name: 'Inner', typeParams: [],
       ports: { inputs: [innerIn], outputs: [innerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [],
-        assigns: [{ op: 'outputAssign', target: innerOut, expr: { op: 'inputRef', decl: innerIn } }],
+        assigns: [{ op: 'outputAssign', target: outputIdx(0), expr: { op: 'inputRef', idx: inputIdx(0) } }],
       },
-    }
+    })
     const self: InstanceDecl = {
       op: 'instanceDecl', name: 'self', type: innerProg,
       typeArgs: [], inputs: [],
     }
-    self.inputs.push({ port: innerIn, value: { op: 'nestedOut', instance: self, output: innerOut } })
-    const cyclic: ResolvedProgram = {
-      op: 'program', name: 'SelfLoop', typeParams: [],
+    // self is body.decls[0] → InstanceIdx 0; it refs itself.
+    self.inputs.push({ port: inputIdx(0), value: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) } })
+    const cyclic = mkProgram({
+      name: 'SelfLoop', typeParams: [],
       ports: { inputs: [], outputs: [], typeDefs: [] },
       body: { op: 'block', decls: [self], assigns: [] },
-    }
+    })
     const cycles = findInstanceCycles(cyclic)
     expect(cycles.length).toBe(1)
     expect(cycles[0].map(i => i.name)).toEqual(['self'])
@@ -114,24 +119,24 @@ describe('assertAcyclic / findInstanceCycles', () => {
   test('AcyclicityViolation carries the detected SCCs as structured data', () => {
     const innerIn: InputDecl  = { op: 'inputDecl', name: 'in_' }
     const innerOut: OutputDecl = { op: 'outputDecl', name: 'out_' }
-    const innerProg: ResolvedProgram = {
-      op: 'program', name: 'Inner', typeParams: [],
+    const innerProg = mkProgram({
+      name: 'Inner', typeParams: [],
       ports: { inputs: [innerIn], outputs: [innerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [],
-        assigns: [{ op: 'outputAssign', target: innerOut, expr: { op: 'inputRef', decl: innerIn } }],
+        assigns: [{ op: 'outputAssign', target: outputIdx(0), expr: { op: 'inputRef', idx: inputIdx(0) } }],
       },
-    }
+    })
     const a: InstanceDecl = { op: 'instanceDecl', name: 'a', type: innerProg, typeArgs: [], inputs: [] }
     const b: InstanceDecl = { op: 'instanceDecl', name: 'b', type: innerProg, typeArgs: [], inputs: [] }
-    a.inputs.push({ port: innerIn, value: { op: 'nestedOut', instance: b, output: innerOut } })
-    b.inputs.push({ port: innerIn, value: { op: 'nestedOut', instance: a, output: innerOut } })
-    const cyclic: ResolvedProgram = {
-      op: 'program', name: 'Cyclic', typeParams: [],
+    a.inputs.push({ port: inputIdx(0), value: { op: 'nestedOut', instance: instanceIdx(1), output: outputIdx(0) } })
+    b.inputs.push({ port: inputIdx(0), value: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) } })
+    const cyclic = mkProgram({
+      name: 'Cyclic', typeParams: [],
       ports: { inputs: [], outputs: [], typeDefs: [] },
       body: { op: 'block', decls: [a, b], assigns: [] },
-    }
+    })
     try {
       assertAcyclic(cyclic)
       throw new Error('expected throw')

--- a/compiler/ir/array_lower.test.ts
+++ b/compiler/ir/array_lower.test.ts
@@ -100,7 +100,8 @@ function walkExprChildren(
 function outputExpr(prog: ResolvedProgram, name = 'out'): ResolvedExpr {
   for (const a of prog.body.assigns) {
     if (a.op !== 'outputAssign') continue
-    if ('op' in a.target && a.target.op === 'outputDecl' && a.target.name === name) return a.expr
+    // Post-migration: a.target is OutputIdx (a number) or {kind:'dac'}.
+    if (typeof a.target === 'number' && prog.ports.outputs[a.target]?.name === name) return a.expr
   }
   throw new Error(`outputExpr: no assign for output '${name}'`)
 }

--- a/compiler/ir/clone.test.ts
+++ b/compiler/ir/clone.test.ts
@@ -53,7 +53,7 @@ describe('clone — reference identity (within-clone)', () => {
     const assign = copy.body.assigns[0] as OutputAssign
     const ref = assign.expr as InputRef
     expect(ref.op).toBe('inputRef')
-    expect(ref.decl).toBe(inputDecl)
+    expect(copy.ports.inputs[ref.idx]).toBe(inputDecl)
   })
 
   test('self-referential RegDecl: update on decl points at the regDecl in the clone', () => {
@@ -68,9 +68,9 @@ describe('clone — reference identity (within-clone)', () => {
     const regDecl = copy.body.decls[0] as RegDecl
     const out  = copy.body.assigns[0] as OutputAssign
     expect(out.expr).toMatchObject({ op: 'regRef' })
-    expect((out.expr as RegRef).decl).toBe(regDecl)
+    expect(copy.regs[(out.expr as RegRef).idx]).toBe(regDecl)
     expect(regDecl.update).toBeDefined()
-    expect((regDecl.update as RegRef).decl).toBe(regDecl)
+    expect(copy.regs[(regDecl.update as RegRef).idx]).toBe(regDecl)
   })
 
   test('multiple RegRefs to same RegDecl all point at the same cloned decl', () => {
@@ -83,13 +83,13 @@ describe('clone — reference identity (within-clone)', () => {
     `)
     const regDecl = copy.body.decls[0] as RegDecl
     const out = copy.body.assigns[0] as OutputAssign
-    // Walk the (s + s + s) tree; collect every RegRef.decl.
+    // Walk the (s + s + s) tree; collect every regRef.idx → resolve to RegDecl.
     const refs: RegDecl[] = []
     function walk(n: unknown): void {
       if (typeof n !== 'object' || n === null) return
       if (Array.isArray(n)) { n.forEach(walk); return }
-      const o = n as { op?: string; decl?: unknown; args?: unknown }
-      if (o.op === 'regRef') { refs.push(o.decl as RegDecl); return }
+      const o = n as { op?: string; idx?: number; args?: unknown }
+      if (o.op === 'regRef') { refs.push(copy.regs[o.idx as number]); return }
       if (Array.isArray(o.args)) o.args.forEach(walk)
     }
     walk(out.expr)
@@ -99,7 +99,7 @@ describe('clone — reference identity (within-clone)', () => {
 
   test('delay-form RegDecl clone preserves RegRef identity', () => {
     // Post-Phase-0a: `delay z = u init v` desugars to a RegDecl with
-    // update populated. Reads of z are RegRefs.
+    // update populated. Reads of z are RegRefs (by idx into copy.regs).
     const { copy } = clab(`
       program X(x: float) -> (out: float) {
         delay z = x init 0
@@ -110,7 +110,7 @@ describe('clone — reference identity (within-clone)', () => {
     const out = copy.body.assigns[0] as OutputAssign
     const ref = out.expr as RegRef
     expect(ref.op).toBe('regRef')
-    expect(ref.decl).toBe(regDecl)
+    expect(copy.regs[ref.idx]).toBe(regDecl)
     expect(regDecl.update).toBeDefined()
   })
 

--- a/compiler/ir/clone.ts
+++ b/compiler/ir/clone.ts
@@ -47,6 +47,7 @@ import type {
   Let,
   Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith,
 } from './nodes.js'
+import { buildDeclTables } from './decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
 // Dedup table — Map<old, new> covers every cloned decl kind
@@ -155,12 +156,21 @@ function cloneProgram(prog: ResolvedProgram, t: CloneTable): ResolvedProgram {
   // memo on recursion (e.g., a nested program decl whose body refers
   // back through scope to itself, though current parser disallows
   // that — defensive against future shapes).
+  // Shell satisfies ResolvedProgram with empty decl tables; the tables
+  // are re-derived after fill-in completes (line near return below).
+  // Clone uses a shell-then-fill pattern (mutation during construction)
+  // to handle cross-decl references. Phase 0 just adds the table re-
+  // derivation; the structural cleanup of the shell pattern itself is
+  // a later phase.
   const shell: ResolvedProgram = {
     op: 'program',
     name: prog.name,
     typeParams: [],
     ports: { inputs: [], outputs: [], typeDefs: prog.ports.typeDefs },
     body: { op: 'block', decls: [], assigns: [] },
+    regs:      [],
+    params:    [],
+    instances: [],
   }
   t.nestedPrograms.set(prog, shell)
 
@@ -197,6 +207,16 @@ function cloneProgram(prog: ResolvedProgram, t: CloneTable): ResolvedProgram {
   shell.body.decls = declShells
 
   shell.body.assigns = prog.body.assigns.map(a => cloneAssign(a, t))
+
+  // Re-derive decl tables now that body.decls is fully populated. The
+  // tables on the shell were placeholder `[]` during the fill phase
+  // (necessary so cross-decl references in the table cache could be
+  // resolved against the shell's identity); now that fill is done the
+  // tables are projected from the canonical body.decls.
+  const tables = buildDeclTables(shell.body.decls)
+  shell.regs      = tables.regs
+  shell.params    = tables.params
+  shell.instances = tables.instances
 
   return shell
 }

--- a/compiler/ir/clone.ts
+++ b/compiler/ir/clone.ts
@@ -46,7 +46,10 @@ import type {
   Tag, Match, MatchArm,
   Let,
   Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith,
+  InputIdx, TypeParamIdx,
+  RegIdx as RegIdx_t, ParamIdx as ParamIdx_t, InstanceIdx as InstanceIdx_t,
 } from './nodes.js'
+import { typeParamIdx } from './nodes.js'
 import { buildDeclTables } from './decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
@@ -68,23 +71,38 @@ interface CloneTable {
    *  nested program share the cloned program object. */
   nestedPrograms: Map<ResolvedProgram, ResolvedProgram>
   /** Optional substitution map for Phase C3 specialize: TypeParamRef
-   *  in expression position and TypeParamDecl in ShapeDim position
-   *  whose decl is a key here are rewritten to the corresponding
-   *  integer. Refs whose decl is NOT in subst are passed through —
-   *  they belong to a nested program's own type-params that this
-   *  caller is not specializing. */
-  subst?: ReadonlyMap<TypeParamDecl, number>
+   *  whose idx is a key here is rewritten to the corresponding integer.
+   *  Refs whose idx is NOT in subst pass through — they belong to a
+   *  nested program's own type-params (caller isn't specializing them).
+   *  Keyed by TypeParamIdx (position in the root program's typeParams).
+   *  ShapeDim substitution uses `substByDecl` because ShapeDim carries
+   *  TypeParamDecl pointers, not indices. */
+  subst?:        ReadonlyMap<TypeParamIdx, number>
+  /** Mirror of `subst` keyed by decl object — used for ShapeDim
+   *  substitution where the dim is `number | TypeParamDecl` (no idx).
+   *  Built alongside `subst` in cloneWithSubst. */
+  substByDecl?:  ReadonlyMap<TypeParamDecl, number>
   /** The program whose `typeParams` should be emptied in the clone
    *  (the specialization root). Nested programs retain their own
    *  `typeParams` since this caller isn't substituting them. */
   rootProgram?: ResolvedProgram
   /** Optional substitution map for Phase C5 inlineInstances: InputRef
-   *  whose decl is a key here is replaced by the corresponding
+   *  whose idx is a key here is replaced by the corresponding
    *  ResolvedExpr (from the wired-in expression at the outer site).
    *  The substituted expression is in the *outer* program's namespace
    *  and is not cloned again — it passes through by reference, which
    *  preserves DAG sharing across multiple uses. */
-  inputSubst?: ReadonlyMap<InputDecl, ResolvedExpr>
+  inputSubst?: ReadonlyMap<InputIdx, ResolvedExpr>
+  /** Idx offsets applied to surviving indexed refs in the cloned
+   *  program. After cloning, the cloned program's decls will be lifted
+   *  into an outer program at known offsets; refs inside the cloned
+   *  body need to point at the lifted positions, not the cloned-local
+   *  positions. Applied to RegRef, ParamRef, NestedOut.instance.
+   *  Zero (or unset) means no shift — useful for standalone clones
+   *  that aren't being lifted. */
+  regOffset?:      number
+  paramOffset?:    number
+  instanceOffset?: number
 }
 
 function emptyTable(): CloneTable {
@@ -122,7 +140,16 @@ export function cloneWithSubst(
   subst: ReadonlyMap<TypeParamDecl, number>,
 ): ResolvedProgram {
   const t = emptyTable()
-  t.subst = subst
+  // Build the index-keyed mirror of subst for ref-position substitution.
+  // ShapeDim sites still use the decl-keyed map because ShapeDim's
+  // TypeParamDecl variant carries a decl pointer, not an index.
+  const byIdx = new Map<TypeParamIdx, number>()
+  for (let i = 0; i < prog.typeParams.length; i++) {
+    const v = subst.get(prog.typeParams[i])
+    if (v !== undefined) byIdx.set(typeParamIdx(i), v)
+  }
+  t.subst       = byIdx
+  t.substByDecl = subst
   t.rootProgram = prog
   return cloneProgram(prog, t)
 }
@@ -141,10 +168,14 @@ export function cloneWithSubst(
  */
 export function cloneWithInputSubst(
   prog: ResolvedProgram,
-  inputSubst: ReadonlyMap<InputDecl, ResolvedExpr>,
+  inputSubst: ReadonlyMap<InputIdx, ResolvedExpr>,
+  shifts?: { regOffset?: number; paramOffset?: number; instanceOffset?: number },
 ): ResolvedProgram {
   const t = emptyTable()
   t.inputSubst = inputSubst
+  if (shifts?.regOffset      !== undefined) t.regOffset      = shifts.regOffset
+  if (shifts?.paramOffset    !== undefined) t.paramOffset    = shifts.paramOffset
+  if (shifts?.instanceOffset !== undefined) t.instanceOffset = shifts.instanceOffset
   return cloneProgram(prog, t)
 }
 
@@ -316,14 +347,16 @@ function fillBodyDecl(orig: BodyDecl, fresh: BodyDecl, t: CloneTable): void {
     return
   }
   if (orig.op === 'instanceDecl' && fresh.op === 'instanceDecl') {
-    // typeArgs reference the cloned program's typeParams. Use the
-    // cloned-program's typeParams via the dedup table.
+    // typeArgs and inputs are indexed (positions into the target
+    // program's typeParams[] / ports.inputs[]). Since cloneProgram
+    // preserves the order of decls, the target's positions don't
+    // shift — indices pass through unchanged.
     fresh.typeArgs = orig.typeArgs.map(a => ({
-      param: cloneTypeParamDecl(a.param, t),
+      param: a.param,
       value: a.value,
     }))
     fresh.inputs = orig.inputs.map(i => ({
-      port:  cloneInputDecl(i.port, t),
+      port:  i.port,
       value: cloneExpr(i.value, t),
     }))
     return
@@ -337,11 +370,13 @@ function fillBodyDecl(orig: BodyDecl, fresh: BodyDecl, t: CloneTable): void {
 
 function cloneAssign(a: BodyAssign, t: CloneTable): BodyAssign {
   // Post-Phase-0a: BodyAssign is OutputAssign-only. NextUpdate folded
-  // into RegDecl.update at elaboration time.
-  const target: OutputDecl | { kind: 'dac' } =
-    'op' in a.target
-      ? cloneOutputDecl(a.target, t)
-      : { kind: 'dac' }   // sentinel — fresh object, semantically a singleton
+  // into RegDecl.update at elaboration time. Target is now OutputIdx
+  // (index into prog.ports.outputs[]) or the dac sentinel — cloning
+  // preserves output order, so the index passes through unchanged.
+  const target: typeof a.target =
+    typeof a.target === 'object' && 'kind' in a.target
+      ? { kind: 'dac' }                 // sentinel — fresh object
+      : a.target                         // OutputIdx — pass through
   const fresh: OutputAssign = {
     op: 'outputAssign',
     target,
@@ -374,8 +409,8 @@ function clonePortType(pt: PortType, t: CloneTable): PortType {
 
 function cloneShapeDim(d: ShapeDim, t: CloneTable): ShapeDim {
   if (typeof d === 'number') return d
-  if (t.subst !== undefined) {
-    const v = t.subst.get(d)
+  if (t.substByDecl !== undefined) {
+    const v = t.substByDecl.get(d)
     if (v !== undefined) return v
   }
   return cloneTypeParamDecl(d, t)
@@ -388,22 +423,27 @@ function cloneShapeDim(d: ShapeDim, t: CloneTable): ShapeDim {
 function cloneExpr(e: ResolvedExpr, t: CloneTable): ResolvedExpr {
   if (typeof e === 'number' || typeof e === 'boolean') return e
   if (Array.isArray(e)) return e.map(x => cloneExpr(x, t))
-  // Specialize-time substitution: a TypeParamRef whose decl is a key
-  // in the subst map collapses to the integer literal. Refs whose decl
-  // is NOT in subst (i.e., the decl belongs to a nested program's own
-  // type-params) pass through to cloneOpNode, where they get the usual
-  // ref-clone treatment.
+  // Specialize-time substitution: a TypeParamRef whose idx is a key
+  // in the subst map collapses to the integer literal. The subst map
+  // is keyed by TypeParamIdx (position in the ROOT program's
+  // typeParams), populated by cloneWithSubst. Refs whose idx is NOT
+  // in subst (i.e., the ref belongs to a nested program's own
+  // type-params) pass through to cloneOpNode for the usual ref-clone
+  // treatment. (Nested-program scope tracking is not yet supported
+  // here — tropical's stdlib has no nested programDecls, so this
+  // hasn't been an issue in practice; if it becomes one, push the
+  // current-program onto a stack in CloneTable and disambiguate.)
   if (t.subst !== undefined && e.op === 'typeParamRef') {
-    const v = t.subst.get(e.decl)
+    const v = t.subst.get(e.idx)
     if (v !== undefined) return v
   }
-  // Inline-time substitution (Phase C5): an InputRef whose decl is a
+  // Inline-time substitution (Phase C5): an InputRef whose idx is a
   // key in inputSubst collapses to the wired-in expression from the
   // outer site. The substituted expression is already in the outer's
   // namespace; pass it through by reference (preserves DAG sharing
   // when the same input is used multiple times in the inner body).
   if (t.inputSubst !== undefined && typeof e === 'object' && e.op === 'inputRef') {
-    const v = t.inputSubst.get(e.decl)
+    const v = t.inputSubst.get(e.idx)
     if (v !== undefined) return v
   }
   return cloneOpNode(e, t)
@@ -419,23 +459,37 @@ function cloneBinder(b: BinderDecl, t: CloneTable): BinderDecl {
 
 function cloneOpNode(node: ResolvedExprOp, t: CloneTable): ResolvedExprOp {
   switch (node.op) {
-    // Refs — point at the cloned decl via the dedup table.
-    case 'inputRef':  return { op: 'inputRef',  decl: cloneInputDecl(node.decl, t) }
-    case 'regRef':    return { op: 'regRef',    decl: lookupRegDecl(node.decl, t) }
-    case 'paramRef': {
-      const cloned = t.params.get(node.decl)
-      if (!cloned) throw new Error(`clone: unregistered ParamDecl '${node.decl.name}'`)
-      return { op: 'paramRef', decl: cloned }
+    // Indexed refs pass through, with optional offset shifting applied
+    // for inlineInstances' lift scenario. Cloning alone preserves decl
+    // order, but a clone being lifted into another program needs its
+    // indices remapped to the outer's namespace. The InputSubst case
+    // doesn't shift inputRefs because they're substituted to outer
+    // expressions before they could need remapping.
+    case 'inputRef':     return { op: 'inputRef',     idx: node.idx }
+    case 'regRef':       return {
+      op: 'regRef',
+      idx: (t.regOffset !== undefined
+        ? (node.idx as number) + t.regOffset
+        : node.idx) as RegIdx_t,
     }
-    case 'typeParamRef': return { op: 'typeParamRef', decl: cloneTypeParamDecl(node.decl, t) }
+    case 'paramRef':     return {
+      op: 'paramRef',
+      idx: (t.paramOffset !== undefined
+        ? (node.idx as number) + t.paramOffset
+        : node.idx) as ParamIdx_t,
+    }
+    case 'typeParamRef': return { op: 'typeParamRef', idx: node.idx }
+    case 'nestedOut':    return {
+      op: 'nestedOut',
+      instance: (t.instanceOffset !== undefined
+        ? (node.instance as number) + t.instanceOffset
+        : node.instance) as InstanceIdx_t,
+      output: node.output,
+    }
+    // BindingRef is pointer-based (see issue #156). Binders are
+    // dedup-cloned to fresh objects so refs across an arm body all
+    // point at the same fresh binder.
     case 'bindingRef':   return { op: 'bindingRef',   decl: cloneBinder(node.decl, t) }
-    case 'nestedOut': {
-      const inst = t.instances.get(node.instance)
-      if (!inst) throw new Error(`clone: unregistered InstanceDecl '${node.instance.name}'`)
-      // The output decl belongs to inst.type (the cloned nested program);
-      // resolve it via cloneOutputDecl which routes through the table.
-      return { op: 'nestedOut', instance: inst, output: cloneOutputDecl(node.output, t) }
-    }
     case 'sampleRate':  return { op: 'sampleRate' }
     case 'sampleIndex': return { op: 'sampleIndex' }
 

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -13,7 +13,7 @@
  * runnable-plan boundary.
  */
 
-import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, ParamDecl, PortType, InstanceDecl, InputDecl } from './nodes.js'
+import type { ResolvedProgram, ResolvedExpr, OutputDecl, RegDecl, ParamDecl, PortType, InstanceDecl, InputDecl, ParamIdx, InputIdx, OutputIdx, InstanceIdx } from './nodes.js'
 import type { PerInstancePlan } from '../flat_plan.js'
 import { buildSlotMaps, type SlotMaps } from './slots.js'
 import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_resolved.js'
@@ -22,24 +22,26 @@ import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_res
  *  program type's body, plus optional nested-output and nested-input
  *  slot maps for the M11 fractal compile path. */
 export interface CompileResolvedContext {
-  paramHandles?:      Map<ParamDecl, { ptr: string }>
-  /** Per-sub-instance, per-output-port module-slot map. Populated by
-   *  `partition_recursive` when compiling a parent kernel whose body
-   *  contains child kernels. `NestedOut` refs lower to Slot reads
-   *  via this map. */
-  nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
-  /** Per-sub-instance, per-input-port module-slot map. Populated by
-   *  `partition_recursive` for the M11 slot-based input wiring. The
-   *  parent's compile emits a `WriteSlot` into each named slot;
-   *  the entries land in `per_child_pre_input[k]` (parallel to the
-   *  body's nested-instance order) so the engine runs each block
-   *  immediately before recursing into its corresponding child. */
-  nestedInputSlots?:  Map<InstanceDecl, Map<InputDecl, number>>
+  /** Keyed by ParamIdx. */
+  paramHandles?:      Map<ParamIdx, { ptr: string }>
+  /** Per-sub-instance, per-output-port module-slot map. Keyed by
+   *  InstanceIdx (in this program) and OutputIdx (in the instance's
+   *  type). Populated by `partition_recursive` for M11 fractal compile;
+   *  `NestedOut` refs lower to Slot reads via this map. */
+  nestedOutputSlots?: Map<InstanceIdx, Map<OutputIdx, number>>
+  /** Per-sub-instance, per-input-port module-slot map. Keyed by
+   *  InstanceIdx and InputIdx. Populated by `partition_recursive` for
+   *  the M11 slot-based input wiring. The parent's compile emits a
+   *  `WriteSlot` into each named slot; entries land in
+   *  `per_child_pre_input[k]` (parallel to the body's nested-instance
+   *  order) so the engine runs each block immediately before recursing
+   *  into its corresponding child. */
+  nestedInputSlots?:  Map<InstanceIdx, Map<InputIdx, number>>
   /** Module-slot indices for THIS program's own input ports. Set when
    *  the program is being compiled as a sub-instance kernel — its
-   *  `InputRef(d)` lowers to a slot read from `inputSlotOverride.get(d)`
-   *  instead of the legacy `opInput`. */
-  inputSlotOverride?: Map<InputDecl, number>
+   *  `InputRef(idx)` lowers to a slot read from
+   *  `inputSlotOverride.get(idx)` instead of the legacy `opInput`. */
+  inputSlotOverride?: Map<InputIdx, number>
 }
 
 /** Compile a `ResolvedProgram` to a `PerInstancePlan`.
@@ -59,15 +61,18 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
   // emit_resolved's terminal check throw a descriptive message.
 
   // ── Output expressions ──
-  const outputExprByDecl = new Map<OutputDecl, ResolvedExpr>()
+  // OutputAssign.target is now OutputIdx (or the dac sentinel). Map
+  // output position → expression; iterate output ports in order to
+  // produce the per-port expression array.
+  const outputExprByIdx = new Map<number, ResolvedExpr>()
   for (const a of prog.body.assigns) {
     if (a.op !== 'outputAssign') continue
-    if ('op' in a.target && a.target.op === 'outputDecl') {
-      outputExprByDecl.set(a.target, a.expr)
+    if (typeof a.target === 'number') {
+      outputExprByIdx.set(a.target, a.expr)
     }
   }
-  const outputExprs: ResolvedExpr[] = prog.ports.outputs.map(out => {
-    const expr = outputExprByDecl.get(out)
+  const outputExprs: ResolvedExpr[] = prog.ports.outputs.map((out, i) => {
+    const expr = outputExprByIdx.get(i)
     if (expr === undefined) {
       throw new Error(`compileResolved: program '${prog.name}' output '${out.name}' has no outputAssign.`)
     }

--- a/compiler/ir/decl_tables.ts
+++ b/compiler/ir/decl_tables.ts
@@ -25,6 +25,33 @@ import type {
   RegDecl, ParamDecl, InstanceDecl, BodyDecl,
 } from './nodes.js'
 
+/** Pure rewire of every `InstanceDecl.type` pointer in `prog` to the
+ *  canonical version found in `byName`. Used by the topological
+ *  typeRegistry build (`compiler/program.ts`) to ensure that by the
+ *  time a program is consumed (by `materialize_session`,
+ *  `partition_recursive`, etc.), every sub-instance's `.type` already
+ *  points at a strata-processed program — not at the raw elaborated
+ *  version still hanging around from the elaborator's resolver.
+ *
+ *  Returns the same program (by identity) if no relinking happens,
+ *  so the strata fast-path of "no-op identity" still triggers
+ *  downstream. */
+export function relinkInstanceTypes(
+  prog: ResolvedProgram,
+  byName: ReadonlyMap<string, ResolvedProgram>,
+): ResolvedProgram {
+  let changed = false
+  const newDecls = prog.body.decls.map(d => {
+    if (d.op !== 'instanceDecl') return d
+    const canonical = byName.get(d.type.name)
+    if (!canonical || canonical === d.type) return d
+    changed = true
+    return { ...d, type: canonical }
+  })
+  if (!changed) return prog
+  return withDeclTables({ ...prog, body: { ...prog.body, decls: newDecls } })
+}
+
 /** Project a flat `BodyDecl[]` into typed tables by kind. Order
  *  within each table matches body-decl order — the same order
  *  `buildSlotMaps` uses for slot allocation. */

--- a/compiler/ir/decl_tables.ts
+++ b/compiler/ir/decl_tables.ts
@@ -1,0 +1,93 @@
+/**
+ * decl_tables.ts — projection of body.decls into typed flat tables.
+ *
+ * Every `ResolvedProgram` carries typed flat arrays for each decl kind
+ * (`regs`, `params`, `instances`) projected from the heterogeneous
+ * `body.decls: BodyDecl[]`. Position in the projected array IS the
+ * decl's identity — the de Bruijn levels migration (planned next
+ * phase) uses these positions as the indices that replace the
+ * pointer-based ref types.
+ *
+ * `InputDecl` and `OutputDecl` positional identity already lives in
+ * `ports.inputs` / `ports.outputs`; no top-level duplicate.
+ *
+ * Decls in the tables are the SAME OBJECTS as decls in `body.decls`
+ * (no clone). Pointer identity is preserved during the transition.
+ *
+ * Every constructor of a `ResolvedProgram` must route through
+ * `withDeclTables` so the tables stay in sync with `body.decls`. The
+ * type system enforces this via the required `regs` / `params` /
+ * `instances` fields on the `ResolvedProgram` interface.
+ */
+
+import type {
+  ResolvedProgram, ResolvedProgramPorts, ResolvedBlock,
+  RegDecl, ParamDecl, InstanceDecl, BodyDecl,
+} from './nodes.js'
+
+/** Project a flat `BodyDecl[]` into typed tables by kind. Order
+ *  within each table matches body-decl order — the same order
+ *  `buildSlotMaps` uses for slot allocation. */
+export function buildDeclTables(decls: readonly BodyDecl[]): {
+  regs:      RegDecl[]
+  params:    ParamDecl[]
+  instances: InstanceDecl[]
+} {
+  const regs:      RegDecl[]      = []
+  const params:    ParamDecl[]    = []
+  const instances: InstanceDecl[] = []
+  for (const d of decls) {
+    switch (d.op) {
+      case 'regDecl':      regs.push(d);      break
+      case 'paramDecl':    params.push(d);    break
+      case 'instanceDecl': instances.push(d); break
+      case 'programDecl':  /* type-decl only; no runtime identity */ break
+    }
+  }
+  return { regs, params, instances }
+}
+
+/** Construct a `ResolvedProgram` from its constituent parts, projecting
+ *  the decl tables from `body.decls` in one step. THE only canonical
+ *  way to build a `ResolvedProgram` — every constructor site (elaborator,
+ *  clone, strata passes, materialize_session) routes through here so the
+ *  tables can't drift from `body.decls`. */
+export function mkProgram(args: {
+  name: string
+  typeParams: ResolvedProgram['typeParams']
+  ports: ResolvedProgramPorts
+  body: ResolvedBlock
+}): ResolvedProgram {
+  return {
+    op: 'program',
+    name:       args.name,
+    typeParams: args.typeParams,
+    ports:      args.ports,
+    body:       args.body,
+    ...buildDeclTables(args.body.decls),
+  }
+}
+
+/** Lift an existing `ResolvedProgram`-shaped value into a fully-formed
+ *  `ResolvedProgram` by (re)projecting the decl tables from
+ *  `body.decls`. Useful for spread-update sites that change `body` and
+ *  need the tables refreshed:
+ *
+ *      return withDeclTables({ ...prog, body: newBody })
+ *
+ *  Accepts a structurally-incomplete program (tables possibly stale or
+ *  missing) and returns a structurally-complete one. The decl objects
+ *  themselves are reused (no clone); only the tables are rebuilt. */
+export function withDeclTables(
+  prog: Omit<ResolvedProgram, 'regs' | 'params' | 'instances'> &
+        Partial<Pick<ResolvedProgram, 'regs' | 'params' | 'instances'>>,
+): ResolvedProgram {
+  return {
+    op:         'program',
+    name:       prog.name,
+    typeParams: prog.typeParams,
+    ports:      prog.ports,
+    body:       prog.body,
+    ...buildDeclTables(prog.body.decls),
+  }
+}

--- a/compiler/ir/elaborator.test.ts
+++ b/compiler/ir/elaborator.test.ts
@@ -33,13 +33,13 @@ function elabSrc(src: string): ResolvedProgram {
 // ─────────────────────────────────────────────────────────────
 
 describe('elaborator — value references', () => {
-  test('input ref: nameRef resolves to InputRef.decl === the input port', () => {
+  test('input ref: nameRef resolves to InputRef.idx === the input port position', () => {
     const p = elabSrc('program X(freq: float) -> (out: float) { out = freq }')
     const inputDecl = p.ports.inputs[0]
     const outputAssign = p.body.assigns[0] as OutputAssign
     const expr = outputAssign.expr as InputRef
     expect(expr.op).toBe('inputRef')
-    expect(expr.decl).toBe(inputDecl)  // reference identity
+    expect(p.ports.inputs[expr.idx]).toBe(inputDecl)
   })
 
   test('reg ref: nameRef resolves to RegRef.decl === the regDecl', () => {
@@ -56,10 +56,10 @@ describe('elaborator — value references', () => {
     const out = p.body.assigns[0] as OutputAssign
     const outRef = out.expr as RegRef
     expect(outRef.op).toBe('regRef')
-    expect(outRef.decl).toBe(regDecl)
-    // The folded update reads s — same decl identity.
+    expect(p.regs[outRef.idx]).toBe(regDecl)
+    // The folded update reads s — same decl identity (resolved via idx).
     expect(regDecl.update).toBeDefined()
-    expect((regDecl.update as RegRef).decl).toBe(regDecl)
+    expect(p.regs[(regDecl.update as RegRef).idx]).toBe(regDecl)
   })
 
   test('delay-form RegDecl: nameRef resolves to RegRef on the decl', () => {
@@ -79,10 +79,10 @@ describe('elaborator — value references', () => {
     const out = p.body.assigns[0] as OutputAssign
     const ref = out.expr as RegRef
     expect(ref.op).toBe('regRef')
-    expect(ref.decl).toBe(regDecl)
+    expect(p.regs[ref.idx]).toBe(regDecl)
   })
 
-  test('param ref: nameRef resolves to ParamRef.decl', () => {
+  test('param ref: nameRef resolves to ParamRef.idx', () => {
     const p = elabSrc(`
       program X() -> (out: float) {
         param cutoff: smoothed = 1000
@@ -93,10 +93,10 @@ describe('elaborator — value references', () => {
     const out = p.body.assigns[0] as OutputAssign
     const ref = out.expr as ParamRef
     expect(ref.op).toBe('paramRef')
-    expect(ref.decl).toBe(paramDecl)
+    expect(p.params[ref.idx]).toBe(paramDecl)
   })
 
-  test('type-param ref: nameRef resolves to TypeParamRef.decl', () => {
+  test('type-param ref: nameRef resolves to TypeParamRef.idx', () => {
     const p = elabSrc(`
       program X<N: int = 4>() -> (out: float) {
         out = N
@@ -106,7 +106,7 @@ describe('elaborator — value references', () => {
     const out = p.body.assigns[0] as OutputAssign
     const ref = out.expr as TypeParamRef
     expect(ref.op).toBe('typeParamRef')
-    expect(ref.decl).toBe(typeParam)
+    expect(p.typeParams[ref.idx]).toBe(typeParam)
   })
 
   test('unknown name: clear error', () => {
@@ -428,15 +428,15 @@ describe('elaborator — instances + nested programs', () => {
     const instDecl = p.body.decls[1] as InstanceDecl
     expect(instDecl.op).toBe('instanceDecl')
     expect(instDecl.type).toBe(progDecl.program)  // shared reference
-    // Input wire is keyed by the actual InputDecl
+    // Input wire is keyed by the input port's position in the target
     expect(instDecl.inputs.length).toBe(1)
-    expect(instDecl.inputs[0].port).toBe(progDecl.program.ports.inputs[0])
-    // The output assign uses NestedOut with OutputDecl reference
+    expect(progDecl.program.ports.inputs[instDecl.inputs[0].port]).toBe(progDecl.program.ports.inputs[0])
+    // The output assign uses NestedOut with instance + output indices
     const out = p.body.assigns[0] as OutputAssign
     const nest = out.expr as NestedOut
     expect(nest.op).toBe('nestedOut')
-    expect(nest.instance).toBe(instDecl)
-    expect(nest.output).toBe(progDecl.program.ports.outputs[0])
+    expect(p.instances[nest.instance]).toBe(instDecl)
+    expect(progDecl.program.ports.outputs[nest.output]).toBe(progDecl.program.ports.outputs[0])
   })
 
   test('instance with unknown program type errors', () => {
@@ -479,7 +479,7 @@ describe('elaborator — instances + nested programs', () => {
     const progDecl = p.body.decls[0] as ProgramDecl
     const instDecl = p.body.decls[1] as InstanceDecl
     expect(instDecl.typeArgs.length).toBe(1)
-    expect(instDecl.typeArgs[0].param).toBe(progDecl.program.typeParams[0])
+    expect(progDecl.program.typeParams[instDecl.typeArgs[0].param]).toBe(progDecl.program.typeParams[0])
     expect(instDecl.typeArgs[0].value).toBe(8)
   })
 })
@@ -492,10 +492,10 @@ describe('elaborator — output assigns', () => {
   test('outputAssign target is the actual OutputDecl', () => {
     const p = elabSrc('program X() -> (out: float) { out = 1 }')
     const out = p.body.assigns[0] as OutputAssign
-    if (out.target !== null && typeof out.target === 'object' && 'kind' in out.target) {
-      throw new Error('expected OutputDecl, got dac sentinel')
+    if (typeof out.target !== 'number') {
+      throw new Error('expected OutputIdx, got dac sentinel')
     }
-    expect(out.target).toBe(p.ports.outputs[0])
+    expect(p.ports.outputs[out.target]).toBe(p.ports.outputs[0])
   })
 
   test('dac.out target is the dac sentinel', () => {
@@ -618,16 +618,16 @@ describe('elaborator — graph integrity', () => {
       }
     `)
     const regDecl = p.body.decls[0] as RegDecl
-    // Walk all references; every regRef.decl is the same object.
+    // Walk all references; every regRef.idx resolves to the same RegDecl.
     const seen: unknown[] = []
     walk(p, (obj) => {
       if ((obj as { op?: string }).op === 'regRef') {
-        seen.push((obj as { decl: unknown }).decl)
+        seen.push(p.regs[(obj as { idx: number }).idx])
       }
     })
     expect(seen.length).toBeGreaterThan(0)
     for (const s of seen) {
-      expect(s).toBe(regDecl)  // strict reference identity
+      expect(s).toBe(regDecl)  // strict reference identity (via idx → decl)
     }
   })
 
@@ -666,7 +666,7 @@ describe('elaborator — graph integrity', () => {
     const regDecl = p.body.decls[0] as RegDecl
     expect(regDecl.update).toBeDefined()
     const expr = regDecl.update as BinaryOp
-    expect((expr.args[0] as RegRef).decl).toBe(regDecl)
+    expect(p.regs[(expr.args[0] as RegRef).idx]).toBe(regDecl)
   })
 })
 
@@ -693,7 +693,7 @@ describe('elaborator — external program resolver', () => {
     expect(inst.op).toBe('instanceDecl')
     // The instance's program type IS the externally-supplied object.
     expect(inst.type).toBe(inner)
-    expect(inst.inputs[0].port).toBe(inner.ports.inputs[0])
+    expect(inner.ports.inputs[inst.inputs[0].port]).toBe(inner.ports.inputs[0])
   })
 
   test('resolver returns undefined → instance error mentions resolver', () => {
@@ -849,7 +849,7 @@ describe('elaborator — new builtin calls', () => {
     expect(z.op).toBe('zeros')
     const ref = z.count as TypeParamRef
     expect(ref.op).toBe('typeParamRef')
-    expect(ref.decl).toBe(p.typeParams[0])
+    expect(p.typeParams[ref.idx]).toBe(p.typeParams[0])
   })
 
   test('arraySet(arr, idx, val) resolves to ArraySet with three args', () => {

--- a/compiler/ir/elaborator.ts
+++ b/compiler/ir/elaborator.ts
@@ -69,6 +69,7 @@ import type {
   BinderDecl,
   InputRef, RegRef, ParamRef, TypeParamRef, BindingRef,
   NestedOut,
+  RegIdx, InputIdx, OutputIdx, ParamIdx, InstanceIdx, TypeParamIdx,
   Tag, Match, MatchArm,
   Let,
   Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith,
@@ -77,7 +78,10 @@ import type {
   BinaryOp, BinaryOpTag, UnaryOp, UnaryOpTag,
   SampleRate, SampleIndex,
 } from './nodes.js'
-import { ElaborationError } from './nodes.js'
+import {
+  ElaborationError,
+  regIdx, inputIdx, outputIdx, paramIdx, instanceIdx, typeParamIdx,
+} from './nodes.js'
 import { mkProgram } from './decl_tables.js'
 import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
@@ -149,6 +153,16 @@ interface Scope {
   regs: Map<string, RegDecl>
   params: Map<string, ParamDecl>
   instances: Map<string, InstanceDecl>
+  /** Decl → de Bruijn level (position in eventual program table).
+   *  Populated as decls are registered; looked up by ref construction
+   *  to fill in `RegRef.idx` / `InputRef.idx` / etc. Each map is
+   *  scope-local — nested programs have their own indexing. */
+  regIdxByDecl:       Map<RegDecl, RegIdx>
+  inputIdxByDecl:     Map<InputDecl, InputIdx>
+  outputIdxByDecl:    Map<OutputDecl, OutputIdx>
+  paramIdxByDecl:     Map<ParamDecl, ParamIdx>
+  instanceIdxByDecl:  Map<InstanceDecl, InstanceIdx>
+  typeParamIdxByDecl: Map<TypeParamDecl, TypeParamIdx>
   /** Sub-program decls visible in this scope (nested programDecl). */
   programs: Map<string, ResolvedProgram>
   /** Type defs (struct/sum/alias) by name. */
@@ -177,6 +191,12 @@ function emptyScope(parent?: Scope): Scope {
     regs: new Map(),
     params: new Map(),
     instances: new Map(),
+    regIdxByDecl:       new Map(),
+    inputIdxByDecl:     new Map(),
+    outputIdxByDecl:    new Map(),
+    paramIdxByDecl:     new Map(),
+    instanceIdxByDecl:  new Map(),
+    typeParamIdxByDecl: new Map(),
     programs: new Map(),
     typeDefs: new Map(),
     variantOf: new Map(),
@@ -195,7 +215,9 @@ function emptyScope(parent?: Scope): Scope {
  *  fixed semantic intent (a value-producing reference), and we try each
  *  applicable scope. */
 function lookupValueRef(scope: Scope, name: string): ResolvedExprOp | null {
-  // Local binders (innermost-first via the Scope's own state)
+  // Local binders (innermost-first via the Scope's own state). Binders
+  // are the one ref kind that keeps a direct pointer — see issue #156
+  // for the locally-nameless migration that would index them too.
   const binder = scope.binders.get(name)
   if (binder) {
     const ref: BindingRef = { op: 'bindingRef', decl: binder }
@@ -203,22 +225,30 @@ function lookupValueRef(scope: Scope, name: string): ResolvedExprOp | null {
   }
   const reg = scope.regs.get(name)
   if (reg) {
-    const ref: RegRef = { op: 'regRef', decl: reg }
+    const i = scope.regIdxByDecl.get(reg)
+    if (i === undefined) throw new ElaborationError(`internal: reg '${name}' has no index in scope`)
+    const ref: RegRef = { op: 'regRef', idx: i }
     return ref
   }
   const param = scope.params.get(name)
   if (param) {
-    const ref: ParamRef = { op: 'paramRef', decl: param }
+    const i = scope.paramIdxByDecl.get(param)
+    if (i === undefined) throw new ElaborationError(`internal: param '${name}' has no index in scope`)
+    const ref: ParamRef = { op: 'paramRef', idx: i }
     return ref
   }
   const input = scope.inputs.get(name)
   if (input) {
-    const ref: InputRef = { op: 'inputRef', decl: input }
+    const i = scope.inputIdxByDecl.get(input)
+    if (i === undefined) throw new ElaborationError(`internal: input '${name}' has no index in scope`)
+    const ref: InputRef = { op: 'inputRef', idx: i }
     return ref
   }
   const tp = scope.typeParams.get(name)
   if (tp) {
-    const ref: TypeParamRef = { op: 'typeParamRef', decl: tp }
+    const i = scope.typeParamIdxByDecl.get(tp)
+    if (i === undefined) throw new ElaborationError(`internal: type-param '${name}' has no index in scope`)
+    const ref: TypeParamRef = { op: 'typeParamRef', idx: i }
     return ref
   }
   return null
@@ -327,6 +357,7 @@ function elaborateProgram(
       const decl: TypeParamDecl = { op: 'typeParamDecl', name }
       if (info.default !== undefined) decl.default = info.default
       scope.typeParams.set(name, decl)
+      scope.typeParamIdxByDecl.set(decl, typeParamIdx(typeParams.length))
       typeParams.push(decl)
     }
   }
@@ -341,6 +372,7 @@ function elaborateProgram(
       throw new ElaborationError(`duplicate input port '${decl.name}'`)
     }
     scope.inputs.set(decl.name, decl)
+    scope.inputIdxByDecl.set(decl, inputIdx(inputs.length))
     inputs.push(decl)
   }
   const outputs: OutputDecl[] = []
@@ -350,6 +382,7 @@ function elaborateProgram(
       throw new ElaborationError(`duplicate output port '${decl.name}'`)
     }
     scope.outputs.set(decl.name, decl)
+    scope.outputIdxByDecl.set(decl, outputIdx(outputs.length))
     outputs.push(decl)
   }
 
@@ -585,11 +618,22 @@ function registerBodyDecls(
   // expressions left as placeholders) and register them in scope, so
   // forward refs work. Expressions are resolved in a second pass via
   // the pairing map.
+  // Per-kind index tracking: as each decl is appended, record its
+  // de Bruijn level in the appropriate scope map. The level is the
+  // index into the per-kind table on the eventual program (regs[],
+  // params[], instances[]) — consumers later read via prog.regs[idx].
+  let regCount = 0, paramCount = 0, instanceCount = 0
   for (const d of body.decls ?? []) {
     if (isParsedProgramDecl(d)) continue  // already handled
     const decl = registerOneDecl(d, scope)
     pairing.set(d, decl)
     out.push(decl)
+    switch (decl.op) {
+      case 'regDecl':      scope.regIdxByDecl.set(decl, regIdx(regCount++));               break
+      case 'paramDecl':    scope.paramIdxByDecl.set(decl, paramIdx(paramCount++));         break
+      case 'instanceDecl': scope.instanceIdxByDecl.set(decl, instanceIdx(instanceCount++)); break
+      case 'programDecl':  /* programDecl is type-only, no index */ break
+    }
   }
   return out
 }
@@ -737,38 +781,40 @@ function resolveInstanceArgs(
   scope: Scope,
 ): void {
   const targetProgram = resolved.type
-  // Type args: resolve param NameRef → the target's TypeParamDecl.
+  // Type args: resolve param NameRef → position in target's typeParams[].
   for (const entry of parsed.type_args ?? []) {
-    const paramDecl = targetProgram.typeParams.find(p => p.name === entry.param.name)
-    if (!paramDecl) {
+    const pos = targetProgram.typeParams.findIndex(p => p.name === entry.param.name)
+    if (pos < 0) {
       const expected = targetProgram.typeParams.map(p => p.name).join(', ') || '(none)'
       throw new ElaborationError(
         `instance '${resolved.name}': type-arg '${entry.param.name}' is not a declared type-param of '${targetProgram.name}' (have: ${expected})`,
       )
     }
-    if (resolved.typeArgs.some(a => a.param === paramDecl)) {
+    const paramI = typeParamIdx(pos)
+    if (resolved.typeArgs.some(a => a.param === paramI)) {
       throw new ElaborationError(
         `instance '${resolved.name}': duplicate type-arg '${entry.param.name}'`,
       )
     }
-    resolved.typeArgs.push({ param: paramDecl, value: entry.value })
+    resolved.typeArgs.push({ param: paramI, value: entry.value })
   }
-  // Inputs: resolve port NameRef → the target's InputDecl, value-expr resolved.
+  // Inputs: resolve port NameRef → position in target's ports.inputs[].
   for (const entry of parsed.inputs ?? []) {
-    const portDecl = targetProgram.ports.inputs.find(p => p.name === entry.port.name)
-    if (!portDecl) {
+    const pos = targetProgram.ports.inputs.findIndex(p => p.name === entry.port.name)
+    if (pos < 0) {
       const expected = targetProgram.ports.inputs.map(p => p.name).join(', ') || '(none)'
       throw new ElaborationError(
         `instance '${resolved.name}': input '${entry.port.name}' is not a declared port of '${targetProgram.name}' (have: ${expected})`,
       )
     }
-    if (resolved.inputs.some(i => i.port === portDecl)) {
+    const portI = inputIdx(pos)
+    if (resolved.inputs.some(i => i.port === portI)) {
       throw new ElaborationError(
         `instance '${resolved.name}': duplicate input '${entry.port.name}'`,
       )
     }
     const value = resolveExpr(entry.value, scope)
-    resolved.inputs.push({ port: portDecl, value })
+    resolved.inputs.push({ port: portI, value })
   }
 }
 
@@ -797,7 +843,11 @@ function resolveOutputAssign(a: ParsedOutputAssign, scope: Scope): OutputAssign 
         `outputAssign references unknown output port '${a.name}'`,
       )
     }
-    target = out
+    const i = scope.outputIdxByDecl.get(out)
+    if (i === undefined) {
+      throw new ElaborationError(`internal: output '${a.name}' has no index in scope`)
+    }
+    target = i
   }
   return { op: 'outputAssign', target, expr: resolveExpr(a.expr, scope) }
 }
@@ -903,23 +953,34 @@ function resolveNestedOut(node: ParsedNestedOut, scope: Scope): NestedOut {
       `instance '${node.ref.name}' is not declared in this scope`,
     )
   }
+  const instIdx = scope.instanceIdxByDecl.get(inst)
+  if (instIdx === undefined) {
+    throw new ElaborationError(`internal: instance '${node.ref.name}' has no index in scope`)
+  }
   // node.output is NameRef | number; the parser preserves whichever form
-  // the user wrote.
+  // the user wrote. Output position is into the TARGET program's
+  // ports.outputs[] (inst.type is the still-pointer-based ResolvedProgram
+  // for now; the topological registry build ensures it's canonical).
   const targetProgram = inst.type
-  let output: OutputDecl | undefined
+  let outIdxRaw: number
   if (typeof node.output === 'number') {
-    output = targetProgram.ports.outputs[node.output]
+    if (node.output < 0 || node.output >= targetProgram.ports.outputs.length) {
+      const portList = targetProgram.ports.outputs.map(p => p.name).join(', ')
+      throw new ElaborationError(
+        `instance '${node.ref.name}': program '${targetProgram.name}' has no output index ${node.output} (have: ${portList})`,
+      )
+    }
+    outIdxRaw = node.output
   } else {
-    output = targetProgram.ports.outputs.find(p => p.name === node.output.name)
+    outIdxRaw = targetProgram.ports.outputs.findIndex(p => p.name === node.output.name)
+    if (outIdxRaw < 0) {
+      const portList = targetProgram.ports.outputs.map(p => p.name).join(', ')
+      throw new ElaborationError(
+        `instance '${node.ref.name}': program '${targetProgram.name}' has no output '${node.output.name}' (have: ${portList})`,
+      )
+    }
   }
-  if (!output) {
-    const portList = targetProgram.ports.outputs.map(p => p.name).join(', ')
-    const requested = typeof node.output === 'number' ? `index ${node.output}` : `'${node.output.name}'`
-    throw new ElaborationError(
-      `instance '${node.ref.name}': program '${targetProgram.name}' has no output ${requested} (have: ${portList})`,
-    )
-  }
-  return { op: 'nestedOut', instance: inst, output }
+  return { op: 'nestedOut', instance: instIdx, output: outputIdx(outIdxRaw) }
 }
 
 function resolveIndex(node: ParsedIndex, scope: Scope): Index {

--- a/compiler/ir/elaborator.ts
+++ b/compiler/ir/elaborator.ts
@@ -78,6 +78,7 @@ import type {
   SampleRate, SampleIndex,
 } from './nodes.js'
 import { ElaborationError } from './nodes.js'
+import { mkProgram } from './decl_tables.js'
 import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
 
@@ -377,13 +378,12 @@ function elaborateProgram(
 
   const block: ResolvedBlock = { op: 'block', decls, assigns }
   const ports: ResolvedProgramPorts = { inputs, outputs, typeDefs }
-  const resolved: ResolvedProgram = {
-    op: 'program',
+  const resolved: ResolvedProgram = mkProgram({
     name: prog.name,
     typeParams,
     ports,
     body: block,
-  }
+  })
 
   // Phase 4b: strict cycle policy. Cycles in source code that don't
   // pass through an explicit user register throw `CycleViolation`.

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -31,8 +31,10 @@
 
 import type {
   ResolvedExpr, ResolvedExprOp,
-  RegDecl, InputDecl, InstanceDecl, OutputDecl, ParamDecl,
+  RegDecl, InputDecl, InstanceDecl, OutputDecl, ParamDecl, PortType,
+  InputIdx, OutputIdx, ParamIdx, InstanceIdx,
 } from './nodes.js'
+import { instanceIdx } from './nodes.js'
 import {
   type TempIdx, type StateRegIdx, type ArraySlotIdx, type ModuleSlotIdx,
   type InputPortIdx,
@@ -245,35 +247,31 @@ export const toWireInstr = (i: NInstr): WireNInstr => ({
 // ─────────────────────────────────────────────────────────────
 
 export interface EmitSlots {
+  /** Kept for back-compat; emit_resolved now uses InputRef.idx directly
+   *  (which equals position in ports.inputs[], same as the value
+   *  buildSlotMaps produces). The map can be empty without breaking
+   *  the new code path. */
   inputs: Map<InputDecl, number>
+  /** Same: emit_resolved now uses RegRef.idx directly. */
   regs:   Map<RegDecl, number>
-  /** Total scalar-register count. Post-Phase-0a all stateful decls live
-   *  in `regs` (former delays included) so this is just `regs.size`. */
+  /** Total scalar-register count. */
   regCount: number
-  /** FFI handle metadata per param/trigger decl. */
-  paramHandles: Map<ParamDecl, { ptr: string }>
+  /** FFI handle metadata per param. Keyed by ParamIdx now (replacing
+   *  the prior ParamDecl pointer key). */
+  paramHandles: Map<ParamIdx, { ptr: string }>
   /** Module slot indices for sub-instance outputs that this kernel's
-   *  body references via `NestedOut`. Populated by `partition_recursive`
-   *  for fractal kernels — each child kernel's outputs occupy slots in
-   *  the shared module-slot array, and the parent reads them via slot
-   *  operands. Map shape: instanceDecl → outputDecl → moduleSlotIdx.
-   *  When undefined (legacy / per-program path), NestedOut throws as
-   *  before. */
-  nestedOutputSlots?: Map<InstanceDecl, Map<OutputDecl, number>>
-  /** Module slot indices for THIS program's own input ports, populated
-   *  by the M11 fractal path. When set, `InputRef(d)` lowers to a Slot
-   *  read from `inputSlotOverride.get(d)` instead of an `Input`
-   *  operand. The parent kernel has written the slot's value via a
-   *  `WriteSlot` in its `per_child_pre_input[k]` block immediately
-   *  before this kernel runs. */
-  inputSlotOverride?: Map<InputDecl, number>
-  /** Per-child module-slot map for sub-instance INPUTS. Used by the
-   *  M11 fractal path when emitting a parent kernel: for each child
-   *  instance and each of its wired inputs, the parent emits a
-   *  `WriteSlot` into the slot named here. Map shape:
-   *  instanceDecl → inputDecl → moduleSlotIdx. Read in conjunction
-   *  with `EmitResolvedInputs.nestedInstances`. */
-  nestedInputSlots?: Map<InstanceDecl, Map<InputDecl, number>>
+   *  body references via `NestedOut`. Map shape:
+   *  InstanceIdx → OutputIdx → moduleSlotIdx. When undefined
+   *  (legacy / per-program path), NestedOut throws as before. */
+  nestedOutputSlots?: Map<InstanceIdx, Map<OutputIdx, number>>
+  /** Module slot indices for THIS program's own input ports. When set,
+   *  `InputRef(idx)` lowers to a Slot read from `inputSlotOverride.get(idx)`
+   *  instead of an `Input` operand. Used by the M11 fractal path. */
+  inputSlotOverride?: Map<InputIdx, number>
+  /** Per-child module-slot map for sub-instance INPUTS. Map shape:
+   *  InstanceIdx → InputIdx → moduleSlotIdx. Used by the M11 fractal
+   *  path when emitting a parent kernel. */
+  nestedInputSlots?: Map<InstanceIdx, Map<InputIdx, number>>
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -408,15 +406,18 @@ class Emitter {
     const obj = node as ResolvedExprOp
     switch (obj.op) {
       case 'inputRef': {
-        const slot = this.slots.inputs.get(obj.decl)
-        if (slot === undefined) throw new Error(`emit_resolved: input '${obj.decl.name}' missing from slot table`)
+        // RegIdx/InputIdx/etc are the de Bruijn levels into the
+        // program's typed decl tables; slots.inputs is keyed by the
+        // same InputDecl objects, in the same order. So obj.idx IS
+        // the slot number (slots.ts assigns slot[i] = position i).
+        const slot = obj.idx as number
         const portT = this.inputPortTypes[slot] ?? 'float'
         // M11 fractal path: when the program is being compiled as a
         // sub-instance kernel, its inputs live in module slots
         // pre-written by the parent's WriteSlot in per_child_pre_input.
         // Lower `InputRef(d)` to a slot read instead of opInput.
         if (this.slots.inputSlotOverride !== undefined) {
-          const overrideSlot = this.slots.inputSlotOverride.get(obj.decl)
+          const overrideSlot = this.slots.inputSlotOverride.get(obj.idx)
           if (overrideSlot !== undefined) {
             return { op: opSlot(moduleSlotIdx(overrideSlot), portT), scalarType: portT }
           }
@@ -424,14 +425,13 @@ class Emitter {
         return { op: opInput(inputPortIdx(slot), portT), scalarType: portT }
       }
       case 'regRef': {
-        const slot = this.slots.regs.get(obj.decl)
-        if (slot === undefined) throw new Error(`emit_resolved: reg '${obj.decl.name}' missing from slot table`)
+        const slot = obj.idx as number
         if (this.arrayRegMap.has(slot)) return null
         const regType = this.stateRegTypes[slot] ?? 'float'
         return { op: opStateReg(stateRegIdx(slot), regType), scalarType: regType }
       }
       case 'paramRef': {
-        const handle = this.slots.paramHandles.get(obj.decl)
+        const handle = this.slots.paramHandles.get(obj.idx)
         if (handle === undefined) {
           // No live FFI handle — emit zero, matching the legacy fallback.
           return { op: opConst(0, 'float'), scalarType: 'float' }
@@ -447,7 +447,7 @@ class Emitter {
         // type comes from the output port's declared type.
         if (this.slots.nestedOutputSlots === undefined) {
           throw new Error(
-            `emit_resolved: NestedOut to '${obj.instance.name}.${obj.output.name}' ` +
+            `emit_resolved: NestedOut to instance idx=${obj.instance} output idx=${obj.output} ` +
             `requires nestedOutputSlots — pass them via EmitSlots when invoking emit ` +
             `on a fractal kernel.`,
           )
@@ -455,7 +455,7 @@ class Emitter {
         const perInst = this.slots.nestedOutputSlots.get(obj.instance)
         if (perInst === undefined) {
           throw new Error(
-            `emit_resolved: NestedOut to instance '${obj.instance.name}' — ` +
+            `emit_resolved: NestedOut to instance idx=${obj.instance} — ` +
             `no slot map entry. partition_recursive should record every child ` +
             `instance before emitting the parent kernel.`,
           )
@@ -463,19 +463,16 @@ class Emitter {
         const slotRaw = perInst.get(obj.output)
         if (slotRaw === undefined) {
           throw new Error(
-            `emit_resolved: NestedOut to '${obj.instance.name}.${obj.output.name}' — ` +
+            `emit_resolved: NestedOut to instance idx=${obj.instance} output idx=${obj.output} — ` +
             `output port not in slot map.`,
           )
         }
         // Determine the scalar type from the output port's declared type.
-        const outType = obj.output.type
-        const scalarType: ScalarType = outType === undefined
-          ? 'float'
-          : outType.kind === 'scalar'
-            ? outType.scalar
-            : outType.kind === 'alias'
-              ? (outType.alias.base as ScalarType)
-              : 'float'   // array — element 0; full array NestedOut not yet supported
+        // Look up the output decl via the program in scope. Without prog
+        // in scope here, default to float. partition_recursive can
+        // thread precise typing through nestedOutputSlots in a followup
+        // if non-float NestedOuts ever need it.
+        const scalarType: ScalarType = 'float'
         return { op: opSlot(moduleSlotIdx(slotRaw), scalarType), scalarType }
       }
     }
@@ -521,11 +518,15 @@ class Emitter {
     } else {
       const obj = node as Record<string, unknown>
       const op = String(obj.op)
+      // Indexed refs: key on op + integer idx (stable across rewrites).
+      // BindingRef keeps the pointer-based decl identity (issue #156).
       if (op === 'regRef' || op === 'paramRef'
-          || op === 'inputRef' || op === 'typeParamRef' || op === 'bindingRef') {
+          || op === 'inputRef' || op === 'typeParamRef') {
+        key = `op:${op}|idx=${obj.idx as number}`
+      } else if (op === 'bindingRef') {
         key = `op:${op}|decl=${this.declIdOf(obj.decl as object)}`
       } else if (op === 'nestedOut') {
-        key = `op:${op}|inst=${this.declIdOf(obj.instance as object)}|out=${this.declIdOf(obj.output as object)}`
+        key = `op:${op}|inst=${obj.instance as number}|out=${obj.output as number}`
       } else {
         const parts: string[] = [`op:${op}`]
         const fieldNames = Object.keys(obj).filter(k => k !== 'op').sort()
@@ -572,8 +573,7 @@ class Emitter {
 
     // Array-typed regRef (filtered out by tryTerminal).
     if (obj.op === 'regRef') {
-      const slot = this.slots.regs.get(obj.decl)
-      if (slot === undefined) throw new Error(`emit_resolved: reg '${obj.decl.name}' missing from slot table`)
+      const slot = obj.idx as number
       const arr = this.arrayRegMap.get(slot)
       if (arr) return { isArray: true, op: opArray(arr.slot), size: arr.size, scalarType: 'float' }
       throw new Error(`emit_resolved: regRef to non-array slot ${slot} reached compileNodeUncached unexpectedly`)
@@ -816,14 +816,20 @@ class Emitter {
     const preChildBaseline = this.instrs.length
     if (nestedInstances !== undefined) {
       const slotMaps = this.slots.nestedInputSlots
-      for (const decl of nestedInstances) {
+      // nestedInstances is body-decl order = prog.instances order, so
+      // position k in this array IS the InstanceIdx for that child.
+      for (let k = 0; k < nestedInstances.length; k++) {
+        const decl = nestedInstances[k]
         const childStart = this.instrs.length
-        const childSlotMap = slotMaps?.get(decl)
+        const childSlotMap = slotMaps?.get(instanceIdx(k))
         if (childSlotMap !== undefined) {
           for (const inp of decl.inputs) {
             const slotIdx = childSlotMap.get(inp.port)
             if (slotIdx === undefined) continue
-            const portT = inputDeclScalarType(inp.port)
+            // inp.port is InputIdx into the child's ports.inputs; look up
+            // the InputDecl for type info.
+            const portDecl = decl.type.ports.inputs[inp.port as number]
+            const portT = inputDeclScalarType(portDecl)
             const r = this.compileNode(inp.value, portT)
             // Wires are scalar (array-typed child input ports aren't
             // currently exercised by the slot-based path). If the wire

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -34,7 +34,7 @@ import type {
   RegDecl, InputDecl, InstanceDecl, OutputDecl, ParamDecl, PortType,
   InputIdx, OutputIdx, ParamIdx, InstanceIdx,
 } from './nodes.js'
-import { instanceIdx } from './nodes.js'
+import { instanceIdx, inputIdx as inputIdxOf } from './nodes.js'
 import {
   type TempIdx, type StateRegIdx, type ArraySlotIdx, type ModuleSlotIdx,
   type InputPortIdx,
@@ -823,14 +823,25 @@ class Emitter {
         const childStart = this.instrs.length
         const childSlotMap = slotMaps?.get(instanceIdx(k))
         if (childSlotMap !== undefined) {
-          for (const inp of decl.inputs) {
-            const slotIdx = childSlotMap.get(inp.port)
+          // Build a wired-by-port lookup so we can iterate ALL ports
+          // (not just decl.inputs). Unwired ports need to receive
+          // their declared port default — otherwise the slot retains
+          // its allocation-time default of 0, which silently masks
+          // the port's actual default (e.g., Bubble's attack_g: 0.05
+          // becomes 0 if a parent program doesn't wire it explicitly,
+          // killing env_smooth evolution).
+          const wiredByPort = new Map<number, ResolvedExpr>()
+          for (const inp of decl.inputs) wiredByPort.set(inp.port as number, inp.value)
+          const ports = decl.type.ports.inputs
+          for (let i = 0; i < ports.length; i++) {
+            const slotIdx = childSlotMap.get(inputIdxOf(i))
             if (slotIdx === undefined) continue
-            // inp.port is InputIdx into the child's ports.inputs; look up
-            // the InputDecl for type info.
-            const portDecl = decl.type.ports.inputs[inp.port as number]
+            const portDecl = ports[i]
             const portT = inputDeclScalarType(portDecl)
-            const r = this.compileNode(inp.value, portT)
+            const wireExpr = wiredByPort.get(i)
+              ?? portDecl.default
+              ?? 0
+            const r = this.compileNode(wireExpr, portT)
             // Wires are scalar (array-typed child input ports aren't
             // currently exercised by the slot-based path). If the wire
             // resolves to an array, project element 0.

--- a/compiler/ir/identity_elim.test.ts
+++ b/compiler/ir/identity_elim.test.ts
@@ -3,6 +3,8 @@ import type {
   ResolvedProgram, InstanceDecl, InputDecl, OutputDecl,
   ResolvedExpr, NestedOut, BinaryOp, RegDecl,
 } from './nodes.js'
+import { inputIdx, outputIdx, instanceIdx } from './nodes.js'
+import { mkProgram } from './decl_tables.js'
 import { identityElim } from './identity_elim.js'
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────
@@ -12,8 +14,7 @@ import { identityElim } from './identity_elim.js'
 function identityProgram(name = 'IdProg'): ResolvedProgram {
   const inDecl: InputDecl  = { op: 'inputDecl',  name: 'in_p' }
   const outDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
-  return {
-    op: 'program',
+  return mkProgram({
     name,
     typeParams: [],
     ports: { inputs: [inDecl], outputs: [outDecl], typeDefs: [] },
@@ -22,19 +23,18 @@ function identityProgram(name = 'IdProg'): ResolvedProgram {
       decls: [],
       assigns: [{
         op: 'outputAssign',
-        target: outDecl,
-        expr: { op: 'inputRef', decl: inDecl },
+        target: outputIdx(0),
+        expr: { op: 'inputRef', idx: inputIdx(0) },
       }],
     },
-  }
+  })
 }
 
 /** Build a non-identity program: body assigns `out = inputRef(p) + 1`. */
 function nonIdentityProgram(name = 'NonIdProg'): ResolvedProgram {
   const inDecl: InputDecl  = { op: 'inputDecl',  name: 'in_p' }
   const outDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
-  return {
-    op: 'program',
+  return mkProgram({
     name,
     typeParams: [],
     ports: { inputs: [inDecl], outputs: [outDecl], typeDefs: [] },
@@ -43,11 +43,11 @@ function nonIdentityProgram(name = 'NonIdProg'): ResolvedProgram {
       decls: [],
       assigns: [{
         op: 'outputAssign',
-        target: outDecl,
-        expr: { op: 'add', args: [{ op: 'inputRef', decl: inDecl }, 1] },
+        target: outputIdx(0),
+        expr: { op: 'add', args: [{ op: 'inputRef', idx: inputIdx(0) }, 1] },
       }],
     },
-  }
+  })
 }
 
 /** Build an InstanceDecl wrapping a program and wiring one input. */
@@ -61,7 +61,7 @@ function makeInstance(
     name: instName,
     type: prog,
     typeArgs: [],
-    inputs: [{ port: prog.ports.inputs[0], value: wireValue }],
+    inputs: [{ port: inputIdx(0), value: wireValue }],
   }
 }
 
@@ -89,8 +89,8 @@ describe('identityElim — no-op cases', () => {
         op: 'block', decls: [],
         assigns: [{
           op: 'outputAssign',
-          target: outDecl,
-          expr: { op: 'inputRef', decl: inDecl },
+          target: outputIdx(0),
+          expr: { op: 'inputRef', idx: inputIdx(0) },
         }],
       },
     }
@@ -105,19 +105,19 @@ describe('identityElim — no-op cases', () => {
     const idProg = nonIdentityProgram()
     const inst = makeInstance(idProg, 'i1', 42)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
-          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+          target: outputIdx(0),
+          expr: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
         }],
       },
-    }
+    })
     const after = identityElim(prog)
     expect(after.body.decls.length).toBe(1)   // not eliminated
   })
@@ -130,19 +130,19 @@ describe('identityElim — elimination', () => {
     const idProg = identityProgram()
     const inst = makeInstance(idProg, 'i1', 42)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
-          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+          target: outputIdx(0),
+          expr: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
         }],
       },
-    }
+    })
     const after = identityElim(prog)
     // The InstanceDecl is gone.
     expect(after.body.decls).toEqual([])
@@ -160,22 +160,22 @@ describe('identityElim — elimination', () => {
     const inst2 = makeInstance(
       idProg,
       'i2',
-      { op: 'nestedOut', instance: inst1, output: idProg.ports.outputs[0] },
+      { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },   // inst1 at body.decls[0]
     )
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst1, inst2],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
-          expr: { op: 'nestedOut', instance: inst2, output: idProg.ports.outputs[0] },
+          target: outputIdx(0),
+          expr: { op: 'nestedOut', instance: instanceIdx(1), output: outputIdx(0) },   // inst2 at body.decls[1]
         }],
       },
-    }
+    })
     const after = identityElim(prog)
     expect(after.body.decls).toEqual([])
     expect((after.body.assigns[0] as { expr: ResolvedExpr }).expr).toBe(7)
@@ -186,21 +186,21 @@ describe('identityElim — elimination', () => {
     const inst = makeInstance(idProg, 'i1', 3.14)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
     const nestedRef: NestedOut = {
-      op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0],
+      op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0),
     }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
+          target: outputIdx(0),
           expr: { op: 'mul', args: [nestedRef, 2] },
         }],
       },
-    }
+    })
     const after = identityElim(prog)
     expect(after.body.decls).toEqual([])
     const expr = (after.body.assigns[0] as { expr: ResolvedExpr }).expr as BinaryOp
@@ -215,25 +215,25 @@ describe('identityElim — elimination', () => {
     const idInst = makeInstance(idProg, 'id1', 5)
     const nonIdInst = makeInstance(nonIdProg, 'non1', 10)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [idInst, nonIdInst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
+          target: outputIdx(0),
           expr: {
             op: 'add',
             args: [
-              { op: 'nestedOut', instance: idInst,    output: idProg.ports.outputs[0] },
-              { op: 'nestedOut', instance: nonIdInst, output: nonIdProg.ports.outputs[0] },
+              { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },   // idInst at body.decls[0]
+              { op: 'nestedOut', instance: instanceIdx(1), output: outputIdx(0) },   // nonIdInst at body.decls[1]
             ],
           },
         }],
       },
-    }
+    })
     const after = identityElim(prog)
     // Identity gone, non-identity remains. The pass clones the program
     // before mutating, so surviving InstanceDecls are fresh objects
@@ -247,10 +247,11 @@ describe('identityElim — elimination', () => {
     const expr = (after.body.assigns[0] as { expr: ResolvedExpr }).expr as BinaryOp
     expect(expr.args[0]).toBe(5)
     expect((expr.args[1] as NestedOut).op).toBe('nestedOut')
-    // The rhs NestedOut MUST reference the surviving instance (not the
-    // dangling original). This is the consistency invariant the
-    // clone-then-mutate approach preserves.
-    expect((expr.args[1] as NestedOut).instance).toBe(survivor)
+    // The rhs NestedOut MUST be remapped to point at the surviving
+    // instance's NEW position. nonIdInst was at body.decls[1] before
+    // elim; after elim (idInst dropped) it's at position 0.
+    expect((expr.args[1] as NestedOut).instance).toBe(0 as never)
+    expect(after.instances[(expr.args[1] as NestedOut).instance]).toBe(survivor)
   })
 
   test('substitution into RegDecl init / update fields', () => {
@@ -261,12 +262,12 @@ describe('identityElim — elimination', () => {
     const reg: RegDecl = {
       op: 'regDecl',
       name: 'r',
-      init: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
-      update: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+      init:   { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
+      update: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
     }
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
@@ -274,12 +275,12 @@ describe('identityElim — elimination', () => {
         assigns: [
           {
             op: 'outputAssign',
-            target: outerOut,
-            expr: { op: 'regRef', decl: reg },
+            target: outputIdx(0),
+            expr: { op: 'regRef', idx: 0 as never },   // reg is at body.regs[0]
           },
         ],
       },
-    }
+    })
     const after = identityElim(prog)
     expect(after.body.decls.length).toBe(1)   // only the RegDecl
     expect(after.body.decls[0].op).toBe('regDecl')
@@ -296,19 +297,19 @@ describe('identityElim — properties', () => {
     const idProg = identityProgram()
     const inst = makeInstance(idProg, 'i1', 99)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
-          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+          target: outputIdx(0),
+          expr: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
         }],
       },
-    }
+    })
     const once = identityElim(prog)
     const twice = identityElim(once)
     expect(JSON.stringify(twice)).toEqual(JSON.stringify(once))
@@ -318,19 +319,19 @@ describe('identityElim — properties', () => {
     const idProg = identityProgram()
     const inst = makeInstance(idProg, 'i1', 99)
     const outerOut: OutputDecl = { op: 'outputDecl', name: 'out' }
-    const prog: ResolvedProgram = {
-      op: 'program', name: 'outer', typeParams: [],
+    const prog = mkProgram({
+      name: 'outer', typeParams: [],
       ports: { inputs: [], outputs: [outerOut], typeDefs: [] },
       body: {
         op: 'block',
         decls: [inst],
         assigns: [{
           op: 'outputAssign',
-          target: outerOut,
-          expr: { op: 'nestedOut', instance: inst, output: idProg.ports.outputs[0] },
+          target: outputIdx(0),
+          expr: { op: 'nestedOut', instance: instanceIdx(0), output: outputIdx(0) },
         }],
       },
-    }
+    })
     const snapshot = JSON.stringify(prog)
     identityElim(prog)
     expect(JSON.stringify(prog)).toBe(snapshot)

--- a/compiler/ir/identity_elim.ts
+++ b/compiler/ir/identity_elim.ts
@@ -39,9 +39,12 @@
 import type {
   ResolvedProgram, ResolvedExpr, ResolvedExprOp,
   InstanceDecl, InputDecl, OutputDecl,
+  InstanceIdx, OutputIdx,
   Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith, Let, Tag, Match,
 } from './nodes.js'
+import { instanceIdx, outputIdx } from './nodes.js'
 import { cloneResolvedProgram } from './clone.js'
+import { withDeclTables } from './decl_tables.js'
 
 // ─── Detection ─────────────────────────────────────────────────────────────
 
@@ -50,9 +53,9 @@ import { cloneResolvedProgram } from './clone.js'
  *  that would substitute for `NestedOut(I, output)`. */
 interface IdentityDeclRewrite {
   readonly inst: InstanceDecl
-  /** For each of the instance's outputs, the expression to substitute
-   *  for `NestedOut(I, output)`. */
-  readonly outputSub: ReadonlyMap<OutputDecl, ResolvedExpr>
+  /** For each of the instance's outputs (by OutputIdx), the expression
+   *  to substitute for `NestedOut(I, output)`. */
+  readonly outputSub: ReadonlyMap<OutputIdx, ResolvedExpr>
 }
 
 /** Recognize whether an InstanceDecl's program body is the identity
@@ -65,32 +68,33 @@ function detectIdentity(inst: InstanceDecl): IdentityDeclRewrite | null {
   // No state, no nested instances, no parameters in the body.
   if (prog.body.decls.length > 0) return null
 
-  // Build input → wired-expression map from this InstanceDecl's inputs.
-  const inputToWire = new Map<InputDecl, ResolvedExpr>()
-  for (const i of inst.inputs) inputToWire.set(i.port, i.value)
+  // Map from this instance's wired port position to the wired expression.
+  // inst.inputs[k].port is InputIdx into prog.ports.inputs[].
+  const wiredByPos = new Map<number, ResolvedExpr>()
+  for (const i of inst.inputs) wiredByPos.set(i.port, i.value)
 
-  const outputSub = new Map<OutputDecl, ResolvedExpr>()
-  for (const o of prog.ports.outputs) {
-    // Find the (single) outputAssign for this output.
+  // For each output position, find its outputAssign expression.
+  // OutputAssign.target is OutputIdx or the dac sentinel.
+  const outputSub = new Map<OutputIdx, ResolvedExpr>()
+  for (let oi = 0; oi < prog.ports.outputs.length; oi++) {
     const assigns = prog.body.assigns.filter(
-      a => a.op === 'outputAssign' && a.target === o,
+      a => a.op === 'outputAssign' && typeof a.target === 'number' && a.target === oi,
     )
     if (assigns.length !== 1) return null   // missing or duplicated
 
     const expr = (assigns[0] as { expr: ResolvedExpr }).expr
-    // Identity case: expr is exactly `inputRef(p)` for some input port p.
+    // Identity case: expr is exactly `inputRef(idx)` for some input port.
     if (typeof expr !== 'object' || expr === null || Array.isArray(expr)) return null
     if (expr.op !== 'inputRef') return null
 
-    const inputDecl = expr.decl
-    const wired = inputToWire.get(inputDecl)
+    const wired = wiredByPos.get(expr.idx)
     if (wired === undefined) {
       // The instance must have a wire for every required input; if not,
       // we don't have enough information to inline. Defensive — should
       // not happen in well-formed IR.
       return null
     }
-    outputSub.set(o, wired)
+    outputSub.set(outputIdx(oi), wired)
   }
 
   // Must have at least one output to be a meaningful identity.
@@ -101,44 +105,59 @@ function detectIdentity(inst: InstanceDecl): IdentityDeclRewrite | null {
 
 // ─── Substitution ─────────────────────────────────────────────────────────
 
-type SubstMap = ReadonlyMap<InstanceDecl, ReadonlyMap<OutputDecl, ResolvedExpr>>
+interface SubstCtx {
+  /** Eliminated-instance lookup: nestedOut(i, o) where i is eliminated
+   *  resolves to the wired-in expression for that port. */
+  eliminatedSub: ReadonlyMap<InstanceIdx, ReadonlyMap<OutputIdx, ResolvedExpr>>
+  /** Surviving-instance remap: oldIdx → newIdx after eliminated decls
+   *  drop out of body.instances. */
+  survivorRemap: ReadonlyMap<InstanceIdx, InstanceIdx>
+}
 
 function substExpr(
   e: ResolvedExpr,
-  subst: SubstMap,
+  ctx: SubstCtx,
   memo: WeakMap<object, ResolvedExpr>,
 ): ResolvedExpr {
   if (typeof e === 'number' || typeof e === 'boolean') return e
   if (Array.isArray(e)) {
     const cached = memo.get(e)
     if (cached !== undefined) return cached
-    const out = e.map(x => substExpr(x, subst, memo))
+    const out = e.map(x => substExpr(x, ctx, memo))
     memo.set(e, out)
     return out
   }
   const cached = memo.get(e)
   if (cached !== undefined) return cached
-  const out = substOpNode(e, subst, memo)
+  const out = substOpNode(e, ctx, memo)
   memo.set(e, out)
   return out
 }
 
 function substOpNode(
   node: ResolvedExprOp,
-  subst: SubstMap,
+  ctx: SubstCtx,
   memo: WeakMap<object, ResolvedExpr>,
 ): ResolvedExpr {
-  const recur = (x: ResolvedExpr) => substExpr(x, subst, memo)
+  const recur = (x: ResolvedExpr) => substExpr(x, ctx, memo)
 
   switch (node.op) {
     case 'nestedOut': {
-      const perInstance = subst.get(node.instance)
-      if (perInstance === undefined) return node
-      const v = perInstance.get(node.output)
-      if (v === undefined) return node
-      // The replacement expression may itself contain nestedOut refs to
-      // OTHER identity instances; walk recursively so chains collapse.
-      return recur(v)
+      const elimSub = ctx.eliminatedSub.get(node.instance)
+      if (elimSub !== undefined) {
+        const v = elimSub.get(node.output)
+        if (v === undefined) return node
+        // The replacement may itself contain nestedOut refs to other
+        // identity instances; walk recursively so chains collapse.
+        return recur(v)
+      }
+      // Surviving instance: remap idx to its new position. If the
+      // remap is the identity (no shifts ahead of it), this is a no-op.
+      const newIdx = ctx.survivorRemap.get(node.instance)
+      if (newIdx !== undefined && newIdx !== node.instance) {
+        return { op: 'nestedOut', instance: newIdx, output: node.output }
+      }
+      return node
     }
     case 'inputRef':
     case 'regRef':
@@ -253,7 +272,13 @@ function substOpNode(
 
 /** Eliminate identity InstanceDecls from a `ResolvedProgram`. Idempotent
  *  — applying twice produces the same result as applying once. Does not
- *  mutate the input program. */
+ *  mutate the input program.
+ *
+ *  After dropping eliminated instances, the surviving instances'
+ *  positions shift — every InstanceIdx ref to a survivor needs remapping
+ *  to its new position. The substitution walk does both jobs in one
+ *  pass: nestedOut(eliminatedIdx) → expr; nestedOut(survivorOldIdx) →
+ *  nestedOut(survivorNewIdx). */
 export function identityElim(prog: ResolvedProgram): ResolvedProgram {
   // Fast path: detect any identities on the input WITHOUT cloning. If
   // none, return the original program unchanged.
@@ -262,54 +287,61 @@ export function identityElim(prog: ResolvedProgram): ResolvedProgram {
   )
   if (!anyIdentity) return prog
 
-  // Clone the program so we can mutate freely. Cloning rewrites all
-  // internal references to the cloned decl objects, which means
-  // identityElim's mutations are local and consistent without a
-  // separate rename pass.
+  // Clone so we can mutate freely. Clone preserves decl positions so
+  // InstanceIdx values transfer directly across the boundary.
   const cloned = cloneResolvedProgram(prog)
 
-  // Re-detect identities on the clone (fresh InstanceDecl objects).
-  const identities: IdentityDeclRewrite[] = []
-  for (const decl of cloned.body.decls) {
-    if (decl.op !== 'instanceDecl') continue
-    const id = detectIdentity(decl)
-    if (id !== null) identities.push(id)
-  }
-  // Defensive — if the clone disagreed with the input, something is wrong.
-  if (identities.length === 0) return cloned
-
-  const subst = new Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>()
-  for (const id of identities) {
-    subst.set(id.inst, new Map(id.outputSub))
-  }
-  const eliminated = new Set<InstanceDecl>(identities.map(id => id.inst))
-  const memo = new WeakMap<object, ResolvedExpr>()
-
-  // Mutate the clone in place. Surviving InstanceDecls keep their
-  // identity; references in expressions stay consistent.
-  for (const decl of cloned.body.decls) {
-    if (decl.op === 'instanceDecl') {
-      if (eliminated.has(decl)) continue   // dropping it; no need to rewrite
-      // Surviving instance: rewrite its input wiring expressions in place.
-      for (const i of decl.inputs) {
-        i.value = substExpr(i.value, subst, memo)
-      }
-    } else if (decl.op === 'regDecl') {
-      decl.init = substExpr(decl.init, subst, memo)
-      if (decl.update !== undefined) {
-        decl.update = substExpr(decl.update, subst, memo)
+  // Build position-keyed identity table: oldInstanceIdx → outputSub map
+  // OR (for survivors) → newInstanceIdx after eliminated decls drop out.
+  const eliminatedSub = new Map<InstanceIdx, ReadonlyMap<OutputIdx, ResolvedExpr>>()
+  const survivorRemap = new Map<InstanceIdx, InstanceIdx>()
+  {
+    let newPos = 0
+    for (let oldPos = 0; oldPos < cloned.instances.length; oldPos++) {
+      const inst = cloned.instances[oldPos]
+      const id = detectIdentity(inst)
+      if (id !== null) {
+        eliminatedSub.set(instanceIdx(oldPos), id.outputSub)
+      } else {
+        survivorRemap.set(instanceIdx(oldPos), instanceIdx(newPos++))
       }
     }
-    // ParamDecl, ProgramDecl — no expressions to rewrite; leave alone.
+  }
+  if (eliminatedSub.size === 0) return cloned   // defensive
+
+  const ctx: SubstCtx = { eliminatedSub, survivorRemap }
+  const memo = new WeakMap<object, ResolvedExpr>()
+
+  // Walk every expression once: rewrite nestedOut for both eliminated
+  // (substitute) and survivor (remap idx) cases. Surviving instances'
+  // input wires also get walked.
+  for (const decl of cloned.body.decls) {
+    if (decl.op === 'instanceDecl') {
+      const oldIdx = cloned.instances.indexOf(decl) as number   // safe: decl is in cloned.instances
+      if (eliminatedSub.has(instanceIdx(oldIdx))) continue   // dropping it
+      for (const i of decl.inputs) {
+        i.value = substExpr(i.value, ctx, memo)
+      }
+    } else if (decl.op === 'regDecl') {
+      decl.init = substExpr(decl.init, ctx, memo)
+      if (decl.update !== undefined) {
+        decl.update = substExpr(decl.update, ctx, memo)
+      }
+    }
   }
   for (const a of cloned.body.assigns) {
-    a.expr = substExpr(a.expr, subst, memo)
+    a.expr = substExpr(a.expr, ctx, memo)
   }
 
   // Drop eliminated InstanceDecls from the body.
-  cloned.body.decls = cloned.body.decls.filter(
-    d => !(d.op === 'instanceDecl' && eliminated.has(d)),
-  )
-
-  return cloned
+  cloned.body.decls = cloned.body.decls.filter(d => {
+    if (d.op !== 'instanceDecl') return true
+    const oldIdx = cloned.instances.indexOf(d)
+    return !eliminatedSub.has(instanceIdx(oldIdx))
+  })
+  // Re-project tables to match the post-filter body.
+  return withDeclTables({
+    ...cloned,
+    body: { ...cloned.body },   // already mutated in place
+  })
 }

--- a/compiler/ir/inline_instances.ts
+++ b/compiler/ir/inline_instances.ts
@@ -60,6 +60,7 @@ import type {
 import { specializeProgram } from './specialize.js'
 import { sumLower } from './sum_lower.js'
 import { cloneResolvedProgram, cloneWithInputSubst } from './clone.js'
+import { mkProgram } from './decl_tables.js'
 
 export function inlineInstances(prog: ResolvedProgram): ResolvedProgram {
   // Fast path: no instances at this level means there's nothing to do.
@@ -137,13 +138,12 @@ export function inlineInstances(prog: ResolvedProgram): ResolvedProgram {
   const newAssigns: BodyAssign[] = outer.body.assigns.map(a => substAssign(a, nestedOutSubst, memo))
 
   const block: ResolvedBlock = { op: 'block', decls: newDecls, assigns: newAssigns }
-  return {
-    op: 'program',
+  return mkProgram({
     name: outer.name,
     typeParams: outer.typeParams,
     ports: outer.ports,
     body: block,
-  }
+  })
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/ir/inline_instances.ts
+++ b/compiler/ir/inline_instances.ts
@@ -56,7 +56,9 @@ import type {
   Tag, Match, MatchArm,
   Let,
   Fold, Scan, Generate, Iterate, Chain, Map2, ZipWith,
+  InputIdx, OutputIdx, InstanceIdx,
 } from './nodes.js'
+import { inputIdx, outputIdx, instanceIdx } from './nodes.js'
 import { specializeProgram } from './specialize.js'
 import { sumLower } from './sum_lower.js'
 import { cloneResolvedProgram, cloneWithInputSubst } from './clone.js'
@@ -96,18 +98,40 @@ export function inlineInstances(prog: ResolvedProgram): ResolvedProgram {
   // memoizes nested programs), so an OutputDecl alone can't
   // distinguish them. The InstanceDecl is the disambiguator.
   const liftedDecls: BodyDecl[] = []
-  const nestedOutSubst = new Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>()
+  // Substitution key is InstanceIdx (position in outer.instances[]) so
+  // substExpr can look up node.instance directly. Inner key is OutputIdx.
+  const nestedOutSubst = new Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>()
 
   const survivingDecls: BodyDecl[] = []
+  // Track instance position as we iterate body.decls (matches the
+  // ordering used by elaborator + decl_tables to assign InstanceIdx).
+  //
+  // For lifting: every RegRef / ParamRef inside a cloned sub-program's
+  // body uses idx values that are valid in the CLONED program. After
+  // lifting into outer, those idx values need to point at positions in
+  // the merged body. The merged body is `survivingDecls + liftedDecls`,
+  // so per-kind position = outer's own count + count lifted from
+  // earlier instances + position-within-this-lift. We pass offsets
+  // (outer count + lifted-so-far) to cloneWithInputSubst, which adds
+  // them during clone — the cloned program comes out with already-
+  // shifted refs that point at the lifted positions.
+  const outerRegCount   = outer.regs.length
+  const outerParamCount = outer.params.length
+  let instCount = 0
   for (const decl of outer.body.decls) {
     if (decl.op !== 'instanceDecl') {
       survivingDecls.push(decl)
       continue
     }
+    const regOffset   = outerRegCount   + liftedDecls.filter(d => d.op === 'regDecl').length
+    const paramOffset = outerParamCount + liftedDecls.filter(d => d.op === 'paramDecl').length
     inlineOneInstance(
       decl,
+      instanceIdx(instCount++),
       liftedDecls,
       nestedOutSubst,
+      regOffset,
+      paramOffset,
     )
   }
 
@@ -152,8 +176,11 @@ export function inlineInstances(prog: ResolvedProgram): ResolvedProgram {
 
 function inlineOneInstance(
   decl: InstanceDecl,
+  instIdx: InstanceIdx,
   liftedDecls: BodyDecl[],
-  nestedOutSubst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  nestedOutSubst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
+  regOffset: number,
+  paramOffset: number,
 ): void {
   // 1. Specialize the inner program. For non-generic instances
   //    (typeArgs.length === 0), this is a no-op identity — the
@@ -185,9 +212,13 @@ function inlineOneInstance(
   const inputSubst = buildInputSubst(decl, flattened)
 
   // 4. Clone the (specialized + sub-inlined) inner with input
-  //    substitution. The result has fresh decl identity throughout;
-  //    InputRefs to substituted decls are replaced inline.
-  const cloned = cloneWithInputSubst(flattened, inputSubst)
+  //    substitution AND idx shifting. The cloned program's RegRefs /
+  //    ParamRefs get their idx shifted by (outer's existing count +
+  //    previously-lifted count), so when the cloned decls are appended
+  //    to the outer's body, the refs already point at the lifted
+  //    positions. InputRefs are substituted to outer expressions
+  //    before any shift could matter.
+  const cloned = cloneWithInputSubst(flattened, inputSubst, { regOffset, paramOffset })
 
   // 5. Lift the cloned inner's body decls into the outer. Names are
   //    prefixed with the instance name to avoid collisions when
@@ -197,10 +228,9 @@ function inlineOneInstance(
   liftClonedBody(decl.name, cloned, liftedDecls)
 
   // 6. Record output expressions for NestedOut substitution.
-  //    The outer's NestedOut refs still point at the *template's*
-  //    OutputDecls (decl.type.ports.outputs[i]), not the cloned ones.
-  //    We index by position to translate.
-  recordOutputs(decl, cloned, nestedOutSubst)
+  //    NestedOut.output is now OutputIdx (position into the target's
+  //    ports.outputs[]); we map each position to its cloned expression.
+  recordOutputs(decl, instIdx, cloned, nestedOutSubst)
 }
 
 /**
@@ -212,8 +242,19 @@ function specializeInner(decl: InstanceDecl): ResolvedProgram {
   if (decl.type.typeParams.length === 0 && decl.typeArgs.length === 0) {
     return decl.type
   }
+  // typeArgs.param is now TypeParamIdx (position in target's typeParams[]).
+  // Convert idx → decl by looking up in decl.type.typeParams.
   const subst = new Map<TypeParamDecl, number>()
-  for (const a of decl.typeArgs) subst.set(a.param, a.value)
+  for (const a of decl.typeArgs) {
+    const pd = decl.type.typeParams[a.param]
+    if (pd === undefined) {
+      throw new Error(
+        `inlineInstances: instance '${decl.name}' typeArg idx=${a.param} out of range ` +
+        `(target '${decl.type.name}' has ${decl.type.typeParams.length} typeParams)`,
+      )
+    }
+    subst.set(pd, a.value)
+  }
   return specializeProgram(decl.type, subst)
 }
 
@@ -228,29 +269,30 @@ function specializeInner(decl: InstanceDecl): ResolvedProgram {
 function buildInputSubst(
   decl: InstanceDecl,
   inner: ResolvedProgram,
-): ReadonlyMap<InputDecl, ResolvedExpr> {
-  const subst = new Map<InputDecl, ResolvedExpr>()
-  const wiredByPort = new Map<InputDecl, ResolvedExpr>()
-  for (const w of decl.inputs) wiredByPort.set(w.port, w.value)
-  // The instance's `inputs` array uses the *template's* InputDecls.
-  // After specialization, we need to map each template InputDecl to
-  // the corresponding cloned InputDecl by position.
+): ReadonlyMap<InputIdx, ResolvedExpr> {
+  // decl.inputs[k].port is now InputIdx into decl.type.ports.inputs[].
+  // The cloned `inner` may have different InputDecl objects but the
+  // positions match (specialize preserves port order). The output
+  // map is keyed by InputIdx — positions in `inner.ports.inputs[]`,
+  // which is what InputRef.idx inside the cloned body references.
+  const wiredByIdx = new Map<number, ResolvedExpr>()
+  for (const w of decl.inputs) wiredByIdx.set(w.port, w.value)
+  const subst = new Map<InputIdx, ResolvedExpr>()
   for (let i = 0; i < decl.type.ports.inputs.length; i++) {
-    const templatePort = decl.type.ports.inputs[i]
-    const innerPort    = inner.ports.inputs[i]
+    const innerPort = inner.ports.inputs[i]
     if (innerPort === undefined) {
       throw new Error(
         `inlineInstances: instance '${decl.name}' input arity mismatch ` +
         `(template: ${decl.type.ports.inputs.length}, specialized: ${inner.ports.inputs.length})`,
       )
     }
-    const wired = wiredByPort.get(templatePort)
+    const wired = wiredByIdx.get(i)
     if (wired !== undefined) {
-      subst.set(innerPort, wired)
+      subst.set(inputIdx(i), wired)
       continue
     }
     if (innerPort.default !== undefined) {
-      subst.set(innerPort, innerPort.default)
+      subst.set(inputIdx(i), innerPort.default)
       continue
     }
     // No wire, no default: the elaborator should have caught it.
@@ -325,53 +367,44 @@ function liftClonedBody(
  */
 function recordOutputs(
   decl: InstanceDecl,
+  instIdx: InstanceIdx,
   cloned: ResolvedProgram,
-  nestedOutSubst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  nestedOutSubst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
 ): void {
-  // Build cloned-output-decl → expression map from the cloned assigns.
-  const clonedOutToExpr = new Map<OutputDecl, ResolvedExpr>()
+  // Build cloned-output-position → expression map from the cloned
+  // assigns. After the migration, OutputAssign.target is an OutputIdx
+  // (position into cloned.ports.outputs[]).
+  const clonedOutExprByIdx = new Map<number, ResolvedExpr>()
   for (const a of cloned.body.assigns) {
     if (a.op !== 'outputAssign') continue
-    if (!('op' in a.target)) continue   // skip 'dac' sentinel
-    if (a.target.op === 'outputDecl') {
-      clonedOutToExpr.set(a.target, a.expr)
-    }
+    if (typeof a.target === 'number') clonedOutExprByIdx.set(a.target, a.expr)
   }
 
-  // For each output of the template, find the cloned output at the
-  // same position and bind its expression. The outer's NestedOut refs
-  // use template OutputDecls (decl.type.ports.outputs).
-  // Two instances of the same program type share OutputDecl objects
-  // (the clone-memo aliases nested programs), so we partition the
-  // substitution table by InstanceDecl identity.
-  const perInstance = new Map<OutputDecl, ResolvedExpr>()
-  nestedOutSubst.set(decl, perInstance)
+  // For each output position of the template, bind the cloned
+  // expression. The outer's NestedOut refs carry the template's
+  // OutputIdx (same position, since specialize preserves output
+  // order). Key the per-instance substitution table by OutputIdx so
+  // the outer's substExpr pass can look it up directly.
+  const perInstance = new Map<OutputIdx, ResolvedExpr>()
+  nestedOutSubst.set(instIdx, perInstance)
 
   const templateOutputs = decl.type.ports.outputs
   const clonedOutputs   = cloned.ports.outputs
   for (let i = 0; i < templateOutputs.length; i++) {
-    const templateOut = templateOutputs[i]
-    const clonedOut   = clonedOutputs[i]
-    if (clonedOut === undefined) {
+    if (clonedOutputs[i] === undefined) {
       throw new Error(
         `inlineInstances: instance '${decl.name}' output arity mismatch ` +
         `(template: ${templateOutputs.length}, cloned: ${clonedOutputs.length})`,
       )
     }
-    const expr = clonedOutToExpr.get(clonedOut)
+    const expr = clonedOutExprByIdx.get(i)
     if (expr === undefined) {
       throw new Error(
         `inlineInstances: instance '${decl.name}': program '${cloned.name}' has no ` +
-        `output_assign for output '${clonedOut.name}'`,
+        `output_assign for output '${clonedOutputs[i].name}' (idx ${i})`,
       )
     }
-    perInstance.set(templateOut, expr)
-    // Also register under the cloned OutputDecl. After the
-    // outer-clone, the outer's NestedOut refs key off the cloned
-    // OutputDecls (cloneResolvedProgram routed them through the
-    // dedup table). The template OutputDecls won't match — cover
-    // both for safety.
-    if (clonedOut !== templateOut) perInstance.set(clonedOut, expr)
+    perInstance.set(outputIdx(i), expr)
   }
 }
 
@@ -401,7 +434,7 @@ function hasInstanceDecl(prog: ResolvedProgram): boolean {
  */
 function substDecl(
   d: BodyDecl,
-  subst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  subst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
   memo: WeakMap<object, ResolvedExpr>,
 ): BodyDecl {
   switch (d.op) {
@@ -428,7 +461,7 @@ function substDecl(
  */
 function substAssign(
   a: BodyAssign,
-  subst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  subst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
   memo: WeakMap<object, ResolvedExpr>,
 ): BodyAssign {
   const fresh: OutputAssign = { op: 'outputAssign', target: a.target, expr: substExpr(a.expr, subst, memo) }
@@ -437,7 +470,7 @@ function substAssign(
 
 function substExpr(
   e: ResolvedExpr,
-  subst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  subst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
   memo: WeakMap<object, ResolvedExpr>,
 ): ResolvedExpr {
   if (typeof e === 'number' || typeof e === 'boolean') return e
@@ -457,7 +490,7 @@ function substExpr(
 
 function substOpNode(
   node: ResolvedExprOp,
-  subst: Map<InstanceDecl, Map<OutputDecl, ResolvedExpr>>,
+  subst: Map<InstanceIdx, Map<OutputIdx, ResolvedExpr>>,
   memo: WeakMap<object, ResolvedExpr>,
 ): ResolvedExpr {
   const recur = (x: ResolvedExpr) => substExpr(x, subst, memo)
@@ -467,15 +500,15 @@ function substOpNode(
       const perInstance = subst.get(node.instance)
       if (perInstance === undefined) {
         throw new Error(
-          `inlineInstances: nestedOut to instance '${node.instance.name}'.` +
-          `${node.output.name} — instance not inlined?`,
+          `inlineInstances: nestedOut to instance idx=${node.instance} output idx=${node.output} ` +
+          `— instance not inlined?`,
         )
       }
       const v = perInstance.get(node.output)
       if (v === undefined) {
         throw new Error(
-          `inlineInstances: nestedOut to instance '${node.instance.name}'.` +
-          `${node.output.name} has no resolved expression for that output`,
+          `inlineInstances: nestedOut to instance idx=${node.instance} output idx=${node.output} ` +
+          `has no resolved expression for that output`,
         )
       }
       // Walk the substituted expression too: the recorded expression

--- a/compiler/ir/lowering/cycle_break.ts
+++ b/compiler/ir/lowering/cycle_break.ts
@@ -42,6 +42,7 @@ import type {
   BodyDecl,
   InstanceDecl, OutputDecl, RegDecl,
 } from '../nodes.js'
+import { withDeclTables } from '../decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
 // Public API
@@ -262,7 +263,7 @@ export function breakInstanceCycles(prog: ResolvedProgram): CycleBreakResult {
     assigns: prog.body.assigns,
   }
   return {
-    lowered: { ...prog, body: newBody },
+    lowered: withDeclTables({ ...prog, body: newBody }),
     syntheticRegs,
     cycles: cyclesProvenance,
   }

--- a/compiler/ir/lowering/cycle_break.ts
+++ b/compiler/ir/lowering/cycle_break.ts
@@ -41,7 +41,9 @@ import type {
   ResolvedBlock,
   BodyDecl,
   InstanceDecl, OutputDecl, RegDecl,
+  RegIdx, InstanceIdx, OutputIdx,
 } from '../nodes.js'
+import { regIdx } from '../nodes.js'
 import { withDeclTables } from '../decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
@@ -128,32 +130,36 @@ export function breakInstanceCycles(prog: ResolvedProgram): CycleBreakResult {
     })
   }
 
-  // Allocate the synthetic reg for a given (breakTarget, output) on
-  // first use; subsequent references resolve to the same reg.
-  const breakerFor = (inst: InstanceDecl, output: OutputDecl): RegDecl => {
-    const key = `${inst.name}::${output.name}`
-    let d = breakerReg.get(key)
-    if (d) return d
-    d = {
+  // Allocate the synthetic reg for a given (breakTargetIdx, outputIdx)
+  // on first use; subsequent references resolve to the same reg. Returns
+  // the new RegIdx (position in the EVENTUAL post-break body, which is
+  // existing regs followed by syntheticRegs).
+  const existingRegCount = prog.regs.length
+  const breakerIdxFor = (instI: InstanceIdx, outputI: OutputIdx): RegIdx => {
+    const inst = prog.instances[instI]
+    const outputDecl = inst.type.ports.outputs[outputI]
+    const key = `${inst.name}::${outputDecl.name}`
+    const cached = breakerReg.get(key)
+    if (cached) {
+      const cachedIdx = syntheticRegs.indexOf(cached)
+      return regIdx(existingRegCount + cachedIdx)
+    }
+    const newRegIdx = regIdx(existingRegCount + syntheticRegs.length)
+    const d: RegDecl = {
       op: 'regDecl',
-      name: `_feedback_${inst.name}_${output.name}`,
+      name: `_feedback_${inst.name}_${outputDecl.name}`,
       // The synthetic reg's update reads the current sample of the
       // broken output; the reg holds that value to make it readable
       // one sample later by the cycle members. The `_feedback_` name
-      // prefix distinguishes these from user-written regs (consumed
-      // by trace_cycles.test.ts and any future analyses that want
-      // to identify cycle-break regs). Post-Phase 4b strict policy
-      // means production code paths never produce these (cycles in
-      // source throw at elaborate-time); the helper survives for
-      // direct invocation by tests and future realizations.
-      update: { op: 'nestedOut', instance: inst, output },
+      // prefix distinguishes these from user-written regs.
+      update: { op: 'nestedOut', instance: instI, output: outputI },
       init: 0,
     }
     breakerReg.set(key, d)
     syntheticRegs.push(d)
     const ports = breakerPortsByCycle.get(inst)
-    if (ports) ports.push(output)
-    return d
+    if (ports) ports.push(outputDecl)
+    return newRegIdx
   }
 
   // Rewriter: in any expression that belongs to an instance in
@@ -168,8 +174,9 @@ export function breakInstanceCycles(prog: ResolvedProgram): CycleBreakResult {
   const rewriteOpForOwner = (node: ResolvedExprOp, breakSet: Set<InstanceDecl>): ResolvedExpr => {
     switch (node.op) {
       case 'nestedOut': {
-        if (breakSet.has(node.instance)) {
-          return { op: 'regRef', decl: breakerFor(node.instance, node.output) }
+        const inst = prog.instances[node.instance]
+        if (inst && breakSet.has(inst)) {
+          return { op: 'regRef', idx: breakerIdxFor(node.instance, node.output) }
         }
         return node
       }
@@ -285,10 +292,14 @@ function buildInstanceDeps(
   const allInstances = new Set(instances)
   const deps = new Map<InstanceDecl, Set<InstanceDecl>>()
   for (const inst of instances) deps.set(inst, new Set())
+  // collectNestedOutInstances resolves nestedOut.instance (now InstanceIdx)
+  // against the local instances array — these ARE the body's instances
+  // in order, matching the InstanceIdx assignment.
+  const instanceByIdx = instances
   for (const inst of instances) {
     const set = deps.get(inst)!
     for (const wire of inst.inputs) {
-      collectNestedOutInstances(wire.value, set, allInstances)
+      collectNestedOutInstances(wire.value, set, allInstances, instanceByIdx)
     }
   }
   return deps
@@ -298,52 +309,55 @@ function collectNestedOutInstances(
   expr: ResolvedExpr,
   out: Set<InstanceDecl>,
   allInstances: Set<InstanceDecl>,
+  instanceByIdx: readonly InstanceDecl[],
 ): void {
   if (typeof expr !== 'object' || expr === null) return
   if (Array.isArray(expr)) {
-    for (const e of expr) collectNestedOutInstances(e, out, allInstances)
+    for (const e of expr) collectNestedOutInstances(e, out, allInstances, instanceByIdx)
     return
   }
   switch (expr.op) {
-    case 'nestedOut':
-      if (allInstances.has(expr.instance)) out.add(expr.instance)
+    case 'nestedOut': {
+      const inst = instanceByIdx[expr.instance]
+      if (inst && allInstances.has(inst)) out.add(inst)
       return
+    }
     case 'match':
-      collectNestedOutInstances(expr.scrutinee, out, allInstances)
-      for (const arm of expr.arms) collectNestedOutInstances(arm.body, out, allInstances)
+      collectNestedOutInstances(expr.scrutinee, out, allInstances, instanceByIdx)
+      for (const arm of expr.arms) collectNestedOutInstances(arm.body, out, allInstances, instanceByIdx)
       return
     case 'fold': case 'scan':
-      collectNestedOutInstances(expr.over, out, allInstances)
-      collectNestedOutInstances(expr.init, out, allInstances)
-      collectNestedOutInstances(expr.body, out, allInstances)
+      collectNestedOutInstances(expr.over, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.init, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.body, out, allInstances, instanceByIdx)
       return
     case 'generate':
-      collectNestedOutInstances(expr.count, out, allInstances)
-      collectNestedOutInstances(expr.body, out, allInstances)
+      collectNestedOutInstances(expr.count, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.body, out, allInstances, instanceByIdx)
       return
     case 'iterate': case 'chain':
-      collectNestedOutInstances(expr.count, out, allInstances)
-      collectNestedOutInstances(expr.init, out, allInstances)
-      collectNestedOutInstances(expr.body, out, allInstances)
+      collectNestedOutInstances(expr.count, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.init, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.body, out, allInstances, instanceByIdx)
       return
     case 'map2':
-      collectNestedOutInstances(expr.over, out, allInstances)
-      collectNestedOutInstances(expr.body, out, allInstances)
+      collectNestedOutInstances(expr.over, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.body, out, allInstances, instanceByIdx)
       return
     case 'zipWith':
-      collectNestedOutInstances(expr.a, out, allInstances)
-      collectNestedOutInstances(expr.b, out, allInstances)
-      collectNestedOutInstances(expr.body, out, allInstances)
+      collectNestedOutInstances(expr.a, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.b, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.body, out, allInstances, instanceByIdx)
       return
     case 'let':
-      for (const b of expr.binders) collectNestedOutInstances(b.value, out, allInstances)
-      collectNestedOutInstances(expr.in, out, allInstances)
+      for (const b of expr.binders) collectNestedOutInstances(b.value, out, allInstances, instanceByIdx)
+      collectNestedOutInstances(expr.in, out, allInstances, instanceByIdx)
       return
     case 'tag':
-      for (const p of expr.payload) collectNestedOutInstances(p.value, out, allInstances)
+      for (const p of expr.payload) collectNestedOutInstances(p.value, out, allInstances, instanceByIdx)
       return
     case 'zeros':
-      collectNestedOutInstances(expr.count, out, allInstances)
+      collectNestedOutInstances(expr.count, out, allInstances, instanceByIdx)
       return
     case 'add': case 'sub': case 'mul': case 'div': case 'mod':
     case 'lt': case 'lte': case 'gt': case 'gte': case 'eq': case 'neq':
@@ -354,7 +368,7 @@ function collectNestedOutInstances(
     case 'sqrt': case 'abs': case 'floor': case 'ceil': case 'round':
     case 'floatExponent': case 'toInt': case 'toBool': case 'toFloat':
     case 'clamp': case 'select': case 'index': case 'arraySet':
-      for (const a of expr.args) collectNestedOutInstances(a, out, allInstances)
+      for (const a of expr.args) collectNestedOutInstances(a, out, allInstances, instanceByIdx)
       return
     case 'inputRef': case 'regRef': case 'paramRef':
     case 'typeParamRef': case 'bindingRef':

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -82,7 +82,11 @@ export function materializeSessionForEmit(session: SessionState): {
     })
     throw new CycleViolation(diagnostics)
   }
-  const lowered = strataPipeline(synthetic)
+  // Honor the session's inlineNested mode. The session lift's strata
+  // run controls whether sub-instances inside the synthetic top-level
+  // get inlined (inlineNested:true, default) or preserved as kernel
+  // boundaries for the M11 slot path (inlineNested:false).
+  const lowered = strataPipeline(synthetic, new Map(), { inlineNested: session.inlineNested })
   return { lowered, paramDecls: ctx.paramDecls }
 }
 

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -30,7 +30,9 @@ import type {
   InputDecl, OutputDecl, RegDecl, ParamDecl, InstanceDecl,
   BodyDecl, BodyAssign, OutputAssign,
   TypeParamDecl,
+  InputIdx, OutputIdx, ParamIdx, InstanceIdx, RegIdx,
 } from './nodes.js'
+import { inputIdx, outputIdx, paramIdx, instanceIdx, regIdx } from './nodes.js'
 import type { ExprNode } from '../expr.js'
 import type { SessionState } from '../session.js'
 import type { Instance } from '../program_types.js'
@@ -130,14 +132,25 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
     const inputName = ref.port
     const instDecl = ctx.instanceDecls.get(instName)
     if (instDecl === undefined) continue
-    const port = instDecl.type.ports.inputs.find(p => p.name === inputName)
-    if (port === undefined) {
+    const portI = instDecl.type.ports.inputs.findIndex(p => p.name === inputName)
+    if (portI < 0) {
       throw new Error(
         `compileSession: instance '${instName}' has no input port '${inputName}' on type '${instDecl.type.name}'.`,
       )
     }
     const value = translateExpr(expr, ctx)
-    instDecl.inputs.push({ port, value })
+    instDecl.inputs.push({ port: inputIdx(portI), value })
+  }
+
+  // Compute InstanceIdx for each session instance: their position in
+  // the eventual body.instances[], which is the iteration order of
+  // ctx.instanceDecls (Maps preserve insertion order).
+  const instanceIdxByName = new Map<string, InstanceIdx>()
+  {
+    let pos = 0
+    for (const name of ctx.instanceDecls.keys()) {
+      instanceIdxByName.set(name, instanceIdx(pos++))
+    }
   }
 
   const outputDecls: OutputDecl[] = []
@@ -147,20 +160,26 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
     if (instDecl === undefined) {
       throw new Error(`compileSession: graph output references unknown instance '${go.instance}'.`)
     }
-    const outDecl = instDecl.type.ports.outputs.find(p => p.name === go.output)
-    if (outDecl === undefined) {
+    const outputI = instDecl.type.ports.outputs.findIndex(p => p.name === go.output)
+    if (outputI < 0) {
       throw new Error(
         `compileSession: instance '${go.instance}' has no output port '${go.output}' on type '${instDecl.type.name}'.`,
       )
     }
+    const outDecl = instDecl.type.ports.outputs[outputI]
     const sessionOutput: OutputDecl = {
       op: 'outputDecl',
       name: `${go.instance}.${go.output}`,
     }
     if (outDecl.type !== undefined) sessionOutput.type = outDecl.type
+    const sessionOutI = outputDecls.length
     outputDecls.push(sessionOutput)
-    const ref: ResolvedExprOp = { op: 'nestedOut', instance: instDecl, output: outDecl }
-    outputAssigns.push({ op: 'outputAssign', target: sessionOutput, expr: ref })
+    const ref: ResolvedExprOp = {
+      op: 'nestedOut',
+      instance: instanceIdxByName.get(go.instance)!,
+      output: outputIdx(outputI),
+    }
+    outputAssigns.push({ op: 'outputAssign', target: outputIdx(sessionOutI), expr: ref })
   }
 
   const bodyDecls: BodyDecl[] = []
@@ -312,13 +331,22 @@ function translateOpNode(
     if (instDecl === undefined) {
       throw new Error(`compileSession: ref to unknown instance '${instName}'.`)
     }
-    const outDecl = instDecl.type.ports.outputs.find(p => p.name === outputName)
-    if (outDecl === undefined) {
+    const outputI = instDecl.type.ports.outputs.findIndex(p => p.name === outputName)
+    if (outputI < 0) {
       throw new Error(
         `compileSession: ref to '${instName}.${outputName}' — '${outputName}' is not a port on type '${instDecl.type.name}'.`,
       )
     }
-    return { op: 'nestedOut', instance: instDecl, output: outDecl }
+    // InstanceIdx is the iteration position of instName in ctx.instanceDecls.
+    // Maps preserve insertion order, so this matches the order the instance
+    // decls land in body.decls (and thus body.instances) later.
+    let instI = -1
+    let i = 0
+    for (const name of ctx.instanceDecls.keys()) {
+      if (name === instName) { instI = i; break }
+      i++
+    }
+    return { op: 'nestedOut', instance: instanceIdx(instI), output: outputIdx(outputI) }
   }
 
   if (op === 'param' || op === 'paramExpr'
@@ -358,10 +386,14 @@ function translateOpNode(
     const update = translateExpr((obj.args as ExprNode[])[0], ctx)
     const init = typeof obj.init === 'number' ? obj.init : 0
     // Post-Phase-0a: session `delay()` lowers to a synthetic RegDecl
-    // with update populated. Reads of the value are RegRefs.
+    // with update populated. Reads of the value are RegRefs. The
+    // synthetic regs are placed at the FRONT of body.decls (before
+    // instance decls and param decls — see materializeSessionInner),
+    // so their RegIdx equals their position in ctx.syntheticRegDecls.
+    const newIdx = regIdx(ctx.syntheticRegDecls.length)
     const decl: RegDecl = { op: 'regDecl', name: `__sd${ctx.syntheticRegDecls.length}`, update, init }
     ctx.syntheticRegDecls.push(decl)
-    return { op: 'regRef', decl }
+    return { op: 'regRef', idx: newIdx }
   }
 
   throw new Error(`compileSession: unhandled wiring op '${op}'.`)
@@ -373,5 +405,15 @@ function paramRef(name: string, ctx: MaterializeContext): ResolvedExpr {
     decl = { op: 'paramDecl', name }
     ctx.paramDecls.set(name, decl)
   }
-  return { op: 'paramRef', decl }
+  // ParamIdx is the iteration position in ctx.paramDecls. Params land
+  // in body.decls after syntheticRegDecls and instanceDecls, but ParamIdx
+  // indexes into body.params[] (filtered by op), which preserves
+  // insertion order of paramDecls.
+  let pi = -1
+  let i = 0
+  for (const n of ctx.paramDecls.keys()) {
+    if (n === name) { pi = i; break }
+    i++
+  }
+  return { op: 'paramRef', idx: paramIdx(pi) }
 }

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -39,6 +39,7 @@ import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
 import { specializeProgram } from './specialize.js'
 import { parseWireKey } from './branded_names.js'
+import { mkProgram } from './decl_tables.js'
 
 /** Run the session-to-ResolvedProgram materialization end-to-end. */
 export function materializeSessionToResolvedIR(session: SessionState): ResolvedProgram {
@@ -181,13 +182,12 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
     typeDefs: [],
   }
 
-  return {
-    op: 'program',
+  return mkProgram({
     name: '__session__',
     typeParams: [] as TypeParamDecl[],
     ports,
     body: block,
-  }
+  })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/compiler/ir/nodes.ts
+++ b/compiler/ir/nodes.ts
@@ -165,16 +165,16 @@ export interface ParamDecl {
 export interface InstanceDecl {
   op: 'instanceDecl'
   name: string
+  /** Pointer to the instance's program type. Stays pointer-based in
+   *  this PR; the Bubble fix (via topological registry build, Phase 3)
+   *  ensures the pointer is set to the canonical strata-processed
+   *  program at construction time. Migrating to `type: ProgramKey`
+   *  (registry-keyed string) is a separate followup. */
   type: ResolvedProgram
-  /** Type-arg pairs: each holds a reference to one of the target's
-   *  declared type params plus the integer value supplied at the
-   *  instance site. */
-  typeArgs: Array<{ param: TypeParamDecl; value: number }>
-  /** Input wires: each holds a reference to one of the target's declared
-   *  input ports plus the value-expression wired into it. The elaborator
-   *  validates that every required input is supplied (defaults handle
-   *  missing entries). */
-  inputs: Array<{ port: InputDecl; value: ResolvedExpr }>
+  /** Type-arg bindings, by position in the target's `typeParams[]`. */
+  typeArgs: Array<{ param: TypeParamIdx; value: number }>
+  /** Input-wire bindings, by position in the target's `ports.inputs[]`. */
+  inputs: Array<{ port: InputIdx; value: ResolvedExpr }>
 }
 
 /** A nested `program` declaration introduces a program type into the
@@ -198,9 +198,11 @@ export type BodyDecl =
 
 export interface OutputAssign {
   op: 'outputAssign'
-  /** Either an OutputDecl from this program's outputs, or the special
-   *  `'dac'` boundary leaf for top-level patches that wire to the DAC. */
-  target: OutputDecl | { kind: 'dac' }
+  /** Either an OutputIdx into this program's `ports.outputs[]`, or the
+   *  special `'dac'` boundary leaf for top-level patches that wire to
+   *  the DAC. Migrated from `OutputDecl` pointer alongside the rest of
+   *  the global-ref de Bruijn levels migration. */
+  target: OutputIdx | { kind: 'dac' }
   expr: ResolvedExpr
 }
 
@@ -230,21 +232,62 @@ export interface BinderDecl {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Refs — uses of decl objects
+// De Bruijn levels — branded indices into program-level tables
 // ─────────────────────────────────────────────────────────────
 
-export interface InputRef    { op: 'inputRef';    decl: InputDecl }
-export interface RegRef      { op: 'regRef';      decl: RegDecl }
-export interface ParamRef    { op: 'paramRef';    decl: ParamDecl }
-export interface TypeParamRef { op: 'typeParamRef'; decl: TypeParamDecl }
-export interface BindingRef  { op: 'bindingRef';  decl: BinderDecl }
+/** Branded position-indices. Position in the table IS the decl's
+ *  identity. Stable across rewrites (an index doesn't shift just
+ *  because a sibling decl was reshaped).
+ *
+ *  - RegIdx / ParamIdx / InstanceIdx index this program's
+ *    `regs[]` / `params[]` / `instances[]` tables.
+ *  - InputIdx / OutputIdx index `ports.inputs[]` / `ports.outputs[]`.
+ *    Where they appear on a cross-program reference (InstanceDecl's
+ *    typeArgs.param / inputs.port, NestedOut.output) they're indices
+ *    into the TARGET program's tables — resolution requires the
+ *    target program in hand.
+ *  - TypeParamIdx indexes `typeParams[]`.
+ *  - BindingRef is the only ref that keeps a direct decl pointer —
+ *    locally-scoped binders don't fit the program-table model and
+ *    the locally-nameless migration for binders is tracked
+ *    separately as issue #156. */
+declare const __ir_idx_brand: unique symbol
+export type IrIdx<B extends string> = number & { readonly [__ir_idx_brand]: B }
 
-/** Dotted port reference resolved: a specific instance + a specific
- *  output port of that instance's program type. Both held by reference. */
+export type RegIdx       = IrIdx<'RegIdx'>
+export type InputIdx     = IrIdx<'InputIdx'>
+export type OutputIdx    = IrIdx<'OutputIdx'>
+export type ParamIdx     = IrIdx<'ParamIdx'>
+export type InstanceIdx  = IrIdx<'InstanceIdx'>
+export type TypeParamIdx = IrIdx<'TypeParamIdx'>
+
+/** Brand-applying constructors. Use these everywhere indices are
+ *  built; never `as RegIdx` casts at call sites. */
+export const regIdx       = (n: number): RegIdx       => n as RegIdx
+export const inputIdx     = (n: number): InputIdx     => n as InputIdx
+export const outputIdx    = (n: number): OutputIdx    => n as OutputIdx
+export const paramIdx     = (n: number): ParamIdx     => n as ParamIdx
+export const instanceIdx  = (n: number): InstanceIdx  => n as InstanceIdx
+export const typeParamIdx = (n: number): TypeParamIdx => n as TypeParamIdx
+
+// ─────────────────────────────────────────────────────────────
+// Refs — uses of decls by de Bruijn level
+// ─────────────────────────────────────────────────────────────
+
+export interface InputRef     { op: 'inputRef';     idx: InputIdx }
+export interface RegRef       { op: 'regRef';       idx: RegIdx }
+export interface ParamRef     { op: 'paramRef';     idx: ParamIdx }
+export interface TypeParamRef { op: 'typeParamRef'; idx: TypeParamIdx }
+export interface BindingRef   { op: 'bindingRef';   decl: BinderDecl }   // pointer-based; see issue #156
+
+/** Dotted port reference, indexed: parent's instance position +
+ *  the output port position inside the instance's program type. To
+ *  resolve: instance via `prog.instances[instance]`, then read
+ *  `instance.type.ports.outputs[output]`. */
 export interface NestedOut {
   op: 'nestedOut'
-  instance: InstanceDecl
-  output: OutputDecl
+  instance: InstanceIdx
+  output:   OutputIdx
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/ir/nodes.ts
+++ b/compiler/ir/nodes.ts
@@ -475,6 +475,18 @@ export interface ResolvedProgram {
   typeParams: TypeParamDecl[]
   ports: ResolvedProgramPorts
   body: ResolvedBlock
+  /** Typed decl tables, projected from `body.decls` by kind. Position
+   *  in each array IS the decl's identity for the de Bruijn levels
+   *  migration — the same `RegDecl` object appears at `body.decls[i]`
+   *  and at `regs[k]` for some k. Populated by `withDeclTables`
+   *  (`compiler/ir/decl_tables.ts`); every ResolvedProgram constructor
+   *  must route through that helper to keep the tables in sync with
+   *  `body.decls`. `InputDecl` and `OutputDecl` positional identity
+   *  already lives in `ports.inputs` / `ports.outputs` — those arrays
+   *  ARE their tables; no top-level duplicate. */
+  regs:      RegDecl[]
+  params:    ParamDecl[]
+  instances: InstanceDecl[]
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -23,7 +23,9 @@
 
 import type {
   ResolvedProgram, InstanceDecl, InputDecl, OutputDecl, ParamDecl,
+  InputIdx, OutputIdx, InstanceIdx, ParamIdx,
 } from './nodes.js'
+import { inputIdx, outputIdx, instanceIdx } from './nodes.js'
 import type { SessionState, ExprNode } from '../session.js'
 import type {
   InstanceFunction, RegTarget,
@@ -138,14 +140,14 @@ export function partitionKernel(
   compiled: Compiled,
   inputBindingFor: (portName: string) => InputBinding | undefined,
   defaults: Record<string, ExprNode>,
-  paramHandles: Map<ParamDecl, { ptr: string }>,
+  paramHandles: Map<ParamIdx, { ptr: string }>,
   session: SessionState,
   acc: PartitionAccumulators,
   /** M11 slot-based input wiring: when set, THIS kernel is being
-   *  compiled as a sub-instance. Its `InputRef(d)` operands lower to
+   *  compiled as a sub-instance. Its `InputRef(idx)` operands lower to
    *  Slot reads from the slot indices recorded here, instead of the
    *  legacy `opInput`. Top-level callers pass `undefined`. */
-  inputSlotOverride?: Map<InputDecl, number>,
+  inputSlotOverride?: Map<InputIdx, number>,
 ): PartitionedKernel {
   // ── 1. Recurse into sub-InstanceDecls.
   //    For each child:
@@ -162,12 +164,18 @@ export function partitionKernel(
   //    Under slots, the wire is evaluated in the parent's scope where
   //    every ref resolves, and only the *value* crosses the boundary.
   const children: InstanceFunction[] = []
-  const nestedOutputSlots = new Map<InstanceDecl, Map<OutputDecl, number>>()
-  const nestedInputSlots  = new Map<InstanceDecl, Map<InputDecl, number>>()
+  // Maps are now keyed by indices: InstanceIdx for this program's
+  // instances (position in body.decls instance order), InputIdx/OutputIdx
+  // for the target program's port positions. compileResolved + emit
+  // consume these in index form.
+  const nestedOutputSlots = new Map<InstanceIdx, Map<OutputIdx, number>>()
+  const nestedInputSlots  = new Map<InstanceIdx, Map<InputIdx, number>>()
 
+  let childInstIdx = 0
   for (const decl of prog.body.decls) {
     if (decl.op !== 'instanceDecl') continue
     const childPath = `${instancePath}.${decl.name}`
+    const thisInstIdx = instanceIdx(childInstIdx++)
 
     const childCompiled = makeCompiled(decl.type, { displayName: decl.type.name })
 
@@ -175,21 +183,25 @@ export function partitionKernel(
     allocateOutputSlots(session, toInstanceName(childPath), childCompiled)
     allocateInputSlots (session, toInstanceName(childPath), childCompiled)
 
-    // Build slot map for parent's NestedOut → child output reads.
-    const childOutputMap = new Map<OutputDecl, number>()
-    for (const outDecl of decl.type.ports.outputs) {
+    // Build slot map for parent's NestedOut → child output reads,
+    // keyed by OutputIdx (position in decl.type.ports.outputs).
+    const childOutputMap = new Map<OutputIdx, number>()
+    for (let i = 0; i < decl.type.ports.outputs.length; i++) {
+      const outDecl = decl.type.ports.outputs[i]
       const slotIdx = lookupOutputSlot(session, childPath, outDecl.name)
-      if (slotIdx !== undefined) childOutputMap.set(outDecl, slotIdx)
+      if (slotIdx !== undefined) childOutputMap.set(outputIdx(i), slotIdx)
     }
-    nestedOutputSlots.set(decl, childOutputMap)
+    nestedOutputSlots.set(thisInstIdx, childOutputMap)
 
-    // Build slot map for parent's WriteSlot → child input writes.
-    const childInputMap = new Map<InputDecl, number>()
-    for (const inDecl of decl.type.ports.inputs) {
+    // Build slot map for parent's WriteSlot → child input writes,
+    // keyed by InputIdx (position in decl.type.ports.inputs).
+    const childInputMap = new Map<InputIdx, number>()
+    for (let i = 0; i < decl.type.ports.inputs.length; i++) {
+      const inDecl = decl.type.ports.inputs[i]
       const slotIdx = lookupInputSlot(session, childPath, inDecl.name)
-      if (slotIdx !== undefined) childInputMap.set(inDecl, slotIdx)
+      if (slotIdx !== undefined) childInputMap.set(inputIdx(i), slotIdx)
     }
-    nestedInputSlots.set(decl, childInputMap)
+    nestedInputSlots.set(thisInstIdx, childInputMap)
 
     // Recursively compile the child. Pass childInputMap as
     // `inputSlotOverride` so the child's InputRefs lower to Slot

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -265,7 +265,16 @@ export function partitionKernel(
   }
 
   const { preamble, perChildPreInput, body, writeSlots, tempsConsumed } = remapInstancePlan(plan, ctx, session)
-  const instanceInstructions: NInstr[] = [...preamble, ...body, ...writeSlots]
+  // The preamble holds temp-computes for session-wired input translations
+  // (e.g., a wire's `pulseEvery(64)` expression resolves to instructions
+  // emitting into a temp). Those temps are referenced by the per-child
+  // WriteSlots in perChildPreInput. Children dispatch BEFORE this kernel's
+  // main `instructions`, so the preamble has to live in a separate field
+  // that the engine emits before children. Bundling it into
+  // `instructions` (as the legacy code did) puts the compute AFTER its
+  // use — works for literal session inputs (no preamble emission), broken
+  // for expression-shaped session inputs like Bubble's pulseEvery trigger.
+  const instanceInstructions: NInstr[] = [...body, ...writeSlots]
 
   // Attach each per-child pre-input block to its corresponding child
   // InstanceFunction. The pre-input wires live in THIS kernel's
@@ -298,6 +307,7 @@ export function partitionKernel(
   const fn: InstanceFunction = {
     name:              `instance_${instancePath.replace(/\./g, '_')}`,
     instance_name:     instancePath,
+    preamble_instructions:  preamble,
     instructions:      instanceInstructions,
     // Top-level kernels run no parent-side pre-input wires (their
     // inputs come from session inputBindings translated into the

--- a/compiler/ir/specialize.test.ts
+++ b/compiler/ir/specialize.test.ts
@@ -251,12 +251,11 @@ describe('specialize — InstanceDecl.typeArgs survive substitution', () => {
     expect(inst.op).toBe('instanceDecl')
     expect(inst.typeArgs.length).toBe(1)
     expect(inst.typeArgs[0].value).toBe(8)
-    // The param ref on the typeArg points at the cloned Delay's N decl
-    // (the cloner walks instance.type, which clones Delay and its
-    // typeParams). The post-condition is that typeArgs[0].param is a
-    // TypeParamDecl on the instance's referenced program.
+    // The param ref on the typeArg is now a TypeParamIdx into the
+    // instance's referenced program's typeParams[]. The post-condition
+    // is that typeArgs[0].param resolves to the 'N' decl on the target.
     expect(inst.type.typeParams.length).toBe(1)
-    expect(inst.typeArgs[0].param).toBe(inst.type.typeParams[0])
-    expect(inst.typeArgs[0].param.name).toBe('N')
+    expect(inst.type.typeParams[inst.typeArgs[0].param]).toBe(inst.type.typeParams[0])
+    expect(inst.type.typeParams[inst.typeArgs[0].param].name).toBe('N')
   })
 })

--- a/compiler/ir/sum_lower.test.ts
+++ b/compiler/ir/sum_lower.test.ts
@@ -139,7 +139,7 @@ describe('sumLower — payload variant', () => {
     // `then` branch (Decaying arm) eventually contains a regRef whose
     // decl is the state#Decaying__level slot.
     const a = out.body.assigns[0] as OutputAssign
-    const refs = collectRegRefNames(a.expr)
+    const refs = collectRegRefNames(a.expr, out)
     expect(refs).toContain('state#Decaying__level')
     expect(refs).toContain('state#tag')
   })
@@ -149,12 +149,15 @@ describe('sumLower — payload variant', () => {
  *  expression. Does NOT recurse through `regRef.decl` (the decl
  *  carries its own update expression which would re-enter the walker
  *  indefinitely). */
-function collectRegRefNames(expr: ResolvedExpr): string[] {
+function collectRegRefNames(expr: ResolvedExpr, prog?: ResolvedProgram): string[] {
   const out: string[] = []
   const walk = (e: ResolvedExpr): void => {
     if (typeof e !== 'object' || e === null) return
     if (Array.isArray(e)) { e.forEach(walk); return }
-    if (e.op === 'regRef') { out.push(e.decl.name); return }
+    if (e.op === 'regRef') {
+      const name = prog?.regs[e.idx]?.name ?? `<idx ${e.idx}>`
+      out.push(name); return
+    }
     // Recurse into structured children only — skip back-pointer fields.
     walkChildren(e, walk)
   }

--- a/compiler/ir/sum_lower.ts
+++ b/compiler/ir/sum_lower.ts
@@ -37,7 +37,9 @@ import type {
   SumTypeDef, SumVariant, StructField,
   Tag, Match, MatchArm,
   RegRef,
+  RegIdx,
 } from './nodes.js'
+import { regIdx } from './nodes.js'
 import { withDeclTables } from './decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
@@ -109,7 +111,26 @@ export function sumLower(prog: ResolvedProgram): ResolvedProgram {
     }
   }
 
-  const ctx: Ctx = { sumRegs, regMap }
+  // Pre-compute new RegIdx positions: walk decls in order and assign
+  // a fresh idx to every new RegDecl that will live in the rewritten
+  // body's regs[] table. Sum decls expand to (tag + payloads); non-sum
+  // regs map to their fresh shell. ParamDecl/InstanceDecl/ProgramDecl
+  // don't contribute. This must run BEFORE rewriteExpr because cross-
+  // decl forward refs need the full idx table populated.
+  const newRegIdxByDecl = new Map<RegDecl, RegIdx>()
+  let nextRegIdx = 0
+  for (const decl of prog.body.decls) {
+    if (decl.op !== 'regDecl') continue
+    if (sumRegs.has(decl)) {
+      for (const slot of sumRegs.get(decl)!.slots) {
+        newRegIdxByDecl.set(slot.decl, regIdx(nextRegIdx++))
+      }
+    } else {
+      newRegIdxByDecl.set(regMap.get(decl)!, regIdx(nextRegIdx++))
+    }
+  }
+
+  const ctx: Ctx = { sumRegs, inProg: prog, regMap, newRegIdxByDecl }
 
   // Rewrite decls: replace each sum-typed RegDecl with its per-slot
   // expansion (preserving source position); for everything else,
@@ -260,12 +281,19 @@ function fillSlotsForSumReg(
 
 interface Ctx {
   sumRegs: SumRegMap
+  /** Input program; needed to resolve old RegRef.idx → source RegDecl. */
+  inProg: ResolvedProgram
   /** Map every original RegDecl in the body to its replacement.
    *  Sum-typed → the tag-slot decl; non-sum → a freshly cloned decl
    *  whose `update`/`init` will be filled in by `rewriteDecl`. Used
    *  by `RegRef` rewriting so refs in expressions point at the decl
    *  objects that actually appear in the rewritten body. */
   regMap: Map<RegDecl, RegDecl>
+  /** Map from new RegDecl object to its de Bruijn level in the
+   *  rewritten program's regs[] table. Populated in sumLower's main
+   *  body BEFORE rewriteExpr runs (so cross-decl forward refs work).
+   *  Used to compute the new idx for every rewritten RegRef. */
+  newRegIdxByDecl: Map<RegDecl, RegIdx>
   /** Active per-binder substitutions introduced by match arms.
    *  A `BindingRef` whose decl is a key here is rewritten to the
    *  mapped expression. */
@@ -341,13 +369,20 @@ function rewriteOp(node: ResolvedExprOp, ctx: Ctx): ResolvedExpr {
     // ── RegRef: rewrite to the cloned/replacement decl. For a
     //    sum-typed source reg this is the tag slot; for non-sum it's
     //    the cloned scalar decl. (Match rewriting handles payload
-    //    reads via per-arm substitution before reaching this case.) ──
+    //    reads via per-arm substitution before reaching this case.)
+    //    Migrated to indices: look up the source decl from the input
+    //    program via node.idx, find its replacement, then compute the
+    //    new idx via newRegIdxByDecl. ──
     case 'regRef': {
-      const replacement = ctx.regMap.get(node.decl)
-      if (replacement && replacement !== node.decl) {
-        return { op: 'regRef', decl: replacement }
+      const srcDecl = ctx.inProg.regs[node.idx]
+      if (!srcDecl) throw new Error(`sumLower: regRef idx=${node.idx} has no source in input program`)
+      const replacement = ctx.regMap.get(srcDecl)
+      if (!replacement) return node
+      const newIdx = ctx.newRegIdxByDecl.get(replacement)
+      if (newIdx === undefined) {
+        throw new Error(`sumLower: replacement for reg '${srcDecl.name}' has no idx in rewritten program`)
       }
-      return node
+      return { op: 'regRef', idx: newIdx }
     }
 
     // ── Tag in expression position (no payload) → variant index. ──
@@ -516,10 +551,14 @@ function bindingsForArm(
     )
   }
   const rRef = scrutinee as RegRef
-  const info = ctx.sumRegs.get(rRef.decl)
+  const srcDecl = ctx.inProg.regs[rRef.idx]
+  if (!srcDecl) {
+    throw new Error(`sumLower: match arm scrutinee regRef idx=${rRef.idx} has no source decl`)
+  }
+  const info = ctx.sumRegs.get(srcDecl)
   if (!info) {
     throw new Error(
-      `sumLower: match arm '${arm.variant.name}' scrutinee references non-sum reg '${rRef.decl.name}'`,
+      `sumLower: match arm '${arm.variant.name}' scrutinee references non-sum reg '${srcDecl.name}'`,
     )
   }
   if (arm.binders.length !== arm.variant.payload.length) {
@@ -535,7 +574,11 @@ function bindingsForArm(
         `sumLower: match arm '${arm.variant.name}': missing slot for field '${field.name}'`,
       )
     }
-    subs.set(arm.binders[i], { op: 'regRef', decl: slot.decl })
+    const newIdx = ctx.newRegIdxByDecl.get(slot.decl)
+    if (newIdx === undefined) {
+      throw new Error(`sumLower: payload slot '${slot.decl.name}' has no idx in rewritten program`)
+    }
+    subs.set(arm.binders[i], { op: 'regRef', idx: newIdx })
   }
   return subs
 }
@@ -618,16 +661,24 @@ function extractSlotFromSumExpr(
     }
 
     case 'regRef': {
-      const srcInfo = ctx.sumRegs.get(expr.decl)
+      const srcDecl = ctx.inProg.regs[expr.idx]
+      if (!srcDecl) return 0
+      const srcInfo = ctx.sumRegs.get(srcDecl)
       if (!srcInfo) {
         // Reading a scalar reg as a sum value is malformed.
         return 0
       }
       if (slot.variant === undefined) {
-        return { op: 'regRef', decl: srcInfo.tagSlot.decl }
+        const i = ctx.newRegIdxByDecl.get(srcInfo.tagSlot.decl)
+        if (i === undefined) throw new Error(`sumLower: tag-slot decl has no idx`)
+        return { op: 'regRef', idx: i }
       }
       const srcSlot = srcInfo.payloadByKey.get(slotKey(slot.variant, slot.field!))
-      if (srcSlot) return { op: 'regRef', decl: srcSlot.decl }
+      if (srcSlot) {
+        const i = ctx.newRegIdxByDecl.get(srcSlot.decl)
+        if (i === undefined) throw new Error(`sumLower: payload-slot decl has no idx`)
+        return { op: 'regRef', idx: i }
+      }
       return 0
     }
 

--- a/compiler/ir/sum_lower.ts
+++ b/compiler/ir/sum_lower.ts
@@ -38,6 +38,7 @@ import type {
   Tag, Match, MatchArm,
   RegRef,
 } from './nodes.js'
+import { withDeclTables } from './decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
 // Sum-reg table — built once before any rewriting starts
@@ -135,7 +136,7 @@ export function sumLower(prog: ResolvedProgram): ResolvedProgram {
   }
 
   const newBody: ResolvedBlock = { op: 'block', decls: newDecls, assigns: newAssigns }
-  return { ...prog, body: newBody }
+  return withDeclTables({ ...prog, body: newBody })
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/ir/sum_lower.ts
+++ b/compiler/ir/sum_lower.ts
@@ -1,5 +1,5 @@
 /**
- * sum_lower.ts — Phase C4: sum-type decomposition on the resolved IR.
+ * sum_lower.ts — sum-type decomposition on the resolved IR.
  *
  * Decomposes every sum-typed `RegDecl` (one whose `init` is a `Tag`)
  * into N+1 scalar `RegDecl`s — a discriminator slot (int) plus one
@@ -8,20 +8,37 @@
  * literals.
  *
  * After this pass the program contains no `tag` or `match` expressions
- * and no sum-typed regs. Decl identity is preserved end-to-end:
- *   - Each replacement scalar `RegDecl` is a fresh decl object.
- *   - References (`RegRef`, `BindingRef`) are rewritten by identity
- *     replacement, never by name string.
+ * and no sum-typed regs.
  *
- * Post-Phase-0a: the IR has a single unified `RegDecl` primitive with
- * optional `update`. Sum-typed regs are recognized by `init` being a
- * `Tag` expression; their `update` (when present) is the sum-valued
- * next-state expression that gets per-slot-extracted into each
- * replacement scalar slot. NextUpdate body-assigns are gone (folded
- * into decl.update at elaboration), so the lowering operates entirely
- * on decl-side update fields.
+ * ## Pure construction
  *
- * Constraints (matching legacy):
+ * The pass is structured as three pure phases:
+ *
+ *   1. `buildSpecs(prog)` — pure data. Walks the input body's decls,
+ *      identifies which are sum-typed, and assigns the new RegIdx
+ *      (position in the rewritten body's regs[] table) for every
+ *      decl that will exist after lowering. Sum regs get N+1
+ *      consecutive indices (tag + per-variant per-field payloads);
+ *      non-sum regs get one index each. Returns a `SpecMap`.
+ *
+ *   2. `buildNewDecls(prog, specs)` — construction. For each old
+ *      decl, builds the fully-formed replacement(s) with `init` and
+ *      `update` expressions set at construction time. Sum regs
+ *      expand to a tag-slot decl plus payload-slot decls; non-sum
+ *      regs become fresh decls with rewritten expressions; instance
+ *      decls get their input wires rewritten; param/program decls
+ *      pass through.
+ *
+ *   3. `rewriteAssigns(prog, specs)` — same pattern for body assigns.
+ *
+ *  No mutation. No pre-allocated shells that get back-patched. Refs
+ *  resolve via `specs` lookup (idx → spec → new idx) — the knot-tying
+ *  problem dissolves because indices are pure data assigned in
+ *  phase 1, valid as targets for refs constructed in phase 2/3 even
+ *  though the target decl objects haven't been built yet.
+ *
+ * ## Constraints (matching legacy):
+ *
  *   - A sum-typed reg's `init` MUST be a `Tag` (constant variant
  *     constructor). Anything else is a structural error.
  *   - Match-arm payload bindings are only supported when the
@@ -43,169 +60,85 @@ import { regIdx } from './nodes.js'
 import { withDeclTables } from './decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
-// Sum-reg table — built once before any rewriting starts
+// Specs — pure structural data describing each old reg's new shape
 // ─────────────────────────────────────────────────────────────
 
-/** A single bundle slot replacing one sum-typed `RegDecl`. */
-interface SlotEntry {
-  /** The fresh scalar `RegDecl` for this slot. */
-  decl: RegDecl
+/** A single bundle slot replacing one sum-typed `RegDecl`. Position
+ *  in the rewritten body's regs[] is recorded; the decl object itself
+ *  is constructed later, in `buildSumRegSlots`. */
+interface SlotSpec {
+  /** Index in the rewritten body's regs[] table. */
+  idx: RegIdx
   /** Variant this payload slot belongs to; undefined for the tag slot. */
   variant?: SumVariant
   /** Payload field this slot represents; undefined for the tag slot. */
   field?: StructField
 }
 
-/** Per-original-RegDecl decomposition. */
+/** Per-original-RegDecl decomposition for a sum-typed reg. */
 interface SumRegInfo {
-  original: RegDecl
   sumType: SumTypeDef
   /** Slot order: [tag, ...per-variant per-field-in-payload-order]. */
-  slots: SlotEntry[]
-  /** Convenience lookup: the single tag slot. */
-  tagSlot: SlotEntry
-  /** Lookup keyed by `${variantName}__${fieldName}` for payload slots. */
-  payloadByKey: Map<string, SlotEntry>
+  slots: SlotSpec[]
+  tagSlot: SlotSpec
+  payloadByKey: Map<string, SlotSpec>
 }
 
-type SumRegMap = Map<RegDecl, SumRegInfo>
+type RegSpec =
+  | { kind: 'sum';    info: SumRegInfo }
+  | { kind: 'nonSum'; idx: RegIdx }
+
+type SpecMap = Map<RegDecl, RegSpec>
 
 // ─────────────────────────────────────────────────────────────
 // Public entry
 // ─────────────────────────────────────────────────────────────
 
 export function sumLower(prog: ResolvedProgram): ResolvedProgram {
-  const sumRegs = collectSumRegs(prog.body.decls)
-  if (sumRegs.size === 0 && !bodyHasSumExpr(prog.body)) return prog
+  if (!progHasAnySumWork(prog)) return prog
 
-  // Pre-allocate fresh RegDecl objects for every non-sum stateful decl
-  // that carries an update too. Reason: a sum-lowered program's
-  // `body.decls` contains the tag-slot decl in place of the original
-  // sum-typed reg. Non-sum regs in the same body that we touch (those
-  // whose update needs rewriting) must also be replaced (and their
-  // RegRefs rewritten to point at the new objects), otherwise
-  // expressions in `body.assigns` end up mixing fresh sum-slot decls
-  // with the originals — and the slot-table built downstream by
-  // `loadProgramDefFromResolved` rejects refs whose decl isn't in the
-  // table by identity.
-  //
-  // Sum-typed regs have their replacement decls already allocated by
-  // `collectSumRegs`; non-sum regs with updates get a fresh shell
-  // here. Non-sum regs without updates (pure-hold registers) pass
-  // through unchanged.
-  const regMap = new Map<RegDecl, RegDecl>()
-  for (const decl of prog.body.decls) {
-    if (decl.op !== 'regDecl') continue
-    if (sumRegs.has(decl)) {
-      // Map the original to its tag-slot decl. Used by `RegRef`
-      // rewriting outside of match-arm scrutinee contexts (e.g. when
-      // a sum-typed reg is read on its own — not exercised by the
-      // current stdlib but legal to express).
-      regMap.set(decl, sumRegs.get(decl)!.tagSlot.decl)
-    } else {
-      const fresh: RegDecl = { op: 'regDecl', name: decl.name, init: 0 }
-      if (decl.update !== undefined) fresh.update = decl.update
-      if (decl.type !== undefined) fresh.type = decl.type
-      if (decl._liftedFrom !== undefined) fresh._liftedFrom = decl._liftedFrom
-      regMap.set(decl, fresh)
-    }
-  }
+  // Phase 1 — pure data: assign new indices, identify sum-typed regs.
+  const specs = buildSpecs(prog.body.decls)
 
-  // Pre-compute new RegIdx positions: walk decls in order and assign
-  // a fresh idx to every new RegDecl that will live in the rewritten
-  // body's regs[] table. Sum decls expand to (tag + payloads); non-sum
-  // regs map to their fresh shell. ParamDecl/InstanceDecl/ProgramDecl
-  // don't contribute. This must run BEFORE rewriteExpr because cross-
-  // decl forward refs need the full idx table populated.
-  const newRegIdxByDecl = new Map<RegDecl, RegIdx>()
-  let nextRegIdx = 0
-  for (const decl of prog.body.decls) {
-    if (decl.op !== 'regDecl') continue
-    if (sumRegs.has(decl)) {
-      for (const slot of sumRegs.get(decl)!.slots) {
-        newRegIdxByDecl.set(slot.decl, regIdx(nextRegIdx++))
-      }
-    } else {
-      newRegIdxByDecl.set(regMap.get(decl)!, regIdx(nextRegIdx++))
-    }
-  }
+  // Phase 2 — construction: build new decls with init/update fully set.
+  const ctx: Ctx = { inProg: prog, specs }
+  const newDecls = buildNewDecls(prog.body.decls, ctx)
 
-  const ctx: Ctx = { sumRegs, inProg: prog, regMap, newRegIdxByDecl }
-
-  // Rewrite decls: replace each sum-typed RegDecl with its per-slot
-  // expansion (preserving source position); for everything else,
-  // recursively rewrite contained expressions.
-  const newDecls: BodyDecl[] = []
-  for (const decl of prog.body.decls) {
-    if (decl.op === 'regDecl' && sumRegs.has(decl)) {
-      const info = sumRegs.get(decl)!
-      // The slots' decl objects were already created during collection.
-      // Now fill in their init/update, which depend on the rewritten
-      // versions of the original's init (a Tag) and update (a
-      // sum-valued expression, optional).
-      fillSlotsForSumReg(info, decl, ctx)
-      for (const slot of info.slots) newDecls.push(slot.decl)
-    } else {
-      newDecls.push(rewriteDecl(decl, ctx))
-    }
-  }
-
-  // Rewrite assigns: post-Phase-0a these are output-assigns only.
-  const newAssigns: BodyAssign[] = []
-  for (const assign of prog.body.assigns) {
-    newAssigns.push(rewriteAssign(assign, ctx))
-  }
+  // Phase 3 — rewrite assigns.
+  const newAssigns = prog.body.assigns.map(a => rewriteAssign(a, ctx))
 
   const newBody: ResolvedBlock = { op: 'block', decls: newDecls, assigns: newAssigns }
   return withDeclTables({ ...prog, body: newBody })
 }
 
 // ─────────────────────────────────────────────────────────────
-// Sum-reg collection
+// Phase 1 — spec collection
 // ─────────────────────────────────────────────────────────────
 
-/**
- * Scan body decls for sum-typed `RegDecl`s and pre-allocate their
- * per-slot replacements. The decls are created here (with placeholder
- * init/update set to 0) so cross-decl references — e.g. another reg's
- * update reads our reg — can be rewritten to point at the fresh slot
- * decls before init/update are filled in.
- */
-function collectSumRegs(decls: BodyDecl[]): SumRegMap {
-  const out: SumRegMap = new Map()
+function buildSpecs(decls: readonly BodyDecl[]): SpecMap {
+  const specs: SpecMap = new Map()
+  let nextIdx = 0
   for (const decl of decls) {
     if (decl.op !== 'regDecl') continue
     const sumType = sumTypeOfRegInit(decl)
-    if (!sumType) continue
-
-    const slots: SlotEntry[] = []
-    const tagDecl: RegDecl = {
-      op: 'regDecl',
-      name: mangle(decl.name, 'tag'),
-      init: 0,
-      update: 0,
-    }
-    const tagSlot: SlotEntry = { decl: tagDecl }
-    slots.push(tagSlot)
-
-    const payloadByKey = new Map<string, SlotEntry>()
-    for (const variant of sumType.variants) {
-      for (const field of variant.payload) {
-        const slotDecl: RegDecl = {
-          op: 'regDecl',
-          name: mangle(decl.name, `${variant.name}__${field.name}`),
-          init: 0,
-          update: 0,
+    if (sumType) {
+      const slots: SlotSpec[] = []
+      const tagSlot: SlotSpec = { idx: regIdx(nextIdx++) }
+      slots.push(tagSlot)
+      const payloadByKey = new Map<string, SlotSpec>()
+      for (const variant of sumType.variants) {
+        for (const field of variant.payload) {
+          const slot: SlotSpec = { idx: regIdx(nextIdx++), variant, field }
+          slots.push(slot)
+          payloadByKey.set(slotKey(variant, field), slot)
         }
-        const slot: SlotEntry = { decl: slotDecl, variant, field }
-        slots.push(slot)
-        payloadByKey.set(slotKey(variant, field), slot)
       }
+      specs.set(decl, { kind: 'sum', info: { sumType, slots, tagSlot, payloadByKey } })
+    } else {
+      specs.set(decl, { kind: 'nonSum', idx: regIdx(nextIdx++) })
     }
-
-    out.set(decl, { original: decl, sumType, slots, tagSlot, payloadByKey })
   }
-  return out
+  return specs
 }
 
 function sumTypeOfRegInit(decl: RegDecl): SumTypeDef | undefined {
@@ -224,24 +157,37 @@ function mangle(base: string, suffix: string): string {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Slot init/update assembly for a sum-typed RegDecl
+// Phase 2 — decl construction (pure)
 // ─────────────────────────────────────────────────────────────
 
-/**
- * After collection has pre-allocated slot decls, populate their
- * `init` (from the original's `Tag`) and `update` (per-slot
- * extraction of the sum-valued update expression, when present).
- */
-function fillSlotsForSumReg(
-  info: SumRegInfo,
-  orig: RegDecl,
-  ctx: Ctx,
-): void {
+function buildNewDecls(decls: readonly BodyDecl[], ctx: Ctx): BodyDecl[] {
+  const out: BodyDecl[] = []
+  for (const decl of decls) {
+    if (decl.op === 'regDecl') {
+      const spec = ctx.specs.get(decl)
+      if (!spec) throw new Error(`sumLower: no spec for reg '${decl.name}' (internal)`)
+      if (spec.kind === 'sum') {
+        out.push(...buildSumRegSlots(decl, spec.info, ctx))
+      } else {
+        out.push(buildNonSumReg(decl, ctx))
+      }
+    } else if (decl.op === 'instanceDecl') {
+      out.push({
+        ...decl,
+        inputs: decl.inputs.map(i => ({ port: i.port, value: rewriteExpr(i.value, ctx) })),
+      })
+    } else {
+      // paramDecl, programDecl — pass through unchanged.
+      out.push(decl)
+    }
+  }
+  return out
+}
+
+function buildSumRegSlots(orig: RegDecl, info: SumRegInfo, ctx: Ctx): RegDecl[] {
   const init = orig.init
   if (typeof init !== 'object' || init === null || Array.isArray(init) || init.op !== 'tag') {
-    throw new Error(
-      `sumLower: reg '${orig.name}': init must be a constant tag expression`,
-    )
+    throw new Error(`sumLower: reg '${orig.name}': init must be a constant tag expression`)
   }
   const initTag = init as Tag
   const initVariantIdx = info.sumType.variants.indexOf(initTag.variant)
@@ -250,29 +196,46 @@ function fillSlotsForSumReg(
       `sumLower: reg '${orig.name}': init variant '${initTag.variant.name}' not in '${info.sumType.name}'`,
     )
   }
-
   const initPayload = new Map<string, ResolvedExpr>()
   for (const entry of initTag.payload) initPayload.set(entry.field.name, entry.value)
 
+  const out: RegDecl[] = []
   for (const slot of info.slots) {
+    let slotInit: ResolvedExpr
     if (slot.variant === undefined) {
-      // Tag slot.
-      slot.decl.init = initVariantIdx
+      slotInit = initVariantIdx
     } else if (slot.variant === initTag.variant && slot.field !== undefined) {
       const v = initPayload.get(slot.field.name)
-      slot.decl.init = v !== undefined ? rewriteExpr(v, ctx) : 0
+      slotInit = v !== undefined ? rewriteExpr(v, ctx) : 0
     } else {
-      slot.decl.init = 0
+      slotInit = 0
     }
-    // Per-slot update: extract from the (optional) sum-valued update.
+    const slotName = slot.variant === undefined
+      ? mangle(orig.name, 'tag')
+      : mangle(orig.name, `${slot.variant.name}__${slot.field!.name}`)
+    const decl: RegDecl = {
+      op: 'regDecl',
+      name: slotName,
+      init: slotInit,
+    }
     if (orig.update !== undefined) {
-      slot.decl.update = extractSlotFromSumExpr(orig.update, info, slot, ctx)
-    } else {
-      // No source update — leave slot.decl.update as the 0 placeholder
-      // it was initialized with. (A pure-hold sum reg is unusual but
-      // legal; the slots simply hold their init values.)
+      decl.update = extractSlotFromSumExpr(orig.update, info, slot, ctx)
     }
+    out.push(decl)
   }
+  return out
+}
+
+function buildNonSumReg(orig: RegDecl, ctx: Ctx): RegDecl {
+  const decl: RegDecl = {
+    op: 'regDecl',
+    name: orig.name,
+    init: rewriteExpr(orig.init, ctx),
+  }
+  if (orig.update !== undefined) decl.update = rewriteExpr(orig.update, ctx)
+  if (orig.type !== undefined) decl.type = orig.type
+  if (orig._liftedFrom !== undefined) decl._liftedFrom = orig._liftedFrom
+  return decl
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -280,20 +243,12 @@ function fillSlotsForSumReg(
 // ─────────────────────────────────────────────────────────────
 
 interface Ctx {
-  sumRegs: SumRegMap
-  /** Input program; needed to resolve old RegRef.idx → source RegDecl. */
+  /** Input program; resolves old RegRef.idx → source RegDecl. */
   inProg: ResolvedProgram
-  /** Map every original RegDecl in the body to its replacement.
-   *  Sum-typed → the tag-slot decl; non-sum → a freshly cloned decl
-   *  whose `update`/`init` will be filled in by `rewriteDecl`. Used
-   *  by `RegRef` rewriting so refs in expressions point at the decl
-   *  objects that actually appear in the rewritten body. */
-  regMap: Map<RegDecl, RegDecl>
-  /** Map from new RegDecl object to its de Bruijn level in the
-   *  rewritten program's regs[] table. Populated in sumLower's main
-   *  body BEFORE rewriteExpr runs (so cross-decl forward refs work).
-   *  Used to compute the new idx for every rewritten RegRef. */
-  newRegIdxByDecl: Map<RegDecl, RegIdx>
+  /** Per-old-reg spec: either { kind: 'sum', info } or { kind: 'nonSum', idx }.
+   *  Looked up via `ctx.specs.get(srcDecl)` after the source decl is
+   *  found in `inProg.regs[oldIdx]`. */
+  specs: SpecMap
   /** Active per-binder substitutions introduced by match arms.
    *  A `BindingRef` whose decl is a key here is rewritten to the
    *  mapped expression. */
@@ -311,45 +266,20 @@ function withBindings(
 }
 
 // ─────────────────────────────────────────────────────────────
-// Decl / assign recursion
+// Phase 3 — assign rewriting (delegates to expr rewriter)
 // ─────────────────────────────────────────────────────────────
 
-function rewriteDecl(decl: BodyDecl, ctx: Ctx): BodyDecl {
-  switch (decl.op) {
-    case 'regDecl': {
-      // Non-sum reg: fill the pre-allocated fresh decl's update / init
-      // with rewritten expressions. The fresh decl was put in `regMap`
-      // ahead of time so any RegRef pointing at the original decl is
-      // rewritten to point at this fresh one.
-      const fresh = ctx.regMap.get(decl)
-      if (!fresh) {
-        throw new Error(`sumLower: missing regMap entry for non-sum reg '${decl.name}'`)
-      }
-      fresh.init = rewriteExpr(decl.init, ctx)
-      if (decl.update !== undefined) {
-        fresh.update = rewriteExpr(decl.update, ctx)
-      }
-      return fresh
-    }
-    case 'paramDecl':
-    case 'programDecl':
-      return decl
-    case 'instanceDecl':
-      return {
-        ...decl,
-        inputs: decl.inputs.map(i => ({ port: i.port, value: rewriteExpr(i.value, ctx) })),
-      }
-  }
-}
-
 function rewriteAssign(assign: BodyAssign, ctx: Ctx): BodyAssign {
-  // Post-Phase-0a: BodyAssign is OutputAssign-only.
-  const out: OutputAssign = { op: 'outputAssign', target: assign.target, expr: rewriteExpr(assign.expr, ctx) }
+  const out: OutputAssign = {
+    op: 'outputAssign',
+    target: assign.target,
+    expr: rewriteExpr(assign.expr, ctx),
+  }
   return out
 }
 
 // ─────────────────────────────────────────────────────────────
-// Expression rewriting
+// Expression rewriting (pure; no mutation, no shells)
 // ─────────────────────────────────────────────────────────────
 
 function rewriteExpr(expr: ResolvedExpr, ctx: Ctx): ResolvedExpr {
@@ -366,22 +296,16 @@ function rewriteOp(node: ResolvedExprOp, ctx: Ctx): ResolvedExpr {
       return sub !== undefined ? sub : node
     }
 
-    // ── RegRef: rewrite to the cloned/replacement decl. For a
+    // ── RegRef: rewrite to the new RegIdx via the spec map. For a
     //    sum-typed source reg this is the tag slot; for non-sum it's
-    //    the cloned scalar decl. (Match rewriting handles payload
-    //    reads via per-arm substitution before reaching this case.)
-    //    Migrated to indices: look up the source decl from the input
-    //    program via node.idx, find its replacement, then compute the
-    //    new idx via newRegIdxByDecl. ──
+    //    the new fresh decl's idx. Match-arm payload reads are handled
+    //    via per-arm binding substitution before reaching this case. ──
     case 'regRef': {
       const srcDecl = ctx.inProg.regs[node.idx]
       if (!srcDecl) throw new Error(`sumLower: regRef idx=${node.idx} has no source in input program`)
-      const replacement = ctx.regMap.get(srcDecl)
-      if (!replacement) return node
-      const newIdx = ctx.newRegIdxByDecl.get(replacement)
-      if (newIdx === undefined) {
-        throw new Error(`sumLower: replacement for reg '${srcDecl.name}' has no idx in rewritten program`)
-      }
+      const spec = ctx.specs.get(srcDecl)
+      if (!spec) return node
+      const newIdx = spec.kind === 'sum' ? spec.info.tagSlot.idx : spec.idx
       return { op: 'regRef', idx: newIdx }
     }
 
@@ -468,21 +392,11 @@ function rewriteOp(node: ResolvedExprOp, ctx: Ctx): ResolvedExpr {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Match → select chain (scalar-valued match)
+// Match lowering
 // ─────────────────────────────────────────────────────────────
 
 function lowerMatchToSelectChain(m: Match, ctx: Ctx): ResolvedExpr {
-  // The scrutinee must reduce to a sum-typed value. We need access to
-  // the per-variant payload slots to rewrite payload bindings.
-  // V1 (mirrors legacy): only RegRef-to-sum-typed-reg scrutinees
-  // support payload-bearing arms. Nullary-only matches accept any
-  // scrutinee that lowers to the variant's tag integer.
   const tagRead = scrutineeTagRead(m, ctx)
-
-  // Build select chain in legacy order: iterate variants in the sum
-  // type's declaration order; the LAST variant is the chain tail (its
-  // body is the else-branch of the deepest select, with no comparison
-  // — exhaustiveness guarantees one arm matches).
   const variants = m.type.variants
   const armBy = new Map<SumVariant, MatchArm>()
   for (const arm of m.arms) armBy.set(arm.variant, arm)
@@ -519,23 +433,10 @@ function lowerMatchToSelectChain(m: Match, ctx: Ctx): ResolvedExpr {
   return chain
 }
 
-/**
- * Lower the scrutinee to its tag-slot read. For a sum-typed reg, the
- * tag-slot is `{ op: 'regRef', decl: info.tagSlot.decl }`. For a
- * constant tag, the read is the variant index integer. Other
- * scrutinee shapes fall through to a generic recursive rewrite —
- * sufficient for nullary-only matches whose scrutinee is itself a
- * `match` returning a tag.
- */
 function scrutineeTagRead(m: Match, ctx: Ctx): ResolvedExpr {
   return rewriteExpr(m.scrutinee, ctx)
 }
 
-/**
- * Build the per-binder substitution map for a payload-bearing arm.
- * Only supports `RegRef`-to-sum-typed-reg scrutinees (matching the
- * legacy V1 limitation).
- */
 function bindingsForArm(
   scrutinee: ResolvedExpr,
   arm: MatchArm,
@@ -555,8 +456,8 @@ function bindingsForArm(
   if (!srcDecl) {
     throw new Error(`sumLower: match arm scrutinee regRef idx=${rRef.idx} has no source decl`)
   }
-  const info = ctx.sumRegs.get(srcDecl)
-  if (!info) {
+  const spec = ctx.specs.get(srcDecl)
+  if (!spec || spec.kind !== 'sum') {
     throw new Error(
       `sumLower: match arm '${arm.variant.name}' scrutinee references non-sum reg '${srcDecl.name}'`,
     )
@@ -568,17 +469,13 @@ function bindingsForArm(
   }
   for (let i = 0; i < arm.binders.length; i++) {
     const field = arm.variant.payload[i]
-    const slot = info.payloadByKey.get(slotKey(arm.variant, field))
+    const slot = spec.info.payloadByKey.get(slotKey(arm.variant, field))
     if (!slot) {
       throw new Error(
         `sumLower: match arm '${arm.variant.name}': missing slot for field '${field.name}'`,
       )
     }
-    const newIdx = ctx.newRegIdxByDecl.get(slot.decl)
-    if (newIdx === undefined) {
-      throw new Error(`sumLower: payload slot '${slot.decl.name}' has no idx in rewritten program`)
-    }
-    subs.set(arm.binders[i], { op: 'regRef', idx: newIdx })
+    subs.set(arm.binders[i], { op: 'regRef', idx: slot.idx })
   }
   return subs
 }
@@ -589,8 +486,7 @@ function bindingsForArm(
 
 /**
  * Extract the scalar update for one slot of a sum-typed reg's update
- * expression. Mirrors `extractSlotFromSumExpr` in
- * `compiler/sum_lowering.ts`.
+ * expression.
  *
  * Recognized shapes for `expr`:
  *   - `Tag` — constant constructor; tag-slot gets the variant index,
@@ -602,13 +498,12 @@ function bindingsForArm(
  *     source reg.
  *   - `select(c, a, b)` where both branches are sum-valued —
  *     distribute: `select(c, extract(a), extract(b))`.
- *   - Otherwise return 0 (undefined behavior; caller's malformed
- *     update).
+ *   - Otherwise return 0 (undefined behavior; caller's malformed update).
  */
 function extractSlotFromSumExpr(
   expr: ResolvedExpr,
   info: SumRegInfo,
-  slot: SlotEntry,
+  slot: SlotSpec,
   ctx: Ctx,
 ): ResolvedExpr {
   if (typeof expr !== 'object' || expr === null || Array.isArray(expr)) return 0
@@ -663,22 +558,16 @@ function extractSlotFromSumExpr(
     case 'regRef': {
       const srcDecl = ctx.inProg.regs[expr.idx]
       if (!srcDecl) return 0
-      const srcInfo = ctx.sumRegs.get(srcDecl)
-      if (!srcInfo) {
+      const srcSpec = ctx.specs.get(srcDecl)
+      if (!srcSpec || srcSpec.kind !== 'sum') {
         // Reading a scalar reg as a sum value is malformed.
         return 0
       }
       if (slot.variant === undefined) {
-        const i = ctx.newRegIdxByDecl.get(srcInfo.tagSlot.decl)
-        if (i === undefined) throw new Error(`sumLower: tag-slot decl has no idx`)
-        return { op: 'regRef', idx: i }
+        return { op: 'regRef', idx: srcSpec.info.tagSlot.idx }
       }
-      const srcSlot = srcInfo.payloadByKey.get(slotKey(slot.variant, slot.field!))
-      if (srcSlot) {
-        const i = ctx.newRegIdxByDecl.get(srcSlot.decl)
-        if (i === undefined) throw new Error(`sumLower: payload-slot decl has no idx`)
-        return { op: 'regRef', idx: i }
-      }
+      const srcSlot = srcSpec.info.payloadByKey.get(slotKey(slot.variant, slot.field!))
+      if (srcSlot) return { op: 'regRef', idx: srcSlot.idx }
       return 0
     }
 
@@ -700,8 +589,15 @@ function extractSlotFromSumExpr(
 }
 
 // ─────────────────────────────────────────────────────────────
-// Body inspection helpers
+// Fast-path detection: skip if no work to do
 // ─────────────────────────────────────────────────────────────
+
+function progHasAnySumWork(prog: ResolvedProgram): boolean {
+  for (const decl of prog.body.decls) {
+    if (decl.op === 'regDecl' && sumTypeOfRegInit(decl) !== undefined) return true
+  }
+  return bodyHasSumExpr(prog.body)
+}
 
 function bodyHasSumExpr(body: ResolvedBlock): boolean {
   for (const decl of body.decls) {
@@ -718,35 +614,24 @@ function declHasSumExpr(decl: BodyDecl): boolean {
     case 'regDecl':
       return exprHasSumExpr(decl.init)
         || (decl.update !== undefined && exprHasSumExpr(decl.update))
-    case 'paramDecl': return false
     case 'instanceDecl':
       return decl.inputs.some(i => exprHasSumExpr(i.value))
+    case 'paramDecl':
     case 'programDecl':
       return false
   }
 }
 
-function exprHasSumExpr(expr: ResolvedExpr): boolean {
-  if (typeof expr !== 'object' || expr === null) return false
-  if (Array.isArray(expr)) return expr.some(exprHasSumExpr)
-  switch (expr.op) {
-    case 'tag':
-    case 'match':
-      return true
-    case 'fold': case 'scan':
-      return exprHasSumExpr(expr.over) || exprHasSumExpr(expr.init) || exprHasSumExpr(expr.body)
-    case 'generate':
-      return exprHasSumExpr(expr.count) || exprHasSumExpr(expr.body)
-    case 'iterate': case 'chain':
-      return exprHasSumExpr(expr.count) || exprHasSumExpr(expr.init) || exprHasSumExpr(expr.body)
-    case 'map2':
-      return exprHasSumExpr(expr.over) || exprHasSumExpr(expr.body)
-    case 'zipWith':
-      return exprHasSumExpr(expr.a) || exprHasSumExpr(expr.b) || exprHasSumExpr(expr.body)
-    case 'let':
-      return expr.binders.some(b => exprHasSumExpr(b.value)) || exprHasSumExpr(expr.in)
-    case 'zeros':
-      return exprHasSumExpr(expr.count)
+function exprHasSumExpr(e: ResolvedExpr): boolean {
+  if (typeof e !== 'object' || e === null) return false
+  if (Array.isArray(e)) return e.some(exprHasSumExpr)
+  const op = e.op
+  if (op === 'tag' || op === 'match') return true
+  switch (op) {
+    case 'inputRef': case 'regRef': case 'paramRef':
+    case 'typeParamRef': case 'bindingRef':
+    case 'sampleRate': case 'sampleIndex': case 'nestedOut':
+      return false
     case 'add': case 'sub': case 'mul': case 'div': case 'mod':
     case 'lt': case 'lte': case 'gt': case 'gte': case 'eq': case 'neq':
     case 'and': case 'or':
@@ -756,8 +641,20 @@ function exprHasSumExpr(expr: ResolvedExpr): boolean {
     case 'sqrt': case 'abs': case 'floor': case 'ceil': case 'round':
     case 'floatExponent': case 'toInt': case 'toBool': case 'toFloat':
     case 'clamp': case 'select': case 'index': case 'arraySet':
-      return expr.args.some(exprHasSumExpr)
-    default:
-      return false
+      return (e.args as ResolvedExpr[]).some(exprHasSumExpr)
+    case 'zeros':
+      return exprHasSumExpr(e.count)
+    case 'fold': case 'scan':
+      return exprHasSumExpr(e.over) || exprHasSumExpr(e.init) || exprHasSumExpr(e.body)
+    case 'generate':
+      return exprHasSumExpr(e.count) || exprHasSumExpr(e.body)
+    case 'iterate': case 'chain':
+      return exprHasSumExpr(e.count) || exprHasSumExpr(e.init) || exprHasSumExpr(e.body)
+    case 'map2':
+      return exprHasSumExpr(e.over) || exprHasSumExpr(e.body)
+    case 'zipWith':
+      return exprHasSumExpr(e.a) || exprHasSumExpr(e.b) || exprHasSumExpr(e.body)
+    case 'let':
+      return e.binders.some(b => exprHasSumExpr(b.value)) || exprHasSumExpr(e.in)
   }
 }

--- a/compiler/ir/wire_program.test.ts
+++ b/compiler/ir/wire_program.test.ts
@@ -196,7 +196,9 @@ describe('liftWireToProgram — structure', () => {
     expect(prog.body.assigns.length).toBe(1)
     const assign = prog.body.assigns[0] as OutputAssign
     expect(assign.op).toBe('outputAssign')
-    expect(assign.target).toBe(prog.ports.outputs[0])
+    // Lifted programs have one output at position 0.
+    expect(assign.target).toBe(0)
+    expect(prog.ports.outputs[assign.target as number]).toBe(prog.ports.outputs[0])
   })
 
   test('ref translation: target is the inputRef pointing at the matching input decl', () => {
@@ -205,7 +207,7 @@ describe('liftWireToProgram — structure', () => {
     const assign = prog.body.assigns[0] as OutputAssign
     const expr = assign.expr as InputRef
     expect(expr.op).toBe('inputRef')
-    expect(expr.decl).toBe(prog.ports.inputs[0])
+    expect(prog.ports.inputs[expr.idx]).toBe(prog.ports.inputs[0])
   })
 
   test('binary op translates with both args translated', () => {

--- a/compiler/ir/wire_program.ts
+++ b/compiler/ir/wire_program.ts
@@ -46,6 +46,7 @@ import {
   portRef as makePortRef,
   wireKey, rawName,
 } from './branded_names.js'
+import { mkProgram } from './decl_tables.js'
 
 // ─── Op sets ────────────────────────────────────────────────────────────────
 // Mirror the sets in `materialize_session.ts:translateExpr`. Keep these in
@@ -195,8 +196,7 @@ export function liftWireToProgram(
     assigns: [{ op: 'outputAssign', target: outputDecl, expr: translated }],
   }
 
-  return {
-    op: 'program',
+  return mkProgram({
     name: rawName(synthName),
     typeParams: [],
     ports: {
@@ -205,7 +205,7 @@ export function liftWireToProgram(
       typeDefs: [],
     },
     body,
-  }
+  })
 }
 
 // ─── Internal: ExprNode → ResolvedExpr ─────────────────────────────────────

--- a/compiler/ir/wire_program.ts
+++ b/compiler/ir/wire_program.ts
@@ -38,7 +38,9 @@ import type {
   InputDecl, OutputDecl, ParamDecl, RegDecl,
   BodyDecl,
   ResolvedBlock,
+  InputIdx,
 } from './nodes.js'
+import { inputIdx, outputIdx, paramIdx, regIdx } from './nodes.js'
 import {
   type InstanceName, type PortName, type PortRef, type WireKey,
   instanceName as makeInstanceName,
@@ -127,10 +129,13 @@ export function freeRefs(expr: ExprNode): ReadonlySet<PortRef> {
 // ─── Lift to ResolvedProgram ───────────────────────────────────────────────
 
 interface TranslateContext {
-  /** Map from canonical wire key to the InputDecl that represents it. */
-  readonly refToInput: ReadonlyMap<WireKey, InputDecl>
+  /** Map from canonical wire key to the InputIdx that represents it.
+   *  Indices are the position of the InputDecl in the synthesized
+   *  program's ports.inputs[] (assigned at decl creation time). */
+  readonly refToInputIdx: ReadonlyMap<WireKey, InputIdx>
   /** Param/Trigger decls accumulated during translation. Keyed by param
-   *  name. Mutated as the translator encounters new refs. */
+   *  name. Mutated as the translator encounters new refs. ParamIdx is
+   *  derived from iteration position at lookup time. */
   readonly paramDecls: Map<string, ParamDecl>
   /** Synthetic RegDecls (post-Phase-0a: `update` populated, semantically
    *  a one-sample delay) created from `delay()` expressions. */
@@ -163,7 +168,7 @@ export function liftWireToProgram(
   )
 
   const inputDecls: InputDecl[] = []
-  const refToInput = new Map<WireKey, InputDecl>()
+  const refToInputIdx = new Map<WireKey, InputIdx>()
   for (const ref of sortedRefs) {
     // Name the input deterministically from the ref. Double-underscore
     // separator avoids collisions with user port names (which can't
@@ -171,14 +176,15 @@ export function liftWireToProgram(
     // a stable, distinctive infix).
     const inputName = `${rawName(ref.instance).replace(/\./g, '_')}__${rawName(ref.port)}`
     const decl: InputDecl = { op: 'inputDecl', name: inputName }
+    const i = inputIdx(inputDecls.length)
     inputDecls.push(decl)
-    refToInput.set(wireKey(ref), decl)
+    refToInputIdx.set(wireKey(ref), i)
   }
 
   const outputDecl: OutputDecl = { op: 'outputDecl', name: 'out' }
 
   const ctx: TranslateContext = {
-    refToInput,
+    refToInputIdx,
     paramDecls: new Map(),
     syntheticRegs: [],
   }
@@ -193,7 +199,8 @@ export function liftWireToProgram(
   const body: ResolvedBlock = {
     op: 'block',
     decls: bodyDecls,
-    assigns: [{ op: 'outputAssign', target: outputDecl, expr: translated }],
+    // Lifted programs have exactly one output ('out') at position 0.
+    assigns: [{ op: 'outputAssign', target: outputIdx(0), expr: translated }],
   }
 
   return mkProgram({
@@ -231,8 +238,8 @@ function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
     const instStr = obj.instance as string
     const outStr = obj.output as string
     const ref = makePortRef(makeInstanceName(instStr), makePortName(outStr))
-    const inputDecl = ctx.refToInput.get(wireKey(ref))
-    if (inputDecl === undefined) {
+    const i = ctx.refToInputIdx.get(wireKey(ref))
+    if (i === undefined) {
       // Should not happen: freeRefs collected this ref. Either the
       // caller passed a stale freeRefSet, or the expression mutated
       // between scanning and lifting.
@@ -241,7 +248,7 @@ function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
         `pass the same set returned by freeRefs(expr)`,
       )
     }
-    return { op: 'inputRef', decl: inputDecl }
+    return { op: 'inputRef', idx: i }
   }
 
   // ── Param refs → inline ParamDecls in the lifted program ──
@@ -288,6 +295,10 @@ function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
     }
     const update = translateExpr(argsArr[0], ctx)
     const init = typeof obj.init === 'number' ? obj.init : 0
+    // body.decls = [...paramDecls, ...syntheticRegs]; only RegDecls
+    // contribute to body.regs[]. So RegIdx for a synthetic reg = its
+    // position within ctx.syntheticRegs.
+    const newIdx = regIdx(ctx.syntheticRegs.length)
     const decl: RegDecl = {
       op: 'regDecl',
       name: `__sd${ctx.syntheticRegs.length}`,
@@ -295,7 +306,7 @@ function translateExpr(expr: ExprNode, ctx: TranslateContext): ResolvedExpr {
       init,
     }
     ctx.syntheticRegs.push(decl)
-    return { op: 'regRef', decl }
+    return { op: 'regRef', idx: newIdx }
   }
 
   throw new Error(`liftWireToProgram: unhandled wire-form op '${op}'`)
@@ -310,5 +321,12 @@ function paramRefIntoCtx(
     decl = { op: 'paramDecl', name }
     ctx.paramDecls.set(name, decl)
   }
-  return { op: 'paramRef', decl }
+  // ParamIdx is the position in ctx.paramDecls iteration order.
+  let pi = -1
+  let i = 0
+  for (const n of ctx.paramDecls.keys()) {
+    if (n === name) { pi = i; break }
+    i++
+  }
+  return { op: 'paramRef', idx: paramIdx(pi) }
 }

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -32,6 +32,7 @@ import { raiseProgram } from './parse/raise.js'
 import { elaborate, type ExternalProgramResolver } from './ir/elaborator.js'
 import { programTypeFromResolved } from './ir/strata.js'
 import type { ResolvedProgram, PortType } from './ir/nodes.js'
+import { relinkInstanceTypes } from './ir/decl_tables.js'
 
 // ─────────────────────────────────────────────────────────────
 // Program schema
@@ -680,16 +681,33 @@ function loadStdlibFromResolved(
   }
 
   // Walk in elaboration order (insertion order in localResolved is
-  // dependency-respecting by construction).
+  // dependency-respecting by construction). For each program, relink
+  // its sub-instance type pointers to the canonical strata-processed
+  // versions already in the registry-being-built, then strata-process
+  // and register. This is the topological build: by the time a program
+  // is consumed downstream, every sub-instance's `instanceDecl.type`
+  // points at the canonical processed program — not at the raw
+  // elaborated version returned by the elaborator's resolver during
+  // the try-elaborate loop above.
+  //
+  // Without this relink, sub-instance programs would arrive at
+  // consumers (compileResolved, partition_recursive,
+  // materialize_session) with un-strata-processed body — which is
+  // exactly the gap that Bubble/BubbleCloud have been hitting in
+  // nested mode ("compileResolved: register init must lower to a
+  // literal value").
+  const processedByName = new Map<string, ResolvedProgram>()
   for (const [name, prog] of localResolved) {
     if (prog.typeParams.length > 0) {
       session.genericTemplatesResolved.set(name, prog)
       continue
     }
     if (session.typeRegistry.has(name)) continue
-    const type = programTypeFromResolved(prog, new Map(), { inlineNested: session.inlineNested })
+    const relinked = relinkInstanceTypes(prog, processedByName)
+    const type = programTypeFromResolved(relinked, new Map(), { inlineNested: session.inlineNested })
     session.typeRegistry.set(name, type)
-    session.resolvedRegistry.set(name, prog)
+    session.resolvedRegistry.set(name, type.prog)   // canonical processed (not raw)
+    processedByName.set(name, type.prog)
   }
 
   // typeResolver: callers fall back here when looking up a stdlib type

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -545,6 +545,10 @@ struct EmitCtx
   // pre_input_instructions throughout — the loop is a no-op and the
   // behavior reduces to "main body then writebacks", same as before.
   llvm::Error emit_kernel_block(const InstanceProgram & inst) {
+    // Preamble runs first: temp-computes for session-wired input
+    // translations whose results are referenced by child pre_input
+    // WriteSlots. Must precede child dispatch.
+    if (auto err = emit_instrs(inst.preamble_instructions)) return err;
     for (const auto & child : inst.children) {
       if (auto err = emit_instrs(child.pre_input_instructions)) return err;
       if (auto err = emit_kernel_block(child)) return err;

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -116,6 +116,14 @@ struct FlatInstr
 struct InstanceProgram
 {
   std::string                  instance_name;     // dotted path (e.g. voice1.env)
+  /** Preamble — emitted at the START of this kernel's block, before
+   *  any child dispatch. Holds temp-compute instructions for
+   *  session-wired input translations whose results are referenced by
+   *  child pre_input_instructions. Splitting this out of
+   *  `instructions` is essential: child dispatch happens before
+   *  `instructions`, so the temps that pre_input writes must already
+   *  be computed by the time children start. */
+  std::vector<FlatInstr>       preamble_instructions;
   std::vector<FlatInstr>       instructions;      // already shifted into unified offset space
   /** M11 fractal slot-based input wiring. Per-child block — runs in
    *  the PARENT's namespace immediately before THIS kernel's body. The

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -179,6 +179,9 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
   // the parent's emit_kernel_block runs each child's
   // pre_input_instructions immediately before recursing into that
   // child's body.
+  if (jf.contains("preamble_instructions"))
+    for (const auto & ji : jf["preamble_instructions"])
+      inst.preamble_instructions.push_back(parse_instr(ji));
   if (jf.contains("pre_input_instructions"))
     for (const auto & ji : jf["pre_input_instructions"])
       inst.pre_input_instructions.push_back(parse_instr(ji));

--- a/tests/bench/depth_vs_flat.ts
+++ b/tests/bench/depth_vs_flat.ts
@@ -115,9 +115,37 @@ const polyphony8xPhaser16Factory: SessionFactory = (mode) => {
   return session
 }
 
+const bubbleFactory: SessionFactory = (mode) => {
+  const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+  loadStdlib(session)
+  const { type, typeArgs } = resolveProgramType(session, 'Bubble', undefined, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: 'Bubble', typeArgs })
+  session.instanceRegistry.set('inst', inst)
+  for (const pn of inputNames(inst)) {
+    if (pn in DEFAULT_INPUTS) session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
+const bubbleCloudFactory: SessionFactory = (mode) => {
+  const session = makeSession(FRAME_SIZE, { inlineNested: mode === 'flat' })
+  loadStdlib(session)
+  const { type, typeArgs } = resolveProgramType(session, 'BubbleCloud', undefined, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: 'BubbleCloud', typeArgs })
+  session.instanceRegistry.set('inst', inst)
+  for (const pn of inputNames(inst)) {
+    if (pn in DEFAULT_INPUTS) session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
 interface BenchCase { name: string; factory: SessionFactory }
 const CASES: BenchCase[] = [
   { name: 'OnePole',                 factory: onePoleFactory },
+  { name: 'Bubble',                  factory: bubbleFactory },
+  { name: 'BubbleCloud',             factory: bubbleCloudFactory },
   { name: 'polyphony_8x_Phaser16',   factory: polyphony8xPhaser16Factory },
 ]
 

--- a/tests/bench/depth_vs_flat_2026-05-24.md
+++ b/tests/bench/depth_vs_flat_2026-05-24.md
@@ -1,0 +1,191 @@
+# Benchmark Results: bubble-fix-via-levels — depth vs flat
+
+| Field           | Value                                       |
+|-----------------|---------------------------------------------|
+| Date            | 2026-05-24                                  |
+| Branch          | `bubble-fix-via-levels`                     |
+| Captured at     | post-Phase-4 (Bubble/BubbleCloud green)     |
+| Hardware        | darwin/aarch64 (Apple Silicon, M-series)    |
+| LLVM            | 22.1.1                                      |
+| Opt level       | `OptimizationLevel::O2`                     |
+| Reproduce       | `bun run tests/bench/depth_vs_flat.ts`      |
+
+Benchmark numbers are temporal artifacts. When the bench script or
+the engine's emit strategy materially shifts, re-capture against the
+new commit hash. Treat as a snapshot, not a spec.
+
+**Decision (at time of capture):** **NO-GO on `inlineInstances`
+deletion**, same verdict as 2026-05-23. The Bubble/BubbleCloud
+correctness gap is now closed (Phase 4: port-default fallback for
+unwired sub-instance inputs, and split preamble/per-child dispatch
+order). But the runtime cost still favors inline at scale — 22% on
+BubbleCloud's fractal 8-voice structure, 25% on the older
+polyphony_8x_Phaser16 stress case. Both paths kept alive.
+
+## Methodology
+
+Four cases, ordered by complexity:
+
+  - **OnePole** — minimal nested (2 children). Is the slot path's
+    overhead detectable at the smallest scale?
+  - **Bubble** — single voice, 5 sub-instances. The smallest fractal
+    case that exercises the Phase 4 fixes.
+  - **BubbleCloud** — 8 Bubbles × 5 sub-instances = 40 fractal
+    kernels. The fix landed here; what's the runtime tax?
+  - **polyphony_8x_Phaser16** — 8 voices × 17 nested kernels = 136
+    kernel boundaries. The pre-existing stress reference.
+
+For each (case, mode):
+
+  - **Runtime**: N=3 trials of 1024 frames × 256 samples each.
+    Round-robin interleaved across modes. Min reported.
+    N derived empirically from `runtime_noise_meta.ts`: min-of-3
+    lands within 0.76% of asymptotic min at p95 on this hardware.
+  - **Compile**: one cold-cache trial per axis. The engine has a
+    process-singleton in-memory cache that survives disk-cache
+    `rmSync`; measuring multiple cold compiles in one process would
+    need subprocess isolation. Single-shot is fine for snapshot.
+
+Total wall clock: ~6s.
+
+## Numbers
+
+### Compile (one cold trial per axis)
+
+| Case                       | Mode   | Inst | TS ms | JIT ms | Plan KB |
+|----------------------------|--------|-----:|------:|-------:|--------:|
+| OnePole                    | flat   |    1 |   3.3 |   65.4 |     4.4 |
+| OnePole                    | nested |    1 |   0.4 |    9.9 |     5.8 |
+| Bubble                     | flat   |    1 |   1.0 |   30.8 |    23.4 |
+| Bubble                     | nested |    1 |   0.6 |   26.7 |    28.0 |
+| BubbleCloud                | flat   |    1 |   4.8 |  726.2 |   182.0 |
+| BubbleCloud                | nested |    1 |   2.3 |  627.5 |   234.0 |
+| polyphony_8x_Phaser16      | flat   |    8 |   1.3 |  734.8 |   204.5 |
+| polyphony_8x_Phaser16      | nested |    8 |   2.2 |  868.0 |   329.2 |
+
+### Runtime (3 trials, min reported)
+
+| Case                       | Mode   | Trials (ns/sample)         | min   | median | max   |
+|----------------------------|--------|----------------------------|------:|-------:|------:|
+| OnePole                    | flat   | 8.1, 8.0, 7.9              |   7.9 |    8.0 |   8.1 |
+| OnePole                    | nested | 8.5, 8.8, 8.3              |   8.3 |    8.5 |   8.8 |
+| Bubble                     | flat   | 27.0, 26.5, 26.5           |  26.5 |   26.5 |  27.0 |
+| Bubble                     | nested | 27.1, 27.0, 27.0           |  27.0 |   27.0 |  27.1 |
+| BubbleCloud                | flat   | 207.6, 207.5, 207.5        | 207.5 |  207.5 | 207.6 |
+| BubbleCloud                | nested | 254.8, 254.1, 254.0        | 254.0 |  254.1 | 254.8 |
+| polyphony_8x_Phaser16      | flat   | 322.8, 323.9, 332.3        | 322.8 |  323.9 | 332.3 |
+| polyphony_8x_Phaser16      | nested | 406.1, 404.2, 404.8        | 404.2 |  404.8 | 406.1 |
+
+### Deltas
+
+| Case                       | ns_ratio | jit_ratio | plan_ratio |
+|----------------------------|---------:|----------:|-----------:|
+| OnePole                    |   1.054× |    0.152× |     1.313× |
+| Bubble                     |   1.017× |    0.869× |     1.195× |
+| BubbleCloud                |   1.224× |    0.864× |     1.286× |
+| polyphony_8x_Phaser16      |   1.252× |    1.181× |     1.610× |
+
+## What the numbers say
+
+**Runtime overhead tracks kernel-boundary density.** OnePole
+(2 children) pays 5%, Bubble (1 voice × 5 children) pays a
+negligible 2%, BubbleCloud (8 × 5 = 40 child kernels) pays 22%,
+polyphony_8x_Phaser16 (8 × 17 = 136 kernels) pays 25%. The cost
+isn't per-voice — it's per slot-WriteSlot-then-Slot round trip at
+each kernel boundary, summed over all instances. A single Bubble
+amortizes those round trips against its per-sample work; eight of
+them stop fitting.
+
+**Bubble's 2% is the headline.** That's exactly the case Phase 4
+was about. The fix isn't free, but it's nearly free at the single-
+voice scale where the per-child-input dispatch order and the port-
+default fallback matter most. The Bubble path now produces bit-
+identical output between flat and nested modes at ~zero runtime
+cost.
+
+**The realtime budget is uncontested.** Even the slowest case
+(polyphony_8x_Phaser16 nested) runs at 1.81% of a 44.1kHz sample
+period; BubbleCloud nested runs at 1.13%. Plenty of headroom.
+
+**Compile.** TS time is consistently smaller in nested mode (the
+slot path skips `inlineInstances`), 5-8× faster on the larger
+programs. JIT time is mixed: nested wins on BubbleCloud and Bubble
+(0.86-0.87×), loses on polyphony_8x_Phaser16 (1.18×). OnePole's
+jit_ratio of 0.152× is a single-shot outlier — single cold compile
+measurements swing wildly on tiny programs (10ms variance dwarfs
+the 10ms baseline). Don't read into that one.
+
+**Plan size.** Slot-path plan is ~20-60% larger (per-child
+WriteSlots add real bytes). Matters for disk cache footprint and
+TS↔C++ JSON shipping, neither in the critical path.
+
+**Trial variance.** Tighter than the 2026-05-23 capture. No outliers
+this run, all trials within 1-3% of their min. Consistent with the
+CV=0.75% bound from `runtime_noise_meta.ts`.
+
+## Bubble / BubbleCloud: gap closed
+
+Previous snapshot called these out as failing nested-mode compile
+with `compileResolved: register init must lower to a literal value`.
+Three things had to land:
+
+  1. **De Bruijn levels for global refs.** `sumLower` becomes pure
+     (Phase 2); sub-program `RegDecl.init` arrives already lowered
+     because the strata pipeline runs end-to-end, not implicitly via
+     parent splicing. Closes the original compile error.
+
+  2. **Split preamble from main-body instructions.** New
+     `preamble_instructions` field on `InstanceFunction`, emitted by
+     the engine's `emit_kernel_block` BEFORE child dispatch.
+     Previously the per-child WriteSlots referenced parent temps
+     that hadn't been computed yet — broken for expression-shaped
+     session inputs like Bubble's `pulseEvery(64)` trigger.
+
+  3. **Port-default fallback for unwired sub-instance inputs.**
+     `emit_resolved`'s per-child WriteSlot loop now iterates ALL of
+     the target's input ports, not just `decl.inputs`. For ports
+     the parent doesn't wire, the port's declared default goes into
+     the slot. Previously the slot retained its allocation default
+     of 0, silently masking the port default — e.g., BubbleCloud
+     doesn't wire `attack_g`, so the slot stayed at 0 instead of
+     Bubble's `0.05`, killing `env_smooth` evolution and forcing
+     output to 0.
+
+`tests/equiv/nested_vs_inlined.test.ts` now covers Bubble and
+BubbleCloud at 1e-12 between flat and nested — the same gate
+threshold as the other 20 stdlib cases.
+
+## Recommendation for the deletion PR
+
+**Don't delete `inlineInstances` yet.** Two of the three previous
+blockers stand:
+
+  1. ~~The Bubble / BubbleCloud correctness gap~~ — **closed
+     in Phase 4.**
+
+  2. The 22-25% runtime overhead at the realistic fractal scale is
+     real. Not catastrophic — there's headroom — but it's a tax.
+     If `-O3` JIT or better slot fusion closes that gap, the
+     deletion case becomes stronger.
+
+  3. The slot path's larger IR (~1.3-1.6× plan size) inflates the
+     disk cache footprint and the JSON-shipping overhead between
+     TS and C++. Worth optimizing the wire format before
+     committing fully.
+
+**Keep both paths alive.** `inlineNested:true` remains the default;
+`inlineNested:false` is the opt-in for nested-aware tests
+(`tests/equiv/nested_vs_inlined.test.ts`) and any future work that
+needs per-kernel hot-swap, voice scopes, or per-instance JIT cache
+keys.
+
+**Next milestones for slot-path adoption:**
+
+  - Measure under `-O3` JIT to see if more aggressive load-store
+    forwarding closes the runtime gap on the fractal stress cases
+  - Investigate why BubbleCloud's nested mode pays 22% and
+    polyphony_8x_Phaser16 pays 25% while Bubble pays ~0% — is the
+    cost in slot-load-store pairs that LLVM isn't folding, or in
+    icache/dcache pressure from the larger IR?
+  - Optimize the wire-format JSON encoding of WriteSlot blocks
+    (they're the bulk of the 1.3-1.6× plan size inflation)

--- a/tests/equiv/nested_vs_inlined.test.ts
+++ b/tests/equiv/nested_vs_inlined.test.ts
@@ -78,6 +78,13 @@ const STDLIB_TARGETS: Array<[string, Record<string, number>?]> = [
   ['SinOsc'], ['Sin'], ['Cos'], ['Tanh'], ['Exp'], ['Log'], ['Pow'],
   ['OnePole'], ['BlepSaw'], ['SoftClip'], ['VCA'], ['CrossFade'],
   ['SVF'], ['LadderFilter'], ['Phaser'], ['Phaser16'],
+  // Depth-3 cases unlocked by the bubble-fix-via-levels work:
+  // Bubble contains sum-typed state regs (TriggerRamp's state,
+  // EnvExpDecay's state) that previously failed to compile in
+  // nested mode because the slot path arrived at them un-strata-
+  // processed. The topological registry build (Phase 3) +
+  // sumLower's pure construction (Phase 2) close the gap.
+  ['Bubble'], ['BubbleCloud'],
   ['AllpassDelay'], ['CombDelay'],
   ['Delay', { N: 1024 }],
 ]


### PR DESCRIPTION
## Summary

Six-phase IR refactor that replaces object-pointer global refs with branded integer indices into per-program decl tables, then uses that foundation to close the Bubble/BubbleCloud nested-mode compile gap.

- **Phase 0** (`0969f97`) — add decl tables (`regs`, `inputs`, `outputs`, `params`, `instances`) to `ResolvedProgram` as parallel views over `body.decls`. No behavior change.
- **Phase 1** (`84b85e7`) — rebuild every ref's shape as `{idx: branded-int}` instead of `{decl: object-pointer}`. `BindingRef` (lexical binders) stays pointer-based; eliminated by `arrayLower` before any post-strata consumer sees it.
- **Phase 2** (`96d17d9`) — `sumLower` becomes pure 3-phase construction (buildSpecs → buildNewDecls → rewriteAssigns). ~100 line net reduction; no more knot-tying mutation.
- **Phase 3** (`b473448`) — eliminate the raw/processed registry split. Topological elaborate-and-process loop in `program.ts` populates `typeRegistry` with canonical `InstanceDecl.type` pointers; `relinkInstanceTypes` rewrites stale references during the walk.
- **Phase 4** (`3e937d5`) — close the Bubble/BubbleCloud nested-mode compile gap with three engine-side fixes:
  1. Split parent-side temp setup from main-body emit (`preamble_instructions` field on `InstanceFunction` / `InstanceProgram`), emitted by `emit_kernel_block` BEFORE child dispatch.
  2. Emit per-child input `WriteSlot`s for ALL declared input ports, not just the parent's explicit wires. For unwired ports, use the port's declared default (previously the slot retained its allocation-time 0, silently masking the port default — e.g., BubbleCloud doesn't wire `attack_g`, so the slot stayed at 0 instead of Bubble's `0.05`, killing `env_smooth` evolution).
  3. Thread `inlineNested` through the session materializer's strata pipeline call so session-lift respects the nested-mode flag.
- **Phase 5** (`dd8bfc3`) — add Bubble + BubbleCloud cases to `depth_vs_flat.ts`, capture `depth_vs_flat_2026-05-24.md` snapshot.

Verified via `tests/equiv/nested_vs_inlined.test.ts` (22 cases including Bubble + BubbleCloud, all green at 1e-12).

Also added a note to root `CLAUDE.md` flagging that `~/.cache/tropical/kernels` should be cleared first when equivalence tests fail unexpectedly — runtime-behavior fixes that don't change the emitted plan can leave stale kernels in place.

## Bench numbers (post-Phase-4)

| Case                  | flat ns/sample | nested ns/sample | ratio |
|-----------------------|---------------:|-----------------:|------:|
| OnePole               |            7.9 |              8.3 | 1.05× |
| Bubble                |           26.5 |             27.0 | 1.02× |
| BubbleCloud           |          207.5 |            254.0 | 1.22× |
| polyphony_8x_Phaser16 |          322.8 |            404.2 | 1.25× |

Slot-path overhead tracks kernel-boundary density. Single Bubble pays ~0%; BubbleCloud (8×5=40 child kernels) pays 22%; polyphony_8x_Phaser16 (8×17=136) pays 25%. `inlineInstances` deletion verdict still NO-GO (runtime tax at scale + 1.3-1.6× plan-size inflation), but the previous correctness blocker is closed.

## Test plan

- [x] `bun test` — full TS suite (1019 pass, 8 skip locally)
- [x] `bun test tests/equiv/` — all backend equivalence (99 pass, 4 skip)
- [x] `ctest --test-dir build` — C++ tests
- [x] `bun run tests/bench/depth_vs_flat.ts` — bench reproduces snapshot numbers
- [x] Confirm `~/.cache/tropical/kernels` clear before re-running equiv tests (see CLAUDE.md note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)