### PR TITLE
fix(ir): evaluate session-level feedback in the interpreter oracle

### DIFF
--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -97,6 +97,7 @@ function makeContext(session: SessionState): MaterializeContext {
     paramDecls:          new Map(),
     programRegistry:     new Map(),
     syntheticRegDecls:   [],
+    slotToReg:           new Map(),
     exprMemo:            new WeakMap(),
     session,
   }
@@ -122,6 +123,13 @@ interface MaterializeContext {
    *  one sample late. Named `__sd${idx}` for uniqueness within the
    *  session-level synthetic program. */
   syntheticRegDecls: RegDecl[]
+  /** Maps a session module-slot index (the `index` carried by a
+   *  `{op:'sessionSlot'}` read) to the RegIdx of the synthetic RegDecl
+   *  that reproduces that hoisted delay. Populated by
+   *  `materializeSessionDelaySlots` before any wire is translated, so
+   *  `sessionSlot` reads — including those nested inside another slot's
+   *  source expression — resolve to a stable reg. */
+  slotToReg: Map<number, RegIdx>
   exprMemo: WeakMap<object, ResolvedExpr>
   session: SessionState
 }
@@ -135,6 +143,11 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
     const decl = buildInstanceDecl(name, inst, ctx)
     ctx.instanceDecls.set(name, decl)
   }
+
+  // Reconstruct the synthetic RegDecls behind session-level delay
+  // slots before translating wires — a wire (or another slot's source)
+  // may read these slots via `{op:'sessionSlot'}`.
+  materializeSessionDelaySlots(session, ctx)
 
   for (const [key, expr] of session.inputExprNodes) {
     let ref
@@ -225,6 +238,72 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
     binderCount: 0,
     programRegistry: ctx.programRegistry,
   })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session delay slots → synthetic RegDecls
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Reconstruct synthetic `RegDecl`s for the session-level delay slots
+ *  that `extractSessionDelays` hoisted out of the wires into
+ *  `session.delaySlotRegistry` (rewriting each `delay()` to a
+ *  `{op:'sessionSlot', index}` read).
+ *
+ *  The JIT path emits one `WriteSlot` per registry entry in the
+ *  scheduler's `state_evolution` phase: the slot is read during the
+ *  sample and written, from the un-delayed source, at the end of the
+ *  sample. The interpreter oracle reproduces exactly this by giving
+ *  each scalar slot a synthetic `RegDecl` whose `update` is the
+ *  translated source expression and whose `init` seeds sample 0 — the
+ *  interpreter's read → snapshot-update → atomic-writeback loop
+ *  (`interpret_resolved.ts`) is the same unit-delay semantics, so the
+ *  oracle now agrees sample-for-sample with the JIT on session-level
+ *  feedback.
+ *
+ *  Reg idx equals position in `ctx.syntheticRegDecls` (the
+ *  front-of-body invariant from `materializeSessionInner`). Every
+ *  slot's reg is reserved first — populating `ctx.slotToReg` — before
+ *  any source expression is translated, because a source may itself
+ *  read another `sessionSlot` (nested `delay(delay(x))`). */
+function materializeSessionDelaySlots(
+  session: SessionState,
+  ctx: MaterializeContext,
+): void {
+  const regForSlot = new Map<number, RegDecl>()
+
+  // Pass 1: reserve a synthetic reg per scalar slot and record the
+  // slotIdx → RegIdx map (so cross-slot reads resolve in pass 2).
+  for (const entry of session.delaySlotRegistry) {
+    if (entry.isArray) {
+      throw new Error(
+        `interpret_resolved: session-level array delay (slot '${entry.slotName}', ` +
+        `size ${entry.arraySize ?? '?'}) is not yet supported by the pure-TS oracle; ` +
+        `scalar session delays are. The JIT path handles it via an array WriteSlot.`,
+      )
+    }
+    if (entry.slotIdx === undefined) {
+      throw new Error(
+        `materializeSession: scalar delay slot '${entry.slotName}' is missing slotIdx.`,
+      )
+    }
+    const regPos = ctx.syntheticRegDecls.length
+    const decl: RegDecl = {
+      op: 'regDecl', name: entry.slotName, init: entry.init, update: 0,
+    }
+    ctx.syntheticRegDecls.push(decl)
+    ctx.slotToReg.set(entry.slotIdx, regIdx(regPos))
+    regForSlot.set(entry.slotIdx, decl)
+  }
+
+  // Pass 2: translate each slot's un-delayed source into the reg's
+  // update. Instance decls are built and `slotToReg` is complete, so
+  // both `{op:'ref'}` (instance outputs) and `{op:'sessionSlot'}`
+  // (nested delays) resolve.
+  for (const entry of session.delaySlotRegistry) {
+    if (entry.isArray) continue
+    const decl = regForSlot.get(entry.slotIdx!)!
+    decl.update = translateExpr(entry.sourceExpr, ctx)
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -423,6 +502,33 @@ function translateOpNode(
     const decl: RegDecl = { op: 'regDecl', name: `__sd${ctx.syntheticRegDecls.length}`, update, init }
     ctx.syntheticRegDecls.push(decl)
     return { op: 'regRef', idx: newIdx }
+  }
+
+  if (op === 'sessionSlot') {
+    // A delay already hoisted out of the wires by `extractSessionDelays`.
+    // `materializeSessionDelaySlots` built the backing synthetic reg
+    // up front; read it.
+    const index = obj.index
+    if (typeof index !== 'number') {
+      throw new Error(`materializeSession: sessionSlot read missing numeric index.`)
+    }
+    const reg = ctx.slotToReg.get(index)
+    if (reg === undefined) {
+      throw new Error(
+        `materializeSession: sessionSlot index ${index} has no delaySlotRegistry entry.`,
+      )
+    }
+    return { op: 'regRef', idx: reg }
+  }
+
+  if (op === 'sessionArraySlot') {
+    // Reached only if a session array delay slipped past
+    // `materializeSessionDelaySlots` (which throws on array entries).
+    throw new Error(
+      `interpret_resolved: session-level array delay (sessionArraySlot index ` +
+      `${typeof obj.index === 'number' ? obj.index : '?'}) is not yet supported ` +
+      `by the pure-TS oracle.`,
+    )
   }
 
   throw new Error(`compileSession: unhandled wiring op '${op}'.`)

--- a/compiler/ir/trace_cycles.test.ts
+++ b/compiler/ir/trace_cycles.test.ts
@@ -770,22 +770,20 @@ describe('Phase A — cycle topologies (TDD plan)', () => {
   // ──────────────────────────────────────────────────────────
   // Test 6 — (D) Session-level feedback via session-level delay
   // ──────────────────────────────────────────────────────────
-  test.skip('(D) session-level delay() between two instances: denotation matches flattened reference', () => {
-    // Phase 5 of M11 lifts `delay()` wire expressions to anonymous
-    // programs whose body contains the delay. But this hides the
-    // session-level delay from traceCycles: the lift turns a 1-sample
-    // delay into a 2-sample delay (one from the lifted body's delay,
-    // one from traceCycles inserting a synthetic delay for the cycle
-    // it now sees with no explicit delay at the session edge).
+  test('(D) session-level delay() between two instances: denotation matches flattened reference', () => {
+    // `extractSessionDelays` hoists each `delay()` wire into a session
+    // module slot (a `{op:'sessionSlot'}` read plus a `delaySlotRegistry`
+    // entry); the JIT emits one `WriteSlot` per slot in `state_evolution`.
+    // The oracle path now mirrors this: `materializeSessionDelaySlots`
+    // rebuilds one synthetic RegDecl per scalar slot
+    // (`materialize_session.ts`), so the interpreter reproduces exactly
+    // one sample of latency per wire — no double delay. This pins the
+    // headline "every MCP wire gains exactly one sample of latency"
+    // semantic against a flattened two-explicit-delay reference.
     //
-    // Correct handling requires lifting that PRESERVES the delay at
-    // the session-edge level — either by leaving `delay()` at the
-    // session level and only lifting its arg, or by teaching
-    // traceCycles to detect existing delays inside lifted wire bodies.
-    // Tracked as a Phase 5 follow-up.
     // Two Inner instances feeding each other through an explicit
-    // delay() expression. The session-level delay() short-circuits the
-    // cycle so traceCycles sees no SCC.
+    // delay() expression. The session-level delay() breaks the cycle,
+    // so the materializer's findInstanceCycles sees no SCC.
     const session = makeSession(8)
     loadProgramAsType(INNER_INC, session)
     loadJSON({

--- a/tests/equiv/jit_vs_interp_stdlib.test.ts
+++ b/tests/equiv/jit_vs_interp_stdlib.test.ts
@@ -39,7 +39,7 @@ import { loadStdlib } from '../../compiler/program.js'
 import { applyFlatPlan } from '../../compiler/apply_plan.js'
 import { interpretSession } from '../../compiler/interpret_resolved'
 import { EDGE_FIXTURES } from '../fixtures/equiv/edge_cases.js'
-import { loadProgramAsType } from '../../compiler/program.js'
+import { loadProgramAsType, type ProgramNode } from '../../compiler/program.js'
 import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
 
 const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
@@ -283,6 +283,62 @@ describe('Phase D — mutual register update absolute-value pin', () => {
     // After /20 mix scaling: out[t] = t / 20.
     for (let t = 0; t < 4; t++) {
       expect(buf[t] * 20).toBeCloseTo(t, 10)
+    }
+    session.graph.dispose()
+  })
+})
+
+describe('JIT ↔ interpreter equivalence — session-level feedback', () => {
+  // Two instances cross-coupled through explicit `delay()` wires — the
+  // inter-instance feedback shape the agentic/MCP path produces ("build
+  // a filter with self-oscillation"). `extractSessionDelays` hoists each
+  // delay into a session module slot (a `{op:'sessionSlot'}` read plus a
+  // `delaySlotRegistry` entry); the JIT emits one `WriteSlot` per slot in
+  // `state_evolution`, and the oracle rebuilds one synthetic `RegDecl`
+  // per slot (`materializeSessionDelaySlots`). Before that, the oracle
+  // threw `unhandled wiring op 'sessionSlot'`, so this case — the
+  // headline feature — sat entirely outside the equivalence gate. These
+  // tests put it back inside.
+  const INC: ProgramNode = {
+    op: 'program', name: 'IncEquiv',
+    ports: { inputs: [{ name: 'x', default: 0 }], outputs: ['y'] },
+    body: { op: 'block', assigns: [
+      { op: 'outputAssign', name: 'y',
+        expr: { op: 'add', args: [{ op: 'input', name: 'x' }, 1] } } ] },
+  }
+
+  function buildFeedbackSession() {
+    const session = makeSession(BUFFER_LENGTH)
+    loadStdlib(session)
+    const type = loadProgramAsType(INC, session)!
+    session.typeRegistry.set(INC.name, type)
+    session.instanceRegistry.set('a', instantiate(type, 'a'))
+    session.instanceRegistry.set('b', instantiate(type, 'b'))
+    // a.x = delay(b.y); b.x = delay(a.y) — a unit delay on each back-edge.
+    session.inputExprNodes.set(wk('a', 'x'),
+      { op: 'delay', init: 0, args: [{ op: 'ref', instance: 'b', output: 'y' }] })
+    session.inputExprNodes.set(wk('b', 'x'),
+      { op: 'delay', init: 0, args: [{ op: 'ref', instance: 'a', output: 'y' }] })
+    session.graphOutputs.push({ instance: 'a', output: 'y' })
+    return session
+  }
+
+  test('cross-coupled instances agree sample-for-sample', () => {
+    const session = buildFeedbackSession()
+    runEquivalence(session, { expectAllFinite: true })
+    session.graph.dispose()
+  })
+
+  test('exactly one sample of latency per wire: out[t] = t+1 (first 4 samples)', () => {
+    const session = buildFeedbackSession()
+    applyFlatPlan(session, session.runtime)
+    session.graph.primeJit()
+    session.graph.process()
+    const buf = session.graph.outputBuffer
+    // After /20 mix scaling: out[t] = (t+1)/20. The failure mode of the
+    // old double-delay bug is off-by-one-sample, so pin exact values.
+    for (let t = 0; t < 4; t++) {
+      expect(buf[t] * 20).toBeCloseTo(t + 1, 10)
     }
     session.graph.dispose()
   })


### PR DESCRIPTION
## Problem

The pure-TS interpreter — the oracle that the README frames as the
compiler's correctness criterion ("the JIT and the pure-TS interpreter
agree on every sample for every input") — **could not evaluate any
session containing inter-instance `delay()` feedback.** It threw
`unhandled wiring op 'sessionSlot'`.

`extractSessionDelays` rewrites every hoisted session delay into a
`{op:'sessionSlot', index}` read plus a `delaySlotRegistry` entry. The
JIT path handles `sessionSlot` (`compile_session_slotted_helpers.ts`);
the oracle path (`interpretSession` → `materializeSession`) had no case
for it and threw.

Consequences:

- The **JIT↔interpreter equivalence gate could not cover session-level
  feedback at all** — the headline agentic feature (self-oscillating
  filters built incrementally over MCP) sat entirely outside the gate.
- `trace_cycles` **test (D)** — the denotation check that session-level
  feedback produces *exactly one sample of latency per wire* (matching
  the JIT and a flattened two-explicit-delay reference) — was **skipped**.

So the most-emphasized correctness mechanism in the project had a hole
precisely where the marquee demo lives.

## Changes

- **`compiler/ir/materialize_session.ts`** — new `materializeSessionDelaySlots`
  rebuilds one synthetic `RegDecl` per scalar `delaySlotRegistry` entry
  (`init = entry.init`, `update = translate(sourceExpr)`), mirroring the
  JIT's per-slot `WriteSlot` in the scheduler's `state_evolution` phase.
  The interpreter's read → snapshot-update → atomic-writeback loop is the
  same unit-delay semantics. `sessionSlot` reads resolve to these regs.
  Slots are reserved *before* their source expressions are translated, so
  nested `delay(delay(x))` resolves correctly.
- Session-level **array** delays remain unsupported in the oracle and now
  raise a **clear, scoped error** instead of a generic unhandled-op throw.
- **`compiler/ir/trace_cycles.test.ts`** — un-skip test (D); refresh its
  stale comment (it described the old M11 anonymous-program lift; the
  mechanism is now `extractSessionDelays`).
- **`tests/equiv/jit_vs_interp_stdlib.test.ts`** — add a session-feedback
  block so the gate *stays* closed: two cross-coupled instances run
  through `runEquivalence` (1024-sample JIT↔interp agreement) plus a
  one-sample-latency absolute-value pin (`out[t] = t+1`).

Net: +175 / −15 across 3 files. The change is additive — it introduces a
new op case and a pre-pass; no existing path is altered.

## Test results

- `bun run tsc --noEmit` — clean.
- **JIT vs oracle on the feedback session: max abs diff `0`** (the part
  that actually closes the gap — the two backends now agree where they
  previously couldn't be compared). Oracle output `[1,2,3,4,5,6]`
  confirms exactly one sample of latency per wire.
- `tests/equiv/jit_vs_interp_stdlib.test.ts` — **47 pass / 0 fail** (was
  45; +2 new feedback tests).
- `compiler/ir/` — **256 pass / 0 fail** (incl. un-skipped test (D)).
- `tests/equiv/wasm_vs_jit` 4/0, `nested_vs_inlined` 22/0,
  `microkernel_vs_fused` 20/0.
- Full `bun test` — **0 test failures**. (The process exits 133 from a
  pre-existing Bun 1.3.11/macOS teardown segfault unrelated to this
  change; the Linux CI runner is unaffected.)

## Follow-ups (not in this PR)

- Session-level **array** feedback in the oracle (depends on the
  in-flight array-I/O work); the same RegDecl-rebuild pattern extends to
  array-typed slots once the interpreter supports array regs end-to-end.
- Separate doc-accuracy pass (the "strict functor" phrasing, stdlib/pass
  counts, the `web_plans_vs_jit` CI gap, orphan `compiler/parse.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)