### PR TITLE
Option A Phase D: array port wiring + array session delays on the root-program path

### DIFF
--- a/HANDOFF_OPTION_A.md
+++ b/HANDOFF_OPTION_A.md
@@ -101,11 +101,28 @@ This is a pure cache-key fix — no emitted-code or golden change. Rebuild requi
    inputs, so this never bites in practice; the `root_vs_flat` osc→amp case wires
    `freq` explicitly. NOT fixed (one-axis-at-a-time; arguably root is *more*
    correct). If a future patch relies on unwired typed defaults, revisit.
-3. **Phase C/D/E** per the plan: soak (flag still OFF), then remove the
-   array-refusal (`sessionHasArrayWiring`) + add array `RegDecl` support
-   (Phase D), then flip the default and delete `compileSessionSlottedPerInstance`
-   + the `state_evolution` emission (Phase E). Keep `delaySlotRegistry`,
-   `emitDacStitch`, `graphOutputs` as the bridge/DAC tap.
+3. **Phase D1 — array-typed PORT wiring: DONE.** Array-typed instance ports now
+   lower on the root path. Two materializer fixes: (a) emit the root's child
+   instances in `computeInstanceTopoOrder` (producer before consumer) — array
+   wires are same-sample (not auto-delayed), so the producer must run first;
+   (b) keep array ports on `InstanceDecl.inputs` so `compileResolved`'s
+   `arrayInfo` branch copies the array `nestedOut` into the child's session-array
+   slot. The dispatch fallback narrowed from `sessionHasArrayWiring` to
+   `sessionHasArrayDelay`. Gate: `root_vs_flat` Sequencer array-literal case;
+   migration goldens forced-on stay 11/11 (now via the root path).
+4. **Phase D2 — array session DELAYS: deferred (fallback is correct).** A
+   `delay()` over an array-shaped source (hoisted to an `ioArraySlot`, `isArray`
+   registry entry) still routes to the per-instance path via
+   `sessionHasArrayDelay`. There is **no consumer in the current corpus** (no
+   fixture/patch produces one; they're hard to even construct — the source must
+   be a `ref` to an array output at extract time), and the fallback yields
+   byte-identical output. Per "don't build ahead of need," left as the narrow
+   fallback until a real array-delay session appears; then either add array
+   `RegDecl` support to the materializer or keep array delays on
+   `state_evolution` in the root path.
+5. **Phase E — cutover** (after the WASM-root gap closes): flip the default and
+   delete `compileSessionSlottedPerInstance` + the `state_evolution` emission.
+   Keep `delaySlotRegistry`, `emitDacStitch`, `graphOutputs` as the bridge/DAC tap.
 
 ## Key invariants to preserve
 

--- a/HANDOFF_OPTION_A.md
+++ b/HANDOFF_OPTION_A.md
@@ -110,16 +110,23 @@ This is a pure cache-key fix — no emitted-code or golden change. Rebuild requi
    slot. The dispatch fallback narrowed from `sessionHasArrayWiring` to
    `sessionHasArrayDelay`. Gate: `root_vs_flat` Sequencer array-literal case;
    migration goldens forced-on stay 11/11 (now via the root path).
-4. **Phase D2 — array session DELAYS: deferred (fallback is correct).** A
-   `delay()` over an array-shaped source (hoisted to an `ioArraySlot`, `isArray`
-   registry entry) still routes to the per-instance path via
-   `sessionHasArrayDelay`. There is **no consumer in the current corpus** (no
-   fixture/patch produces one; they're hard to even construct — the source must
-   be a `ref` to an array output at extract time), and the fallback yields
-   byte-identical output. Per "don't build ahead of need," left as the narrow
-   fallback until a real array-delay session appears; then either add array
-   `RegDecl` support to the materializer or keep array delays on
-   `state_evolution` in the root path.
+4. **Phase D2 — array session DELAYS: DONE.** A `delay()` over an array-shaped
+   source (hoisted to an `ioArraySlot`, `isArray` registry entry) now
+   materializes to an **array-typed root `RegDecl`**: `init` is an
+   `arraySize`-long literal array (so `compileResolved` allocates a backing array
+   slot via its `arrayRegMap`), and `update` is the translated array source
+   (`nestedOut` to the producer's array output). `emit_resolved` lowers the
+   array-result update to an elementwise copy at writeback — the same per-element
+   one-sample latency the per-instance `state_evolution` array `Add` gave.
+   `sessionArraySlot` reads translate to `regRef`. One supporting engine-free fix
+   in `emit_resolved.ts`: the array-reg writeback now accepts a
+   `session_array_reg` source (a sibling's array output), not just kernel-local
+   `array_reg` (`remapInstancePlan` already lowers it to an absolute slot). The
+   dispatch fallback is gone — array sessions go through the root path. Gate:
+   `root_vs_flat` array-session-delay case (`delay([s, s+10, s+20]) → ArrSum`,
+   25 pass) — a time-varying array source makes any latency/permutation bug
+   visible. Motivation: polyphony and any cross-voice array feedback will hit
+   this routinely.
 5. **Phase E — cutover** (after the WASM-root gap closes): flip the default and
    delete `compileSessionSlottedPerInstance` + the `state_evolution` emission.
    Keep `delaySlotRegistry`, `emitDacStitch`, `graphOutputs` as the bridge/DAC tap.

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -61,27 +61,13 @@ export function compileSessionSlotted(
 ): FlatPlan {
   const mode = options.compilation_mode ?? 'fused'
   const rootProgram = process.env.TROPICAL_ROOT_PROGRAM === '1' || options.rootProgram === true
-  // The root lowering handles scalar wiring and array-typed *port*
-  // wiring (array slots are delivered by aliasing + the recursive
-  // partitioner). Array session *delays* — `delay()` over an
-  // array-shaped source, hoisted to an `ioArraySlot` with an
-  // `isArray` registry entry — still need the per-instance
-  // `state_evolution` elementwise-copy path (a later phase lifts
-  // this). Fall back transparently so the flag stays safe to force on.
-  if (rootProgram && !sessionHasArrayDelay(session)) {
+  // The root lowering handles scalar wiring, array-typed *port* wiring
+  // (delivered by aliasing + the recursive partitioner), and array
+  // session *delays* (hoisted `ioArraySlot` entries → array `RegDecl`s).
+  if (rootProgram) {
     return compileSessionSlottedRoot(session, mode)
   }
   return compileSessionSlottedPerInstance(session, mode)
-}
-
-/** True if the session has an array-typed session delay — a `delay()`
- *  whose source is array-shaped, which `extractSessionDelays` hoists to
- *  an `ioArraySlot` (`isArray` registry entry). The root path doesn't
- *  represent these yet; they route to the per-instance path. Array
- *  *ports* and internal array state (e.g. a `Delay`'s ring buffer) are
- *  fully supported on the root path and do NOT count here. */
-function sessionHasArrayDelay(session: SessionState): boolean {
-  return session.delaySlotRegistry.some(e => e.isArray)
 }
 
 /** Recursively allocate output slots for an instance and every nested
@@ -372,19 +358,13 @@ function compileSessionSlottedPerInstance(
  *  `state_evolution` `WriteSlot`s provided. The scheduler is reduced
  *  to the DAC-stitch postamble (`state_evolution` is empty).
  *
- *  Scalar session delays only (Phase B). Array session delays still
- *  route through the per-instance path. */
+ *  Scalar session delays become scalar `RegDecl`s; array session delays
+ *  become array `RegDecl`s (their elementwise-copy writeback replaces
+ *  the per-instance path's `state_evolution` array `Add`). */
 function compileSessionSlottedRoot(
   session: SessionState,
   compilationMode: CompilationMode,
 ): FlatPlan {
-  if (session.delaySlotRegistry.some(e => e.isArray)) {
-    throw new Error(
-      'compileSessionSlottedRoot: session-level array delays are not yet ' +
-      'supported on the root-program path (Phase D); use the per-instance path.',
-    )
-  }
-
   // Two-phase slot pre-allocation — identical to the per-instance
   // path. partitionKernel re-issues these idempotently during its own
   // child walk.

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -61,31 +61,27 @@ export function compileSessionSlotted(
 ): FlatPlan {
   const mode = options.compilation_mode ?? 'fused'
   const rootProgram = process.env.TROPICAL_ROOT_PROGRAM === '1' || options.rootProgram === true
-  // Phase B root lowering is scalar-only. A session that carries any
-  // array-typed wiring — array-typed instance ports, or array session
-  // delays — still needs the per-instance `state_evolution`/array-slot
-  // machinery (Phase C/D lifts this). Fall back transparently so the
-  // flag stays safe to force on across the whole corpus.
-  if (rootProgram && !sessionHasArrayWiring(session)) {
+  // The root lowering handles scalar wiring and array-typed *port*
+  // wiring (array slots are delivered by aliasing + the recursive
+  // partitioner). Array session *delays* — `delay()` over an
+  // array-shaped source, hoisted to an `ioArraySlot` with an
+  // `isArray` registry entry — still need the per-instance
+  // `state_evolution` elementwise-copy path (a later phase lifts
+  // this). Fall back transparently so the flag stays safe to force on.
+  if (rootProgram && !sessionHasArrayDelay(session)) {
     return compileSessionSlottedRoot(session, mode)
   }
   return compileSessionSlottedPerInstance(session, mode)
 }
 
-/** True if the session has any array-typed wiring the scalar-only root
- *  lowering can't yet represent: an array-typed instance input/output
- *  port, or an array-typed session delay. Internal array state (e.g. a
- *  `Delay`'s ring buffer) does NOT count — it lives inside one
- *  instance's scalar-port kernel and never crosses a session wire. */
-function sessionHasArrayWiring(session: SessionState): boolean {
-  if (session.delaySlotRegistry.some(e => e.isArray)) return true
-  for (const [, inst] of session.instanceRegistry) {
-    const prog = inst.compiled?.prog
-    if (prog === undefined) continue
-    for (const p of prog.ports.inputs)  if (p.type?.kind === 'array') return true
-    for (const p of prog.ports.outputs) if (p.type?.kind === 'array') return true
-  }
-  return false
+/** True if the session has an array-typed session delay — a `delay()`
+ *  whose source is array-shaped, which `extractSessionDelays` hoists to
+ *  an `ioArraySlot` (`isArray` registry entry). The root path doesn't
+ *  represent these yet; they route to the per-instance path. Array
+ *  *ports* and internal array state (e.g. a `Delay`'s ring buffer) are
+ *  fully supported on the root path and do NOT count here. */
+function sessionHasArrayDelay(session: SessionState): boolean {
+  return session.delaySlotRegistry.some(e => e.isArray)
 }
 
 /** Recursively allocate output slots for an instance and every nested

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -1186,10 +1186,23 @@ class Emitter {
         if (!arrInfo) {
           throw new Error(`emitProgram: array-result update on non-array reg ${ri}`)
         }
-        if (r.op.kind !== 'array_reg') {
+        // The update may resolve to a kernel-local `array_reg` (e.g. an
+        // `arraySet` on the reg's own slot) or a `session_array_reg` —
+        // a read of a sibling instance's array output, which is how an
+        // array session delay's source (`nestedOut` to a producer's
+        // array port) surfaces in the synthetic root program. Both are
+        // valid array sources; `remapInstancePlan` lowers
+        // `session_array_reg` to an absolute `array_reg`.
+        if (r.op.kind !== 'array_reg' && r.op.kind !== 'session_array_reg') {
           throw new Error(`emitProgram: array result has non-array operand kind ${r.op.kind}`)
         }
-        if (rawIdx(r.op.slot) !== rawIdx(arrInfo.slot)) {
+        // Skip the copy only for an in-place kernel-local update whose
+        // source slot already IS the reg's backing slot. A
+        // `session_array_reg` source lives in the session-absolute
+        // namespace (distinct from the reg's kernel-local slot), so it
+        // always needs the elementwise copy.
+        const inPlace = r.op.kind === 'array_reg' && rawIdx(r.op.slot) === rawIdx(arrInfo.slot)
+        if (!inPlace) {
           arrayCopies.push({ src: r.op, dst: arrInfo.slot, size: arrInfo.size })
         }
         register_targets.push(ArrayManagedTarget)

--- a/compiler/ir/materialize_session.test.ts
+++ b/compiler/ir/materialize_session.test.ts
@@ -86,10 +86,13 @@ describe('materializeSessionToResolvedIR', () => {
     expect(amp.inputs.length).toBe(2)
   })
 
-  test('throws on array session delays (scalar-first guard)', () => {
+  test('array session delays become array RegDecls', () => {
     const session = makeOscAmpSession()
-    // Inject an array delay entry directly — the root path does not yet
-    // support array-typed RegDecls (Phase D).
+    // Inject an array delay entry directly (as `extractSessionDelays`
+    // would for a `delay()` over an array-shaped source). It should
+    // materialize to an array-typed root RegDecl whose init is a
+    // size-long literal array — the backing store `compileResolved`
+    // turns into an array slot.
     session.delaySlotRegistry.push({
       slotName: '__arr_delay_test',
       sourceExpr: { op: 'ref', instance: 'osc', output: 'saw' },
@@ -99,7 +102,14 @@ describe('materializeSessionToResolvedIR', () => {
       arraySlot: 0,
       arraySize: 8,
     })
-    expect(() => materializeSessionToResolvedIR(session)).toThrow(/array delay/)
+    const root = materializeSessionToResolvedIR(session)
+    const arrReg = root.regs.find(r => r.name === '__arr_delay_test')
+    expect(arrReg).toBeDefined()
+    // Array-typed init: a length-8 literal array (the scalar delays
+    // carry plain-number inits).
+    expect(Array.isArray(arrReg!.init)).toBe(true)
+    expect((arrReg!.init as unknown[]).length).toBe(8)
+    expect(arrReg!.update).toBeDefined()
   })
 
   test('throws CycleViolation on an undelayed inter-instance cycle', () => {

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -54,6 +54,7 @@ import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
 import { parseWireKey } from './branded_names.js'
 import { mkProgram } from './decl_tables.js'
+import { computeInstanceTopoOrder } from './compile_session_slotted_helpers.js'
 
 /** Run the session → root `ResolvedProgram` materialization end-to-end.
  *  The result is the synthetic top-level program; callers lower it via
@@ -130,9 +131,22 @@ interface MaterializeContext {
 }
 
 function materializeSessionInner(session: SessionState, ctx: MaterializeContext): ResolvedProgram {
-  for (const [name, inst] of session.instanceRegistry) {
-    const decl = buildInstanceDecl(name, inst, ctx)
-    ctx.instanceDecls.set(name, decl)
+  // Build instances in TOPOLOGICAL order (producer before consumer),
+  // the same order the per-instance path's `instance_functions` use.
+  // This matters for same-sample (un-delayed) wires — array wires in
+  // particular, which `setWireExpr` does NOT auto-delay: the producer
+  // kernel must run before the consumer reads its (aliased) array
+  // slot. Scalar cross-instance wires are all delayed (their edges
+  // vanish after `extractSessionDelays`), so for purely-scalar
+  // sessions this degenerates to insertion order — the Phase B
+  // behavior. The chosen order also fixes `InstanceIdx` (iteration
+  // position in `ctx.instanceDecls`), which must agree with the
+  // instance order in `body.decls` for `compileResolved`.
+  const order = computeInstanceTopoOrder(session)
+  for (const name of order) {
+    const inst = session.instanceRegistry.get(name)
+    if (inst === undefined) continue
+    ctx.instanceDecls.set(name, buildInstanceDecl(name, inst, ctx))
   }
 
   // Reconstruct the synthetic RegDecls behind session-level delay
@@ -154,6 +168,13 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
         `materializeSession: instance '${instName}' has no input port '${inputName}' on type '${instType.name}'.`,
       )
     }
+    // Array-typed ports are carried on `InstanceDecl.inputs` just like
+    // scalar ports; `compileResolved` discriminates on the port's
+    // allocation class and lowers an array wire (a `nestedOut` to a
+    // producer's array output) via an elementwise copy into the child's
+    // session-array slot. The producer-before-consumer instance order
+    // above is what makes that child array slot resolve (the wire is
+    // same-sample, not delayed).
     const value = translateExpr(expr, ctx)
     instDecl.inputs.push({ port: inputIdx(portI), value })
   }

--- a/compiler/ir/materialize_session.ts
+++ b/compiler/ir/materialize_session.ts
@@ -48,7 +48,7 @@ import type {
 } from './nodes.js'
 import { inputIdx, outputIdx, paramIdx, instanceIdx, regIdx, programKey } from './nodes.js'
 import type { ExprNode } from '../expr.js'
-import type { SessionState } from '../session.js'
+import type { SessionState, DelaySlotEntry } from '../session.js'
 import type { Instance } from '../program_types.js'
 import { findInstanceCycles } from './lowering/cycle_break.js'
 import { CycleViolation, type CycleDiagnostic } from './elaboration_diagnostics.js'
@@ -97,6 +97,7 @@ function makeContext(session: SessionState): MaterializeContext {
     programRegistry:     new Map(),
     syntheticRegDecls:   [],
     slotToReg:           new Map(),
+    arraySlotToReg:      new Map(),
     exprMemo:            new WeakMap(),
     session,
   }
@@ -126,6 +127,11 @@ interface MaterializeContext {
    *  `sessionSlot` reads — including those nested inside another slot's
    *  source expression — resolve to a stable reg. */
   slotToReg: Map<number, RegIdx>
+  /** Sibling of `slotToReg` for array session delays: maps an
+   *  `ioArraySlot` index (the `index` carried by a
+   *  `{op:'sessionArraySlot'}` read) to the RegIdx of the synthetic
+   *  array `RegDecl` reproducing that hoisted array delay. */
+  arraySlotToReg: Map<number, RegIdx>
   exprMemo: WeakMap<object, ResolvedExpr>
   session: SessionState
 }
@@ -237,47 +243,67 @@ function materializeSessionInner(session: SessionState, ctx: MaterializeContext)
  *
  *  Reg idx equals position in `ctx.syntheticRegDecls` (the
  *  front-of-body invariant from `materializeSessionInner`). Every
- *  slot's reg is reserved first — populating `ctx.slotToReg` — before
- *  any source expression is translated, because a source may itself
- *  read another `sessionSlot` (nested `delay(delay(x))`). */
+ *  slot's reg is reserved first — populating `ctx.slotToReg` /
+ *  `ctx.arraySlotToReg` — before any source expression is translated,
+ *  because a source may itself read another `sessionSlot` /
+ *  `sessionArraySlot` (nested `delay(delay(x))`).
+ *
+ *  Array session delays (`isArray` entries, hoisted by
+ *  `extractSessionDelays` to an `ioArraySlot`) become array-typed
+ *  `RegDecl`s: `init` is an `arraySize`-long literal array (so
+ *  `compileResolved` allocates a backing array slot via its
+ *  `arrayRegMap`), and `update` is the translated array source — a
+ *  `nestedOut` to the producer instance's array output. `emit_resolved`
+ *  lowers the array-result update to an elementwise copy from the
+ *  producer's output array slot into the reg's backing slot at
+ *  writeback time — the same one-sample latency the per-instance
+ *  path's `state_evolution` elementwise `Add` provides. */
 function materializeSessionDelaySlots(
   session: SessionState,
   ctx: MaterializeContext,
 ): void {
-  const regForSlot = new Map<number, RegDecl>()
+  const regForEntry = new Map<DelaySlotEntry, RegDecl>()
 
-  // Pass 1: reserve a synthetic reg per scalar slot and record the
-  // slotIdx → RegIdx map (so cross-slot reads resolve in pass 2).
+  // Pass 1: reserve a synthetic reg per delay slot (scalar → scalar
+  // reg, array → array reg) and record the slot → RegIdx maps so
+  // cross-slot reads resolve in pass 2.
   for (const entry of session.delaySlotRegistry) {
+    const regPos = ctx.syntheticRegDecls.length
     if (entry.isArray) {
-      throw new Error(
-        `materializeSession: session-level array delay (slot '${entry.slotName}', ` +
-        `size ${entry.arraySize ?? '?'}) is not yet supported on the root-program path; ` +
-        `scalar session delays are. Use the legacy flat-list path for array session delays.`,
-      )
+      if (entry.arraySlot === undefined || entry.arraySize === undefined) {
+        throw new Error(
+          `materializeSession: array delay slot '${entry.slotName}' is missing arraySlot/arraySize.`,
+        )
+      }
+      // Array-typed init: an `arraySize`-long literal array. `regInit`
+      // (compile_resolved) returns it as-is and `emit_resolved`'s
+      // constructor allocates the backing array slot (`arrayRegMap`).
+      const init: ResolvedExpr = new Array(entry.arraySize).fill(entry.init) as ResolvedExpr
+      const decl: RegDecl = { op: 'regDecl', name: entry.slotName, init, update: 0 }
+      ctx.syntheticRegDecls.push(decl)
+      ctx.arraySlotToReg.set(entry.arraySlot, regIdx(regPos))
+      regForEntry.set(entry, decl)
+      continue
     }
     if (entry.slotIdx === undefined) {
       throw new Error(
         `materializeSession: scalar delay slot '${entry.slotName}' is missing slotIdx.`,
       )
     }
-    const regPos = ctx.syntheticRegDecls.length
     const decl: RegDecl = {
       op: 'regDecl', name: entry.slotName, init: entry.init, update: 0,
     }
     ctx.syntheticRegDecls.push(decl)
     ctx.slotToReg.set(entry.slotIdx, regIdx(regPos))
-    regForSlot.set(entry.slotIdx, decl)
+    regForEntry.set(entry, decl)
   }
 
   // Pass 2: translate each slot's un-delayed source into the reg's
-  // update. Instance decls are built and `slotToReg` is complete, so
-  // both `{op:'ref'}` (instance outputs) and `{op:'sessionSlot'}`
-  // (nested delays) resolve.
+  // update. Instance decls are built and both slot maps are complete,
+  // so `{op:'ref'}` (instance outputs), `{op:'sessionSlot'}`, and
+  // `{op:'sessionArraySlot'}` (nested delays) all resolve.
   for (const entry of session.delaySlotRegistry) {
-    if (entry.isArray) continue
-    const decl = regForSlot.get(entry.slotIdx!)!
-    decl.update = translateExpr(entry.sourceExpr, ctx)
+    regForEntry.get(entry)!.update = translateExpr(entry.sourceExpr, ctx)
   }
 }
 
@@ -461,13 +487,23 @@ function translateOpNode(
   }
 
   if (op === 'sessionArraySlot') {
-    // Reached only if a session array delay slipped past
-    // `materializeSessionDelaySlots` (which throws on array entries).
-    throw new Error(
-      `materializeSession: session-level array delay (sessionArraySlot index ` +
-      `${typeof obj.index === 'number' ? obj.index : '?'}) is not yet supported ` +
-      `on the root-program path.`,
-    )
+    // An array delay already hoisted out of the wires by
+    // `extractSessionDelays` into an `ioArraySlot`.
+    // `materializeSessionDelaySlots` built the backing array reg up
+    // front; read it. The `regRef` to an array-init reg lowers (in
+    // `emit_resolved`) to an `array_reg` operand, which the consuming
+    // array-input port copies into its own slot.
+    const index = obj.index
+    if (typeof index !== 'number') {
+      throw new Error(`materializeSession: sessionArraySlot read missing numeric index.`)
+    }
+    const reg = ctx.arraySlotToReg.get(index)
+    if (reg === undefined) {
+      throw new Error(
+        `materializeSession: sessionArraySlot index ${index} has no array delaySlotRegistry entry.`,
+      )
+    }
+    return { op: 'regRef', idx: reg }
   }
 
   throw new Error(`materializeSession: unhandled wiring op '${op}'.`)

--- a/tests/equiv/root_vs_flat.test.ts
+++ b/tests/equiv/root_vs_flat.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { makeSession, resolveProgramType, instantiate, inputNames, outputNames, setWireExpr } from '../../compiler/session.js'
+import { makeSession, loadJSON, resolveProgramType, instantiate, inputNames, outputNames, setWireExpr } from '../../compiler/session.js'
 import type { ExprNode } from '../../compiler/expr.js'
 import { loadStdlib } from '../../compiler/program.js'
 import { applyFlatPlan } from '../../compiler/apply_plan.js'
@@ -188,6 +188,47 @@ describe('root-vs-flat array-port wiring', () => {
     const flat = captureOutput(setup(), false)
     const root = captureOutput(setup(), true)
     assertEqual('Sequencer[values]', flat, root)
+  })
+})
+
+describe('root-vs-flat array session delay', () => {
+  // An array-shaped `delay()`: the wire `sum.a = delay([s, s+10, s+20])`
+  // carries a time-varying array literal. `liftWiresToInstances` lifts
+  // the literal to an anonymous producer instance; `extractSessionDelays`
+  // hoists the surrounding `delay()` into an `ioArraySlot` (an `isArray`
+  // registry entry). On the per-instance path that's a `state_evolution`
+  // elementwise array `Add`; on the root path it becomes an array
+  // `RegDecl` whose elementwise-copy writeback must reproduce the SAME
+  // one-sample, per-element latency. The time-varying source makes any
+  // latency or element-permutation bug visible.
+  const arrDelayProgram = {
+    schema: 'tropical_program_2', name: 'arr_delay_test',
+    body: { op: 'block', decls: [
+      { op: 'programDecl', name: 'ArrSum', program: {
+        op: 'program', name: 'ArrSum',
+        ports: { inputs: [{ name: 'a', type: { element: 'float', shape: [3] } }], outputs: ['out'] },
+        body: { op: 'block', decls: [], assigns: [
+          { op: 'outputAssign', name: 'out', expr: { op: 'add', args: [
+            { op: 'index', args: [{ op: 'input', name: 'a' }, 0] },
+            { op: 'mul', args: [{ op: 'index', args: [{ op: 'input', name: 'a' }, 1] }, 100] } ] } } ] } } },
+      { op: 'instanceDecl', name: 'sum', program: 'ArrSum', inputs: { a: { op: 'delay', args: [
+        { op: 'array', items: [
+          { op: 'sampleIndex' },
+          { op: 'add', args: [{ op: 'sampleIndex' }, 10] },
+          { op: 'add', args: [{ op: 'sampleIndex' }, 20] } ] } ] } } } ],
+      assigns: [] },
+    audio_outputs: [{ instance: 'sum', output: 'out' }],
+  }
+  test('delay([s, s+10, s+20]) → ArrSum', () => {
+    function setup() {
+      const session = makeSession(BUFFER_LENGTH)
+      loadStdlib(session)
+      loadJSON(arrDelayProgram as Parameters<typeof loadJSON>[0], session)
+      return session
+    }
+    const flat = captureOutput(setup(), false)
+    const root = captureOutput(setup(), true)
+    assertEqual('array-delay', flat, root)
   })
 })
 

--- a/tests/equiv/root_vs_flat.test.ts
+++ b/tests/equiv/root_vs_flat.test.ts
@@ -165,6 +165,32 @@ describe('root-vs-flat multi-instance (auto-delayed wires)', () => {
   })
 })
 
+describe('root-vs-flat array-port wiring', () => {
+  // A Sequencer's `values: float[N]` array input wired with an array
+  // literal. `liftWiresToInstances` lifts the literal to an anonymous
+  // producer instance whose array output is aliased into the
+  // sequencer's input slot — a same-sample (un-delayed) array wire, so
+  // the root path must emit the producer before the consumer and copy
+  // the array into the child's session-array slot.
+  test('Sequencer with array-literal values', () => {
+    function setup() {
+      const session = makeSession(BUFFER_LENGTH)
+      loadStdlib(session)
+      const { type, typeArgs } = resolveProgramType(session, 'Sequencer', { N: 8 }, undefined)
+      const inst = instantiate(type, 'seq', { baseTypeName: 'Sequencer', typeArgs })
+      session.instanceRegistry.set('seq', inst)
+      session.inputExprNodes.set(wk('seq', 'clock'), pulseEvery(64))
+      session.inputExprNodes.set(wk('seq', 'values'),
+        { op: 'array', items: [110, 138.59, 164.81, 220, 261.63, 329.63, 220, 164.81] })
+      session.graphOutputs.push({ instance: 'seq', output: outputNames(inst)[0] })
+      return session
+    }
+    const flat = captureOutput(setup(), false)
+    const root = captureOutput(setup(), true)
+    assertEqual('Sequencer[values]', flat, root)
+  })
+})
+
 describe('root-vs-flat polyphony', () => {
   test('8x SinOsc voices', () => {
     function setupPolyphony() {


### PR DESCRIPTION
Follow-up to #169 (Option A Phases A+B). Extends the root-program lowering to
handle **all array-typed session wiring** — array-typed instance ports *and*
array session delays — removing the per-instance fallback entirely. Builds on
`main`.

Motivation: polyphony and any cross-voice array feedback will hit array wiring
routinely, so this is real feature support (with manufactured tests), not a
speculative generalization.

## D1 — array-typed port wiring

Two materializer fixes (`materialize_session.ts`):

1. **Topological instance order.** Root child instances are emitted in
   `computeInstanceTopoOrder` (producer before consumer). Array wires are
   **same-sample** — `setWireExpr` does not auto-delay them — so the producer
   kernel must run before the consumer reads its aliased session-array slot.
   Scalar cross-instance wires are all delayed, so purely-scalar sessions
   degenerate to insertion order (Phase B behavior). The order also fixes
   `InstanceIdx`, which must agree with `body.decls` order.
2. **Keep array ports on `InstanceDecl.inputs`** — `compileResolved`'s `arrayInfo`
   branch copies the array `nestedOut` into the child's session-array slot. The
   prior zeros were purely the missing order.

## D2 — array session delays

A `delay()` over an array source (hoisted by `extractSessionDelays` to an
`ioArraySlot`, `isArray` registry entry) now materializes to an **array-typed
root `RegDecl`**:

- `init` is an `arraySize`-long literal array → `compileResolved` allocates a
  backing array slot (`arrayRegMap`).
- `update` is the translated array source (`nestedOut` to the producer's array
  output); `emit_resolved` lowers it to an elementwise copy at writeback — the
  same per-element one-sample latency the per-instance `state_evolution` array
  `Add` gave. `sessionArraySlot` reads translate to `regRef`.
- One engine-free `emit_resolved.ts` fix: the array-reg writeback accepts a
  `session_array_reg` source (a sibling's array output), not just kernel-local
  `array_reg` (`remapInstancePlan` already lowers it to an absolute slot).

The dispatch fallback is gone — array sessions go through the root path.

## Gate

`tests/equiv/root_vs_flat.test.ts` (now **25 pass**) gains:
- a **Sequencer array-literal** case (array-port wiring), and
- an **array session delay** case `delay([s, s+10, s+20]) → ArrSum` with a
  time-varying source, so any latency or element-permutation bug diverges from
  the flat oracle.

The materializer unit test flips from "throws on array delays" to asserting
array-`RegDecl` creation.

- `bun test` (flag off): **1037 pass / 0 fail**
- `TROPICAL_ROOT_PROGRAM=1` migration_audio: **11 pass**; root_vs_flat: **25 pass**
- `ctest`: pass · `tsc`: clean

## Unchanged limitations (`HANDOFF_OPTION_A.md`)

- **WASM-root** — the 4 forced-on `wasm_vs_jit` failures are the pre-existing
  WASM-can't-consume-root gap (scalar SinOsc), unrelated to arrays. The flag
  defaults off; Phase E cutover is gated on closing this.
- **Unwired typed defaults** — benign, documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)