### PR TITLE
chore: remove stale phase/milestone references

### DIFF
--- a/compiler/CLAUDE.md
+++ b/compiler/CLAUDE.md
@@ -116,7 +116,7 @@ runtime/
 ```
 
 `flatten.ts`, `interpret.ts`, `emit_numeric.ts`, and `ir/load.ts` /
-`ir/program_type_builder.ts` are gone. The post-Phase-D path is
+`ir/program_type_builder.ts` are gone. The path is
 `elaborate → strata → compile_resolved` (or `interpret_resolved` /
 `emit_wasm`), with `materialize_session` injecting sessions into the
 same pipeline.

--- a/compiler/emit_wasm.ts
+++ b/compiler/emit_wasm.ts
@@ -420,7 +420,7 @@ function emitInstruction(c: Code, instr: NInstr, ctx: EmitCtx): void {
   return emitScalar(c, instr, ctx)
 }
 
-// ── WriteSlot: publish a temp value to slots[dst] (M10) ──
+// ── WriteSlot: publish a temp value to slots[dst] ──
 // `dst` is the slot index (not a temp); `args[0]` is the value. The
 // instruction produces no temp result — pure side effect. Coerces to
 // float since slots are stored as f64 (matching the JIT).
@@ -473,7 +473,7 @@ function pushOperand(c: Code, op: NOperand, ctx: EmitCtx): ScalarType {
       c.localGet(L_SIDX); return 'int'
     }
     case 'slot': {
-      // M10: inter-module slot read. Slots are stored as f64 in the
+      // Inter-module slot read. Slots are stored as f64 in the
       // dedicated `slotsOffset` region (mirrors the native engine —
       // see store_slot_f64 in OrcJitEngine.cpp). Result is always
       // float; callers `coerce` to int/bool as needed.

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -159,8 +159,9 @@ export interface InstanceFunction {
   preamble_instructions: NInstr[]
   /** Instructions with operands already shifted into unified space. */
   instructions:      NInstr[]
-  /** M11 fractal slot-based input wiring. Instructions the PARENT
-   *  runs in its own namespace just before invoking this kernel:
+  /** Slot-based parent→child input wiring (the fractal path).
+   *  Instructions the PARENT runs in its own namespace just before
+   *  invoking this kernel:
    *  evaluate each wire expression, then `WriteSlot` the value to
    *  this kernel's pre-allocated input slot. The child reads from
    *  the slot at the start of its body. Per-child placement (vs
@@ -181,9 +182,10 @@ export interface InstanceFunction {
   /** Writebacks for this instance — entries are either an absolute
    *  unified temp index or `arrayManaged`. */
   register_targets:  RegTarget[]
-  /** Nested kernels (M11 fractal architecture). Sub-InstanceDecls
-   *  within this program's body become child kernels, emitted inside
-   *  this kernel's body. Empty for leaf kernels. */
+  /** Nested kernels (the fractal architecture: one kernel per
+   *  InstanceDecl at every nesting depth). Sub-InstanceDecls within
+   *  this program's body become child kernels, emitted inside this
+   *  kernel's body. Empty for leaf kernels. */
   children:          InstanceFunction[]
 }
 
@@ -256,7 +258,7 @@ export interface WireInstanceFunction {
    *  reference. Optional in the wire format (legacy plans had this
    *  bundled inside `instructions`; parsed as [] when missing). */
   preamble_instructions?: WireNInstr[]
-  /** M11 fractal slot-based input wiring (per-child). Parent's
+  /** Slot-based parent→child input wiring (per-child). Parent's
    *  WriteSlot instructions that run just before this kernel's body.
    *  May be missing in legacy JSON (parsed as []). */
   pre_input_instructions?: WireNInstr[]

--- a/compiler/ir/acyclic.ts
+++ b/compiler/ir/acyclic.ts
@@ -7,12 +7,13 @@
  * with the cycle-break helper; this module supplies the
  * strataPipeline-specific assertion + error class.
  *
- * Currently called from inside `strataPipeline` immediately after
- * `traceCycles`, where the assertion is a tautology (the cycle pass
- * just ran). Phase 3 moves `traceCycles` out of the compiler and the
- * assertion becomes load-bearing: any cycle reaching `strataPipeline`
- * is a caller bug, surfaced immediately rather than producing a
- * malformed plan downstream.
+ * Called from inside `strataPipeline` to enforce the contract that
+ * its input is acyclic. Cycle-breaking is the responsibility of the
+ * realization layer above the compiler — the elaborator throws on
+ * source-level cycles and the session materializer extracts session-
+ * level `delay()` ops. Any cycle reaching `strataPipeline` is a
+ * caller bug, surfaced immediately rather than producing a malformed
+ * plan downstream.
  */
 
 import type { ResolvedProgram, InstanceDecl } from './nodes.js'

--- a/compiler/ir/array_lower.ts
+++ b/compiler/ir/array_lower.ts
@@ -58,7 +58,7 @@ import { mkProgram, getInstanceType } from './decl_tables.js'
  * substituting expressions while preserving decl positions keeps
  * every ref valid without any pointer-identity discipline.
  *
- * M11 fractal: surviving `InstanceDecl`s' sub-programs are lowered
+ * Fractal: surviving `InstanceDecl`s' sub-programs are lowered
  * recursively via `prog.programRegistry` — we build a new registry
  * with each entry mapped, and the InstanceDecls keep their `typeKey`
  * pointing at the same key (the LOWERED sub-program now lives behind
@@ -130,7 +130,7 @@ function declNeedsLowering(decl: BodyDecl, enclosing: ResolvedProgram): boolean 
         || (decl.update !== undefined && exprNeedsLowering(decl.update))
     case 'paramDecl':    return false
     case 'instanceDecl': {
-      // M11 fractal: also check sub-program for surviving combinators.
+      // Fractal: also check sub-program for surviving combinators.
       // Sub-program bodies are lowered recursively when arrayLower fires.
       const subType = getInstanceType(enclosing, decl)
       return decl.inputs.some(i => exprNeedsLowering(i.value))
@@ -226,7 +226,7 @@ function lowerDecl(decl: BodyDecl, subst: SubstMap, memo: Memo): BodyDecl {
     case 'programDecl':
       return decl
     case 'instanceDecl': {
-      // M11 fractal: surviving InstanceDecls keep their typeKey; the
+      // Fractal: surviving InstanceDecls keep their typeKey; the
       // sub-program behind that key was already lowered into the new
       // registry by arrayLower's top-level loop. We just lower this
       // instance's input wire expressions in the current scope.

--- a/compiler/ir/array_lower.ts
+++ b/compiler/ir/array_lower.ts
@@ -1,5 +1,5 @@
 /**
- * array_lower.ts — Phase C6: combinator unrolling and array-op lowering.
+ * array_lower.ts — combinator unrolling and array-op lowering.
  *
  * After this pass:
  *   - No `let`, `fold`, `scan`, `generate`, `iterate`, `chain`, `map2`,

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -20,18 +20,18 @@ import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_res
 
 /** Param-handle bindings for FFI param/trigger decls embedded in a
  *  program type's body, plus optional nested-output and nested-input
- *  slot maps for the M11 fractal compile path. */
+ *  slot maps for the fractal compile path. */
 export interface CompileResolvedContext {
   /** Keyed by ParamIdx. */
   paramHandles?:      Map<ParamIdx, { ptr: string }>
   /** Per-sub-instance, per-output-port module-slot map. Keyed by
    *  InstanceIdx (in this program) and OutputIdx (in the instance's
-   *  type). Populated by `partition_recursive` for M11 fractal compile;
+   *  type). Populated by `partition_recursive` for fractal compile;
    *  `NestedOut` refs lower to Slot reads via this map. */
   nestedOutputSlots?: Map<InstanceIdx, Map<OutputIdx, number>>
   /** Per-sub-instance, per-input-port module-slot map. Keyed by
    *  InstanceIdx and InputIdx. Populated by `partition_recursive` for
-   *  the M11 slot-based input wiring. The parent's compile emits a
+   *  slot-based input wiring. The parent's compile emits a
    *  `WriteSlot` into each named slot; entries land in
    *  `per_child_pre_input[k]` (parallel to the body's nested-instance
    *  order) so the engine runs each block immediately before recursing
@@ -116,13 +116,13 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     inputSlotOverride: ctx.inputSlotOverride,
   }
 
-  // M11 fractal: collect sub-instance decls so emit_resolved can emit
+  // Fractal: collect sub-instance decls so emit_resolved can emit
   // a `WriteSlot` for each of their wired inputs in
   // `per_child_pre_input[k]`. The order here is significant — it's
   // the dispatch order partition_recursive will use when packing
   // children into the InstanceFunction tree, so per_child_pre_input
   // and the children array stay parallel. Empty when the program has
-  // no nested instances (legacy flat path).
+  // no nested instances (flat path).
   const nestedInstances: InstanceDecl[] = []
   for (const d of prog.body.decls) {
     if (d.op === 'instanceDecl') nestedInstances.push(d)

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -191,7 +191,7 @@ function buildSlotMetadata(session: SessionState): {
     slotNames[entry.slotIdx]    = entry.slotName
     slotDefaults[entry.slotIdx] = entry.init
   }
-  // Input slots for sub-instance ports (M11 fractal path). Prefixed
+  // Input slots for sub-instance ports (the fractal path). Prefixed
   // with `input:` so the namespace is distinct from output-slot names
   // (which carry `instance.port` without prefix) and from
   // `param:` / delay-slot names. Defaults are 0 (parent overwrites

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -396,7 +396,7 @@ export function remapInstancePlan(
     args: instr.args.map(remapOperand),
   }))
 
-  // M11 fractal slot-based input wiring: each child's pre-input block
+  // Slot-based parent→child input wiring: each child's pre-input block
   // (parent's wires → WriteSlot to that child's input slot) gets the
   // same per-instance operand/dst remap as the main body. The blocks
   // reference the same temp/state/array spaces (Emitter allocates them

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -82,8 +82,9 @@ export interface FlatProgram {
   array_slot_count: number
   array_slot_sizes: number[]
   instructions:     NInstr[]
-  /** M11 fractal slot-based input wiring. Parallel to the caller's
-   *  `nestedInstances` array: `per_child_pre_input[k]` holds the
+  /** Slot-based parent→child input wiring (the fractal path).
+   *  Parallel to the caller's `nestedInstances` array:
+   *  `per_child_pre_input[k]` holds the
    *  WriteSlot block for the k-th sub-instance — the parent runs that
    *  block in its own namespace immediately before invoking that
    *  child's kernel body. Per-child placement (vs hoisting into a
@@ -267,10 +268,10 @@ export interface EmitSlots {
   nestedOutputSlots?: Map<InstanceIdx, Map<OutputIdx, number>>
   /** Module slot indices for THIS program's own input ports. When set,
    *  `InputRef(idx)` lowers to a Slot read from `inputSlotOverride.get(idx)`
-   *  instead of an `Input` operand. Used by the M11 fractal path. */
+   *  instead of an `Input` operand. Used by the fractal path. */
   inputSlotOverride?: Map<InputIdx, number>
   /** Per-child module-slot map for sub-instance INPUTS. Map shape:
-   *  InstanceIdx → InputIdx → moduleSlotIdx. Used by the M11 fractal
+   *  InstanceIdx → InputIdx → moduleSlotIdx. Used by the fractal
    *  path when emitting a parent kernel. */
   nestedInputSlots?: Map<InstanceIdx, Map<InputIdx, number>>
 }
@@ -413,7 +414,7 @@ class Emitter {
         // the slot number (slots.ts assigns slot[i] = position i).
         const slot = obj.idx as number
         const portT = this.inputPortTypes[slot] ?? 'float'
-        // M11 fractal path: when the program is being compiled as a
+        // Fractal path: when the program is being compiled as a
         // sub-instance kernel, its inputs live in module slots
         // pre-written by the parent's WriteSlot in per_child_pre_input.
         // Lower `InputRef(d)` to a slot read instead of opInput.
@@ -786,7 +787,7 @@ class Emitter {
     const output_targets: TempIdx[] = []
     const register_targets: RegTarget[] = []
 
-    // ── M11 fractal: emit per-child pre-input WriteSlots ──
+    // ── Fractal: emit per-child pre-input WriteSlots ──
     // For each child, evaluate each wired input expression in THIS
     // kernel's scope (where wire refs to our regs, params, and inputs
     // resolve naturally) and emit a WriteSlot into the child's pre-
@@ -869,8 +870,8 @@ class Emitter {
     // block, which the engine emits before the main body anyway).
     this.instrs = this.instrs.slice(0, preChildBaseline)
 
-    // Output-targets contract (M11 Phase 3): ONE entry per scalar slot
-    // of every declared output port. Scalar/alias ports contribute 1
+    // Output-targets contract: ONE entry per scalar slot of every
+    // declared output port. Scalar/alias ports contribute 1
     // entry; array ports of total scalar count N contribute N entries
     // in row-major order matching `expandPortToSlots`'s naming.
     //
@@ -1009,18 +1010,19 @@ export interface EmitResolvedInputs {
   stateRegTypes: ScalarType[]
   inputPortTypes: ScalarType[]
   slots: EmitSlots
-  /** M11 fractal: sub-instance decls whose input wires need parent-side
-   *  WriteSlot emission. Each entry's `inp.value` (wire expression) is
-   *  compiled in the parent's scope; the result is written to the slot
-   *  named in `slots.nestedInputSlots.get(decl).get(inp.port)`. The
-   *  WriteSlot instructions land in `per_child_pre_input[k]`, parallel
-   *  to `nestedInstances[k]`, so the engine can run each block
-   *  immediately before recursing into its corresponding child. */
-  /** M11 fractal context. The list is empty when this kernel has no
-   *  surviving sub-instances (legacy flat path); the `enclosing`
-   *  program is always present because it's the program whose kernel
-   *  we're emitting — there's no "missing enclosing" case. Resolving
-   *  each `instances[k].typeKey` reads `enclosing.programRegistry`. */
+  /** Fractal context: sub-instance decls whose input wires need
+   *  parent-side WriteSlot emission. Each entry's `inp.value` (wire
+   *  expression) is compiled in the parent's scope; the result is
+   *  written to the slot named in
+   *  `slots.nestedInputSlots.get(decl).get(inp.port)`. The WriteSlot
+   *  instructions land in `per_child_pre_input[k]`, parallel to
+   *  `nestedInstances[k]`, so the engine can run each block
+   *  immediately before recursing into its corresponding child. The
+   *  list is empty when this kernel has no surviving sub-instances
+   *  (flat path); the `enclosing` program is always present because
+   *  it's the program whose kernel we're emitting — there's no
+   *  "missing enclosing" case. Resolving each `instances[k].typeKey`
+   *  reads `enclosing.programRegistry`. */
   nested: NestedContext
 }
 

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -741,7 +741,7 @@ class Emitter {
         `emit_resolved: 'index' op has non-array operand. This usually means an ` +
         `array-typed input port (e.g. \`sequence: int[N]\`) is being indexed inside ` +
         `the program body — the per-instance compile path doesn't yet materialize ` +
-        `array input operands. Tracked as a follow-up to active-set M11.`,
+        `array input operands.`,
       )
     }
     const dst = this.allocReg()

--- a/compiler/ir/identity_elim.ts
+++ b/compiler/ir/identity_elim.ts
@@ -14,21 +14,21 @@
  * wired into `p` at the consumer site, and the `InstanceDecl` is dropped
  * from the body.
  *
- * Under the fractal architecture (M11 Phase 4+, `inlineInstances`
- * retired), trivial wires lifted by `liftWireToProgram` would survive
- * as identity `InstanceDecl`s — one kernel per trivial wire — bloating
- * slot space and adding pointless read/write instructions per sample.
- * `identityElim` recognizes and eliminates them, returning the wire to
- * a direct slot-read on the consumer side. The pass is the structural
- * analogue of compiler peephole optimizations, but it isn't a peephole:
- * it's a categorical equation made operational, exactly parallel to the
- * other strata passes (each one mechanizes some category-theoretic law
- * about the IR).
+ * In the `inlineNested: false` fractal path, trivial wires lifted by
+ * `liftWireToProgram` would survive as identity `InstanceDecl`s —
+ * one kernel per trivial wire — bloating slot space and adding
+ * pointless read/write instructions per sample. `identityElim`
+ * recognizes and eliminates them, returning the wire to a direct
+ * slot-read on the consumer side. The pass is the structural
+ * analogue of compiler peephole optimizations, but it isn't a
+ * peephole: it's a categorical equation made operational, exactly
+ * parallel to the other strata passes (each one mechanizes some
+ * category-theoretic law about the IR).
  *
- * Implementation discipline: we never mutate the input. When work needs
- * to be done, we deep-clone via `cloneResolvedProgram` and mutate the
- * clone freely. This keeps the rewrite local — surviving `InstanceDecl`
- * objects preserve their identity inside the clone, so cross-decl
+ * Implementation discipline: we never mutate the input. When work
+ * needs to be done, the rewrite is constructed via `mkProgram` over
+ * the surviving decls plus rewritten output assigns. Surviving
+ * `InstanceDecl` objects preserve their identity, so cross-decl
  * `NestedOut` refs stay consistent without an explicit rename pass.
  *
  * Pure, idempotent, meaning-preserving. Runs at every level of the

--- a/compiler/ir/inline_instances.ts
+++ b/compiler/ir/inline_instances.ts
@@ -1,5 +1,5 @@
 /**
- * inline_instances.ts — Phase C5: splice each `InstanceDecl` into its parent.
+ * inline_instances.ts — splice each `InstanceDecl` into its parent.
  *
  * After this pass, `prog.body.decls` contains no `InstanceDecl` and
  * no expression in the program contains a `NestedOut` ref. The inner
@@ -10,18 +10,18 @@
  *   2. Sub-instances inside the (specialized) inner are inlined first
  *      (depth-first, bottom-up). After this, the inner has zero
  *      `InstanceDecl`s of its own.
- *   3. The inner is cloned with input substitution: every `InputRef`
- *      whose decl belongs to the inner's `ports.inputs` is replaced
- *      by the wired-in expression from `instanceDecl.inputs[port]`.
- *      The substituted expression passes through by reference,
- *      preserving DAG sharing.
- *   4. Cloned `RegDecl`s are lifted into the outer's `body.decls`,
- *      renamed `${instance.name}_${innerName}`. Post-Phase-0a the
- *      update expression travels on `decl.update` (no separate
- *      NextUpdate assigns), so lifting the decl carries its update
- *      with it — no per-assign rewrite needed. `ProgramDecl`s and
- *      `ParamDecl`s are lifted as-is (no rename: ParamDecls are
- *      session-scoped by name, ProgramDecls are passive type bindings).
+ *   3. The inner is rewritten with input substitution: every
+ *      `InputRef` whose decl belongs to the inner's `ports.inputs`
+ *      is replaced by the wired-in expression from
+ *      `instanceDecl.inputs[port]`. The substituted expression
+ *      passes through by reference, preserving DAG sharing.
+ *   4. Rewritten `RegDecl`s are lifted into the outer's `body.decls`,
+ *      renamed `${instance.name}_${innerName}`. The update
+ *      expression travels on `decl.update`, so lifting the decl
+ *      carries its update with it — no per-assign rewrite needed.
+ *      `ProgramDecl`s and `ParamDecl`s are lifted as-is (no rename:
+ *      ParamDecls are session-scoped by name, ProgramDecls are
+ *      passive type bindings).
  *   5. The cloned inner's `outputAssign` expressions are recorded in
  *      a substitution table keyed by the *template's* `OutputDecl`
  *      (matched by position to the cloned program's outputs). Every

--- a/compiler/ir/lift_wires.ts
+++ b/compiler/ir/lift_wires.ts
@@ -2,10 +2,9 @@
  * lift_wires.ts — pre-compile pass that lifts complex wire expressions
  * to anonymous program instances.
  *
- * Phase 5 of M11 fractal compilation. Wires whose expression contains
- * forms that `translateNode` doesn't support (array literals, session-
- * level `delay()`) are extracted into anonymous programs at session
- * pre-compile time. The lifted program goes through the full strata
+ * Wires whose expression contains forms that `translateNode` doesn't
+ * support (array literals, session-level `delay()`) are extracted
+ * into anonymous programs at session pre-compile time. The lifted program goes through the full strata
  * pipeline — `arrayLower` handles array literals; `delay()` desugars
  * to a synthetic `RegDecl` with `update` populated, which the
  * standard slot allocator handles like any user-written reg — and

--- a/compiler/ir/lowering/cycle_break.ts
+++ b/compiler/ir/lowering/cycle_break.ts
@@ -2,18 +2,15 @@
  * compiler/ir/lowering/cycle_break.ts — shared cycle-break helper.
  *
  * This module is the single home of the cycle-detection + cycle-break
- * algorithm for tropical's resolved IR. Two consumers:
- *
- *   - `compiler/ir/trace_cycles.ts` — Phase 0+ shim that calls
- *     `breakInstanceCycles` to produce the post-trace IR for the
- *     compiler's strata pipeline. (Phase 3 retires this in-pipeline
- *     use; cycle-breaking moves to the realization layer above the
- *     compiler.)
- *
- *   - `compiler/ir/acyclic.ts` — the strataPipeline-boundary
- *     acyclicity check, which consumes only `findInstanceCycles`
- *     (the detector) and `AcyclicityViolation` to assert the
- *     post-trace invariant.
+ * algorithm for tropical's resolved IR. Cycle-breaking is the
+ * responsibility of the realization layer above the compiler (the
+ * elaborator throws `CycleViolation` on source-level cycles, the
+ * session materializer extracts session-level `delay()` ops); this
+ * file exposes the shared algorithm for realization-side use and for
+ * the strataPipeline-boundary acyclicity assertion in
+ * `compiler/ir/acyclic.ts`, which consumes only `findInstanceCycles`
+ * (the detector) and `AcyclicityViolation` to assert the invariant
+ * at the compile entry.
  *
  * Algorithm:
  *   1. Build an instance-level dependency graph: instance A depends

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -86,7 +86,7 @@ export function materializeSessionForEmit(session: SessionState): {
   // Honor the session's inlineNested mode. The session lift's strata
   // run controls whether sub-instances inside the synthetic top-level
   // get inlined (inlineNested:true, default) or preserved as kernel
-  // boundaries for the M11 slot path (inlineNested:false).
+  // boundaries for the slot-based fractal path (inlineNested:false).
   const lowered = strataPipeline(synthetic, new Map(), { inlineNested: session.inlineNested })
   return { lowered, paramDecls: ctx.paramDecls }
 }

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -100,7 +100,7 @@ function lookupOutputSlot(
 }
 
 /** Look up the (first scalar) slot index for an instance's INPUT port.
- *  Mirror of `lookupOutputSlot` against the M11 input-slot registry. */
+ *  Mirror of `lookupOutputSlot` against the input-slot registry. */
 function lookupInputSlot(
   session: SessionState,
   instancePath: string,
@@ -130,10 +130,12 @@ export interface PartitionedKernel {
  *
  *  `inputBindingFor` provides the binding for each input port of THIS
  *  kernel. For top-level session instances, it consults
- *  `session.inputExprNodes`. For nested kernels, all input ports have
- *  been substituted out by `cloneWithInputSubst`, so this function is
- *  unused (no `opInput` operands survive). Pass `() => undefined` for
- *  nested calls; the defaults-fallback handles unused declared inputs.
+ *  `session.inputExprNodes`. For nested kernels, all input ports are
+ *  handled by slot-based parent→child wiring (the child's
+ *  `InputRef(idx)` lowers to a Slot read via `inputSlotOverride`), so
+ *  this function is unused (no `opInput` operands survive). Pass
+ *  `() => undefined` for nested calls; the defaults-fallback handles
+ *  unused declared inputs.
  */
 export function partitionKernel(
   instancePath: string,
@@ -144,7 +146,7 @@ export function partitionKernel(
   paramHandles: Map<ParamIdx, { ptr: string }>,
   session: SessionState,
   acc: PartitionAccumulators,
-  /** M11 slot-based input wiring: when set, THIS kernel is being
+  /** Slot-based input wiring: when set, THIS kernel is being
    *  compiled as a sub-instance. Its `InputRef(idx)` operands lower to
    *  Slot reads from the slot indices recorded here, instead of the
    *  legacy `opInput`. Top-level callers pass `undefined`. */

--- a/compiler/ir/specialize.ts
+++ b/compiler/ir/specialize.ts
@@ -1,5 +1,5 @@
 /**
- * specialize.ts — Phase C3: type-param substitution on resolved IR.
+ * specialize.ts — type-param substitution on resolved IR.
  *
  * Functional rewrite (no clone). Produces a fresh `ResolvedProgram`
  * per (template, type-args) pair by walking the source with
@@ -16,8 +16,8 @@
  * variants by `===`).
  *
  * Purity: this function does not consult or modify any cache. The
- * cache lives in the loader (Phase C7) — the call site is responsible
- * for memoizing on the (template, args) pair.
+ * cache lives in the loader — the call site is responsible for
+ * memoizing on the (template, args) pair.
  *
  * `InstanceDecl.typeArgs[i].value` is currently typed as `number`
  * (parser only admits integer literals), so no substitution is needed

--- a/compiler/ir/strata.ts
+++ b/compiler/ir/strata.ts
@@ -6,23 +6,22 @@
  *   assertAcyclic → specialize → sumLower → inlineInstances
  *                 → arrayLower → identityElim
  *
- * Post-Phase 3, `strataPipeline` is a *checking* pipeline: it requires
- * its input to be already-acyclic. Cycle-breaking is the responsibility
- * of the caller (the "standard realization" — elaborator output and
- * session materialization). The two entry points
- * (`programTypeFromResolved` and `materializeSession`) run
- * `breakInstanceCycles` on their inputs before invoking
- * `strataPipeline`; the `assertAcyclic` at strata entry guarantees
- * any escape would surface immediately rather than producing a
- * malformed plan.
+ * `strataPipeline` is a *checking* pipeline: it requires its input to
+ * be already-acyclic. Cycle-breaking is the responsibility of the
+ * caller (the "standard realization" — elaborator output and session
+ * materialization). The two entry points (`programTypeFromResolved`
+ * and `materializeSession`) run `breakInstanceCycles` on their inputs
+ * before invoking `strataPipeline`; the `assertAcyclic` at strata
+ * entry guarantees any escape would surface immediately rather than
+ * producing a malformed plan.
  *
- * `identityElim` (M11 Phase 2) is the categorical identity-law rewrite:
- * it eliminates `InstanceDecl`s whose program body is the identity
- * morphism. Today (pre-Phase-4) it rarely fires at the per-program
- * level — `inlineInstances` runs first and absorbs trivial sub-instances.
- * Once Phase 4 retires `inlineInstances` from the session-level
- * pipeline, `identityElim` catches the trivial wire-programs that would
- * otherwise survive as no-op kernels.
+ * `identityElim` is the categorical identity-law rewrite: it
+ * eliminates `InstanceDecl`s whose program body is the identity
+ * morphism. In the default `inlineNested: true` path it rarely fires
+ * at the per-program level — `inlineInstances` runs first and
+ * absorbs trivial sub-instances. In the `inlineNested: false` fractal
+ * path it catches the trivial wire-programs that would otherwise
+ * survive as no-op kernels.
  *
  * After identityElim, the result is a post-strata `ResolvedProgram`
  * consumed by either `compileResolved` (the JIT path) or
@@ -40,10 +39,11 @@ import { assertAcyclic } from './acyclic.js'
 
 export interface StrataOptions {
   /** Whether to flatten nested `InstanceDecl`s via `inlineInstances`.
-   *  Default `true` (legacy / per-program-emit behavior). The fractal
-   *  session path passes `false` so sub-instances survive as kernel
-   *  boundaries — every `InstanceDecl` at every level becomes its own
-   *  kernel in `partition_recursive`. */
+   *  Default `true` (the flat-IR path; production default per the
+   *  depth-vs-flat cost tradeoff). The fractal session path passes
+   *  `false` so sub-instances survive as kernel boundaries — every
+   *  `InstanceDecl` at every level becomes its own kernel in
+   *  `partition_recursive`. */
   inlineNested?: boolean
 }
 
@@ -70,24 +70,24 @@ export function strataPipeline(
  *  port/register/default metadata via free functions over the resolved
  *  IR.
  *
- *  Default behavior uses `inlineNested: true` — the legacy flat-IR
- *  path. The fractal session path (M11 activation) passes
- *  `inlineNested: false` so sub-instance `InstanceDecl`s survive
- *  into `partition_recursive`, where they become real kernel
- *  boundaries instead of being splatted into their parent's body.
- *  The slot-based input-wiring redesign makes the `false` path
- *  correct end-to-end; until that lands, callers should leave
- *  `inlineNested` at its default. */
+ *  Default behavior uses `inlineNested: true` — the flat-IR path.
+ *  The fractal path passes `inlineNested: false` so sub-instance
+ *  `InstanceDecl`s survive into `partition_recursive`, where they
+ *  become real kernel boundaries via slot-based parent→child input
+ *  wiring instead of being splatted into their parent's body. Both
+ *  paths are correct end-to-end (verified sample-for-sample at 1e-12
+ *  by `tests/equiv/nested_vs_inlined.test.ts`); the choice is a
+ *  runtime-cost tradeoff documented in
+ *  `tests/bench/depth_vs_flat_*.md`. */
 export function programTypeFromResolved(
   prog: ResolvedProgram,
   typeArgs: ReadonlyMap<TypeParamDecl, number>,
   opts?: { displayName?: string; inlineNested?: boolean },
 ): Compiled {
-  // Post-Phase 4b: the elaborator throws on cyclic source code, and
-  // lifted wire-programs are acyclic by construction (no
-  // InstanceDecls). The strataPipeline's `assertAcyclic` at entry
-  // confirms the contract; no separate cycle-break call is needed
-  // here.
+  // The elaborator throws on cyclic source code, and lifted wire-
+  // programs are acyclic by construction (no InstanceDecls). The
+  // strataPipeline's `assertAcyclic` at entry confirms the contract;
+  // no separate cycle-break call is needed here.
   const strataOptions: StrataOptions = opts?.inlineNested !== undefined
     ? { inlineNested: opts.inlineNested } : {}
   return makeCompiled(strataPipeline(prog, typeArgs, strataOptions), opts)

--- a/compiler/ir/wire_program.ts
+++ b/compiler/ir/wire_program.ts
@@ -3,11 +3,11 @@
  *
  * A wire is a `ref(instance, output)` and a transformation expression
  * that turns one or more such refs into a value consumed by a downstream
- * instance. Today wires are handled by a parallel mini-compiler
- * (`translateNode` in `compile_session_slotted_helpers.ts`) that knows
- * only a subset of expression shapes. Under the fractal architecture
- * (M11 Phase 5), wires lift to anonymous programs and flow through the
- * same per-program path as user-authored types.
+ * instance. The fractal-architecture path lifts each wire to an
+ * anonymous program that flows through the same per-program path as
+ * user-authored types; the legacy parallel mini-compiler
+ * (`translateNode` in `compile_session_slotted_helpers.ts`) still
+ * handles wires whose shape is a strict subset of the fractal lift.
  *
  * The lift is precise: given an `ExprNode` `e` with free refs `r₁..rₖ`,
  * we synthesize a program shape-identical to one a user could have
@@ -28,8 +28,8 @@
  * anywhere else.
  *
  * Both exports are pure, total, and stateless. No engine, no FFI, no
- * session. They are the foundational lift; Phase 4's partitioner and
- * Phase 5's materializer consume them.
+ * session. They are the foundational lift; `partition_recursive` and
+ * the session materializer consume them.
  */
 
 import type { ExprNode } from '../expr.js'

--- a/compiler/parse/declarations.ts
+++ b/compiler/parse/declarations.ts
@@ -32,7 +32,8 @@
  *  - Bare-name ports (just `name`) emit a string entry
  *  - Nested `program` decls in body, recursive
  *
- * Out of scope (deferred to B5): ADTs and `match` (`type_defs` field).
+ * ADTs (struct/enum/type) parse into `type_defs`; the ADT parser
+ * lives in this file (see `parseADT` and friends below).
  */
 
 import { tokenize, type Tok } from './lexer.js'

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -373,7 +373,7 @@ export function loadProgramAsSession(
     session.instanceRegistry.set(instance.name, instance)
     // Slot model: allocate output slots for the instance, parallel to
     // what MCP add_instance does. Required for the per-instance
-    // compile path (M9a+) to find each output's slot index.
+    // compile path to find each output's slot index.
     allocateOutputSlots(session, toInstanceName(instance.name), type)
 
     // Populate wiring from instance inputs
@@ -530,7 +530,7 @@ export function mergeProgramIntoSession(
     session.instanceRegistry.set(instance.name, instance)
     // Slot model: allocate output slots for the instance, parallel to
     // what MCP add_instance does. Required for the per-instance
-    // compile path (M9a+) to find each output's slot index.
+    // compile path to find each output's slot index.
     allocateOutputSlots(session, toInstanceName(instance.name), type)
 
     // Populate wiring from instance inputs

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -162,14 +162,15 @@ export interface SessionState {
    *  per-namespace counts (output + param + input + delay). */
   slotCount:          number
   /** Input expressions keyed by scalar-slot name "${instance}:${scalarSlotName}".
-   *  Coexists with inputExprNodes during the migration; M8 unifies them. */
+   *  Coexists with `inputExprNodes`; a future cleanup will unify them. */
   inputExprs:         Map<string, ExprNode>
   /** Whether the strata pipeline should flatten nested `InstanceDecl`s
-   *  via `inlineInstances`. Default `true` (legacy flat-IR path).
-   *  When `false`, sub-instance kernels survive as kernel boundaries
-   *  in `partition_recursive` — the M11 fractal path. All program-
-   *  loading entry points consult this field to keep the IR shape
-   *  consistent across a session. */
+   *  via `inlineInstances`. Default `true` (the flat-IR path, production
+   *  default per the depth-vs-flat cost tradeoff). When `false`,
+   *  sub-instance kernels survive as kernel boundaries in
+   *  `partition_recursive` — the fractal path. All program-loading
+   *  entry points consult this field to keep the IR shape consistent
+   *  across a session. */
   inlineNested:       boolean
   /** FlatRuntime — all audio goes through this. */
   runtime: Runtime
@@ -428,7 +429,7 @@ export function allocateOutputSlots(
 
 /** Allocate slot indices for every INPUT port of an instance. Used by
  *  `partition_recursive` when emitting slot-based parent→child input
- *  wiring (the M11 fractal path with `inlineNested:false`). The parent
+ *  wiring (the fractal path with `inlineNested:false`). The parent
  *  emits a `WriteSlot` into each of these slots before invoking the
  *  child; the child's `InputRef`s lower to `Slot` reads via
  *  `compileResolved`'s `nestedInputSlots` context.

--- a/compiler/wasm_memory_layout.ts
+++ b/compiler/wasm_memory_layout.ts
@@ -22,7 +22,7 @@ export type WasmLayout = {
   arraysOffset:      number
   arrayOffsets:      number[]     // per array slot: absolute byte offset
   paramTableOffset:  number       // f64[paramCount]
-  slotsOffset:       number       // f64[slotCount] — inter-module slot array (M10)
+  slotsOffset:       number       // f64[slotCount] — inter-module slot array
   outputOffset:      number       // f64[maxBlockSize]
   totalBytes:        number
   /** Number of 64 KiB WASM pages needed */
@@ -52,7 +52,7 @@ export function computeLayout(args: {
   paramPtrs: string[]
   /** Max audio block size the kernel will be asked to render in one call. */
   maxBlockSize: number
-  /** Number of inter-module slots (M10). 0 for legacy plans. */
+  /** Number of inter-module slots. 0 for legacy plans. */
   slotCount?: number
 }): WasmLayout {
   const { plan, inputCount, paramPtrs, maxBlockSize } = args
@@ -80,7 +80,7 @@ export function computeLayout(args: {
   const paramTableOffset = cursor
   cursor = align8(cursor + paramPtrs.length * f64)
 
-  // Inter-module slot array (M10). Slot-mode plans pass slotCount > 0;
+  // Inter-module slot array. Slot-mode plans pass slotCount > 0;
   // legacy plans omit it and the region is zero-sized.
   const slotsOffset = cursor
   cursor = align8(cursor + requestedSlotCount * f64)

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -333,13 +333,20 @@ For each instance, depth-first bottom-up:
 name-prefix parsing pattern. Identifying a decl's lineage is now an
 object-field check, not a string regex.
 
-The `inlineNested: false` option is the entry point for the future
-fractal-compilation path: when it's flipped, sub-instances survive
-as kernel boundaries and `partitionKernel` (the recursive
-partitioner in `compile_session_slotted.ts`) emits an
-`InstanceFunction` for every `InstanceDecl` at every level. The
-infrastructure is complete; activation is gated on cross-kernel
-input-wiring resolution.
+The `inlineNested: false` option is the entry point for the
+fractal-compilation path: sub-instances survive as kernel boundaries
+and `partitionKernel` (the recursive partitioner in
+`compile_session_slotted.ts`) emits an `InstanceFunction` for every
+`InstanceDecl` at every level. Cross-kernel input wiring is handled
+by slot-based parent→child writes: the parent's body emits
+`WriteSlot` ops into a per-child `pre_child_instructions` block
+(evaluated in the parent's scope, so every ref resolves), and the
+child reads its inputs via slot reads in its own body. Both paths
+(`inlineNested: true` flat, `inlineNested: false` fractal) are
+verified sample-for-sample at 1e-12 by
+`tests/equiv/nested_vs_inlined.test.ts`; the choice between them is
+a runtime-cost tradeoff documented in
+`tests/bench/depth_vs_flat_*.md`.
 
 ### 3.5 arrayLower — drops shapes and combinators
 
@@ -492,14 +499,27 @@ covers gating via direct slot writes from the scheduler.
 
 ### 4.3 Fixed-topology compilation
 
-Tropical compiles a session graph to one monolithic kernel; the
-topology is fixed for the lifetime of the kernel. Topology changes
-(adding/removing instances, rewiring) trigger hot-swap to a freshly
-compiled kernel with state transferred by name. There is no
-per-instance runtime gating — every instance runs every sample, and
-LLVM fuses across instances aggressively. This is the shape of
-synthesis the language is good at; dynamic-lifecycle semantics
-belong in a different language with a different runtime.
+Tropical compiles a session graph to native code with a fixed
+topology for the lifetime of the kernel. Two compilation modes
+selected by `FlatPlan.compilation_mode`:
+
+- `'fused'` (default) — one monolithic LLVM function for the whole
+  session per buffer. LLVM fuses across instances aggressively.
+- `'microkernel'` — one LLVM function per top-level session instance,
+  plus preamble / state_evolution / postamble_mix; the per-sample
+  outer loop runs in C++ and dispatches them via function pointers.
+  Trades cross-instance fusion for superlinear cold-compile speedup
+  (LLVM optimizer scales worse on one huge function than on N
+  smaller ones). Sample-for-sample equivalent to fused at 1e-12 per
+  `tests/equiv/microkernel_vs_fused.test.ts`.
+
+Topology changes (adding/removing instances, rewiring) trigger
+hot-swap to a freshly compiled kernel with state transferred by
+name; both modes use the same hot-swap mechanism. There is no
+per-instance runtime gating — every instance runs every sample.
+This is the shape of synthesis the language is good at;
+dynamic-lifecycle semantics belong in a different language with a
+different runtime.
 
 ---
 

--- a/engine/c_api/tropical_c.h
+++ b/engine/c_api/tropical_c.h
@@ -84,13 +84,14 @@ void             tropical_runtime_begin_fade_in(tropical_runtime_t);
 void             tropical_runtime_begin_fade_out(tropical_runtime_t);
 bool             tropical_runtime_is_fade_out_complete(tropical_runtime_t);
 
-/* ---------- Slot model (M5+) ----------
+/* ---------- Slot model ----------
  *
- * Slots are an inter-module shared array introduced by the slot model.
- * Each output port of every instance + each control-plane param has a
- * dedicated slot index. Until M6 plumbs slot reads into the JIT IR,
- * only control-plane writes (set_slot) take effect; the kernel doesn't
- * yet read from slots.
+ * Slots are an inter-module shared array. Each output port of every
+ * instance + each control-plane param has a dedicated slot index. The
+ * JIT codegen reads slots via 'slot' operands and writes via WriteSlot
+ * instructions (parent→child input wiring, MCP wire auto-delay,
+ * session-level delay extraction). Control-plane writes from outside
+ * the kernel go through `set_slot`.
  *
  * `slot_index` returns UINT32_MAX when no slot with that name exists
  * in the active plan — typical lookup pattern is to resolve the name

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -521,7 +521,7 @@ struct EmitCtx
   // ── Per-instance writebacks ──
   void emit_writebacks(const std::vector<InstanceProgram::Writeback> & wbs);
 
-  // ── Per-instance dispatch (M11 fractal interleaved order) ──
+  // ── Per-instance dispatch (fractal interleaved order) ──
   // For each child:
   //   1. emit child.pre_input_instructions (in THIS kernel's namespace
   //      — wire expressions referencing parent regs/inputs/params resolve,
@@ -1229,9 +1229,9 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
 
   // ── Per-instance dispatch ──
   // For each top-level instance, EmitCtx::emit_kernel_block recursively
-  // emits its M11 children inside the parent's body, then the parent's
-  // own instructions, then writebacks. Children run BEFORE the parent
-  // so it can read their freshly-written slot values (M11 fractal).
+  // emits its nested children inside the parent's body, then the
+  // parent's own instructions, then writebacks. Children run BEFORE
+  // the parent so it can read their freshly-written slot values.
 
   for (const auto & inst : program.instance_functions)
   {
@@ -1508,9 +1508,9 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
   };
 
   // ── Emit one PerSampleFn from one InstanceProgram (body + writebacks + children) ──
-  // Recursive: M11 children are inlined into this function's body via
-  // EmitCtx::emit_kernel_block. One LLVM function per top-level session
-  // instance.
+  // Recursive: nested children are inlined into this function's body
+  // via EmitCtx::emit_kernel_block. One LLVM function per top-level
+  // session instance.
   auto emit_instance_function = [&](
     const std::string & sym,
     const InstanceProgram & inst) -> llvm::Error
@@ -1595,8 +1595,8 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
   };
 
   // ── Emit all functions ──
-  // One LLVM function per top-level session instance, with M11 children
-  // inlined recursively via emit_kernel_block. Plus preamble,
+  // One LLVM function per top-level session instance, with nested
+  // children inlined recursively via emit_kernel_block. Plus preamble,
   // state_evolution, and postamble_mix as their own functions.
   const std::string sym_preamble        = "mk_" + hash + "_preamble";
   const std::string sym_state_evolution = "mk_" + hash + "_state_evo";

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -361,13 +361,11 @@ llvm::Expected<uint64_t> OrcJitEngine::lookup(const std::string & symbol_name)
 // so a write in one function's body is observable to a later function's
 // read of the same unified-namespace temp slot.
 //
-// compile_flat_program (fused mode) does NOT use EmitCtx — its in-place
-// lambdas are kept byte-identical to the pre-spike codegen so fused mode
-// stays a known-good reference for the microkernel-vs-fused equivalence
-// suite (Phase 6). The methods below are functionally identical to those
-// lambdas; the duplication is honest spike scaffolding. If the spike
-// graduates, a follow-up commit can switch compile_flat_program over to
-// EmitCtx and the dual maintenance burden disappears.
+// Both compile_flat_program (fused mode) and compile_microkernel
+// (microkernel mode) build an EmitCtx; codegen is shared via the methods
+// on this struct. The microkernel-vs-fused equivalence suite
+// (tests/equiv/microkernel_vs_fused.test.ts) covers the shared path
+// sample-for-sample at 1e-12.
 // ---------------------------------------------------------------------------
 
 namespace
@@ -1334,8 +1332,8 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
 
   // ── Param index + cache-key serialization ──
   // Duplicated from compile_flat_program with the only diff being the
-  // mode tag prefix on the cache key. Sharing the serialization across
-  // both modes is a follow-up if the spike graduates.
+  // mode tag prefix on the cache key. A future refactor could share
+  // the serialization across both modes.
   auto visit_all_instructions = [&](auto && fn) {
     for (const auto & instr : program.scheduler.preamble) fn(instr);
     for (const auto & inst : program.instance_functions)

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -112,7 +112,8 @@ struct FlatInstr
 // Per-instance kernel slice. Each session instance contributes one of
 // these to the multi-function plan. The compiler emits all instances
 // inline within one LLVM function — `children` are emitted recursively
-// inside the parent's body (M11 fractal architecture).
+// inside the parent's body (the fractal architecture: one kernel per
+// InstanceDecl at every nesting depth).
 struct InstanceProgram
 {
   std::string                  instance_name;     // dotted path (e.g. voice1.env)
@@ -125,7 +126,7 @@ struct InstanceProgram
    *  be computed by the time children start. */
   std::vector<FlatInstr>       preamble_instructions;
   std::vector<FlatInstr>       instructions;      // already shifted into unified offset space
-  /** M11 fractal slot-based input wiring. Per-child block — runs in
+  /** Slot-based parent→child input wiring. Per-child block — runs in
    *  the PARENT's namespace immediately before THIS kernel's body. The
    *  parent's emit_kernel_block dispatches each child as:
    *      emit_instrs(child.pre_input_instructions)

--- a/engine/runtime/FlatRuntime.hpp
+++ b/engine/runtime/FlatRuntime.hpp
@@ -51,12 +51,12 @@ struct KernelState
   // Output extraction
   uint32_t output_count = 0;
 
-  // ── Slot model state (M5) ────────────────────────────────────────────────
-  // Inter-module slot array. M5 uses it for control-plane writes only
-  // (via tropical_runtime_set_slot); M6 introduces JIT codegen that
-  // reads from it via 'slot' operands. Slots survive hot-swap by name
-  // so control values set from outside persist; this transfer becomes
-  // unnecessary in M8 once the kernel rewrites slots every sample.
+  // ── Slot model state ─────────────────────────────────────────────────────
+  // Inter-module slot array. Control-plane writes via
+  // tropical_runtime_set_slot; JIT codegen reads via 'slot' operands and
+  // writes via WriteSlot instructions (parent→child input wiring,
+  // MCP wire auto-delay, etc.). Slots survive hot-swap by name so
+  // control values set from outside persist across kernel rebuilds.
   std::vector<double>      slots;
   std::vector<std::string> slot_names;
 

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -173,7 +173,7 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
   if (jf.contains("instructions"))
     for (const auto & ji : jf["instructions"])
       inst.instructions.push_back(parse_instr(ji));
-  // M11 fractal slot-based input wiring. Optional in the wire format
+  // Slot-based parent→child input wiring. Optional in the wire format
   // (legacy plans don't have it; absent → empty). Same instruction
   // shape as `instructions`; difference is purely WHEN they emit —
   // the parent's emit_kernel_block runs each child's
@@ -201,7 +201,8 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
       });
     }
   }
-  // Recurse into nested children (M11 fractal architecture). Absent or
+  // Recurse into nested children (the fractal architecture: one
+  // kernel per InstanceDecl at every nesting depth). Absent or
   // empty `children` array means a leaf kernel.
   if (jf.contains("children"))
     for (const auto & jc : jf["children"])
@@ -210,10 +211,10 @@ inline tropical_jit::InstanceProgram parse_instance_program(const nlohmann::json
 }
 
 /** Parse a tropical_plan_5 JSON object. The C++ side supports nested
- *  `instance_functions` (M11 fractal architecture): each function may
+ *  `instance_functions` (the fractal architecture): each function may
  *  have `children: InstanceFunction[]` that emit recursively inside the
- *  parent's alive-conditional. Legacy plans without nested children
- *  parse as leaf-only kernels. */
+ *  parent's body. Legacy plans without nested children parse as
+ *  leaf-only kernels. */
 inline ParsedPlan5 parse_plan5(const nlohmann::json & plan)
 {
   ParsedPlan5 result;


### PR DESCRIPTION
## Summary

Phase 0 of the deep-microkernel-mode implementation plan. Comments and docs whose claims about deferred or in-progress work no longer match the codebase after PRs #155, #157, #158, #159 are cleaned up. No behavior changes — comments and docs only.

## The load-bearing edit

`compiler/ir/strata.ts` — the `programTypeFromResolved` docstring still claimed the slot-based input-wiring redesign was unlanded:

> The slot-based input-wiring redesign makes the `false` path correct end-to-end; until that lands, callers should leave `inlineNested` at its default.

PR #157 landed that redesign two days after the docstring was written. Both `inlineNested: true` (flat) and `inlineNested: false` (fractal) paths are correct end-to-end, verified sample-for-sample at 1e-12 by `tests/equiv/nested_vs_inlined.test.ts`. The choice between them is a documented runtime-cost tradeoff per `tests/bench/depth_vs_flat_*.md`, not a deferred feature.

## Other cleanups in the same spirit

| File | What was stale |
|---|---|
| `compiler/ir/identity_elim.ts` | Reference to deleted `cloneResolvedProgram`; futurity language about "M11 Phase 4+, inlineInstances retired" (inlineInstances is the default-mode path, not retired) |
| `compiler/ir/lift_wires.ts`, `wire_program.ts` | "Phase N of M11" futurity |
| `compiler/ir/lowering/cycle_break.ts` | Reference to deleted `trace_cycles.ts` and "Phase 3 retires" futurity |
| `compiler/ir/acyclic.ts` | "Phase 3 moves" — Phase 3 happened, traceCycles is gone |
| `compiler/ir/emit_resolved.ts` | "follow-up to active-set M11" — active-set runtime removed in #153 |
| `compiler/parse/declarations.ts` | "deferred to B5: ADTs" — ADTs work; the ADT parser is in this file |
| `engine/jit/OrcJitEngine.cpp` | "If the spike graduates" framing — microkernel mode graduated in #155, and `compile_flat_program` does in fact use `EmitCtx` despite the comment claiming otherwise |
| `specialize.ts`, `inline_instances.ts`, `array_lower.ts` | Dropped "Phase Cn:" prefixes (pass names already describe what each does) |
| `compiler/CLAUDE.md` | "post-Phase-D path is..." → "path is..." |
| `design/architecture.md` | "future fractal-compilation path" → current-state description with slot-based parent→child input wiring; "Fixed-topology compilation" section now mentions microkernel mode |
| `compiler/ir/strata.ts` | StrataOptions doc: dropped "legacy" framing on `inlineNested:true` (it's the production default, not legacy) |

## Kept as load-bearing context

M-series milestone tags (M9a/M9d/M10/M11) where they document when an architectural field arrived. Test description strings excluded per the cleanup-scope decision.

## Verification

- `make validate` green: 1011/1011 TS tests pass, `ctest module_process` pass, stdlib validator 3 pass / 0 fail / 9 expected skips
- Manual grep sweep confirms no in-scope "until that lands" / "deferred to" / "spike graduates" claims survive

## Test plan

- [x] `bun test` — 1011/1011 pass
- [x] `make build` — green on LLVM 20.1.8
- [x] `ctest --test-dir build` — 1/1 pass
- [x] `bun run scripts/validate_stdlib.ts` — 3 pass / 0 fail / 9 expected skips
- [x] Manual grep sweep clean for in-scope categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)