### PR TITLE
Option A: WASM root support + Phase E cutover (root lowering is the default)

### DIFF
--- a/HANDOFF_OPTION_A.md
+++ b/HANDOFF_OPTION_A.md
@@ -129,9 +129,31 @@ This is a pure cache-key fix — no emitted-code or golden change. Rebuild requi
    25 pass) — a time-varying array source makes any latency/permutation bug
    visible. Motivation: polyphony and any cross-voice array feedback will hit
    this routinely.
-5. **Phase E — cutover** (after the WASM-root gap closes): flip the default and
-   delete `compileSessionSlottedPerInstance` + the `state_evolution` emission.
-   Keep `delaySlotRegistry`, `emitDacStitch`, `graphOutputs` as the bridge/DAC tap.
+5. **Phase E — cutover (default flipped): DONE.** `compileSessionSlotted` now
+   defaults to the root path; `compileSession(session)` with no options compiles
+   a root plan. `options.rootProgram === false` selects the legacy per-instance
+   path (kept as the `root_vs_flat` oracle + escape hatch); `TROPICAL_ROOT_PROGRAM=0`
+   forces it off when no explicit option is passed. Supporting fix:
+   **slot-based session params on the root path.** Session params are
+   `param:name` module slots (control plane via `setSlot`, hot-swap by name), but
+   the materializer's `paramRef` lowered to a dead FFI handle (empty map → param
+   reads returned 0). Added a `paramSlots: Map<ParamIdx, number>` threaded
+   `compileSessionSlottedRoot → partitionKernel(root only) → compileResolved →
+   emit_resolved`, so `ParamRef` lowers to `opSlot(param slot)` — mirroring the
+   per-instance `translateNode`. `paramSlots` is NOT propagated to child kernels
+   (`ParamIdx` is per-program). A handful of per-instance *structural* tests
+   (instruction/instance-function-count, param-slot-operand placement) are pinned
+   to `rootProgram: false` since they assert that lowering's emit shape; the
+   audio/behavior param tests run on the default (root) path as coverage. Full
+   suite 1039 pass with the default flipped; `TROPICAL_ROOT_PROGRAM=0` and
+   `root_vs_flat` keep the per-instance path exercised.
+
+   **Remaining (deferred, plan's "after a release"):** delete
+   `compileSessionSlottedPerInstance` + the `state_evolution` emission block and
+   rewrite/remove the pinned per-instance structural tests + the `root_vs_flat`
+   oracle. Keep `delaySlotRegistry`, `emitDacStitch`, `graphOutputs` as the
+   bridge/DAC tap. Not done here — the per-instance path is still the
+   differential oracle, so deleting it now would remove the safety net mid-soak.
 
 ## Key invariants to preserve
 

--- a/HANDOFF_OPTION_A.md
+++ b/HANDOFF_OPTION_A.md
@@ -85,14 +85,16 @@ This is a pure cache-key fix — no emitted-code or golden change. Rebuild requi
 
 ## Known limitations / next steps
 
-1. **WASM backend does not support root plans yet.** With the flag forced ON
-   globally, `tests/equiv/wasm_vs_jit.test.ts` has 4 failures (SinOsc×2,
-   SinOsc→OnePole, the array-zipWith case). JIT-root is correct (proven by
-   `root_vs_flat`); the diverging side is `emit_wasm`, which doesn't handle the
-   root-program plan shape (deeper nesting + root `RegDecl` writebacks +
-   empty top-level body). Phase B targets the **JIT** path; WASM root support is
-   Phase C/E. The flag defaults OFF, so normal WASM operation is unaffected. If
-   you force the flag on, scope it to JIT suites.
+1. **WASM backend supports root plans: DONE.** `emit_wasm` now recurses through
+   nested `children` with the same four-phase order as the C++
+   `emit_kernel_block` (preamble → per-child {pre_input, child} → body →
+   writebacks), instead of treating each `instance_function` as a flat leaf. The
+   recursive `collectKernelInstrs` also walks the tree for param discovery /
+   layout sizing. No engine change; pure `emit_wasm.ts`. Both backends now agree
+   on the root-program shape: `tests/equiv/wasm_vs_jit.test.ts` gains two
+   permanent (non-env) root-mode cases, and the whole equiv suite is green with
+   `TROPICAL_ROOT_PROGRAM=1`. **The flag is now backend-complete — Phase E
+   cutover is unblocked.**
 2. **Unwired typed-bound defaults differ (documented, benign).** An UNWIRED
    input with a typed-bound default (`freq: freq = 440`) resolves to 0 on the
    flat top-level path (its plain-number-only `defaults` builder skips the

--- a/compiler/emit_wasm.ts
+++ b/compiler/emit_wasm.ts
@@ -24,7 +24,7 @@
  *   - slots        → f64 cells (inter-module shared array)
  */
 
-import type { FlatPlan } from './flat_plan'
+import type { FlatPlan, InstanceFunction } from './flat_plan'
 import type { NInstr, NOperand, ScalarType } from './ir/emit_resolved'
 import { dstAsTemp, dstAsArray, dstAsModuleSlot } from './ir/emit_resolved'
 import { rawIdx, rawOffset } from './ir/slot_indices'
@@ -285,18 +285,36 @@ export type EmitWasmOptions = {
   sampleRate?: number
 }
 
+/** Depth-first collect every instruction a kernel (and its nested
+ *  children) executes, in execution order: preamble, then per child
+ *  {pre_input, child…}, then this kernel's body. Param operands and
+ *  array/temp refs can live in any nested block, so layout sizing +
+ *  param discovery must walk the whole tree. */
+function collectKernelInstrs(inst: InstanceFunction, out: NInstr[]): void {
+  for (const i of inst.preamble_instructions) out.push(i)
+  for (const child of inst.children) {
+    for (const i of child.pre_input_instructions) out.push(i)
+    collectKernelInstrs(child, out)
+  }
+  for (const i of inst.instructions) out.push(i)
+}
+
 export function emitWasm(plan: FlatPlan, opts: EmitWasmOptions = {}): EmitWasmResult {
   const inputCount = opts.inputCount ?? 0
   const maxBlockSize = opts.maxBlockSize ?? 2048
   const sampleRate = opts.sampleRate ?? plan.config.sampleRate
 
   // WASM consumes plan_5 by flattening per sample: scheduler.preamble
-  // → for each instance: body + writebacks → state_evolution →
-  // scheduler.postamble. Matches the C++ scheduler structure exactly.
+  // → for each instance kernel (recursively: preamble, per-child
+  // {pre_input, child}, body + writebacks) → state_evolution →
+  // scheduler.postamble. Matches the C++ `emit_kernel_block` structure
+  // exactly, including the fractal (nested-`children`) shape the
+  // root-program session lowering produces. `allInstructions` is only
+  // used for param discovery + layout sizing, so it just needs to
+  // contain every instruction the kernel tree executes.
   const allInstructions: NInstr[] = []
   for (const i of plan.scheduler_function.preamble) allInstructions.push(i)
-  for (const inst of plan.instance_functions)
-    for (const i of inst.instructions) allInstructions.push(i)
+  for (const inst of plan.instance_functions) collectKernelInstrs(inst, allInstructions)
   for (const i of plan.scheduler_function.state_evolution) allInstructions.push(i)
   for (const i of plan.scheduler_function.postamble) allInstructions.push(i)
 
@@ -335,14 +353,24 @@ export function emitWasm(plan: FlatPlan, opts: EmitWasmOptions = {}): EmitWasmRe
   // Scheduler preamble
   for (const instr of plan.scheduler_function.preamble) emitInstruction(c, instr, ctx)
 
-  // Per-instance body + writebacks (unconditional — every instance runs every sample).
-  for (const inst of plan.instance_functions) {
+  // Per-instance body + writebacks (unconditional — every instance runs
+  // every sample). `emitKernelBlock` recurses into nested children with
+  // the same four-phase order the C++ engine uses (preamble → per-child
+  // {pre_input, child} → body → writebacks), so the root-program plan's
+  // nested instance bodies are emitted, not just the empty root body.
+  const emitKernelBlock = (inst: InstanceFunction): void => {
+    for (const instr of inst.preamble_instructions) emitInstruction(c, instr, ctx)
+    for (const child of inst.children) {
+      for (const instr of child.pre_input_instructions) emitInstruction(c, instr, ctx)
+      emitKernelBlock(child)
+    }
     for (const instr of inst.instructions) emitInstruction(c, instr, ctx)
 
     // Per-instance writebacks. Pattern-match on the RegTarget sum
     // type — the `arrayManaged` case carries no temp index because
     // array regs persist via in-place SetElement / strided-Add
-    // instructions earlier in the body.
+    // instructions earlier in the body. Each kernel uses its OWN
+    // state_reg_offset, so nested kernels write the right slots.
     for (let j = 0; j < inst.register_targets.length; j++) {
       const target = inst.register_targets[j]!
       if (target.kind === 'arrayManaged') continue
@@ -361,6 +389,7 @@ export function emitWasm(plan: FlatPlan, opts: EmitWasmOptions = {}): EmitWasmRe
       }
     }
   }
+  for (const inst of plan.instance_functions) emitKernelBlock(inst)
 
   // State-evolution (per-sample WriteSlots for extracted delays)
   for (const instr of plan.scheduler_function.state_evolution) emitInstruction(c, instr, ctx)

--- a/compiler/ir/compile_resolved.ts
+++ b/compiler/ir/compile_resolved.ts
@@ -24,6 +24,11 @@ import { emitResolvedProgram, type EmitSlots, type ScalarType } from './emit_res
 export interface CompileResolvedContext {
   /** Keyed by ParamIdx. */
   paramHandles?:      Map<ParamIdx, { ptr: string }>
+  /** Session param module-slot indices, keyed by ParamIdx. When set,
+   *  `ParamRef` lowers to a slot read (the session slot-based param
+   *  model) instead of an FFI handle. Threaded by the root-program
+   *  session lowering for the root kernel. */
+  paramSlots?:        Map<ParamIdx, number>
   /** Per-sub-instance, per-output-port module-slot map. Keyed by
    *  InstanceIdx (in this program) and OutputIdx (in the instance's
    *  type). Populated by `partition_recursive` for fractal compile;
@@ -128,6 +133,7 @@ export function compileResolved(prog: ResolvedProgram, ctx: CompileResolvedConte
     regs:                    slots.regs,
     regCount:                slots.regDecls.length,
     paramHandles:            ctx.paramHandles ?? new Map(),
+    paramSlots:              ctx.paramSlots,
     nestedOutputSlots:       ctx.nestedOutputSlots,
     nestedInputSlots:        ctx.nestedInputSlots,
     inputSlotOverride:       ctx.inputSlotOverride,

--- a/compiler/ir/compile_session.test.ts
+++ b/compiler/ir/compile_session.test.ts
@@ -40,7 +40,7 @@ describe('compileSession — single-instance sessions', () => {
   ] as const) {
     test(`emits well-formed tropical_plan_5: ${typeName}`, () => {
       const session = singleInstanceSession(typeName)
-      const plan = compileSession(session)
+      const plan = compileSession(session, { rootProgram: false })
 
       expect(plan.schema).toBe('tropical_plan_5')
       const totalInstrs =
@@ -74,7 +74,7 @@ describe('compileSession — two-instance refs', () => {
 
     session.graphOutputs.push({ instance: 'amp', output: 'out' })
 
-    const plan = compileSession(session)
+    const plan = compileSession(session, { rootProgram: false })
     expect(plan.scheduler_function.outputs.length).toBe(1)
     expect(plan.instance_functions.length).toBe(2)
   })

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -27,8 +27,8 @@ import {
   type InstanceName,
 } from './branded_names.js'
 import type { FlatPlan, InstanceFunction, SchedulerFunction, CompilationMode } from '../flat_plan.js'
-import type { ResolvedProgram, InputIdx } from './nodes.js'
-import { inputIdx } from './nodes.js'
+import type { ResolvedProgram, InputIdx, ParamIdx } from './nodes.js'
+import { inputIdx, paramIdx } from './nodes.js'
 import { getInstanceType } from './decl_tables.js'
 import type { NInstr } from './emit_resolved.js'
 import { instrWriteSlot, instrArray, opArray, opConst } from './emit_resolved.js'
@@ -60,10 +60,13 @@ export function compileSessionSlotted(
   options: CompileSessionSlottedOptions = {},
 ): FlatPlan {
   const mode = options.compilation_mode ?? 'fused'
-  const rootProgram = process.env.TROPICAL_ROOT_PROGRAM === '1' || options.rootProgram === true
-  // The root lowering handles scalar wiring, array-typed *port* wiring
-  // (delivered by aliasing + the recursive partitioner), and array
-  // session *delays* (hoisted `ioArraySlot` entries → array `RegDecl`s).
+  // Root-program lowering is the default (Option A cutover). It handles
+  // scalar wiring, array-typed port wiring, array session delays, and
+  // slot-based session params. An explicit `rootProgram: false` selects
+  // the legacy per-instance path (kept as the `root_vs_flat` oracle and
+  // an escape hatch); `TROPICAL_ROOT_PROGRAM=0` forces it off when no
+  // explicit option is passed.
+  const rootProgram = options.rootProgram ?? (process.env.TROPICAL_ROOT_PROGRAM !== '0')
   if (rootProgram) {
     return compileSessionSlottedRoot(session, mode)
   }
@@ -397,6 +400,19 @@ function compileSessionSlottedRoot(
   const root = materializeSessionToResolvedIR(session)
   const rootCompiled = makeCompiled(root, { displayName: '__session__' })
 
+  // Session params are slot-based (`param:name` module slots driven by
+  // the control plane via setSlot, transferred by name on hot-swap).
+  // The materializer turned each `{op:'param', name}` wire into a root
+  // `ParamDecl`; map each root ParamIdx to its session param slot so
+  // `compileResolved` lowers the ref to a slot read (mirroring the
+  // per-instance `translateNode`), instead of a dead FFI handle.
+  // `root.params[i]` corresponds to `paramIdx(i)` (decl-table order).
+  const paramSlots = new Map<ParamIdx, number>()
+  for (let i = 0; i < root.params.length; i++) {
+    const slot = session.paramSlotRegistry.get(root.params[i].name)
+    if (slot !== undefined) paramSlots.set(paramIdx(i), slot)
+  }
+
   const { fn } = partitionKernel(
     /* instancePath    */ ROOT_INSTANCE_PATH,
     /* prog            */ root,
@@ -406,6 +422,9 @@ function compileSessionSlottedRoot(
     /* paramHandles    */ new Map(),
     session,
     acc,
+    /* inputSlotOverride */ undefined,
+    /* inputArraySlots   */ undefined,
+    /* paramSlots        */ paramSlots,
   )
   const instanceFunctions: InstanceFunction[] = [fn]
 

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -350,6 +350,15 @@ export interface EmitSlots {
   /** FFI handle metadata per param. Keyed by ParamIdx now (replacing
    *  the prior ParamDecl pointer key). */
   paramHandles: Map<ParamIdx, { ptr: string }>
+  /** Session param module-slot indices, keyed by ParamIdx. When a param
+   *  has an entry here, `ParamRef(idx)` lowers to a module-slot read
+   *  (`opSlot`) instead of an FFI-handle `opParam` — the slot-based
+   *  param model the session lowering uses (`param:name` slots driven by
+   *  the control plane via `setSlot`, transferred by name on hot-swap).
+   *  The root-program path threads this for the root kernel so a
+   *  `{op:'param', name}` wire resolves to the same slot the per-instance
+   *  path's `translateNode` reads. Checked before `paramHandles`. */
+  paramSlots?: Map<ParamIdx, number>
   /** Module slot indices for sub-instance outputs that this kernel's
    *  body references via `NestedOut`. Map shape:
    *  InstanceIdx → OutputIdx → moduleSlotIdx. When undefined
@@ -547,6 +556,13 @@ class Emitter {
         return { op: opStateReg(stateRegIdx(slot), regType), scalarType: regType }
       }
       case 'paramRef': {
+        // Slot-based session param: read the `param:name` module slot
+        // (the control plane drives it via setSlot; hot-swap transfers
+        // it by name). Checked before the FFI-handle path.
+        const slot = this.slots.paramSlots?.get(obj.idx)
+        if (slot !== undefined) {
+          return { op: opSlot(moduleSlotIdx(slot), 'float'), scalarType: 'float' }
+        }
         const handle = this.slots.paramHandles.get(obj.idx)
         if (handle === undefined) {
           // No live FFI handle — emit zero, matching the legacy fallback.

--- a/compiler/ir/n_write_slot_expansion.test.ts
+++ b/compiler/ir/n_write_slot_expansion.test.ts
@@ -64,7 +64,7 @@ describe('array-output writeback shape', () => {
     expect(aMeta!.arraySlot).toBeDefined()
     expect(aMeta!.arraySize).toBe(3)
 
-    const plan = compileSession(session)
+    const plan = compileSession(session, { rootProgram: false })
     expect(plan.instance_functions.length).toBe(1)
     const instFn = plan.instance_functions[0]
 
@@ -109,7 +109,7 @@ describe('array-output writeback shape', () => {
       audio_outputs: [{ instance: 'a', output: 's' }],
     } as Parameters<typeof loadJSON>[0], session)
 
-    const plan = compileSession(session)
+    const plan = compileSession(session, { rootProgram: false })
     const writeSlots = plan.instance_functions[0].instructions.filter(i => i.tag === 'WriteSlot')
     // 1 for the scalar output (alive comes from scheduler preamble).
     expect(writeSlots.length).toBe(1)

--- a/compiler/ir/partition_recursive.ts
+++ b/compiler/ir/partition_recursive.ts
@@ -208,6 +208,12 @@ export function partitionKernel(
    *  array maps are disjoint by construction — each port appears in
    *  exactly one. */
   inputArraySlots?:  Map<InputIdx, { slot: number; size: number }>,
+  /** Session param module-slot indices for THIS kernel, keyed by the
+   *  kernel program's ParamIdx. When set, `ParamRef` lowers to a slot
+   *  read (the slot-based session param model). NOT propagated to child
+   *  recursions — `ParamIdx` is per-program, so a child resolves its own
+   *  params via its own (typically empty) handle/slot maps. */
+  paramSlots?:       Map<ParamIdx, number>,
 ): PartitionedKernel {
   // ── 1. Recurse into sub-InstanceDecls.
   //    For each child:
@@ -327,6 +333,7 @@ export function partitionKernel(
   //        inputArraySlots (to session_array_reg operands).
   const plan = compileResolved(prog, {
     paramHandles,
+    paramSlots,
     nestedOutputSlots,
     nestedInputSlots,
     nestedOutputArraySlots,

--- a/compiler/runtime/m9b_param_slot_equiv.test.ts
+++ b/compiler/runtime/m9b_param_slot_equiv.test.ts
@@ -51,7 +51,13 @@ describe('M9b: params as slot reads in per-instance path', () => {
     s.inputExprNodes.set(wk("osc", "freq"), { op: 'param', name: 'cutoff' })
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
-    const plan = compileSessionSlotted(s)
+    // Structural assertion about the per-instance emit shape (the param
+    // slot read lands in instance_functions[].instructions). The root
+    // path also reads params as slots but nests instance bodies under
+    // children, so pin the per-instance lowering here; root param-slot
+    // behavior is covered by the audio tests in this file (which run on
+    // the default lowering).
+    const plan = compileSessionSlotted(s, { rootProgram: false })
 
     // Find the SinOsc body's freq read and verify it's a slot operand
     // pointing at the param's slot index. Search across all instance
@@ -161,7 +167,9 @@ describe('M9b: legacy trigger refs as slot reads', () => {
     s.inputExprNodes.set(wk("osc", "freq"), { op: 'triggerParamExpr', name: 'go' })
     s.graphOutputs.push({ instance: 'osc', output: 'sine' })
 
-    const plan = compileSessionSlotted(s)
+    // Per-instance emit-shape assertion — pin the per-instance lowering
+    // (see the note on the paramRef structural test above).
+    const plan = compileSessionSlotted(s, { rootProgram: false })
     const allInstrs = [
       ...plan.scheduler_function.preamble,
       ...plan.scheduler_function.postamble,

--- a/tests/equiv/root_vs_flat.test.ts
+++ b/tests/equiv/root_vs_flat.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { makeSession, loadJSON, resolveProgramType, instantiate, inputNames, outputNames, setWireExpr } from '../../compiler/session.js'
+import { makeSession, loadJSON, resolveProgramType, instantiate, inputNames, outputNames, setWireExpr, allocateParamSlot } from '../../compiler/session.js'
 import type { ExprNode } from '../../compiler/expr.js'
 import { loadStdlib } from '../../compiler/program.js'
 import { applyFlatPlan } from '../../compiler/apply_plan.js'
@@ -162,6 +162,30 @@ describe('root-vs-flat multi-instance (auto-delayed wires)', () => {
     const flat = captureOutput(setupOscAmp(), false)
     const root = captureOutput(setupOscAmp(), true)
     assertEqual('osc→amp', flat, root)
+  })
+})
+
+describe('root-vs-flat slot-based params', () => {
+  // A `{op:'param'}` wire reads a session `param:name` module slot. The
+  // per-instance path lowers it to `opSlot(paramSlotRegistry)`; the root
+  // path threads `paramSlots` so `ParamRef` lowers to the same slot read
+  // (rather than a dead FFI handle that reads 0). Both must agree.
+  test('VCA.cv driven by a param', () => {
+    function setup() {
+      const session = makeSession(BUFFER_LENGTH)
+      loadStdlib(session)
+      const { type } = resolveProgramType(session, 'VCA', undefined, undefined)
+      session.instanceRegistry.set('amp', instantiate(type, 'amp', { baseTypeName: 'VCA' }))
+      session.paramRegistry.set('gain', { value: 0.5 } as unknown as never)
+      allocateParamSlot(session, 'gain')
+      session.inputExprNodes.set(wk('amp', 'audio'), 0.4)
+      session.inputExprNodes.set(wk('amp', 'cv'), { op: 'param', name: 'gain' })
+      session.graphOutputs.push({ instance: 'amp', output: 'out' })
+      return session
+    }
+    const flat = captureOutput(setup(), false)
+    const root = captureOutput(setup(), true)
+    assertEqual('param:gain', flat, root)
   })
 })
 

--- a/tests/equiv/wasm_vs_jit.test.ts
+++ b/tests/equiv/wasm_vs_jit.test.ts
@@ -63,7 +63,7 @@ function runNative(plan: FlatPlan, samples: number): Float64Array {
   }
 }
 
-function makeSinOscPlan(freqHz: number): FlatPlan {
+function makeSinOscPlan(freqHz: number, rootProgram = false): FlatPlan {
   const session = makeSession(64)
   try {
     loadStdlib(session)
@@ -76,13 +76,13 @@ function makeSinOscPlan(freqHz: number): FlatPlan {
       audio_outputs: [{ instance: 'osc', output: 'sine' }],
     }
     loadJSON(prog, session)
-    return compileSession(session)
+    return compileSession(session, { rootProgram })
   } finally {
     session.runtime.dispose()
   }
 }
 
-function makeOnePolePlan(cutoff: number): FlatPlan {
+function makeOnePolePlan(cutoff: number, rootProgram = false): FlatPlan {
   const session = makeSession(64)
   try {
     loadStdlib(session)
@@ -99,7 +99,7 @@ function makeOnePolePlan(cutoff: number): FlatPlan {
       audio_outputs: [{ instance: 'lp', output: 'out' }],
     }
     loadJSON(prog, session)
-    return compileSession(session)
+    return compileSession(session, { rootProgram })
   } finally {
     session.runtime.dispose()
   }
@@ -161,6 +161,35 @@ describe('wasm vs native JIT', () => {
     }
 
     const N = 64
+    const nat = runNative(plan, N)
+    const wasm = await runWasm(plan, N)
+    for (let i = 0; i < N; i++) {
+      expect(Math.abs(wasm[i]! - nat[i]!)).toBeLessThan(TOL)
+    }
+  })
+})
+
+// Root-program lowering (Option A): the whole session compiles to one
+// synthetic root kernel whose `instance_functions[0]` has an empty body
+// and the real instance bodies as nested `children`. This is the shape
+// that forced emit_wasm to recurse like the C++ `emit_kernel_block`
+// (preamble → per-child {pre_input, child} → body → writebacks). Same
+// patches as above, compiled with `rootProgram: true`, asserting WASM
+// still matches the native JIT on the nested plan.
+describe('wasm vs native JIT (root-program lowering)', () => {
+  test('SinOsc 440 Hz — root plan', async () => {
+    const plan = makeSinOscPlan(440, /* rootProgram */ true)
+    const N = 64
+    const nat = runNative(plan, N)
+    const wasm = await runWasm(plan, N)
+    for (let i = 0; i < N; i++) {
+      expect(Math.abs(wasm[i]! - nat[i]!)).toBeLessThan(TOL)
+    }
+  })
+
+  test('SinOsc → OnePole(1000 Hz) — root plan (nested children)', async () => {
+    const plan = makeOnePolePlan(1000, /* rootProgram */ true)
+    const N = 256
     const nat = runNative(plan, N)
     const wasm = await runWasm(plan, N)
     for (let i = 0; i < N; i++) {


### PR DESCRIPTION
Follow-up to #170. Closes the last backend gap **and** flips Option A's cutover:
the root-program lowering is now the default on both backends. Builds on `main`.

## Part 1 — WASM consumes root-program (nested) plans

`emit_wasm` treated each `instance_function` as a flat leaf — it never recursed
into `inst.children` or emitted `preamble_instructions` / `pre_input_instructions`.
Root plans put every real instance body in `rootFn.children` with an empty
top-level body, so WASM emitted nothing.

Fix: mirror the C++ `emit_kernel_block` four-phase order recursively
(`preamble → per-child {pre_input, child} → body → writebacks`); each kernel uses
its own `state_reg_offset` for writebacks. A recursive `collectKernelInstrs`
walks the tree for param discovery + layout sizing. Pure `emit_wasm.ts`; flat
plans degenerate to the old behavior. Gate: two permanent (non-env) root-mode
`wasm_vs_jit` cases.

## Part 2 — Phase E cutover (root is the default)

`compileSessionSlotted` now defaults to the root path. `rootProgram: false`
selects the legacy per-instance path (kept as the `root_vs_flat` oracle + escape
hatch); `TROPICAL_ROOT_PROGRAM=0` forces it off when no option is passed.

**Supporting fix — slot-based session params on the root path.** Session params
are `param:name` module slots (control plane via `setSlot`, hot-swap by name),
but the materializer's `paramRef` lowered to a dead FFI handle (empty map → param
reads returned **0**). Threaded a `paramSlots: Map<ParamIdx, number>` from
`compileSessionSlottedRoot → partitionKernel` (root kernel only) →
`compileResolved → emit_resolved`, so `ParamRef` lowers to `opSlot(param slot)` —
mirroring the per-instance `translateNode`. Not propagated to child kernels
(`ParamIdx` is per-program).

A handful of per-instance **structural** tests (instruction / instance-function
counts, param-slot-operand placement) are pinned to `rootProgram: false` since
they assert that lowering's emit shape; the audio/behavior param tests run on the
default (root) path as coverage. `root_vs_flat` gains a slot-based-param
differential.

## Gate

- `bun test` (root default): **1040 pass / 0 fail**
- `TROPICAL_ROOT_PROGRAM=0 bun test` and `root_vs_flat` keep the per-instance path
  exercised (escape hatch + oracle)
- `ctest`: pass · `tsc`: clean

## Deferred (plan's "after a release")

Deleting `compileSessionSlottedPerInstance` + the `state_evolution` emission block
(and rewriting the pinned structural tests + the `root_vs_flat` oracle) — the
per-instance path is still the differential oracle, so removing it now would drop
the safety net mid-soak. Only remaining quirk: unwired typed-bound defaults
(benign, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)