### PR TITLE
feat: microkernel-deep mode

### DIFF
--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -48,14 +48,21 @@ import { toWireInstr } from './ir/emit_resolved'
 // ─── CompilationMode: how the engine should realize the plan ───────────────
 // `fused` (default, legacy): one monolithic LLVM kernel function that
 // inlines every instance body inside the outer sample loop.
-// `microkernel`: N+1 LLVM functions in one module (preamble, per-instance
+// `microkernel`: N+3 LLVM functions in one module (preamble, per-instance
 // kernels, state_evolution, postamble_mix); the C++ scheduler dispatches
-// them via function pointers per sample. The field is part of the plan
-// because the cache must be partitioned by mode — different return types
-// from `compile_*` mean a fused-mode cache hit cannot satisfy a
-// microkernel-mode query.
+// them via function pointers per sample. Top-level session instances
+// each get their own function; nested children are inlined into their
+// parent's function.
+// `microkernel-deep`: like `microkernel`, but children are also emitted
+// as their own LLVM functions instead of being inlined — one function
+// per `InstanceFunction` at every nesting depth. Requires the plan to
+// carry non-empty `children` arrays (i.e., the session was compiled
+// with `inlineNested: false`).
+// The field is part of the plan because the cache must be partitioned
+// by mode — different return types from `compile_*` mean a fused-mode
+// cache hit cannot satisfy a microkernel-mode query.
 
-export type CompilationMode = 'fused' | 'microkernel'
+export type CompilationMode = 'fused' | 'microkernel' | 'microkernel-deep'
 
 /** Parse a wire-format mode string, defaulting to 'fused' for legacy
  *  plans that pre-date the field. Throws on unknown strings — we fail
@@ -63,8 +70,9 @@ export type CompilationMode = 'fused' | 'microkernel'
  *  intend. */
 export function parseCompilationMode(s: string | undefined): CompilationMode {
   if (s === undefined || s === 'fused') return 'fused'
-  if (s === 'microkernel') return 'microkernel'
-  throw new Error(`flat_plan: unknown compilation_mode '${s}' (expected 'fused' | 'microkernel')`)
+  if (s === 'microkernel')      return 'microkernel'
+  if (s === 'microkernel-deep') return 'microkernel-deep'
+  throw new Error(`flat_plan: unknown compilation_mode '${s}' (expected 'fused' | 'microkernel' | 'microkernel-deep')`)
 }
 
 // ─── RegTarget: sum type replacing the `-1`-sentinel int field ──────────────
@@ -429,11 +437,11 @@ export function toWirePlan(plan: FlatPlan): WireFlatPlan {
     schema:           plan.schema,
     config:           plan.config,
     // Omit 'fused' from the wire format so golden JSON fixtures
-    // (which predate this field) don't gain a spurious key. Only
-    // 'microkernel' emits explicitly.
-    ...(plan.compilation_mode === 'microkernel'
-      ? { compilation_mode: 'microkernel' as const }
-      : {}),
+    // (which predate this field) don't gain a spurious key. Other
+    // modes emit explicitly.
+    ...(plan.compilation_mode === 'fused'
+      ? {}
+      : { compilation_mode: plan.compilation_mode }),
     state_init:       plan.state_init,
     register_names:   plan.register_names,
     register_types:   plan.register_types,

--- a/compiler/flat_plan_mode.test.ts
+++ b/compiler/flat_plan_mode.test.ts
@@ -1,18 +1,18 @@
 /**
  * flat_plan_mode.test.ts — round-trip coverage for the `compilation_mode`
- * field added in Phase 1 of the microkernel-mode spike.
+ * field.
  *
  * Pure-TS test: no FFI, no native runtime. The compileSession →
  * compileSessionSlotted threading is covered transitively by the
- * cross-mode equivalence suite (Phase 6); this file pins the
- * data-format contract.
+ * cross-mode equivalence suite; this file pins the data-format
+ * contract.
  *
- * Three properties under test:
- *   1. `parseCompilationMode` accepts 'fused' / 'microkernel' / undefined,
- *      fails closed on anything else.
- *   2. `toWirePlan` / `parseWirePlan` round-trip the mode losslessly; the
- *      legacy default 'fused' is *omitted* from the wire format so
- *      pre-existing golden fixtures don't gain a spurious key.
+ * Properties under test:
+ *   1. `parseCompilationMode` accepts 'fused' / 'microkernel' /
+ *      'microkernel-deep' / undefined, fails closed on anything else.
+ *   2. `toWirePlan` / `parseWirePlan` round-trip the mode losslessly;
+ *      the legacy default 'fused' is *omitted* from the wire format
+ *      so pre-existing golden fixtures don't gain a spurious key.
  *   3. `parseWirePlan` on legacy wire plans (no `compilation_mode`
  *      field) yields `'fused'`.
  */
@@ -56,15 +56,17 @@ describe('parseCompilationMode', () => {
     expect(parseCompilationMode(undefined)).toBe('fused')
   })
 
-  test('explicit fused / microkernel pass through', () => {
+  test('explicit fused / microkernel / microkernel-deep pass through', () => {
     expect(parseCompilationMode('fused')).toBe('fused')
     expect(parseCompilationMode('microkernel')).toBe('microkernel')
+    expect(parseCompilationMode('microkernel-deep')).toBe('microkernel-deep')
   })
 
   test('unknown strings fail closed', () => {
     expect(() => parseCompilationMode('FUSED')).toThrow(/unknown compilation_mode/)
     expect(() => parseCompilationMode('')).toThrow(/unknown compilation_mode/)
     expect(() => parseCompilationMode('hybrid')).toThrow(/unknown compilation_mode/)
+    expect(() => parseCompilationMode('microkernel_deep')).toThrow(/unknown compilation_mode/)  // underscore, not hyphen
   })
 })
 
@@ -87,6 +89,12 @@ describe('parseWirePlan: legacy compatibility', () => {
     const plan = parseWirePlan(wire)
     expect(plan.compilation_mode).toBe('microkernel')
   })
+
+  test("wire plan with compilation_mode: 'microkernel-deep' parses as microkernel-deep", () => {
+    const wire: WireFlatPlan = { ...makeEmptyWirePlan(), compilation_mode: 'microkernel-deep' }
+    const plan = parseWirePlan(wire)
+    expect(plan.compilation_mode).toBe('microkernel-deep')
+  })
 })
 
 describe('toWirePlan: serialization', () => {
@@ -107,6 +115,13 @@ describe('toWirePlan: serialization', () => {
     const wire = toWirePlan(plan)
     expect(wire.compilation_mode).toBe('microkernel')
   })
+
+  test('microkernel-deep mode is emitted explicitly', () => {
+    const wire0 = makeEmptyWirePlan()
+    const plan: FlatPlan = { ...parseWirePlan(wire0), compilation_mode: 'microkernel-deep' }
+    const wire = toWirePlan(plan)
+    expect(wire.compilation_mode).toBe('microkernel-deep')
+  })
 })
 
 describe('full round-trip', () => {
@@ -121,6 +136,22 @@ describe('full round-trip', () => {
     const plan: FlatPlan = { ...parseWirePlan(wire0), compilation_mode: 'microkernel' }
     const roundTripped = parseWirePlan(toWirePlan(plan))
     expect(roundTripped.compilation_mode).toBe('microkernel')
+  })
+
+  test('microkernel-deep: parseWirePlan ∘ toWirePlan = identity', () => {
+    const wire0 = makeEmptyWirePlan()
+    const plan: FlatPlan = { ...parseWirePlan(wire0), compilation_mode: 'microkernel-deep' }
+    const roundTripped = parseWirePlan(toWirePlan(plan))
+    expect(roundTripped.compilation_mode).toBe('microkernel-deep')
+  })
+
+  test('JSON-string round trip preserves microkernel-deep mode', () => {
+    const wire0 = makeEmptyWirePlan()
+    const plan: FlatPlan = { ...parseWirePlan(wire0), compilation_mode: 'microkernel-deep' }
+    const json = JSON.stringify(toWirePlan(plan))
+    const wire = JSON.parse(json) as WireFlatPlan
+    expect(wire.compilation_mode).toBe('microkernel-deep')
+    expect(parseWirePlan(wire).compilation_mode).toBe('microkernel-deep')
   })
 
   test('JSON-string round trip preserves microkernel mode', () => {

--- a/compiler/ir/compile_session.ts
+++ b/compiler/ir/compile_session.ts
@@ -35,6 +35,25 @@ export function compileSession(
   session: SessionState,
   options: CompileSessionOptions = {},
 ): FlatPlan {
+  // Auto-flip: `microkernel-deep` mode requires the plan to carry
+  // non-empty `children` arrays at every nesting level so the engine
+  // can emit one LLVM function per `InstanceFunction`. That shape
+  // comes from `inlineNested: false` in the strata pipeline. Force
+  // the session to honor it before materialize-time strata runs.
+  //
+  // Known limitation: program types loaded into the session BEFORE
+  // this point were strata-processed with whatever `inlineNested`
+  // value the session had at load time. For sub-instances inside
+  // those program types to survive as kernel boundaries, the caller
+  // must have constructed the session with `inlineNested: false`
+  // (e.g., `makeSession(N, { inlineNested: false })`). This auto-
+  // flip handles the session-level synthetic top-level program only.
+  // A future refinement may make `compilation_mode` a session-
+  // construction-time argument so the two stay coupled by design.
+  if (options.compilation_mode === 'microkernel-deep' && session.inlineNested) {
+    session.inlineNested = false
+  }
+
   // Pre-compile: hoist array-literal wires to anonymous programs.
   liftWiresToInstances(session)
 

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -425,6 +425,13 @@ struct EmitCtx
   // compile share the same symbol table.
   std::vector<ST> * temp_types = nullptr;
 
+  // ── Deep-mode dispatch ──
+  // When set, `emit_kernel_block` emits `CreateCall(child_fn, args)` for
+  // each child instead of recursing inline. The map gives each
+  // InstanceProgram its pre-declared LLVM function. nullptr → shallow
+  // mode (inline recursion).
+  const std::unordered_map<const InstanceProgram*, llvm::Function*> * deep_child_fns = nullptr;
+
   // ── Slot helpers ──
   llvm::Value * gep_temp(uint32_t idx) const {
     return builder->CreateInBoundsGEP(i64_ty, temps_arg, builder->getInt64(idx));
@@ -549,7 +556,29 @@ struct EmitCtx
     if (auto err = emit_instrs(inst.preamble_instructions)) return err;
     for (const auto & child : inst.children) {
       if (auto err = emit_instrs(child.pre_input_instructions)) return err;
-      if (auto err = emit_kernel_block(child)) return err;
+      if (deep_child_fns != nullptr) {
+        // Deep mode: each child is its own LLVM function. Call it
+        // with the same per-sample args we received; the child's
+        // body executes (and may recursively call its own children).
+        // The four-phase order is preserved across the function
+        // boundary because pre_input ran above in OUR scope, and the
+        // child's body runs as a leaf operation here.
+        auto it = deep_child_fns->find(&child);
+        if (it == deep_child_fns->end()) {
+          return llvm::make_error<llvm::StringError>(
+            "emit_kernel_block: deep mode missing function for child '"
+            + child.instance_name + "'",
+            llvm::inconvertibleErrorCode());
+        }
+        llvm::Value * args[] = {
+          regs_arg, arrays_arg, array_sizes_arg, temps_arg,
+          sample_rate_arg, current_sample_idx, param_ptrs_arg, slots_arg,
+        };
+        builder->CreateCall(it->second, args);
+      } else {
+        // Shallow mode: inline the child's body recursively.
+        if (auto err = emit_kernel_block(child)) return err;
+      }
     }
     if (auto err = emit_instrs(inst.instructions)) return err;
     emit_writebacks(inst.writebacks);
@@ -1319,7 +1348,8 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
 // ---------------------------------------------------------------------------
 
 llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
-  const FlatProgram & program)
+  const FlatProgram & program,
+  bool deep)
 {
   if (!jit_)
   {
@@ -1354,9 +1384,11 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
 
   std::string cache_key;
   // Mode-tagged: keeps microkernel cache disjoint from fused mode's
-  // "flat5:fused:" entries — both compile_* methods return different
-  // types, so a wrong-mode hit would be a type-confusion bug.
-  cache_key += "flat5:mk:";
+  // "flat5:fused:" entries, and keeps shallow ("flat5:mk:") and deep
+  // ("flat5:mkd:") modes disjoint from each other — both compile_*
+  // calls return different LLVM module shapes for the same input
+  // FlatProgram, so a wrong-mode hit would be a type-confusion bug.
+  cache_key += deep ? "flat5:mkd:" : "flat5:mk:";
   cache_key += opt_level_tag(opt_level_);
   cache_key += ":";
   {
@@ -1507,22 +1539,56 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
     return llvm::Error::success();
   };
 
-  // ── Emit one PerSampleFn from one InstanceProgram (body + writebacks + children) ──
-  // Recursive: nested children are inlined into this function's body
-  // via EmitCtx::emit_kernel_block. One LLVM function per top-level
-  // session instance.
+  // ── Pre-declare LLVM functions for deep mode ──
+  // In deep mode, each InstanceProgram (top-level AND every descendant)
+  // becomes its own LLVM function. The parent's body emits CreateCall
+  // to each child's function instead of inlining. All function symbols
+  // must exist BEFORE any function body is emitted, so we pre-declare
+  // every node's function first, then emit bodies in a second pass.
+  //
+  // `nested_to_emit` lists ONLY the descendants (not top-level), since
+  // top-level functions are created in the main emission loop below
+  // anyway and have the C++-scheduler-visible symbols.
+  std::unordered_map<const InstanceProgram *, llvm::Function *> node_to_fn;
+  std::vector<std::pair<const InstanceProgram *, llvm::Function *>> nested_to_emit;
+  if (deep) {
+    std::function<void(const InstanceProgram &, const std::string &)> declare_descendants =
+      [&](const InstanceProgram & inst, const std::string & path) {
+        for (std::size_t i = 0; i < inst.children.size(); ++i) {
+          const auto & child = inst.children[i];
+          const std::string sub_path = path + "_c" + std::to_string(i);
+          llvm::Function * child_fn = llvm::Function::Create(
+            per_sample_ty, llvm::Function::ExternalLinkage,
+            "mk_" + hash + sub_path, module.get());
+          node_to_fn[&child] = child_fn;
+          nested_to_emit.push_back({&child, child_fn});
+          declare_descendants(child, sub_path);
+        }
+      };
+    for (std::size_t i = 0; i < program.instance_functions.size(); ++i) {
+      declare_descendants(program.instance_functions[i], "_inst_" + std::to_string(i));
+    }
+  }
+
+  // ── Emit one PerSampleFn from one InstanceProgram (preamble + per-child {pre_input + child} + main + writebacks) ──
+  // Shallow mode (`deep_child_fns == nullptr`): emit_kernel_block
+  // recurses inline — one LLVM function per top-level session
+  // instance, children inlined.
+  // Deep mode (`deep_child_fns` populated): emit_kernel_block emits
+  // CreateCall to each child's pre-declared function. The C++
+  // scheduler still only iterates top-level instances; the recursive
+  // tree of calls happens entirely in LLVM IR.
   auto emit_instance_function = [&](
-    const std::string & sym,
+    llvm::Function * fn,
     const InstanceProgram & inst) -> llvm::Error
   {
-    llvm::Function * fn = llvm::Function::Create(
-      per_sample_ty, llvm::Function::ExternalLinkage, sym, module.get());
     EmitCtx ctx;
     emit_ctx_init_module(ctx, *context, builder, *module);
     ctx.fn          = fn;
     ctx.program     = &program;
     ctx.param_index = &param_index;
     ctx.temp_types  = &temp_types;
+    ctx.deep_child_fns = deep ? &node_to_fn : nullptr;
     bind_per_sample_args(fn, ctx);
 
     llvm::BasicBlock * entry = llvm::BasicBlock::Create(*context, "entry", fn);
@@ -1532,7 +1598,7 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
 
     if (llvm::verifyFunction(*fn, &llvm::errs()))
       return llvm::make_error<llvm::StringError>(
-        "compile_microkernel: invalid IR in " + sym,
+        "compile_microkernel: invalid IR in " + std::string(fn->getName()),
         llvm::inconvertibleErrorCode());
     return llvm::Error::success();
   };
@@ -1595,24 +1661,54 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
   };
 
   // ── Emit all functions ──
-  // One LLVM function per top-level session instance, with nested
-  // children inlined recursively via emit_kernel_block. Plus preamble,
-  // state_evolution, and postamble_mix as their own functions.
+  // Both modes emit one LLVM function per top-level session instance;
+  // the C++ scheduler iterates only those. The shapes differ inside:
+  // shallow inlines nested children; deep emits each nested child as
+  // its own LLVM function and the parent calls them via CreateCall.
+  // Either way, preamble / state_evolution / postamble_mix are their
+  // own functions.
   const std::string sym_preamble        = "mk_" + hash + "_preamble";
   const std::string sym_state_evolution = "mk_" + hash + "_state_evo";
   const std::string sym_postamble_mix   = "mk_" + hash + "_postamble_mix";
+
+  // Top-level instance function names. The C++ scheduler dispatches
+  // these in source order per sample.
   std::vector<std::string> sym_instances;
   sym_instances.reserve(program.instance_functions.size());
-  for (std::size_t i = 0; i < program.instance_functions.size(); ++i)
-    sym_instances.push_back("mk_" + hash + "_inst_" + std::to_string(i));
+  std::vector<llvm::Function *> top_fns;
+  top_fns.reserve(program.instance_functions.size());
+  for (std::size_t i = 0; i < program.instance_functions.size(); ++i) {
+    const std::string sym = "mk_" + hash + "_inst_" + std::to_string(i);
+    sym_instances.push_back(sym);
+    llvm::Function * fn = llvm::Function::Create(
+      per_sample_ty, llvm::Function::ExternalLinkage, sym, module.get());
+    if (deep) {
+      // Register the top-level function in node_to_fn too, in case any
+      // sibling references it (shouldn't normally happen — children
+      // can't reference top-level instances — but the map is the
+      // authoritative lookup for child dispatches).
+      node_to_fn[&program.instance_functions[i]] = fn;
+    }
+    top_fns.push_back(fn);
+  }
 
-  // Emit in the order the scheduler will call them so that the
-  // temp_types table is built up consistently with the runtime
-  // dispatch sequence.
+  // Emit in scheduler-call order so temp_types builds up consistently
+  // with the runtime dispatch sequence.
   if (auto err = emit_per_sample_function(sym_preamble, program.scheduler.preamble))
     return std::move(err);
+  // In deep mode, emit nested-child function bodies first (any order is
+  // safe — they all call into each other via pre-declared symbols),
+  // then top-levels. Bodies don't depend on emission order because
+  // cross-function data flow uses the unified slot/state-reg arrays,
+  // not LLVM SSA across function boundaries.
+  if (deep) {
+    for (const auto & [inst_ptr, fn] : nested_to_emit) {
+      if (auto err = emit_instance_function(fn, *inst_ptr))
+        return std::move(err);
+    }
+  }
   for (std::size_t i = 0; i < program.instance_functions.size(); ++i) {
-    if (auto err = emit_instance_function(sym_instances[i], program.instance_functions[i]))
+    if (auto err = emit_instance_function(top_fns[i], program.instance_functions[i]))
       return std::move(err);
   }
   if (auto err = emit_per_sample_function(sym_state_evolution, program.scheduler.state_evolution))

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -294,11 +294,22 @@ class OrcJitEngine
     llvm::Expected<NumericKernelFn> compile_flat_program(
       const FlatProgram & program);
 
-    /** Microkernel-mode codegen: N+1 LLVM functions in one module.
-     *  Phase 3 supplies the implementation; Phase 2 lands the type
-     *  surface and a stub that errors. */
+    /** Microkernel-mode codegen: N+3 LLVM functions in one module.
+     *
+     *  `deep = false` (default): one function per top-level session
+     *  instance, with nested children inlined into the parent's
+     *  function via recursive emit_kernel_block. Cache prefix:
+     *  "flat5:mk:".
+     *
+     *  `deep = true`: one function per InstanceProgram at EVERY
+     *  nesting depth. The tree is post-order flattened so children
+     *  emit (and dispatch) before their parents — the unified
+     *  temp/slot dataflow stays intact. Cache prefix: "flat5:mkd:".
+     *  Requires the plan to carry non-empty `children` arrays
+     *  (i.e., the session was compiled with inlineNested:false). */
     llvm::Expected<MicrokernelKernels> compile_microkernel(
-      const FlatProgram & program);
+      const FlatProgram & program,
+      bool deep = false);
 
   private:
     OrcJitEngine();

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -180,19 +180,30 @@ struct FlatProgram
 
 // Engine realization strategy.
 //
-//   Fused       — one monolithic LLVM kernel function that inlines every
-//                 instance body inside the outer sample loop. Legacy
-//                 default; consumed by FlatRuntime via NumericKernelFn.
-//   Microkernel — N+1 LLVM functions in one module (preamble, N per-
-//                 instance kernels, state_evolution, postamble_mix);
-//                 the C++ scheduler dispatches them via function
-//                 pointers per sample. Consumed by FlatRuntime via
-//                 MicrokernelKernels.
+//   Fused           — one monolithic LLVM kernel function that inlines
+//                     every instance body inside the outer sample loop.
+//                     Legacy default; consumed by FlatRuntime via
+//                     NumericKernelFn.
+//   Microkernel     — N+3 LLVM functions in one module (preamble, N per-
+//                     instance kernels, state_evolution, postamble_mix);
+//                     the C++ scheduler dispatches them via function
+//                     pointers per sample. Top-level session instances
+//                     each get their own function; nested children are
+//                     inlined into their parent's function. Consumed by
+//                     FlatRuntime via MicrokernelKernels.
+//   MicrokernelDeep — like Microkernel, but children are also emitted
+//                     as their own LLVM functions instead of being
+//                     inlined — one function per `InstanceProgram` at
+//                     every nesting depth. Requires plans with non-
+//                     empty `children` arrays. Codegen lands in a
+//                     follow-up (Phase 2); the parser accepts the value
+//                     so plans round-trip, but the compile path throws
+//                     "not yet implemented" if asked to realize it.
 //
 // Distinguished by *return type* from the compiler, not by a runtime
 // flag — the cache must be partitioned by mode so a fused-mode cache
 // hit cannot satisfy a microkernel-mode query.
-enum class CompilationMode : uint8_t { Fused, Microkernel };
+enum class CompilationMode : uint8_t { Fused, Microkernel, MicrokernelDeep };
 
 // ── Fused-mode kernel signature ──
 // `slots` (M6+) is the shared inter-module slot array passed by

--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -26,7 +26,19 @@ bool FlatRuntime::load_plan(const std::string & plan_json)
 
   KernelState new_state;
   new_state.mode = parsed.compilation_mode;
-  if (parsed.compilation_mode == tropical_jit::CompilationMode::Microkernel)
+  if (parsed.compilation_mode == tropical_jit::CompilationMode::MicrokernelDeep)
+  {
+    // Schema is wired through (Phase 1); codegen lands in Phase 2.
+    // Fail loudly rather than silently falling back to a different
+    // mode — the cache-key partitioning and the deep-mode dispatch
+    // surface aren't there yet, so any silent fallback would produce
+    // wrong results.
+    throw std::runtime_error(
+      "FlatRuntime: compilation_mode 'microkernel-deep' is not yet "
+      "implemented in the engine (Phase 2). The schema is wired and "
+      "plans round-trip, but the JIT cannot realize this mode yet.");
+  }
+  else if (parsed.compilation_mode == tropical_jit::CompilationMode::Microkernel)
   {
     auto mk_result = tropical_jit::OrcJitEngine::instance().compile_microkernel(parsed.program);
     if (!mk_result)

--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -26,27 +26,21 @@ bool FlatRuntime::load_plan(const std::string & plan_json)
 
   KernelState new_state;
   new_state.mode = parsed.compilation_mode;
-  if (parsed.compilation_mode == tropical_jit::CompilationMode::MicrokernelDeep)
+  if (parsed.compilation_mode == tropical_jit::CompilationMode::Microkernel
+      || parsed.compilation_mode == tropical_jit::CompilationMode::MicrokernelDeep)
   {
-    // Schema is wired through (Phase 1); codegen lands in Phase 2.
-    // Fail loudly rather than silently falling back to a different
-    // mode — the cache-key partitioning and the deep-mode dispatch
-    // surface aren't there yet, so any silent fallback would produce
-    // wrong results.
-    throw std::runtime_error(
-      "FlatRuntime: compilation_mode 'microkernel-deep' is not yet "
-      "implemented in the engine (Phase 2). The schema is wired and "
-      "plans round-trip, but the JIT cannot realize this mode yet.");
-  }
-  else if (parsed.compilation_mode == tropical_jit::CompilationMode::Microkernel)
-  {
-    auto mk_result = tropical_jit::OrcJitEngine::instance().compile_microkernel(parsed.program);
+    const bool deep =
+      parsed.compilation_mode == tropical_jit::CompilationMode::MicrokernelDeep;
+    auto mk_result = tropical_jit::OrcJitEngine::instance().compile_microkernel(parsed.program, deep);
     if (!mk_result)
     {
       std::string err;
       llvm::handleAllErrors(mk_result.takeError(),
         [&err](const llvm::ErrorInfoBase & e) { err = e.message(); });
-      throw std::runtime_error("FlatRuntime: microkernel JIT compilation failed: " + err);
+      throw std::runtime_error(
+        std::string("FlatRuntime: ") +
+        (deep ? "microkernel-deep" : "microkernel") +
+        " JIT compilation failed: " + err);
     }
     new_state.microkernels = *mk_result;
   }
@@ -116,8 +110,9 @@ bool FlatRuntime::load_plan(const std::string & plan_json)
   // surface flips a session between fused and microkernel for A/B
   // testing); state transfer by name is mode-agnostic.
   const bool old_has_kernel =
-    (old_state.mode == tropical_jit::CompilationMode::Fused      && old_state.kernel != nullptr) ||
-    (old_state.mode == tropical_jit::CompilationMode::Microkernel && old_state.microkernels.preamble != nullptr);
+    (old_state.mode == tropical_jit::CompilationMode::Fused          && old_state.kernel != nullptr) ||
+    (old_state.mode == tropical_jit::CompilationMode::Microkernel    && old_state.microkernels.preamble != nullptr) ||
+    (old_state.mode == tropical_jit::CompilationMode::MicrokernelDeep && old_state.microkernels.preamble != nullptr);
   if (old_has_kernel)
   {
     const auto mapping       = compute_register_mapping(old_state, new_state);

--- a/engine/runtime/FlatRuntime.hpp
+++ b/engine/runtime/FlatRuntime.hpp
@@ -108,12 +108,15 @@ public:
 
     KernelState & state = states_[state_idx];
 
-    // No active kernel — emit silence (covers both fused and microkernel
-    // modes; the "no kernel" predicate is mode-specific).
+    // No active kernel — emit silence (covers fused, microkernel, and
+    // microkernel-deep modes; the "no kernel" predicate is mode-
+    // specific).
     const bool fused_ready = state.mode == tropical_jit::CompilationMode::Fused
                           && state.kernel != nullptr;
-    const bool mk_ready    = state.mode == tropical_jit::CompilationMode::Microkernel
-                          && state.microkernels.preamble != nullptr;
+    const bool mk_ready    =
+      (state.mode == tropical_jit::CompilationMode::Microkernel
+       || state.mode == tropical_jit::CompilationMode::MicrokernelDeep)
+      && state.microkernels.preamble != nullptr;
     if (!fused_ready && !mk_ready)
     {
       std::fill(outputBuffer.begin(), outputBuffer.end(), 0.0);

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -156,8 +156,9 @@ inline tropical_jit::CompilationMode parse_compilation_mode(const nlohmann::json
 {
   if (!plan.contains("compilation_mode")) return tropical_jit::CompilationMode::Fused;
   const std::string s = plan["compilation_mode"].get<std::string>();
-  if (s == "fused")       return tropical_jit::CompilationMode::Fused;
-  if (s == "microkernel") return tropical_jit::CompilationMode::Microkernel;
+  if (s == "fused")             return tropical_jit::CompilationMode::Fused;
+  if (s == "microkernel")       return tropical_jit::CompilationMode::Microkernel;
+  if (s == "microkernel-deep")  return tropical_jit::CompilationMode::MicrokernelDeep;
   throw std::runtime_error("NumericProgramParser: unknown compilation_mode '" + s + "'");
 }
 

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -912,24 +912,20 @@ static void test_microkernel_mode_sawtooth()
 }
 
 /**
- * 14. Microkernel-deep mode (Phase 1) — the schema is wired through
- *     but the engine doesn't yet realize this mode; loading a plan
- *     with `compilation_mode: "microkernel-deep"` must return false
- *     and surface a "not yet implemented" message via
- *     tropical_last_error. Phase 2 lands the codegen and updates this
- *     test to a positive equivalence assertion (mirroring
- *     test_microkernel_mode_sawtooth).
+ * 14. Microkernel-deep mode — same sawtooth plan as test 1, with
+ *     compilation_mode: "microkernel-deep". For a single-instance
+ *     plan (no nested children), deep mode is structurally identical
+ *     to shallow microkernel mode — one LLVM function for the lone
+ *     top-level instance — and the engine must produce the same
+ *     output. The TS-side equivalence suite covers the truly nested
+ *     cases (depth-2 stdlib programs) across the full corpus.
  */
-static void test_microkernel_deep_not_yet_implemented()
+static void test_microkernel_deep_sawtooth()
 {
   const unsigned int buf_len = 256;
   tropical_runtime_t rt = tropical_runtime_new(buf_len);
   ASSERT(rt != nullptr);
 
-  // Same plan shape as the microkernel sawtooth test, just the mode
-  // string differs. Plan_4 auto-lifts to one-instance plan_5; either
-  // way the engine sees compilation_mode = MicrokernelDeep and must
-  // refuse to compile.
   std::string plan = R"({
     "schema": "tropical_plan_4",
     "compilation_mode": "microkernel-deep",
@@ -938,36 +934,39 @@ static void test_microkernel_deep_not_yet_implemented()
     "register_names": ["phase"],
     "outputs": [0],
     "instructions": [
-      {"tag":"Add","dst":0,"args":[{"kind":"state_reg","slot":0},{"kind":"const","val":0.0}],"loop_count":1,"strides":[]}
+      {"tag":"Mul","dst":0,"args":[{"kind":"state_reg","slot":0},{"kind":"const","val":2.0}],"loop_count":1,"strides":[]},
+      {"tag":"Sub","dst":1,"args":[{"kind":"reg","slot":0},{"kind":"const","val":1.0}],"loop_count":1,"strides":[]},
+      {"tag":"Mul","dst":2,"args":[{"kind":"reg","slot":1},{"kind":"const","val":10.0}],"loop_count":1,"strides":[]},
+      {"tag":"Add","dst":3,"args":[{"kind":"reg","slot":2},{"kind":"const","val":0.0}],"loop_count":1,"strides":[]},
+      {"tag":"Div","dst":4,"args":[{"kind":"const","val":440.0},{"kind":"rate"}],"loop_count":1,"strides":[]},
+      {"tag":"Add","dst":5,"args":[{"kind":"state_reg","slot":0},{"kind":"reg","slot":4}],"loop_count":1,"strides":[]},
+      {"tag":"Mod","dst":6,"args":[{"kind":"reg","slot":5},{"kind":"const","val":1.0}],"loop_count":1,"strides":[]},
+      {"tag":"Add","dst":7,"args":[{"kind":"reg","slot":6},{"kind":"const","val":0.0}],"loop_count":1,"strides":[]}
     ],
-    "register_count": 1,
+    "register_count": 8,
     "array_slot_count": 0,
     "array_slot_sizes": [],
-    "output_targets": [0],
-    "register_targets": [0]
+    "output_targets": [3],
+    "register_targets": [7]
   })";
 
-  bool ok = tropical_runtime_load_plan(rt, plan.c_str(), plan.size());
-  if (ok) {
-    printf("FAIL\n    expected load_plan to fail for microkernel-deep "
-           "(Phase 1 throws 'not yet implemented')\n");
-    ++g_fail;
-    tropical_runtime_free(rt);
-    return;
-  }
+  ASSERT_OK(tropical_runtime_load_plan(rt, plan.c_str(), plan.size()));
+  tropical_runtime_process(rt);
 
-  const char* err = tropical_last_error();
-  ASSERT(err != nullptr);
-  // Match on a substring the throw site emits. If the message
-  // changes, update both this test and the throw site.
-  if (std::string(err).find("microkernel-deep") == std::string::npos ||
-      std::string(err).find("not yet implemented") == std::string::npos)
-  {
-    printf("FAIL\n    expected error to mention 'microkernel-deep' and "
-           "'not yet implemented'; got: %s\n", err);
-    ++g_fail;
-    tropical_runtime_free(rt);
-    return;
+  const double* buf = tropical_runtime_output_buffer(rt);
+  ASSERT(buf != nullptr);
+
+  // Same expectations as test_sawtooth / test_microkernel_mode_sawtooth:
+  // sample 0 audio = -0.5; sample 1 follows from the phase increment.
+  ASSERT_NEAR(buf[0], -0.5, 1e-6);
+
+  double phase1 = 440.0 / 44100.0;
+  double expected1 = (phase1 * 2.0 - 1.0) * 10.0 / 20.0;
+  ASSERT_NEAR(buf[1], expected1, 1e-6);
+
+  // Monotonic increase before the first phase wrap.
+  for (unsigned int i = 1; i < 50; ++i) {
+    ASSERT(buf[i] > buf[i - 1]);
   }
 
   tropical_runtime_free(rt);
@@ -992,7 +991,7 @@ int main()
   run_test("float→int register writeback coercion", test_float_to_int_register_writeback);
   run_test("cast ops (to_int/to_bool/to_float)", test_cast_ops);
   run_test("microkernel mode — sawtooth",    test_microkernel_mode_sawtooth);
-  run_test("microkernel-deep — not yet implemented (Phase 1)", test_microkernel_deep_not_yet_implemented);
+  run_test("microkernel-deep — sawtooth",   test_microkernel_deep_sawtooth);
 
   printf("\n  %d passed, %d failed\n", g_pass, g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -911,6 +911,68 @@ static void test_microkernel_mode_sawtooth()
   tropical_runtime_free(rt);
 }
 
+/**
+ * 14. Microkernel-deep mode (Phase 1) — the schema is wired through
+ *     but the engine doesn't yet realize this mode; loading a plan
+ *     with `compilation_mode: "microkernel-deep"` must return false
+ *     and surface a "not yet implemented" message via
+ *     tropical_last_error. Phase 2 lands the codegen and updates this
+ *     test to a positive equivalence assertion (mirroring
+ *     test_microkernel_mode_sawtooth).
+ */
+static void test_microkernel_deep_not_yet_implemented()
+{
+  const unsigned int buf_len = 256;
+  tropical_runtime_t rt = tropical_runtime_new(buf_len);
+  ASSERT(rt != nullptr);
+
+  // Same plan shape as the microkernel sawtooth test, just the mode
+  // string differs. Plan_4 auto-lifts to one-instance plan_5; either
+  // way the engine sees compilation_mode = MicrokernelDeep and must
+  // refuse to compile.
+  std::string plan = R"({
+    "schema": "tropical_plan_4",
+    "compilation_mode": "microkernel-deep",
+    "config": { "sampleRate": 44100.0 },
+    "state_init": [0.0],
+    "register_names": ["phase"],
+    "outputs": [0],
+    "instructions": [
+      {"tag":"Add","dst":0,"args":[{"kind":"state_reg","slot":0},{"kind":"const","val":0.0}],"loop_count":1,"strides":[]}
+    ],
+    "register_count": 1,
+    "array_slot_count": 0,
+    "array_slot_sizes": [],
+    "output_targets": [0],
+    "register_targets": [0]
+  })";
+
+  bool ok = tropical_runtime_load_plan(rt, plan.c_str(), plan.size());
+  if (ok) {
+    printf("FAIL\n    expected load_plan to fail for microkernel-deep "
+           "(Phase 1 throws 'not yet implemented')\n");
+    ++g_fail;
+    tropical_runtime_free(rt);
+    return;
+  }
+
+  const char* err = tropical_last_error();
+  ASSERT(err != nullptr);
+  // Match on a substring the throw site emits. If the message
+  // changes, update both this test and the throw site.
+  if (std::string(err).find("microkernel-deep") == std::string::npos ||
+      std::string(err).find("not yet implemented") == std::string::npos)
+  {
+    printf("FAIL\n    expected error to mention 'microkernel-deep' and "
+           "'not yet implemented'; got: %s\n", err);
+    ++g_fail;
+    tropical_runtime_free(rt);
+    return;
+  }
+
+  tropical_runtime_free(rt);
+}
+
 // ---- main -------------------------------------------------------------------
 
 int main()
@@ -930,6 +992,7 @@ int main()
   run_test("float→int register writeback coercion", test_float_to_int_register_writeback);
   run_test("cast ops (to_int/to_bool/to_float)", test_cast_ops);
   run_test("microkernel mode — sawtooth",    test_microkernel_mode_sawtooth);
+  run_test("microkernel-deep — not yet implemented (Phase 1)", test_microkernel_deep_not_yet_implemented);
 
   printf("\n  %d passed, %d failed\n", g_pass, g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -8,7 +8,7 @@ via `bun run`, not `bun test` — these are scripts, not assertions.
 | `compile.ts`               | TS-pipeline-only cost. Times `compileSession` end-to-end on a fixed 13-module patch and per-module to find bottlenecks. |
 | `jit_runtime.ts`           | End-to-end: TS pipeline → JSON.stringify → JIT loadPlan → `runtime.process` loop. Per-patch ns/sample and realtime ratio. Wipes the kernel cache for cold compiles. |
 | `wasm_vs_jit.ts`           | Head-to-head: same FlatPlan compiled through both backends. Compile-time (TS, WASM emit/instantiate, JIT load) and runtime (ns/sample). |
-| `microkernel_vs_fused.ts`  | Head-to-head: same session compiled in `fused` mode vs `microkernel` mode. Per-mode ns/sample, compile latency, and rt-ratio across small/medium/polyphony cases. |
+| `microkernel_vs_fused.ts`  | Head-to-head: same session compiled in `fused`, `microkernel`, and `microkernel-deep` modes. Per-mode ns/sample, compile latency, and rt-ratio across small/medium/polyphony cases. Polyphony cases use `inlineNested:false` so deep mode actually exercises per-sub-instance dispatch (e.g. each SinOsc voice's nested Sin child is its own LLVM function); patch-file cases use the default `inlineNested:true` and deep mode degenerates to shallow there. |
 | `corpus.ts`                | Shared list of patches that currently compile through `compileSession`. Other patches in `patches/` are blocked on known limitations (see file). |
 
 ## Snapshots

--- a/tests/bench/microkernel_vs_fused.ts
+++ b/tests/bench/microkernel_vs_fused.ts
@@ -1,11 +1,17 @@
 /**
  * microkernel_vs_fused.ts — head-to-head runtime + compile benchmark.
  *
- * For each patch, compile and run twice — once in `fused` mode (single
- * monolithic LLVM kernel, the legacy default), once in `microkernel`
- * mode (N+3 per-sample functions dispatched by FlatRuntime). Report
- * ns/sample, rt_ratio (% of 44.1kHz sample period), and TS+JIT
- * compile-latency deltas per mode per patch.
+ * For each case, compile and run three times — once each in `fused`,
+ * `microkernel`, and `microkernel-deep` mode. Report ns/sample,
+ * rt_ratio (% of 44.1kHz sample period), and TS+JIT compile-latency
+ * deltas per mode per case.
+ *
+ * For deep mode to actually exercise per-sub-instance dispatch, the
+ * session must be constructed with `inlineNested: false` so the
+ * post-strata IR carries non-empty `children` arrays. The factory
+ * for each case below sets this; for patch-file cases that don't,
+ * deep mode degenerates to shallow microkernel (same dispatch shape,
+ * different cache prefix) and the slowdown ratio will be ~1.0×.
  *
  * Usage:  bun run tests/bench/microkernel_vs_fused.ts [--frames=N] [--keep-cache]
  *
@@ -115,6 +121,9 @@ function benchSession(
 }
 
 // ── Patch-file cases ──────────────────────────────────────────────────
+// Patch-file factories use makeSession() with default inlineNested:true.
+// For deep mode this means children are absent from the IR; deep mode
+// degenerates to shallow (same shape, different cache prefix).
 function patchSessionFactory(patchPath: string) {
   const json = JSON.parse(readFileSync(patchPath, 'utf-8'))
   return () => {
@@ -126,9 +135,14 @@ function patchSessionFactory(patchPath: string) {
 }
 
 // ── Polyphony case: N independent SinOsc voices, freq-spread ──────────
-function polyphonySessionFactory(voiceCount: number) {
+// Polyphony factory takes `inlineNested` so the same shape can be
+// benched under both flat and nested IR. Deep mode requires nested
+// (otherwise it degenerates to shallow); shallow + fused work fine on
+// either, but the apples-to-apples comparison needs all three on the
+// same IR shape.
+function polyphonySessionFactory(voiceCount: number, inlineNested: boolean) {
   return () => {
-    const session = makeSession(FRAME_SIZE)
+    const session = makeSession(FRAME_SIZE, { inlineNested })
     loadBuiltins(session)
     const { type, typeArgs } = resolveProgramType(session, 'SinOsc', undefined, undefined)
     for (let i = 0; i < voiceCount; i++) {
@@ -152,15 +166,18 @@ interface BenchCase {
 
 // Polyphony at multiple sizes shows how dispatch cost scales with
 // instance count — the property that matters most for the per-voice
-// microkernel roadmap.
+// microkernel roadmap. Polyphony cases use inlineNested:false so deep
+// mode can actually dispatch through the per-voice tree (each SinOsc
+// has a nested Sin child); the patch-file cases use the default
+// inlineNested:true and deep mode degenerates to shallow there.
 const CASES: BenchCase[] = [
-  { name: 'bubble_drip',         factory: patchSessionFactory(resolve('patches/bubble_drip.json')) },
-  { name: 'cross_fm_4',          factory: patchSessionFactory(resolve('patches/cross_fm_4.json')) },
-  { name: 'odd_harmonics',       factory: patchSessionFactory(resolve('patches/odd_harmonics.json')) },
-  { name: 'polyphony_4x_SinOsc', factory: polyphonySessionFactory(4) },
-  { name: 'polyphony_8x_SinOsc', factory: polyphonySessionFactory(8) },
-  { name: 'polyphony_16x_SinOsc', factory: polyphonySessionFactory(16) },
-  { name: 'polyphony_32x_SinOsc', factory: polyphonySessionFactory(32) },
+  { name: 'bubble_drip',          factory: patchSessionFactory(resolve('patches/bubble_drip.json')) },
+  { name: 'cross_fm_4',           factory: patchSessionFactory(resolve('patches/cross_fm_4.json')) },
+  { name: 'odd_harmonics',        factory: patchSessionFactory(resolve('patches/odd_harmonics.json')) },
+  { name: 'polyphony_4x_SinOsc',  factory: polyphonySessionFactory(4,  false) },
+  { name: 'polyphony_8x_SinOsc',  factory: polyphonySessionFactory(8,  false) },
+  { name: 'polyphony_16x_SinOsc', factory: polyphonySessionFactory(16, false) },
+  { name: 'polyphony_32x_SinOsc', factory: polyphonySessionFactory(32, false) },
 ]
 
 const COLS = [
@@ -170,8 +187,10 @@ const COLS = [
 ]
 console.log(COLS.join('\t'))
 
+const MODES = ['fused', 'microkernel', 'microkernel-deep'] as const
+
 for (const c of CASES) {
-  for (const mode of ['fused', 'microkernel'] as const) {
+  for (const mode of MODES) {
     try {
       const r = benchSession(c.name, c.factory, mode)
       results.push(r)
@@ -194,39 +213,52 @@ for (const c of CASES) {
 }
 
 // ── Compute mode deltas for the report ────────────────────────────────
-const deltas: Array<{
+// Deep-mode slowdown is computed relative to BOTH fused (the prod
+// baseline) and shallow microkernel (the closest neighbor). The
+// shallow→deep delta is the "deep-dispatch overhead in isolation."
+interface ModeDelta {
   case:           string
   instances:      number
   fused_ns:       number
   microkernel_ns: number
-  slowdown:       number     // microkernel / fused; >1 means microkernel is slower
-  fused_jit_ms:   number
-  microkernel_jit_ms: number
-}> = []
+  deep_ns:        number
+  slowdown_mk:    number  // microkernel / fused
+  slowdown_deep:  number  // deep / fused
+  slowdown_deep_vs_mk: number  // deep / microkernel (incremental cost of going deep)
+  fused_jit_ms:        number
+  microkernel_jit_ms:  number
+  deep_jit_ms:         number
+}
+const deltas: ModeDelta[] = []
 for (const c of CASES) {
   const f = results.find(r => r.case === c.name && r.mode === 'fused')
   const m = results.find(r => r.case === c.name && r.mode === 'microkernel')
-  if (f && m) {
+  const d = results.find(r => r.case === c.name && r.mode === 'microkernel-deep')
+  if (f && m && d) {
     deltas.push({
       case:               c.name,
       instances:          f.instances,
       fused_ns:           f.ns_per_sample,
       microkernel_ns:     m.ns_per_sample,
-      slowdown:           m.ns_per_sample / f.ns_per_sample,
+      deep_ns:            d.ns_per_sample,
+      slowdown_mk:        m.ns_per_sample / f.ns_per_sample,
+      slowdown_deep:      d.ns_per_sample / f.ns_per_sample,
+      slowdown_deep_vs_mk: d.ns_per_sample / m.ns_per_sample,
       fused_jit_ms:       f.jit_ms,
       microkernel_jit_ms: m.jit_ms,
+      deep_jit_ms:        d.jit_ms,
     })
   }
 }
 
-console.log('\nDeltas (microkernel / fused):')
+console.log('\nDeltas (slowdown vs fused; deep vs mk shown separately):')
 for (const d of deltas) {
   console.log(
     `  ${d.case.padEnd(22)} ` +
-    `${d.instances}×inst  ` +
-    `ns: ${d.fused_ns.toFixed(1)} → ${d.microkernel_ns.toFixed(1)} ` +
-    `(${d.slowdown.toFixed(2)}×)  ` +
-    `jit: ${d.fused_jit_ms.toFixed(0)} → ${d.microkernel_jit_ms.toFixed(0)} ms`,
+    `${String(d.instances).padStart(3)}×inst  ` +
+    `ns: ${d.fused_ns.toFixed(1).padStart(6)} → mk ${d.microkernel_ns.toFixed(1).padStart(6)} (${d.slowdown_mk.toFixed(2)}×) ` +
+    `→ deep ${d.deep_ns.toFixed(1).padStart(6)} (${d.slowdown_deep.toFixed(2)}× | ${d.slowdown_deep_vs_mk.toFixed(2)}× vs mk)  ` +
+    `jit: ${d.fused_jit_ms.toFixed(0)} / ${d.microkernel_jit_ms.toFixed(0)} / ${d.deep_jit_ms.toFixed(0)} ms`,
   )
 }
 

--- a/tests/equiv/microkernel_deep.test.ts
+++ b/tests/equiv/microkernel_deep.test.ts
@@ -1,0 +1,179 @@
+/**
+ * microkernel_deep.test.ts — three-way equivalence: fused JIT,
+ * shallow microkernel JIT, deep microkernel JIT.
+ *
+ * For each stdlib program in the equivalence corpus, compile and run
+ * the same nested-IR session three times — once with each
+ * `compilation_mode` — and assert sample-for-sample agreement across
+ * all three runs.
+ *
+ * All three sessions are constructed with `inlineNested: false` so the
+ * IR carries non-empty `children` arrays at every nesting level. This
+ * gives deep mode something to dispatch over (otherwise it
+ * degenerates to shallow microkernel mode for single-instance plans),
+ * and keeps fused / shallow comparisons honest — they consume the
+ * same nested plan as deep mode, just lower it to a single LLVM
+ * function (fused) or one-function-per-top-level-instance with
+ * inlined children (shallow).
+ *
+ * Depth-2 stdlib programs (Pow, OnePole, LadderFilter, Phaser,
+ * Phaser16, AllpassDelay, CombDelay, Delay, SVF) are where the
+ * deep-mode dispatch surface actually engages — they have nested
+ * InstanceDecls that survive as kernel boundaries under
+ * `inlineNested: false`.
+ *
+ * Requires libtropical.dylib (build with `make build` first).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, inputNames, outputNames } from '../../compiler/session.js'
+import type { ExprNode } from '../../compiler/expr.js'
+import { loadStdlib } from '../../compiler/program.js'
+import { applyFlatPlan } from '../../compiler/apply_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+import type { CompilationMode } from '../../compiler/flat_plan.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+
+const BUFFER_LENGTH  = 256
+const N_BUFFERS      = 4
+const TOTAL_SAMPLES  = BUFFER_LENGTH * N_BUFFERS
+const TOLERANCE      = 1e-12   // same-codegen-path tolerance
+
+function pulseEvery(n: number): ExprNode {
+  return { op: 'lt', args: [{ op: 'mod', args: [{ op: 'sampleIndex' }, n] }, 1] }
+}
+
+const DEFAULT_INPUTS: Record<string, ExprNode> = {
+  freq: 220, x: 0.5, y: 0.5, audio: 0.5, input: 0.5, cv: 0.5,
+  cutoff: 1000, q: 0.5, drive: 1.0, mix: 0.5, a: 0.3, b: 0.7,
+  coeff: 0.4, feedback: 0.4, lfo_speed: 0.2, decay: 0.99,
+  rate: 5, g: 0.1, resonance: 0.5,
+  trigger: pulseEvery(64), clock: pulseEvery(32),
+}
+
+// Corpus mirrors microkernel_vs_fused but emphasizes depth-2 programs
+// where the deep-mode dispatch surface actually engages. Bubble /
+// BubbleCloud were the Phase-4 nested-mode gap closed by PR #158;
+// included here as regression coverage.
+const STDLIB_TARGETS: Array<[string, Record<string, number>?]> = [
+  ['SinOsc'], ['Sin'], ['Cos'], ['Tanh'], ['Exp'], ['Log'], ['Pow'],
+  ['OnePole'], ['BlepSaw'], ['SoftClip'], ['VCA'], ['CrossFade'],
+  ['SVF'], ['LadderFilter'], ['Phaser'], ['Phaser16'],
+  ['Bubble'], ['BubbleCloud'],
+  ['AllpassDelay'], ['CombDelay'],
+  ['Delay', { N: 1024 }],
+]
+
+function setupInstance(
+  typeName: string,
+  typeArgs?: Record<string, number>,
+) {
+  // inlineNested:false so the post-strata IR carries the children we
+  // want deep mode to dispatch over. Fused and shallow microkernel
+  // both happily consume the same shape — they just emit different
+  // LLVM code.
+  const session = makeSession(BUFFER_LENGTH, { inlineNested: false })
+  loadStdlib(session)
+  const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: typeName, typeArgs: resolved })
+  session.instanceRegistry.set('inst', inst)
+  for (const portName of inputNames(inst)) {
+    if (portName in DEFAULT_INPUTS) {
+      session.inputExprNodes.set(wk('inst', portName), DEFAULT_INPUTS[portName])
+    }
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
+function captureOutput(
+  session: ReturnType<typeof setupInstance>,
+  mode: CompilationMode,
+): Float64Array {
+  applyFlatPlan(session, session.runtime, { compilation_mode: mode })
+  session.graph.primeJit()
+  const out = new Float64Array(TOTAL_SAMPLES)
+  for (let f = 0; f < N_BUFFERS; f++) {
+    session.runtime.process()
+    const buf = session.runtime.outputBuffer
+    out.set(buf.subarray(0, BUFFER_LENGTH), f * BUFFER_LENGTH)
+  }
+  return out
+}
+
+function maxAbsDiff(a: Float64Array, b: Float64Array): { maxAbsDiff: number, firstDiffIdx: number } {
+  let maxAbsDiff = 0
+  let firstDiffIdx = -1
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    const x = a[i], y = b[i]
+    if (Number.isNaN(x) && Number.isNaN(y)) continue
+    const d = Math.abs(x - y)
+    if (d > maxAbsDiff) maxAbsDiff = d
+    if (d > TOLERANCE && firstDiffIdx < 0) firstDiffIdx = i
+  }
+  return { maxAbsDiff, firstDiffIdx }
+}
+
+describe('microkernel-deep stdlib equivalence (three-way: fused / shallow / deep)', () => {
+  for (const [typeName, typeArgs] of STDLIB_TARGETS) {
+    test(`${typeName}${typeArgs ? `<${JSON.stringify(typeArgs)}>` : ''}`, () => {
+      // Three independent sessions so each mode starts from identical
+      // register/slot inits. Sharing a session across modes would
+      // invoke hot-swap state transfer, which is a separate axis.
+      const fusedOut    = captureOutput(setupInstance(typeName, typeArgs), 'fused')
+      const shallowOut  = captureOutput(setupInstance(typeName, typeArgs), 'microkernel')
+      const deepOut     = captureOutput(setupInstance(typeName, typeArgs), 'microkernel-deep')
+
+      // Deep vs fused
+      const dfDiff = maxAbsDiff(deepOut, fusedOut)
+      if (dfDiff.maxAbsDiff > TOLERANCE) {
+        const i = dfDiff.firstDiffIdx
+        throw new Error(
+          `${typeName}: deep/fused diverged at sample ${i} ` +
+          `(deep=${deepOut[i]}, fused=${fusedOut[i]}, maxAbsDiff=${dfDiff.maxAbsDiff})`,
+        )
+      }
+      expect(dfDiff.maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+
+      // Deep vs shallow microkernel
+      const dsDiff = maxAbsDiff(deepOut, shallowOut)
+      if (dsDiff.maxAbsDiff > TOLERANCE) {
+        const i = dsDiff.firstDiffIdx
+        throw new Error(
+          `${typeName}: deep/shallow-microkernel diverged at sample ${i} ` +
+          `(deep=${deepOut[i]}, shallow=${shallowOut[i]}, maxAbsDiff=${dsDiff.maxAbsDiff})`,
+        )
+      }
+      expect(dsDiff.maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+    })
+  }
+})
+
+// Polyphony: 8 SinOsc voices in one session. Each voice is a top-level
+// instance with a nested Sin child — deep mode dispatches 16 LLVM
+// functions (8 SinOsc + 8 Sin) where shallow dispatches 8 and fused
+// emits 1.
+describe('microkernel-deep polyphony (8x SinOsc voices)', () => {
+  test('all three modes agree', () => {
+    function setupPolyphony() {
+      const session = makeSession(BUFFER_LENGTH, { inlineNested: false })
+      loadStdlib(session)
+      const { type, typeArgs } = resolveProgramType(session, 'SinOsc', undefined, undefined)
+      for (let i = 0; i < 8; i++) {
+        const name = `osc${i}`
+        const inst = instantiate(type, name, { baseTypeName: 'SinOsc', typeArgs })
+        session.instanceRegistry.set(name, inst)
+        session.inputExprNodes.set(wk(name, 'freq'), 110 + 22 * i)
+        session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
+      }
+      return session
+    }
+    const fusedOut   = captureOutput(setupPolyphony(), 'fused')
+    const shallowOut = captureOutput(setupPolyphony(), 'microkernel')
+    const deepOut    = captureOutput(setupPolyphony(), 'microkernel-deep')
+
+    expect(maxAbsDiff(deepOut, fusedOut).maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+    expect(maxAbsDiff(deepOut, shallowOut).maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+  })
+})


### PR DESCRIPTION
## Summary

Full deep-microkernel-mode rollout: schema, engine codegen, equivalence tests, and benchmarks. Replaces what would have been four separate PRs with one. Per-phase commits below.

`microkernel-deep` emits one LLVM function per `InstanceProgram` at every nesting depth, rather than one per top-level session instance (`microkernel`) or one monolithic kernel (`fused`). The parent's body calls each child via `CreateCall`; the C++ scheduler still only iterates top-level instances.

## Commits

| Commit | Subject |
|---|---|
| `dfa9310` | feat(schema): add 'microkernel-deep' CompilationMode value |
| `edb1766` | feat(jit): emit per-sub-instance LLVM functions for microkernel-deep |
| `1ea2834` | test(equiv) + bench: deep-mode equivalence + three-way bench |

## Design note: LLVM-side dispatch (not C++-side)

The original env-var spike on `origin/microkernel-mode-spike` used post-order C++ dispatch — the C++ scheduler iterated all nodes (top-level + descendants) in post-order, with each LLVM function emitting only its own `instructions + writebacks`. That design predates PR #157's slot-based parent→child input wiring, where `pre_input_instructions` execute in the **parent's** scope (referencing parent regs/params, possibly sibling output slots). Post-order C++ dispatch would run children before the parent's preamble had built up the temps `pre_input` depends on, breaking the four-phase ordering.

This PR replaces that with LLVM-side dispatch: each `InstanceProgram` gets its own LLVM function, and the parent's function calls children via `CreateCall` between the parent's preamble and the parent's main instructions:

```
fn parent:
  preamble_instructions
  for each child:
    pre_input_instructions[child]    // in parent's scope, writes child's input slots
    call child_fn(args)               // child runs (recursively the same way)
  instructions
  writebacks
```

The C++ scheduler still only iterates top-level functions; the recursive tree of calls is encoded entirely in LLVM IR. This preserves the four-phase ordering and lets LLVM's optimizer inline calls when beneficial (it does this aggressively for the trivial cases like `SinOsc → Sin`).

## Verification

- **TS:** 1037/1045 pass (8 expected skips). +22 tests from `tests/equiv/microkernel_deep.test.ts`.
- **C++ ctest:** 14/14 pass. `microkernel-deep — sawtooth` is the smoke (single-instance degenerate case where deep ≡ shallow); the truly-nested coverage is in TS.
- **Equivalence:** fused / shallow microkernel / deep microkernel are sample-for-sample identical at 1e-12 across the stdlib corpus, including depth-2 cases (Pow, OnePole, LadderFilter, Phaser, Phaser16, AllpassDelay, CombDelay, Delay, SVF, Bubble, BubbleCloud) and 8× SinOsc polyphony.
- **`make validate`** green.

## Bench headline (M1, --frames=1024)

| case                       | fused ns | mk ns  | deep ns | deep/mk | fused jit | mk jit | deep jit |
|----------------------------|---------:|-------:|--------:|--------:|----------:|-------:|---------:|
| bubble_drip       (3 inst) |     50.7 |   65.7 |    67.8 |   1.03× |    0 ms   |  41 ms |   43 ms  |
| cross_fm_4        (8 inst) |     47.5 |   57.3 |    57.5 |   1.00× |    1 ms   |  30 ms |   30 ms  |
| odd_harmonics    (50 inst) |    174.5 |  220.5 |   220.4 |   1.00× |    2 ms   |  95 ms |   96 ms  |
| polyphony  4× SinOsc       |     25.0 |   41.1 |    41.3 |   1.00× |   36 ms   |  21 ms |   28 ms  |
| polyphony  8× SinOsc       |     64.1 |   85.4 |    85.7 |   1.00× |  109 ms   |  35 ms |   48 ms  |
| polyphony 16× SinOsc       |    132.0 |  174.8 |   174.8 |   1.00× |  293 ms   |  60 ms |   86 ms  |
| polyphony 32× SinOsc       |    320.5 |  357.8 |   369.7 |   1.03× |  797 ms   | 113 ms |  173 ms  |

**Key findings:**
- Deep's incremental overhead vs shallow is **~0%** in the trivial cases and **~3%** at 32 voices. The env-var spike's measured 6% was inflated by C++-side dispatch overhead that LLVM-side dispatch avoids.
- Cold JIT compile scales linearly with function count rather than the superlinear scaling fused mode hits. 32-voice polyphony cold compile: 797ms (fused) → 113ms (shallow) → 173ms (deep). Deep is 4.6× faster cold compile than fused at this scale despite emitting more LLVM functions.

## Known limitation (carried over from Phase 1)

The auto-flip in `compileSession` sets `session.inlineNested = false` when entering with `compilation_mode: 'microkernel-deep'`, but this only catches the materialize-time strata call. Program types loaded into the session BEFORE `compileSession` runs were strata-processed with whatever `inlineNested` was at load time. To exercise deep mode through nested program types, the caller currently needs to construct the session with `inlineNested: false` from the start. A future refinement may make `compilation_mode` a session-construction-time argument so the two stay coupled by design.

## Test plan

- [x] `make validate` — green
- [x] `bun test tests/equiv/microkernel_deep.test.ts` — 22/22 pass at 1e-12
- [x] `bun test tests/equiv/microkernel_vs_fused.test.ts` — still green (no regression)
- [x] `bun test tests/equiv/nested_vs_inlined.test.ts` — still green
- [x] `ctest --test-dir build` — 14/14 pass
- [x] `bun run tests/bench/microkernel_vs_fused.ts` — produces sensible numbers; deep mode shows ~0% incremental overhead vs shallow on most cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)