### PR TITLE
Option A: lower sessions as a single root ResolvedProgram (behind a flag)

### DIFF
--- a/HANDOFF_OPTION_A.md
+++ b/HANDOFF_OPTION_A.md
@@ -1,0 +1,117 @@
+# Handoff — Option A, Phases A + B (session → root ResolvedProgram)
+
+**Date:** 2026-05-31
+**Branch:** `feat/single-mcp-server` (working tree; nothing committed for this work)
+**Plan:** `/Users/rhizome/.claude/plans/great-let-s-build-a-fluttering-lake.md` (full phased plan, approved)
+**Background memory:** `project_session_program_divergence.md` (architecture rationale).
+
+## Status: Phases A + B COMPLETE and green.
+
+Option A makes a **session** materialize into a single root `ResolvedProgram`
+(instances → `InstanceDecl`s, wires → `InstanceDecl.inputs`, per-wire unit
+delays → root `RegDecl`s) and lowers it through the **existing**
+`partitionKernel` path, behind a flag (default OFF). The C++ engine is
+semantically unchanged; the scheduler becomes a DAC-stitch postamble only.
+
+### What's done
+
+**Phase A — materializer + unit test (green).**
+- `compiler/ir/materialize_session.ts` — `materializeSessionToResolvedIR(session)`.
+  - Builds each instance's `InstanceDecl` from **`inst.compiled.prog`** (the exact
+    fully-strata-lowered program the flat path compiles, with its own
+    `programRegistry` so `partitionKernel`'s recursive `getInstanceType` resolves
+    the whole subtree). *Do not* re-fetch/re-specialize from `session.programs` —
+    that risked a less-lowered child (surviving `let`/`fold`) that `compileResolved`
+    rejects. This was a real bug found and fixed during Phase B.
+  - Scalar session delays → reserve-then-fill synthetic `RegDecl{init,update}`
+    (two-pass `slotToReg` so nested `delay(delay(x))` resolves). Array delays throw.
+  - No strata call, no DAC branch (DAC stays on `emitDacStitch`/`graphOutputs`).
+- `compiler/ir/materialize_session.test.ts` — 5 cases, all pass
+  (`bun test compiler/ir/materialize_session.test.ts`). Uses `resolveProgramType` +
+  `instantiate` to build instances; dac goes on `session.graphOutputs` (NOT
+  `setWireExpr`, which would auto-delay it). Cycle test keys `inputExprNodes`
+  via `wireKey(...)`.
+
+**extractSessionDelays concern (from prior handoff): VERIFIED CLEAN — non-issue.**
+A real osc→amp→dac session yields exactly one `delaySlotRegistry` entry per
+non-dac wire, distinct `sourceExpr`s, no phantom/aliased entries. The prior
+worry was a test artifact (dac routed through `setWireExpr`). No blocker.
+
+**Phase B — root lowering behind a flag (green).**
+- Flag `rootProgram?: boolean` on `CompileSessionOptions` +
+  `CompileSessionSlottedOptions`; env `TROPICAL_ROOT_PROGRAM=1` forces it on.
+- `compileSessionSlottedRoot(session, mode)` in `compile_session_slotted.ts`:
+  materialize → `makeCompiled(root, {displayName:'__session__'})` →
+  `partitionKernel(ROOT_INSTANCE_PATH, root, ...)` → `instance_functions=[rootFn]`;
+  `emitDacStitch` postamble; `state_evolution=[]`.
+- **Naming transparency** (`partition_recursive.ts`): `ROOT_INSTANCE_PATH`
+  (`'__root__'`) is a sentinel `instancePath` that `joinInstancePath` treats as
+  no-prefix, so the root's children and own registers carry BARE names
+  (`amp.out`, `osc.phase`) — `emitDacStitch`'s `graphOutputs` lookup and
+  register names land exactly where the flat path puts them.
+- **Array fallback:** `sessionHasArrayWiring(session)` (array-typed instance
+  ports OR array session delays) routes back to `compileSessionSlottedPerInstance`.
+  Phase B is scalar-only; this keeps `TROPICAL_ROOT_PROGRAM=1` safe to force on
+  across the whole corpus (internal array state like `Delay`'s ring buffer does
+  NOT count — it never crosses a session wire).
+- **Gate:** `tests/equiv/root_vs_flat.test.ts` — flag-off vs flag-on via
+  `renderFramesJit`, 1e-12, over the stdlib corpus + a multi-instance
+  auto-delayed osc→amp session + 8× polyphony. **23/23 pass.**
+- **Migration goldens forced-on:** `TROPICAL_ROOT_PROGRAM=1 bun test
+  tests/equiv/migration_audio.test.ts` → **11/11 pass** (array patches fall back).
+
+### Two engine bugs found + fixed (cache-key completeness, `OrcJitEngine.cpp`)
+
+The JIT cache key serialization (BOTH the fused `kernel_cache_` key ~L1100 and
+the microkernel/deep `microkernel_cache_` key ~L1437) hashed only each top-level
+function's own `instructions` + `instance_name` + `register_count` — it never
+recursed into `children` / `preamble_instructions` / `pre_input_instructions` /
+`writebacks`. The flat/nested paths dodged this because their top-level body
+always differs per type. The **root path exposes it**: every root plan's single
+top-level function is empty-bodied and identically named (`instance___root__`),
+so all root plans collided and served each other's cached kernels (Cos got Exp's
+kernel, etc.). Fixed by making both keys recurse via a `serialize_fn` lambda.
+This is a pure cache-key fix — no emitted-code or golden change. Rebuild required
+(`cmake --build build`); build-id auto-invalidates the disk cache.
+
+## Verification (all green unless noted)
+
+- `npx tsc --noEmit` — clean.
+- `bun test` (flag OFF, default) — **1035 pass / 0 fail.**
+- `bun test tests/equiv/` flag OFF — 107 pass.
+- `TROPICAL_ROOT_PROGRAM=1 bun test tests/equiv/root_vs_flat.test.ts` — 23 pass.
+- `TROPICAL_ROOT_PROGRAM=1 bun test tests/equiv/migration_audio.test.ts` — 11 pass.
+- `ctest --test-dir build` — pass.
+
+## Known limitations / next steps
+
+1. **WASM backend does not support root plans yet.** With the flag forced ON
+   globally, `tests/equiv/wasm_vs_jit.test.ts` has 4 failures (SinOsc×2,
+   SinOsc→OnePole, the array-zipWith case). JIT-root is correct (proven by
+   `root_vs_flat`); the diverging side is `emit_wasm`, which doesn't handle the
+   root-program plan shape (deeper nesting + root `RegDecl` writebacks +
+   empty top-level body). Phase B targets the **JIT** path; WASM root support is
+   Phase C/E. The flag defaults OFF, so normal WASM operation is unaffected. If
+   you force the flag on, scope it to JIT suites.
+2. **Unwired typed-bound defaults differ (documented, benign).** An UNWIRED
+   input with a typed-bound default (`freq: freq = 440`) resolves to 0 on the
+   flat top-level path (its plain-number-only `defaults` builder skips the
+   `ExprNode` default) but to the declared 440 on the root child path
+   (`rawInputDefaults`). Every realistic session and every equiv test wires its
+   inputs, so this never bites in practice; the `root_vs_flat` osc→amp case wires
+   `freq` explicitly. NOT fixed (one-axis-at-a-time; arguably root is *more*
+   correct). If a future patch relies on unwired typed defaults, revisit.
+3. **Phase C/D/E** per the plan: soak (flag still OFF), then remove the
+   array-refusal (`sessionHasArrayWiring`) + add array `RegDecl` support
+   (Phase D), then flip the default and delete `compileSessionSlottedPerInstance`
+   + the `state_evolution` emission (Phase E). Keep `delaySlotRegistry`,
+   `emitDacStitch`, `graphOutputs` as the bridge/DAC tap.
+
+## Key invariants to preserve
+
+- One-axis-at-a-time: no golden re-baselining. The cache-key fix doesn't move
+  goldens (it can only AVOID wrong-kernel reuse).
+- DAC stays on `emitDacStitch`/`graphOutputs`; root has no output ports.
+- Delay ordering (R1): root `RegDecl` writebacks are a trailing read-old/write-new
+  batch; the engine runs children(pre_input+body) → root body → root writebacks,
+  so one-sample latency is preserved by construction. `root_vs_flat` proves it.

--- a/compiler/ir/compile_session.ts
+++ b/compiler/ir/compile_session.ts
@@ -30,6 +30,13 @@ import { instanceName as toInstanceName } from './branded_names.js'
 export interface CompileSessionOptions {
   /** Engine realization strategy. Defaults to `'fused'`. */
   compilation_mode?: CompilationMode
+  /** Option A: lower the whole session as a single synthetic root
+   *  `ResolvedProgram` through the shared `partitionKernel` path
+   *  (instances → `InstanceDecl`s, per-wire unit delays → root
+   *  `RegDecl`s) instead of the per-instance scheduler path. Defaults
+   *  to false; `TROPICAL_ROOT_PROGRAM=1` forces it on (for the equiv
+   *  suite). Scalar-delay sessions only in Phase B. */
+  rootProgram?: boolean
 }
 
 export function compileSession(

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -42,13 +42,16 @@ import {
   tempIdx, moduleSlotIdx, tempOffset,
   rawOffset,
 } from './slot_indices.js'
-import { partitionKernel, makeAccumulators } from './partition_recursive.js'
+import { partitionKernel, makeAccumulators, ROOT_INSTANCE_PATH } from './partition_recursive.js'
+import { materializeSessionToResolvedIR } from './materialize_session.js'
 import { makeCompiled, type Compiled } from '../program_types.js'
 import { slotKey } from './branded_names.js'
 
 export interface CompileSessionSlottedOptions {
   /** Engine realization strategy. Defaults to `'fused'`. */
   compilation_mode?: CompilationMode
+  /** Option A root-program lowering (see CompileSessionOptions). */
+  rootProgram?: boolean
 }
 
 /** Compile the session into a `tropical_plan_5` `FlatPlan`. */
@@ -56,7 +59,33 @@ export function compileSessionSlotted(
   session: SessionState,
   options: CompileSessionSlottedOptions = {},
 ): FlatPlan {
-  return compileSessionSlottedPerInstance(session, options.compilation_mode ?? 'fused')
+  const mode = options.compilation_mode ?? 'fused'
+  const rootProgram = process.env.TROPICAL_ROOT_PROGRAM === '1' || options.rootProgram === true
+  // Phase B root lowering is scalar-only. A session that carries any
+  // array-typed wiring — array-typed instance ports, or array session
+  // delays — still needs the per-instance `state_evolution`/array-slot
+  // machinery (Phase C/D lifts this). Fall back transparently so the
+  // flag stays safe to force on across the whole corpus.
+  if (rootProgram && !sessionHasArrayWiring(session)) {
+    return compileSessionSlottedRoot(session, mode)
+  }
+  return compileSessionSlottedPerInstance(session, mode)
+}
+
+/** True if the session has any array-typed wiring the scalar-only root
+ *  lowering can't yet represent: an array-typed instance input/output
+ *  port, or an array-typed session delay. Internal array state (e.g. a
+ *  `Delay`'s ring buffer) does NOT count — it lives inside one
+ *  instance's scalar-port kernel and never crosses a session wire. */
+function sessionHasArrayWiring(session: SessionState): boolean {
+  if (session.delaySlotRegistry.some(e => e.isArray)) return true
+  for (const [, inst] of session.instanceRegistry) {
+    const prog = inst.compiled?.prog
+    if (prog === undefined) continue
+    for (const p of prog.ports.inputs)  if (p.type?.kind === 'array') return true
+    for (const p of prog.ports.outputs) if (p.type?.kind === 'array') return true
+  }
+  return false
 }
 
 /** Recursively allocate output slots for an instance and every nested
@@ -329,6 +358,108 @@ function compileSessionSlottedPerInstance(
     array_slot_count:  acc.nextArrayRaw,
     array_slot_sizes:  acc.arraySlotSizes,
     register_count:    stateEvolutionNextTempRaw,
+    instance_functions: instanceFunctions,
+    scheduler_function: schedulerFunction,
+    ...buildSlotMetadata(session),
+  }
+}
+
+/** Option A: compile the session as a single synthetic root
+ *  `ResolvedProgram` lowered through the shared `partitionKernel`
+ *  path, instead of composing per-instance plans with a scheduler.
+ *
+ *  The session's top-level instances survive as `InstanceDecl`
+ *  children of the root (boxes closed — `inlineNested:false`); the
+ *  per-wire unit delays that `extractSessionDelays` hoisted into
+ *  `delaySlotRegistry` become root-level `RegDecl`s whose writebacks
+ *  reproduce the one-sample latency that the per-instance path's
+ *  `state_evolution` `WriteSlot`s provided. The scheduler is reduced
+ *  to the DAC-stitch postamble (`state_evolution` is empty).
+ *
+ *  Scalar session delays only (Phase B). Array session delays still
+ *  route through the per-instance path. */
+function compileSessionSlottedRoot(
+  session: SessionState,
+  compilationMode: CompilationMode,
+): FlatPlan {
+  if (session.delaySlotRegistry.some(e => e.isArray)) {
+    throw new Error(
+      'compileSessionSlottedRoot: session-level array delays are not yet ' +
+      'supported on the root-program path (Phase D); use the per-instance path.',
+    )
+  }
+
+  // Two-phase slot pre-allocation — identical to the per-instance
+  // path. partitionKernel re-issues these idempotently during its own
+  // child walk.
+  for (const [name, inst] of session.instanceRegistry) {
+    if (inst.compiled !== undefined) {
+      preallocateOutputsRecursive(session, toInstanceName(name), inst.compiled.prog, inst.compiled)
+    }
+  }
+  for (const [name, inst] of session.instanceRegistry) {
+    if (inst.compiled !== undefined) {
+      preallocateInputsRecursive(session, toInstanceName(name), inst.compiled.prog, inst.compiled)
+    }
+  }
+
+  const acc = makeAccumulators()
+  // Seed the array-slot accumulator with the session-level I/O array
+  // slots (verbatim from the per-instance path) so kernel-local array
+  // slots land at globalIdx >= ioArraySlotCount.
+  for (let i = 0; i < session.ioArraySlotCount; i++) {
+    acc.arraySlotSizes.push(session.ioArraySlotSizes[i])
+    acc.arraySlotNames.push(session.ioArraySlotNames[i])
+  }
+  acc.nextArrayRaw = session.ioArraySlotCount
+
+  // Materialize the session → synthetic root and lower it once. The
+  // root path is naming-transparent (ROOT_INSTANCE_PATH), so child
+  // output slots / register names land under bare paths exactly where
+  // the flat per-instance path puts them — `emitDacStitch` and
+  // hot-swap state-transfer-by-name resolve unchanged.
+  const root = materializeSessionToResolvedIR(session)
+  const rootCompiled = makeCompiled(root, { displayName: '__session__' })
+
+  const { fn } = partitionKernel(
+    /* instancePath    */ ROOT_INSTANCE_PATH,
+    /* prog            */ root,
+    /* compiled        */ rootCompiled,
+    /* inputBindingFor */ () => undefined,
+    /* defaults        */ {},
+    /* paramHandles    */ new Map(),
+    session,
+    acc,
+  )
+  const instanceFunctions: InstanceFunction[] = [fn]
+
+  // DAC stitch is unchanged — reads each graphOutput slot in the
+  // postamble after the root kernel has run.
+  const dac = emitDacStitch(session, tempOffset(acc.nextRegRaw))
+  const dacEndRaw = acc.nextRegRaw + dac.tempCount
+
+  // No state-evolution phase: the per-wire delays became root RegDecl
+  // writebacks inside the root kernel (a trailing read-old/write-new
+  // batch), preserving one-sample latency by construction.
+  const schedulerFunction: SchedulerFunction = {
+    preamble:        [],
+    state_evolution: [],
+    postamble:       dac.instructions,
+    output_targets:  dac.outputTargets,
+    outputs:         dac.outputs,
+  }
+
+  return {
+    schema: 'tropical_plan_5',
+    config: { sampleRate: 44100 },
+    compilation_mode:  compilationMode,
+    state_init:        acc.stateInit,
+    register_names:    acc.registerNames,
+    register_types:    acc.registerTypes,
+    array_slot_names:  acc.arraySlotNames,
+    array_slot_count:  acc.nextArrayRaw,
+    array_slot_sizes:  acc.arraySlotSizes,
+    register_count:    dacEndRaw,
     instance_functions: instanceFunctions,
     scheduler_function: schedulerFunction,
     ...buildSlotMetadata(session),

--- a/compiler/ir/materialize_session.test.ts
+++ b/compiler/ir/materialize_session.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, setWireExpr } from '../session.js'
+import { loadStdlib } from '../program.js'
+import { wireKey, portRef, instanceName as toInstanceName, portName as toPortName } from './branded_names.js'
+import { liftWiresToInstances } from './lift_wires.js'
+import { extractSessionDelays } from './lowering/extract_session_delays.js'
+import { materializeSessionToResolvedIR } from './materialize_session.js'
+import { CycleViolation } from './elaboration_diagnostics.js'
+
+/** Instantiate a stdlib type into the session's instanceRegistry. */
+function addInst(session: ReturnType<typeof makeSession>, name: string, typeName: string) {
+  const { type } = resolveProgramType(session, typeName, undefined, undefined)
+  const inst = instantiate(type, name, { baseTypeName: typeName })
+  session.instanceRegistry.set(name, inst)
+}
+
+/** Build a minimal osc→amp→dac session and run the two pre-passes that
+ *  precede materialization in the real compile path (array-literal wire
+ *  lift, then session-delay extraction). Returns the prepared session. */
+function makeOscAmpSession() {
+  const session = makeSession()
+  loadStdlib(session)
+  addInst(session, 'osc', 'BlepSaw')
+  addInst(session, 'amp', 'VCA')
+  setWireExpr(
+    session,
+    portRef(toInstanceName('amp'), toPortName('audio')),
+    { op: 'ref', instance: 'osc', output: 'saw' },
+  )
+  setWireExpr(session, portRef(toInstanceName('amp'), toPortName('cv')), 0.5)
+  // dac — special-cased into session.graphOutputs (NOT via setWireExpr,
+  // which would auto-wrap it in a spurious unit delay).
+  session.graphOutputs.push({ instance: 'amp', output: 'out' })
+  liftWiresToInstances(session)
+  extractSessionDelays(session)
+  return session
+}
+
+describe('materializeSessionToResolvedIR', () => {
+  test('produces a valid root program (no strata, no flatten)', () => {
+    const session = makeOscAmpSession()
+    const root = materializeSessionToResolvedIR(session)
+
+    // mkProgram validated the programRegistry covers every instance
+    // typeKey (it throws otherwise) — reaching here proves that.
+    expect(root.name).toBe('__session__')
+    expect(root.op).toBe('program')
+
+    // Boxes stay closed: every top-level instance survives as an
+    // InstanceDecl (NOT inlined away). One per session instance.
+    expect(root.instances.length).toBe(session.instanceRegistry.size)
+    const instNames = root.instances.map(i => i.name).sort()
+    expect(instNames).toEqual([...session.instanceRegistry.keys()].sort())
+
+    // The root carries NO output ports — DAC stays on session.graphOutputs.
+    expect(root.ports.outputs.length).toBe(0)
+    expect(root.body.assigns.length).toBe(0)
+    expect(root.ports.inputs.length).toBe(0)
+  })
+
+  test('scalar session delays become root RegDecls (naming-transparent)', () => {
+    const session = makeOscAmpSession()
+    const scalarDelays = session.delaySlotRegistry.filter(e => !e.isArray)
+    // Two non-dac wires (amp.audio, amp.cv) each auto-delayed by setWireExpr.
+    expect(scalarDelays.length).toBeGreaterThan(0)
+
+    const root = materializeSessionToResolvedIR(session)
+
+    // One root RegDecl per scalar delay entry.
+    expect(root.regs.length).toBe(scalarDelays.length)
+    // Naming transparency: each delay reg carries the registry's stable
+    // slotName (the hot-swap state key), NOT a root-prefixed name. This
+    // is what keeps state-transfer-by-name byte-identical to the flat path.
+    const regNames = root.regs.map(r => r.name).sort()
+    const slotNames = scalarDelays.map(e => e.slotName).sort()
+    expect(regNames).toEqual(slotNames)
+    // Every delay reg has an update populated (it's a unit delay).
+    for (const r of root.regs) expect(r.update).toBeDefined()
+  })
+
+  test('wires land on InstanceDecl.inputs', () => {
+    const session = makeOscAmpSession()
+    const root = materializeSessionToResolvedIR(session)
+    const amp = root.instances.find(i => i.name === 'amp')!
+    // amp has two wired inputs (audio, cv).
+    expect(amp.inputs.length).toBe(2)
+  })
+
+  test('throws on array session delays (scalar-first guard)', () => {
+    const session = makeOscAmpSession()
+    // Inject an array delay entry directly — the root path does not yet
+    // support array-typed RegDecls (Phase D).
+    session.delaySlotRegistry.push({
+      slotName: '__arr_delay_test',
+      sourceExpr: { op: 'ref', instance: 'osc', output: 'saw' },
+      init: 0,
+      scalarType: 'float',
+      isArray: true,
+      arraySlot: 0,
+      arraySize: 8,
+    })
+    expect(() => materializeSessionToResolvedIR(session)).toThrow(/array delay/)
+  })
+
+  test('throws CycleViolation on an undelayed inter-instance cycle', () => {
+    const session = makeSession()
+    loadStdlib(session)
+    addInst(session, 'a', 'VCA')
+    addInst(session, 'b', 'VCA')
+    // Hand-build a combinational cycle a.audio←b.out, b.audio←a.out by
+    // writing inputExprNodes directly (bypassing setWireExpr's auto-delay),
+    // so no delay breaks the loop.
+    session.inputExprNodes.set(
+      wireKey(portRef(toInstanceName('a'), toPortName('audio'))),
+      { op: 'ref', instance: 'b', output: 'out' },
+    )
+    session.inputExprNodes.set(
+      wireKey(portRef(toInstanceName('b'), toPortName('audio'))),
+      { op: 'ref', instance: 'a', output: 'out' },
+    )
+    expect(() => materializeSessionToResolvedIR(session)).toThrow(CycleViolation)
+  })
+})

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -1,0 +1,472 @@
+/**
+ * materialize_session.ts — Session → root `ResolvedProgram` materialization.
+ *
+ * Lifts a session — a partially-typed graph of `Instance`s plus
+ * session-keyed wiring `ExprNode`s — into a single synthetic top-level
+ * ("root") `ResolvedProgram` whose `body.decls` are the session's
+ * top-level instances as `InstanceDecl`s. Wires become each instance's
+ * `InstanceDecl.inputs`; per-wire unit delays (hoisted into
+ * `session.delaySlotRegistry` by `extractSessionDelays`) become root-level
+ * `RegDecl`s with `update` populated.
+ *
+ * This is the **root-program** session lowering (Option A): the produced
+ * root is handed directly to `partitionKernel` with `inlineNested:false`
+ * (boxes closed), the SAME shared path the per-program fractal lowering
+ * uses. It deliberately does NOT run the strata pipeline — that would
+ * inline the instances away (the FLATTEN mistake that motivated deleting
+ * the previous `materialize_session.ts`).
+ *
+ * DAC outputs are NOT carried on the root. `{op:'outputAssign',
+ * target:{kind:'dac'}}` assigns are silently dropped by `compileResolved`
+ * (it records only numeric output targets), so the root has no output
+ * ports; `emitDacStitch` continues to tap `session.graphOutputs` directly
+ * (reading each producer instance's already-allocated output slot). This
+ * keeps the C++ engine unchanged. (Routing `dac.out` through the root body
+ * is Option B.)
+ *
+ * ## Invariants
+ *
+ *  - Zero scope analysis. The translator does no name resolution other
+ *    than `instanceRegistry.get(instanceName)` and
+ *    `findOutput(instance, outputName)`. Every reference becomes a
+ *    direct decl-identity ResolvedExpr ref.
+ *  - Decl creation is bounded: the materializer creates fresh `RegDecl`
+ *    objects (with `update` populated) for session-level `delay()` nodes.
+ *  - Scalar session delays only. Array session delays (`isArray` entries
+ *    in `delaySlotRegistry`) throw here; they are handled on the legacy
+ *    flat-list path until the root model gains array-`RegDecl` support.
+ */
+
+import type {
+  ResolvedProgram, ResolvedExpr, ResolvedBlock,
+  ResolvedProgramPorts,
+  InputDecl, OutputDecl, RegDecl, ParamDecl, InstanceDecl,
+  BodyDecl, BodyAssign,
+  TypeParamDecl,
+  RegIdx,
+  ProgramKey,
+} from './nodes.js'
+import { inputIdx, outputIdx, paramIdx, instanceIdx, regIdx, programKey } from './nodes.js'
+import type { ExprNode } from '../expr.js'
+import type { SessionState } from '../session.js'
+import type { Instance } from '../program_types.js'
+import { findInstanceCycles } from './lowering/cycle_break.js'
+import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
+import { parseWireKey } from './branded_names.js'
+import { mkProgram } from './decl_tables.js'
+
+/** Run the session → root `ResolvedProgram` materialization end-to-end.
+ *  The result is the synthetic top-level program; callers lower it via
+ *  `partitionKernel(..., inlineNested:false)`. */
+export function materializeSessionToResolvedIR(session: SessionState): ResolvedProgram {
+  const ctx = makeContext(session)
+  const root = materializeSessionInner(session, ctx)
+
+  // Strict cycle policy at the session boundary. Cycles in session
+  // wiring that don't pass through an explicit `delay()` in the wire
+  // throw `CycleViolation` here, with port-detailed error messages
+  // referencing session-level instance names. Sessions break cycles
+  // explicitly via `delay(...)` in wire expressions, which materializes
+  // to a synthetic RegDecl and breaks the inter-instance dependency chain.
+  const cycles = findInstanceCycles(root)
+  if (cycles.length > 0) {
+    const diagnostics: CycleDiagnostic[] = cycles.map(scc => {
+      const sortedScc = [...scc]
+      const target = sortedScc[0]
+      return {
+        kind: 'cycle',
+        scc: sortedScc,
+        programName: '__session__',
+        suggestedFix:
+          `Suggested fix: wrap a wire from '${target.name}' in 'delay(...)' ` +
+          `to break the cycle explicitly. Example: wire { instance: '${sortedScc[1]?.name ?? '<consumer>'}', ` +
+          `input: '<port>', expr: { op: 'delay', args: [{ op: 'ref', instance: '${target.name}', output: '<port>' }] } }.`,
+      }
+    })
+    throw new CycleViolation(diagnostics)
+  }
+
+  return root
+}
+
+function makeContext(session: SessionState): MaterializeContext {
+  return {
+    instanceDecls:       new Map(),
+    paramDecls:          new Map(),
+    programRegistry:     new Map(),
+    syntheticRegDecls:   [],
+    slotToReg:           new Map(),
+    exprMemo:            new WeakMap(),
+    session,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session → synthetic root ResolvedProgram
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MaterializeContext {
+  instanceDecls: Map<string, InstanceDecl>
+  paramDecls: Map<string, ParamDecl>
+  /** Per-typeKey ResolvedProgram for each instance type referenced in
+   *  the session. Populated by `buildInstanceDecl` and used by the
+   *  port-lookup sites below to resolve instance type info without
+   *  the dropped `.type` pointer. */
+  programRegistry: Map<ProgramKey, ResolvedProgram>
+  /** Synthetic RegDecls (with update populated) generated from session-
+   *  level `delay()` expressions in wires. Each becomes a stateful slot
+   *  one sample late. Named `__sd${idx}` for uniqueness within the
+   *  session-level synthetic program. */
+  syntheticRegDecls: RegDecl[]
+  /** Maps a session module-slot index (the `index` carried by a
+   *  `{op:'sessionSlot'}` read) to the RegIdx of the synthetic RegDecl
+   *  that reproduces that hoisted delay. Populated by
+   *  `materializeSessionDelaySlots` before any wire is translated, so
+   *  `sessionSlot` reads — including those nested inside another slot's
+   *  source expression — resolve to a stable reg. */
+  slotToReg: Map<number, RegIdx>
+  exprMemo: WeakMap<object, ResolvedExpr>
+  session: SessionState
+}
+
+function materializeSessionInner(session: SessionState, ctx: MaterializeContext): ResolvedProgram {
+  for (const [name, inst] of session.instanceRegistry) {
+    const decl = buildInstanceDecl(name, inst, ctx)
+    ctx.instanceDecls.set(name, decl)
+  }
+
+  // Reconstruct the synthetic RegDecls behind session-level delay
+  // slots before translating wires — a wire (or another slot's source)
+  // may read these slots via `{op:'sessionSlot'}`.
+  materializeSessionDelaySlots(session, ctx)
+
+  for (const [key, expr] of session.inputExprNodes) {
+    let ref
+    try { ref = parseWireKey(key) } catch { continue }
+    const instName = ref.instance
+    const inputName = ref.port
+    const instDecl = ctx.instanceDecls.get(instName)
+    if (instDecl === undefined) continue
+    const instType = ctx.programRegistry.get(instDecl.typeKey)!
+    const portI = instType.ports.inputs.findIndex(p => p.name === inputName)
+    if (portI < 0) {
+      throw new Error(
+        `materializeSession: instance '${instName}' has no input port '${inputName}' on type '${instType.name}'.`,
+      )
+    }
+    const value = translateExpr(expr, ctx)
+    instDecl.inputs.push({ port: inputIdx(portI), value })
+  }
+
+  // Body decl order: synthetic delay regs first (so their RegIdx equals
+  // their position in ctx.syntheticRegDecls — the invariant the delay /
+  // sessionSlot translation relies on), then instances, then params.
+  const bodyDecls: BodyDecl[] = []
+  for (const decl of ctx.syntheticRegDecls)      bodyDecls.push(decl)
+  for (const decl of ctx.instanceDecls.values()) bodyDecls.push(decl)
+  for (const decl of ctx.paramDecls.values())    bodyDecls.push(decl)
+
+  // The root carries NO output ports and NO assigns. DAC outputs stay on
+  // `session.graphOutputs` (tapped by `emitDacStitch`); `{kind:'dac'}`
+  // assigns would be dropped by `compileResolved` anyway.
+  const bodyAssigns: BodyAssign[] = []
+
+  const block: ResolvedBlock = {
+    op: 'block',
+    decls:   bodyDecls,
+    assigns: bodyAssigns,
+  }
+
+  const ports: ResolvedProgramPorts = {
+    inputs:   [] as InputDecl[],
+    outputs:  [] as OutputDecl[],
+    typeDefs: [],
+  }
+
+  return mkProgram({
+    name: '__session__',
+    typeParams: [] as TypeParamDecl[],
+    ports,
+    body: block,
+    // Session-level wires are scalar expressions with no combinators
+    // or let-bindings — no binders are introduced. The synthetic
+    // program's binderCount is therefore 0.
+    binderCount: 0,
+    programRegistry: ctx.programRegistry,
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session delay slots → synthetic RegDecls
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Reconstruct synthetic `RegDecl`s for the session-level delay slots
+ *  that `extractSessionDelays` hoisted out of the wires into
+ *  `session.delaySlotRegistry` (rewriting each `delay()` to a
+ *  `{op:'sessionSlot', index}` read).
+ *
+ *  The legacy flat path emits one `WriteSlot` per registry entry in the
+ *  scheduler's `state_evolution` phase: the slot is read during the
+ *  sample and written, from the un-delayed source, at the end of the
+ *  sample. The root model reproduces exactly this by giving each scalar
+ *  slot a `RegDecl` whose `update` is the translated source expression
+ *  and whose `init` seeds sample 0 — the engine's read-old / write-new
+ *  register writeback (`emit_resolved` trailing batch) is the same
+ *  unit-delay semantics.
+ *
+ *  Reg idx equals position in `ctx.syntheticRegDecls` (the
+ *  front-of-body invariant from `materializeSessionInner`). Every
+ *  slot's reg is reserved first — populating `ctx.slotToReg` — before
+ *  any source expression is translated, because a source may itself
+ *  read another `sessionSlot` (nested `delay(delay(x))`). */
+function materializeSessionDelaySlots(
+  session: SessionState,
+  ctx: MaterializeContext,
+): void {
+  const regForSlot = new Map<number, RegDecl>()
+
+  // Pass 1: reserve a synthetic reg per scalar slot and record the
+  // slotIdx → RegIdx map (so cross-slot reads resolve in pass 2).
+  for (const entry of session.delaySlotRegistry) {
+    if (entry.isArray) {
+      throw new Error(
+        `materializeSession: session-level array delay (slot '${entry.slotName}', ` +
+        `size ${entry.arraySize ?? '?'}) is not yet supported on the root-program path; ` +
+        `scalar session delays are. Use the legacy flat-list path for array session delays.`,
+      )
+    }
+    if (entry.slotIdx === undefined) {
+      throw new Error(
+        `materializeSession: scalar delay slot '${entry.slotName}' is missing slotIdx.`,
+      )
+    }
+    const regPos = ctx.syntheticRegDecls.length
+    const decl: RegDecl = {
+      op: 'regDecl', name: entry.slotName, init: entry.init, update: 0,
+    }
+    ctx.syntheticRegDecls.push(decl)
+    ctx.slotToReg.set(entry.slotIdx, regIdx(regPos))
+    regForSlot.set(entry.slotIdx, decl)
+  }
+
+  // Pass 2: translate each slot's un-delayed source into the reg's
+  // update. Instance decls are built and `slotToReg` is complete, so
+  // both `{op:'ref'}` (instance outputs) and `{op:'sessionSlot'}`
+  // (nested delays) resolve.
+  for (const entry of session.delaySlotRegistry) {
+    if (entry.isArray) continue
+    const decl = regForSlot.get(entry.slotIdx!)!
+    decl.update = translateExpr(entry.sourceExpr, ctx)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build InstanceDecl
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildInstanceDecl(
+  name: string,
+  inst: Instance,
+  ctx: MaterializeContext,
+): InstanceDecl {
+  // Use the EXACT program the per-instance (flat) path compiles —
+  // `inst.compiled.prog`. It is already monomorphized and fully
+  // strata-lowered (combinator-free), and carries its own
+  // `programRegistry` covering its nested children, so
+  // `partitionKernel`'s recursive `getInstanceType` resolves the whole
+  // subtree. Re-deriving from `session.programs` here risked picking a
+  // less-lowered form (e.g. retaining `let`/`fold` in a nested child),
+  // which `compileResolved` rejects.
+  const resolvedType = inst.compiled.prog
+
+  const tk = programKey(resolvedType.name)
+  // Register the resolved type so port-lookup sites can resolve it
+  // without a `.type` pointer. If two instances share the same type,
+  // the registry holds one canonical entry.
+  ctx.programRegistry.set(tk, resolvedType)
+  const decl: InstanceDecl = {
+    op: 'instanceDecl',
+    name,
+    typeKey: tk,
+    typeArgs: [],
+    inputs: [],
+  }
+
+  return decl
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExprNode → ResolvedExpr translation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BINARY_OPS = new Set([
+  'add', 'sub', 'mul', 'div', 'mod',
+  'lt', 'lte', 'gt', 'gte', 'eq', 'neq',
+  'and', 'or',
+  'bitAnd', 'bitOr', 'bitXor', 'lshift', 'rshift',
+  'floorDiv', 'ldexp',
+])
+
+const UNARY_OPS = new Set([
+  'neg', 'not', 'bitNot',
+  'sqrt', 'abs', 'floor', 'ceil', 'round',
+  'floatExponent', 'toInt', 'toBool', 'toFloat',
+])
+
+const TERNARY_OPS = new Set(['clamp', 'select', 'arraySet'])
+
+function translateExpr(expr: ExprNode, ctx: MaterializeContext): ResolvedExpr {
+  if (typeof expr === 'number')  return expr
+  if (typeof expr === 'boolean') return expr
+  if (Array.isArray(expr)) {
+    const cached = ctx.exprMemo.get(expr)
+    if (cached !== undefined) return cached
+    const out = expr.map(e => translateExpr(e, ctx)) as ResolvedExpr
+    ctx.exprMemo.set(expr, out)
+    return out
+  }
+  if (typeof expr !== 'object' || expr === null) {
+    throw new Error(`materializeSession: invalid expr value: ${JSON.stringify(expr)}`)
+  }
+
+  const cached = ctx.exprMemo.get(expr)
+  if (cached !== undefined) return cached
+
+  const obj = expr as Record<string, unknown>
+  const op = obj.op
+  if (typeof op !== 'string') {
+    throw new Error(`materializeSession: expression missing op tag: ${JSON.stringify(expr).slice(0, 100)}`)
+  }
+
+  const out = translateOpNode(obj, op, ctx)
+  ctx.exprMemo.set(expr, out)
+  return out
+}
+
+function translateOpNode(
+  obj: Record<string, unknown>,
+  op: string,
+  ctx: MaterializeContext,
+): ResolvedExpr {
+  if (op === 'ref') {
+    const instName = obj.instance as string
+    const outputName = obj.output as string
+    const instDecl = ctx.instanceDecls.get(instName)
+    if (instDecl === undefined) {
+      throw new Error(`materializeSession: ref to unknown instance '${instName}'.`)
+    }
+    const instType = ctx.programRegistry.get(instDecl.typeKey)!
+    const outputI = instType.ports.outputs.findIndex(p => p.name === outputName)
+    if (outputI < 0) {
+      throw new Error(
+        `materializeSession: ref to '${instName}.${outputName}' — '${outputName}' is not a port on type '${instType.name}'.`,
+      )
+    }
+    // InstanceIdx is the iteration position of instName in ctx.instanceDecls.
+    // Maps preserve insertion order, so this matches the order the instance
+    // decls land in body.decls (and thus body.instances) later.
+    let instI = -1
+    let i = 0
+    for (const name of ctx.instanceDecls.keys()) {
+      if (name === instName) { instI = i; break }
+      i++
+    }
+    return { op: 'nestedOut', instance: instanceIdx(instI), output: outputIdx(outputI) }
+  }
+
+  if (op === 'param' || op === 'paramExpr'
+      || op === 'trigger' || op === 'triggerParamExpr') {
+    return paramRef(obj.name as string, ctx)
+  }
+
+  if (op === 'sampleRate')  return { op: 'sampleRate' }
+  if (op === 'sampleIndex') return { op: 'sampleIndex' }
+
+  if (BINARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0], args[1]] } as ResolvedExpr
+  }
+
+  if (UNARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0]] } as ResolvedExpr
+  }
+
+  if (TERNARY_OPS.has(op)) {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op, args: [args[0], args[1], args[2]] } as ResolvedExpr
+  }
+
+  if (op === 'index') {
+    const args = (obj.args as ExprNode[]).map(a => translateExpr(a, ctx))
+    return { op: 'index', args: [args[0], args[1]] } as ResolvedExpr
+  }
+
+  if (op === 'array') {
+    const items = (obj.items as ExprNode[]).map(item => translateExpr(item, ctx))
+    return items as ResolvedExpr
+  }
+
+  if (op === 'delay') {
+    const update = translateExpr((obj.args as ExprNode[])[0], ctx)
+    const init = typeof obj.init === 'number' ? obj.init : 0
+    // A session `delay()` that survived to translation (i.e. was NOT
+    // hoisted by extractSessionDelays) lowers to a synthetic RegDecl
+    // with update populated. Reads of the value are RegRefs. The
+    // synthetic regs are placed at the FRONT of body.decls (before
+    // instance decls and param decls — see materializeSessionInner),
+    // so their RegIdx equals their position in ctx.syntheticRegDecls.
+    const newIdx = regIdx(ctx.syntheticRegDecls.length)
+    const decl: RegDecl = { op: 'regDecl', name: `__sd${ctx.syntheticRegDecls.length}`, update, init }
+    ctx.syntheticRegDecls.push(decl)
+    return { op: 'regRef', idx: newIdx }
+  }
+
+  if (op === 'sessionSlot') {
+    // A delay already hoisted out of the wires by `extractSessionDelays`.
+    // `materializeSessionDelaySlots` built the backing synthetic reg
+    // up front; read it.
+    const index = obj.index
+    if (typeof index !== 'number') {
+      throw new Error(`materializeSession: sessionSlot read missing numeric index.`)
+    }
+    const reg = ctx.slotToReg.get(index)
+    if (reg === undefined) {
+      throw new Error(
+        `materializeSession: sessionSlot index ${index} has no delaySlotRegistry entry.`,
+      )
+    }
+    return { op: 'regRef', idx: reg }
+  }
+
+  if (op === 'sessionArraySlot') {
+    // Reached only if a session array delay slipped past
+    // `materializeSessionDelaySlots` (which throws on array entries).
+    throw new Error(
+      `materializeSession: session-level array delay (sessionArraySlot index ` +
+      `${typeof obj.index === 'number' ? obj.index : '?'}) is not yet supported ` +
+      `on the root-program path.`,
+    )
+  }
+
+  throw new Error(`materializeSession: unhandled wiring op '${op}'.`)
+}
+
+function paramRef(name: string, ctx: MaterializeContext): ResolvedExpr {
+  let decl = ctx.paramDecls.get(name)
+  if (decl === undefined) {
+    decl = { op: 'paramDecl', name }
+    ctx.paramDecls.set(name, decl)
+  }
+  // ParamIdx is the iteration position in ctx.paramDecls. Params land
+  // in body.decls after syntheticRegDecls and instanceDecls, but ParamIdx
+  // indexes into body.params[] (filtered by op), which preserves
+  // insertion order of paramDecls.
+  let pi = -1
+  let i = 0
+  for (const n of ctx.paramDecls.keys()) {
+    if (n === name) { pi = i; break }
+    i++
+  }
+  return { op: 'paramRef', idx: paramIdx(pi) }
+}

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -144,6 +144,23 @@ function lookupInputArraySlot(
   return { slot: meta.arraySlot, size: meta.arraySize }
 }
 
+/** Sentinel `instancePath` for the synthetic session root (Option A).
+ *  `partitionKernel` treats it as naming-transparent: the root's
+ *  children and its own registers carry BARE names (no `__root__.`
+ *  prefix), so child output-slot keys (`amp.out`) and per-instance
+ *  register names land byte-for-byte where the flat per-instance path
+ *  puts them. Without this the root would prefix every nested name and
+ *  break `emitDacStitch`'s `graphOutputs` slot lookup and hot-swap
+ *  state-transfer-by-name. */
+export const ROOT_INSTANCE_PATH = '__root__'
+
+/** Join an instance path with a child segment, transparently for the
+ *  synthetic root (no prefix). For any real instance path this is the
+ *  ordinary dotted join. */
+function joinInstancePath(parent: string, child: string): string {
+  return parent === ROOT_INSTANCE_PATH ? child : `${parent}.${child}`
+}
+
 // ─── Entry point ──────────────────────────────────────────────────────────
 
 /** Result of compiling a single kernel: the InstanceFunction (with
@@ -229,7 +246,7 @@ export function partitionKernel(
   let childInstIdx = 0
   for (const decl of prog.body.decls) {
     if (decl.op !== 'instanceDecl') continue
-    const childPath = `${instancePath}.${decl.name}`
+    const childPath = joinInstancePath(instancePath, decl.name)
     const thisInstIdx = instanceIdx(childInstIdx++)
 
     const declType = getInstanceType(prog, decl)
@@ -412,11 +429,11 @@ export function partitionKernel(
   // ── 4. Update accumulators (THIS kernel's contribution to the unified
   //    namespaces). Note: children's accumulator updates already happened
   //    via the recursive calls above, so we just add this kernel's own.
-  for (const n of plan.register_names) acc.registerNames.push(`${instancePath}.${n}`)
+  for (const n of plan.register_names) acc.registerNames.push(joinInstancePath(instancePath, n))
   acc.registerTypes.push(...plan.register_types)
   for (const v of plan.state_init) acc.stateInit.push(v as number | boolean)
   acc.arraySlotSizes.push(...plan.array_slot_sizes)
-  for (const n of plan.array_slot_names) acc.arraySlotNames.push(`${instancePath}.${n}`)
+  for (const n of plan.array_slot_names) acc.arraySlotNames.push(joinInstancePath(instancePath, n))
 
   acc.nextRegRaw   += plan.register_count + tempsConsumed
   acc.nextStateRaw += plan.state_init.length

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -1131,6 +1131,42 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
         append(instr.strides.data(), instr.strides.size());
     };
 
+    // Serialize one instance function INCLUDING its preamble,
+    // pre_input, writebacks, and nested children. Recursing into
+    // children is essential: under the root-program (Option A)
+    // lowering every plan's single top-level function has an empty
+    // body and the same `instance_name` ("instance___root__"), so the
+    // whole plan's identity lives in the child subtree. Hashing only
+    // the top-level `instructions` (as before) made all such plans
+    // collide and serve each other's cached kernels. Leaf/flat plans
+    // are unaffected — their bodies were already distinct.
+    std::function<void(const InstanceProgram &)> serialize_fn =
+      [&](const InstanceProgram & inst) {
+        append(&inst.register_count, sizeof(uint32_t));
+        uint32_t nameLen = static_cast<uint32_t>(inst.instance_name.size());
+        append(&nameLen, sizeof(uint32_t));
+        if (!inst.instance_name.empty())
+          append(inst.instance_name.data(), inst.instance_name.size());
+        auto serialize_block = [&](const std::vector<FlatInstr> & block) {
+          uint32_t n = static_cast<uint32_t>(block.size());
+          append(&n, sizeof(uint32_t));
+          for (const auto & instr : block) serialize_instr(instr);
+        };
+        serialize_block(inst.preamble_instructions);
+        serialize_block(inst.pre_input_instructions);
+        serialize_block(inst.instructions);
+        uint32_t nwb = static_cast<uint32_t>(inst.writebacks.size());
+        append(&nwb, sizeof(uint32_t));
+        for (const auto & wb : inst.writebacks)
+        {
+          append(&wb.state_slot, sizeof(uint32_t));
+          append(&wb.temp_slot,  sizeof(int32_t));
+        }
+        uint32_t nch = static_cast<uint32_t>(inst.children.size());
+        append(&nch, sizeof(uint32_t));
+        for (const auto & child : inst.children) serialize_fn(child);
+      };
+
     append(&program.register_count, sizeof(uint32_t));
     // Scheduler: preamble + state_evolution + postamble
     uint32_t npre = static_cast<uint32_t>(program.scheduler.preamble.size());
@@ -1142,20 +1178,10 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
     uint32_t npost = static_cast<uint32_t>(program.scheduler.postamble.size());
     append(&npost, sizeof(uint32_t));
     for (const auto & instr : program.scheduler.postamble) serialize_instr(instr);
-    // Instance functions
+    // Instance functions (recursively, including children)
     uint32_t nfns = static_cast<uint32_t>(program.instance_functions.size());
     append(&nfns, sizeof(uint32_t));
-    for (const auto & inst : program.instance_functions)
-    {
-      append(&inst.register_count, sizeof(uint32_t));
-      uint32_t nameLen = static_cast<uint32_t>(inst.instance_name.size());
-      append(&nameLen, sizeof(uint32_t));
-      if (!inst.instance_name.empty())
-        append(inst.instance_name.data(), inst.instance_name.size());
-      uint32_t ni = static_cast<uint32_t>(inst.instructions.size());
-      append(&ni, sizeof(uint32_t));
-      for (const auto & instr : inst.instructions) serialize_instr(instr);
-    }
+    for (const auto & inst : program.instance_functions) serialize_fn(inst);
     // Mix outputs
     uint32_t nm = static_cast<uint32_t>(program.mix_output_temps.size());
     append(&nm, sizeof(uint32_t));
@@ -1445,6 +1471,35 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
         append(instr.strides.data(), instr.strides.size());
     };
 
+    // Recurse into preamble/pre_input/writebacks/children — same
+    // completeness requirement as the fused cache key (a root-program
+    // plan's identity lives entirely in its child subtree).
+    std::function<void(const InstanceProgram &)> serialize_fn =
+      [&](const InstanceProgram & inst) {
+        append(&inst.register_count, sizeof(uint32_t));
+        uint32_t nameLen = static_cast<uint32_t>(inst.instance_name.size());
+        append(&nameLen, sizeof(uint32_t));
+        if (!inst.instance_name.empty())
+          append(inst.instance_name.data(), inst.instance_name.size());
+        auto serialize_block = [&](const std::vector<FlatInstr> & block) {
+          uint32_t n = static_cast<uint32_t>(block.size());
+          append(&n, sizeof(uint32_t));
+          for (const auto & instr : block) serialize_instr(instr);
+        };
+        serialize_block(inst.preamble_instructions);
+        serialize_block(inst.pre_input_instructions);
+        serialize_block(inst.instructions);
+        uint32_t nwb = static_cast<uint32_t>(inst.writebacks.size());
+        append(&nwb, sizeof(uint32_t));
+        for (const auto & wb : inst.writebacks) {
+          append(&wb.state_slot, sizeof(uint32_t));
+          append(&wb.temp_slot,  sizeof(int32_t));
+        }
+        uint32_t nch = static_cast<uint32_t>(inst.children.size());
+        append(&nch, sizeof(uint32_t));
+        for (const auto & child : inst.children) serialize_fn(child);
+      };
+
     append(&program.register_count, sizeof(uint32_t));
     uint32_t npre = static_cast<uint32_t>(program.scheduler.preamble.size());
     append(&npre, sizeof(uint32_t));
@@ -1457,16 +1512,7 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
     for (const auto & instr : program.scheduler.postamble) serialize_instr(instr);
     uint32_t nfns = static_cast<uint32_t>(program.instance_functions.size());
     append(&nfns, sizeof(uint32_t));
-    for (const auto & inst : program.instance_functions) {
-      append(&inst.register_count, sizeof(uint32_t));
-      uint32_t nameLen = static_cast<uint32_t>(inst.instance_name.size());
-      append(&nameLen, sizeof(uint32_t));
-      if (!inst.instance_name.empty())
-        append(inst.instance_name.data(), inst.instance_name.size());
-      uint32_t ni = static_cast<uint32_t>(inst.instructions.size());
-      append(&ni, sizeof(uint32_t));
-      for (const auto & instr : inst.instructions) serialize_instr(instr);
-    }
+    for (const auto & inst : program.instance_functions) serialize_fn(inst);
     uint32_t nm = static_cast<uint32_t>(program.mix_output_temps.size());
     append(&nm, sizeof(uint32_t));
     for (uint32_t mt : program.mix_output_temps)

--- a/tests/equiv/root_vs_flat.test.ts
+++ b/tests/equiv/root_vs_flat.test.ts
@@ -1,0 +1,187 @@
+/**
+ * root_vs_flat.test.ts — Option A equivalence gate.
+ *
+ * The session compiler has two lowerings that must agree sample-for-
+ * sample on the audio output:
+ *
+ *   • flat (default) — `compileSessionSlottedPerInstance`: each
+ *     top-level instance compiles to its own `InstanceFunction`; a
+ *     scheduler runs them in topo order, then a `state_evolution`
+ *     phase writes one slot per extracted per-wire unit delay, then
+ *     the DAC-stitch postamble.
+ *
+ *   • root (`rootProgram:true`) — `compileSessionSlottedRoot`: the
+ *     whole session materializes into one synthetic root
+ *     `ResolvedProgram` (instances → `InstanceDecl` children, per-wire
+ *     unit delays → root `RegDecl`s) lowered through the SAME
+ *     `partitionKernel` path the per-program fractal lowering uses.
+ *     The scheduler is reduced to the DAC postamble; the delays are
+ *     root RegDecl writebacks.
+ *
+ * Both feed the JIT through the identical `tropical_plan_5` schema.
+ * Any divergence is a materializer, naming-transparency, or delay-
+ * ordering bug. The flat path is the oracle.
+ *
+ * Requires libtropical.dylib (build with `make build` first).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, inputNames, outputNames, setWireExpr } from '../../compiler/session.js'
+import type { ExprNode } from '../../compiler/expr.js'
+import { loadStdlib } from '../../compiler/program.js'
+import { applyFlatPlan } from '../../compiler/apply_plan.js'
+import { wireKey, portRef, instanceName, portName } from '../../compiler/ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+
+const BUFFER_LENGTH = 256
+const N_BUFFERS     = 4
+const TOTAL_SAMPLES = BUFFER_LENGTH * N_BUFFERS
+// Both paths run identical per-instruction LLVM codegen; the only
+// difference is how the cross-instance/delay plumbing is expressed
+// (scheduler state_evolution slots vs. root RegDecl writebacks). LLVM
+// folds the equivalent store/load round-trips → byte-equal output.
+const TOLERANCE     = 1e-12
+
+function pulseEvery(n: number): ExprNode {
+  return { op: 'lt', args: [{ op: 'mod', args: [{ op: 'sampleIndex' }, n] }, 1] }
+}
+
+const DEFAULT_INPUTS: Record<string, ExprNode> = {
+  freq: 220, x: 0.5, y: 0.5, audio: 0.5, input: 0.5, cv: 0.5,
+  cutoff: 1000, q: 0.5, drive: 1.0, mix: 0.5, a: 0.3, b: 0.7,
+  coeff: 0.4, feedback: 0.4, lfo_speed: 0.2, decay: 0.99,
+  rate: 5, g: 0.1, resonance: 0.5,
+  trigger: pulseEvery(64), clock: pulseEvery(32),
+}
+
+const STDLIB_TARGETS: Array<[string, Record<string, number>?]> = [
+  ['SinOsc'], ['Sin'], ['Cos'], ['Tanh'], ['Exp'], ['Log'], ['Pow'],
+  ['OnePole'], ['BlepSaw'], ['SoftClip'], ['VCA'], ['CrossFade'],
+  ['SVF'], ['LadderFilter'], ['Phaser'], ['Phaser16'],
+  ['Bubble'], ['BubbleCloud'],
+  ['AllpassDelay'], ['CombDelay'],
+  ['Delay', { N: 1024 }],
+]
+
+function setupInstance(
+  typeName: string,
+  typeArgs: Record<string, number> | undefined,
+) {
+  const session = makeSession(BUFFER_LENGTH)
+  loadStdlib(session)
+  const { type, typeArgs: resolved } = resolveProgramType(session, typeName, typeArgs, undefined)
+  const inst = instantiate(type, 'inst', { baseTypeName: typeName, typeArgs: resolved })
+  session.instanceRegistry.set('inst', inst)
+  for (const pn of inputNames(inst)) {
+    if (pn in DEFAULT_INPUTS) {
+      session.inputExprNodes.set(wk('inst', pn), DEFAULT_INPUTS[pn])
+    }
+  }
+  session.graphOutputs.push({ instance: 'inst', output: outputNames(inst)[0] })
+  return session
+}
+
+/** osc(BlepSaw) → amp(VCA) → dac, wired via `setWireExpr` so every
+ *  cross-instance wire is auto-delayed → a delaySlotRegistry entry →
+ *  (root path) a root RegDecl. This is the case the per-instance
+ *  state_evolution phase exists for; the root differential proves the
+ *  RegDecl-writeback replacement is byte-identical. */
+function setupOscAmp() {
+  const session = makeSession(BUFFER_LENGTH)
+  loadStdlib(session)
+  for (const [name, ty] of [['osc', 'BlepSaw'], ['amp', 'VCA']] as const) {
+    const { type } = resolveProgramType(session, ty, undefined, undefined)
+    session.instanceRegistry.set(name, instantiate(type, name, { baseTypeName: ty }))
+  }
+  // Wire freq explicitly. An UNWIRED typed-bound input (`freq: freq =
+  // 440`) is handled differently by the two paths — the flat
+  // top-level builder only honors plain-number defaults (→ 0 here),
+  // while the root path's child default uses `rawInputDefaults` (→
+  // 440). That divergence is a pre-existing default-policy quirk
+  // orthogonal to Option A; every realistic session (and every other
+  // equiv test) wires its inputs, so we do too.
+  session.inputExprNodes.set(wk('osc', 'freq'), 220)
+  setWireExpr(session, portRef(instanceName('amp'), portName('audio')),
+    { op: 'ref', instance: 'osc', output: 'saw' })
+  setWireExpr(session, portRef(instanceName('amp'), portName('cv')), 0.5)
+  session.graphOutputs.push({ instance: 'amp', output: 'out' })
+  return session
+}
+
+function captureOutput(
+  session: ReturnType<typeof setupInstance>,
+  rootProgram: boolean,
+): Float64Array {
+  applyFlatPlan(session, session.runtime, { rootProgram })
+  session.graph.primeJit()
+  const out = new Float64Array(TOTAL_SAMPLES)
+  for (let f = 0; f < N_BUFFERS; f++) {
+    session.runtime.process()
+    const buf = session.runtime.outputBuffer
+    out.set(buf.subarray(0, BUFFER_LENGTH), f * BUFFER_LENGTH)
+  }
+  return out
+}
+
+function assertEqual(label: string, flat: Float64Array, root: Float64Array) {
+  let maxAbsDiff = 0
+  let firstDiffIdx = -1
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    const f = flat[i]
+    const r = root[i]
+    if (Number.isNaN(f) && Number.isNaN(r)) continue
+    const d = Math.abs(f - r)
+    if (d > maxAbsDiff) maxAbsDiff = d
+    if (d > TOLERANCE && firstDiffIdx < 0) firstDiffIdx = i
+  }
+  if (maxAbsDiff > TOLERANCE) {
+    const i = firstDiffIdx
+    throw new Error(
+      `${label}: flat/root diverged at sample ${i} ` +
+      `(flat=${flat[i]}, root=${root[i]}, maxAbsDiff=${maxAbsDiff})`,
+    )
+  }
+  expect(maxAbsDiff).toBeLessThanOrEqual(TOLERANCE)
+}
+
+describe('root-vs-flat stdlib equivalence (single instance)', () => {
+  for (const [typeName, typeArgs] of STDLIB_TARGETS) {
+    test(`${typeName}${typeArgs ? `<${JSON.stringify(typeArgs)}>` : ''}`, () => {
+      // Independent sessions per path so state inits match (no
+      // hot-swap state transfer crossing the axis).
+      const flat = captureOutput(setupInstance(typeName, typeArgs), false)
+      const root = captureOutput(setupInstance(typeName, typeArgs), true)
+      assertEqual(typeName, flat, root)
+    })
+  }
+})
+
+describe('root-vs-flat multi-instance (auto-delayed wires)', () => {
+  test('BlepSaw → VCA → dac', () => {
+    const flat = captureOutput(setupOscAmp(), false)
+    const root = captureOutput(setupOscAmp(), true)
+    assertEqual('osc→amp', flat, root)
+  })
+})
+
+describe('root-vs-flat polyphony', () => {
+  test('8x SinOsc voices', () => {
+    function setupPolyphony() {
+      const session = makeSession(BUFFER_LENGTH)
+      loadStdlib(session)
+      const { type, typeArgs } = resolveProgramType(session, 'SinOsc', undefined, undefined)
+      for (let i = 0; i < 8; i++) {
+        const name = `osc${i}`
+        const inst = instantiate(type, name, { baseTypeName: 'SinOsc', typeArgs })
+        session.instanceRegistry.set(name, inst)
+        session.inputExprNodes.set(wk(name, 'freq'), 110 + 22 * i)
+        session.graphOutputs.push({ instance: name, output: outputNames(inst)[0] })
+      }
+      return session
+    }
+    const flat = captureOutput(setupPolyphony(), false)
+    const root = captureOutput(setupPolyphony(), true)
+    assertEqual('8x SinOsc', flat, root)
+  })
+})


### PR DESCRIPTION
## Summary

Implements **Option A** (Phases A + B of the approved plan): a session
materializes into one synthetic **root `ResolvedProgram`** — instances become
`InstanceDecl`s, wires become `InstanceDecl.inputs`, and per-wire unit delays
become root `RegDecl`s — and is lowered through the **existing**
`partitionKernel` path. The program and session paths now share one lowering;
the scheduler reduces to a DAC-stitch postamble (`state_evolution` empty).

Gated behind a flag (default **OFF**) / `TROPICAL_ROOT_PROGRAM=1`. The C++
engine is semantically unchanged.

## What's here

- **`compiler/ir/materialize_session.ts` (+ unit test)** — `materializeSessionToResolvedIR`.
  Each `InstanceDecl` is built from `inst.compiled.prog` (the exact
  strata-lowered program the flat path compiles, carrying its own
  `programRegistry` so `partitionKernel`'s recursive `getInstanceType` resolves
  the whole subtree). Scalar session delays → reserve-then-fill synthetic
  `RegDecl{init,update}`; array delays throw (out of scope).
- **`compileSessionSlottedRoot` + `rootProgram` flag** — materialize →
  `partitionKernel(ROOT_INSTANCE_PATH, …)` → one `instance_functions` entry +
  DAC postamble.
- **Naming transparency** (`partition_recursive.ts`) — `ROOT_INSTANCE_PATH`
  sentinel keeps the root's children and own registers at bare names
  (`amp.out`, `osc.phase`), so `emitDacStitch`'s `graphOutputs` lookup and
  state-transfer-by-name resolve exactly as on the flat path.
- **Array fallback** — `sessionHasArrayWiring` routes array sessions back to the
  per-instance path, keeping Phase B scalar-only and the flag safe to force on.
- **`tests/equiv/root_vs_flat.test.ts`** — flag-off vs flag-on JIT equivalence
  (1e-12) over the stdlib corpus + a delayed multi-instance osc→amp session +
  8× polyphony.

## Engine bug fixed (cache-key completeness)

The JIT cache-key serialization (both the fused `kernel_cache_` key and the
microkernel/deep `microkernel_cache_` key) hashed only each top-level
function's own `instructions`/`instance_name`/`register_count` — it never
recursed into `children`/`preamble`/`pre_input`/`writebacks`. Flat plans dodged
this because their top-level body differs per type; **root plans all share an
empty, identically-named top-level function**, so they collided and served each
other's cached kernels. Fixed by recursing via a `serialize_fn` lambda. Pure
cache-key fix — no emitted-code or golden movement.

## Verification

- `bun test` (flag off, default): **1035 pass / 0 fail**
- `TROPICAL_ROOT_PROGRAM=1 bun test tests/equiv/root_vs_flat.test.ts`: **23 pass**
- `TROPICAL_ROOT_PROGRAM=1 bun test tests/equiv/migration_audio.test.ts`: **11 pass**
- `ctest --test-dir build`: pass · `npx tsc --noEmit`: clean

## Known limitations (see `HANDOFF_OPTION_A.md`)

- **WASM backend** doesn't handle root plans yet — forcing the flag on globally
  yields 4 `wasm_vs_jit` failures (JIT side is correct; `emit_wasm` is the
  diverging side). Phase B targets the JIT path; WASM root support is Phase C/E.
  The flag defaults off, so normal WASM operation is unaffected.
- **Unwired typed-bound defaults** (`freq = 440`) resolve to 0 on the flat
  top-level path vs the declared default on the root child path. Benign — every
  realistic session wires its inputs. Documented, not fixed (one-axis-at-a-time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)