### PR TITLE
fix(mcp): handle post-compile sessionSlot ops in prettyExpr, remove_instance, and save

### DIFF
--- a/compiler/expr.ts
+++ b/compiler/expr.ts
@@ -350,12 +350,21 @@ export interface ConstNode {
   type?: ScalarKind
 }
 
+/** A read of a hoisted unit-delay module slot, produced by
+ *  `extractSessionDelays` when it lifts a `delay()` out of a wire. The
+ *  delayed source lives in `session.delaySlotRegistry[index]`, not here,
+ *  so this is a leaf (no ExprNode children). */
+export interface SessionSlotNode { op: 'sessionSlot'; index: number }
+/** Array sibling of `SessionSlotNode` (a hoisted array delay slot). */
+export interface SessionArraySlotNode { op: 'sessionArraySlot'; index: number; size?: number }
+
 /** All leaf ops in a single union. */
 export type LeafNode =
   | InputNode | RegRefNode | DelayRefNode | DelayValueNode
   | NestedOutNode | NestedOutputNode | BindingNode | TypeParamNode
   | SampleRateNode | SampleIndexNode
   | ParamRefNode | ConstNode
+  | SessionSlotNode | SessionArraySlotNode
 
 // ── Decl ops (top-level only — appear at decl/assign positions) ─────────
 

--- a/compiler/pretty_expr.test.ts
+++ b/compiler/pretty_expr.test.ts
@@ -1,0 +1,67 @@
+/**
+ * pretty_expr.test.ts — `prettyExpr` renders the hoisted unit-delay
+ * slots that `extractSessionDelays` writes into wires during compile.
+ *
+ * Regression: inspecting a session AFTER a compile (e.g. `list_wiring`
+ * / `get_info` over MCP on a patch with a feedback ring) threw
+ * `prettyExpr: unhandled op 'sessionSlot'`, because every MCP wire is
+ * unit-delay-wrapped and the compile rewrites those `delay()` nodes to
+ * `sessionSlot` / `sessionArraySlot` reads. `prettyExpr` now resolves
+ * the slot back to its registered source when given the registry.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, setWireExpr, prettyExpr } from './session.js'
+import { loadStdlib } from './program.js'
+import { compileSession } from './ir/compile_session.js'
+import { portRef, instanceName, portName, wireKey } from './ir/branded_names.js'
+
+const wk = (i: string, p: string) => wireKey(portRef(instanceName(i), portName(p)))
+
+describe('prettyExpr on post-compile sessionSlot wires', () => {
+  function feedbackRingSession() {
+    const s = makeSession(64)
+    loadStdlib(s)
+    for (const n of ['lfo1', 'lfo2']) {
+      const { type } = resolveProgramType(s, 'SinOsc', undefined, undefined)
+      s.instanceRegistry.set(n, instantiate(type, n, { baseTypeName: 'SinOsc' }))
+    }
+    // Two-LFO feedback ring; MCP wires are unit-delay-wrapped, so the
+    // cycle is broken automatically and the compile hoists the delays
+    // into sessionSlot reads.
+    setWireExpr(s, portRef(instanceName('lfo1'), portName('freq')),
+      { op: 'add', args: [0.3, { op: 'ref', instance: 'lfo2', output: 'sine' }] })
+    setWireExpr(s, portRef(instanceName('lfo2'), portName('freq')),
+      { op: 'ref', instance: 'lfo1', output: 'sine' })
+    s.graphOutputs.push({ instance: 'lfo1', output: 'sine' })
+    compileSession(s) // mutates inputExprNodes: delay() → sessionSlot
+    return s
+  }
+
+  test('resolves the slot source to delay(<source>) with the registry', () => {
+    const s = feedbackRingSession()
+    const rendered = [...s.inputExprNodes.values()]
+      .map(v => prettyExpr(v, s.instanceRegistry, s.delaySlotRegistry))
+      .sort()
+    // The feedback wires render as delays of their resolved sources,
+    // not opaque slot indices — and nothing throws.
+    expect(rendered).toEqual([
+      'delay((0.3 + lfo2.sine), 0)',
+      'delay(lfo1.sine, 0)',
+    ])
+  })
+
+  test('does not throw, and degrades to slot index, without the registry', () => {
+    const s = feedbackRingSession()
+    for (const v of s.inputExprNodes.values()) {
+      // No registry: must not throw; renders a slot placeholder.
+      const out = prettyExpr(v, s.instanceRegistry)
+      expect(out).toMatch(/^delay\(slot:\d+\)$/)
+    }
+  })
+
+  test('the wire keys are intact', () => {
+    const s = feedbackRingSession()
+    expect(new Set(s.inputExprNodes.keys())).toEqual(new Set([wk('lfo1', 'freq'), wk('lfo2', 'freq')]))
+  })
+})

--- a/compiler/program.ts
+++ b/compiler/program.ts
@@ -9,7 +9,7 @@
 import type { ExprNode } from './expr.js'
 import { validateExpr } from './expr.js'
 import type { TypeDefJSON, SessionState } from './session.js'
-import { resolveProgramType, allocateParamSlot, allocateOutputSlots } from './session.js'
+import { resolveProgramType, allocateParamSlot, allocateOutputSlots, reconstructWireDelays } from './session.js'
 import { applyFlatPlan } from './apply_plan.js'
 import { Param } from './runtime/param.js'
 import {
@@ -745,7 +745,10 @@ export function saveProgramFromSession(
     for (const portName of inputNames(inst)) {
       const key = wireKey(portRef(toInstanceName(name), toPortName(portName)))
       const expr = session.inputExprNodes.get(key)
-      if (expr !== undefined) inputs[portName] = expr
+      // Reverse the compile's delay-hoisting: a post-compile wire holds
+      // `sessionSlot` reads whose source lives in delaySlotRegistry.
+      // Emit the authored `delay(<source>)` form so the patch reloads.
+      if (expr !== undefined) inputs[portName] = reconstructWireDelays(expr, session.delaySlotRegistry)
     }
     if (Object.keys(inputs).length > 0) entry.inputs = inputs
     decls.push(entry as ExprNode)

--- a/compiler/save_round_trip.test.ts
+++ b/compiler/save_round_trip.test.ts
@@ -1,0 +1,57 @@
+/**
+ * save_round_trip.test.ts — `saveProgramFromSession` round-trips a
+ * compiled feedback patch.
+ *
+ * Regression: every MCP wire is unit-delay-wrapped, and a compile
+ * rewrites the ring's wires into `sessionSlot` reads (the delayed source
+ * moves into `delaySlotRegistry`). `save` serialized those raw
+ * `sessionSlot` indices, so the emitted patch was unloadable — the index
+ * means nothing in a fresh session. `save` now reverses the hoisting
+ * (`reconstructWireDelays`) and emits the authored `delay(<source>)`
+ * form, which reloads and re-hoists cleanly.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { makeSession, resolveProgramType, instantiate, setWireExpr, loadJSON, v2NodeToFile } from './session.js'
+import { loadStdlib, saveProgramFromSession } from './program.js'
+import { compileSession } from './ir/compile_session.js'
+import { portRef, instanceName, portName } from './ir/branded_names.js'
+
+function feedbackRing() {
+  const s = makeSession(64)
+  loadStdlib(s)
+  for (const n of ['lfo1', 'lfo2', 'lfo3']) {
+    const { type } = resolveProgramType(s, 'SinOsc', undefined, undefined)
+    s.instanceRegistry.set(n, instantiate(type, n, { baseTypeName: 'SinOsc' }))
+  }
+  const fm = (base: number, from: string) =>
+    ({ op: 'add', args: [base, { op: 'ref', instance: from, output: 'sine' }] } as const)
+  setWireExpr(s, portRef(instanceName('lfo1'), portName('freq')), fm(0.3, 'lfo3'))
+  setWireExpr(s, portRef(instanceName('lfo2'), portName('freq')), fm(0.5, 'lfo1'))
+  setWireExpr(s, portRef(instanceName('lfo3'), portName('freq')), fm(0.7, 'lfo2'))
+  s.graphOutputs.push({ instance: 'lfo1', output: 'sine' })
+  return s
+}
+
+describe('save round-trips a compiled feedback patch', () => {
+  test('emits delay() wires, not sessionSlot indices, and reloads', () => {
+    const s = feedbackRing()
+    compileSession(s) // hoists the ring's delays → sessionSlot in inputExprNodes
+    expect([...s.inputExprNodes.values()].some(v => (v as { op?: string }).op === 'sessionSlot')).toBe(true)
+
+    const { node, topLevel } = saveProgramFromSession(s)
+    const file = v2NodeToFile(node as never, topLevel)
+    const json = JSON.stringify(file)
+    // No raw hoisted-slot ops leak into the saved patch.
+    expect(json).not.toContain('sessionSlot')
+    expect(json).toContain('"delay"')
+
+    // Reload into a fresh session and recompile — the reconstructed
+    // delays must break the ring's cycle again (no CycleViolation).
+    const s2 = makeSession(64)
+    loadStdlib(s2)
+    loadJSON(file as { schema: string; [k: string]: unknown }, s2)
+    expect([...s2.instanceRegistry.keys()].sort()).toEqual(['lfo1', 'lfo2', 'lfo3'])
+    expect(() => compileSession(s2)).not.toThrow()
+  })
+})

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -394,6 +394,54 @@ function wrapInUnitDelay(expr: ExprNode, init: number, id: string): ExprNode {
   return { op: 'delay', args: [expr], init, id } as ExprNode
 }
 
+/** Reverse `extractSessionDelays`: rewrite the hoisted `sessionSlot` /
+ *  `sessionArraySlot` reads a compile leaves in `inputExprNodes` back
+ *  into `delay(<source>, init)` using the registry. This is what makes
+ *  a post-compile wire round-trip — `save` must emit the authored
+ *  `delay()` form, not an opaque slot index, so a reload (which re-hoists
+ *  the delays) reproduces the same per-wire unit latency. Recurses into
+ *  the resolved source (nested `delay(delay(x))`) and is cycle-safe via
+ *  a visited-slot set. Non-slot expressions pass through structurally
+ *  unchanged. */
+export function reconstructWireDelays(
+  expr: ExprNode,
+  registry: readonly DelaySlotEntry[],
+  seen: ReadonlySet<string> = new Set(),
+): ExprNode {
+  if (typeof expr !== 'object' || expr === null) return expr
+  if (Array.isArray(expr)) return expr.map(e => reconstructWireDelays(e, registry, seen))
+
+  const n = expr as { op?: unknown; index?: unknown; [k: string]: unknown }
+  if ((n.op === 'sessionSlot' || n.op === 'sessionArraySlot') && typeof n.index === 'number') {
+    const isArray = n.op === 'sessionArraySlot'
+    const tag = `${isArray ? 'a' : 's'}${n.index}`
+    const entry = registry.find(e =>
+      isArray ? (e.isArray && e.arraySlot === n.index)
+              : (!e.isArray && e.slotIdx === n.index))
+    // Unknown slot or a cycle (malformed registry) — leave as-is rather
+    // than loop forever; the slot index at least survives.
+    if (entry === undefined || seen.has(tag)) return expr
+    const src = reconstructWireDelays(entry.sourceExpr, registry, new Set(seen).add(tag))
+    return { op: 'delay', args: [src], init: entry.init ?? 0 } as ExprNode
+  }
+
+  // Structural recurse into every expression-valued field (args, items,
+  // match arms, …) — mirrors extractSessionDelays' own generic walk.
+  const out: Record<string, unknown> = { ...n }
+  for (const [k, v] of Object.entries(n)) {
+    if (k === 'op') continue
+    if (Array.isArray(v)) {
+      out[k] = v.map(item =>
+        (typeof item === 'object' || typeof item === 'number' || typeof item === 'boolean')
+          ? reconstructWireDelays(item as ExprNode, registry, seen)
+          : item)
+    } else if (typeof v === 'object' && v !== null) {
+      out[k] = reconstructWireDelays(v as ExprNode, registry, seen)
+    }
+  }
+  return out as ExprNode
+}
+
 // ─────────────────────────────────────────────────────────────
 // Slot allocation (M2 — additive helpers, no callers yet)
 // ─────────────────────────────────────────────────────────────

--- a/compiler/session.ts
+++ b/compiler/session.ts
@@ -910,70 +910,94 @@ const UNARY_PREFIX: Record<string, string> = { neg: '-' }
 export function prettyExpr(
   node: ExprNode,
   instanceRegistry: Map<string, Instance>,
+  /** Optional delay-slot registry. When supplied, `sessionSlot` /
+   *  `sessionArraySlot` reads (the hoisted unit-delay slots that
+   *  `extractSessionDelays` rewrites wires into during compile — e.g.
+   *  for a feedback ring) render as `delay(<source>)` by resolving the
+   *  slot back to its registered source expression. Without it they
+   *  render as `delay(slot:<i>)`. Callers that inspect a session AFTER
+   *  a compile should pass `session.delaySlotRegistry`. */
+  delaySlots?: readonly DelaySlotEntry[],
 ): string {
-  if (typeof node === 'number') return String(node)
-  if (typeof node === 'boolean') return String(node)
-  if (Array.isArray(node)) return `[${node.map(n => prettyExpr(n, instanceRegistry)).join(', ')}]`
+  const go = (node: ExprNode): string => {
+    if (typeof node === 'number') return String(node)
+    if (typeof node === 'boolean') return String(node)
+    if (Array.isArray(node)) return `[${node.map(go).join(', ')}]`
 
-  const n = node as { op: string; [k: string]: unknown }
-  const op = n.op
-  const args = (n.args as ExprNode[] | undefined) ?? []
+    const n = node as { op: string; [k: string]: unknown }
+    const op = n.op
+    const args = (n.args as ExprNode[] | undefined) ?? []
 
-  if (op === 'ref') {
-    const mod = n.instance as string
-    const out = n.output
-    const inst = instanceRegistry.get(mod)
-    const outName = inst && typeof out === 'number' ? (outputNames(inst)[out] ?? String(out)) : String(out)
-    return `${mod}.${outName}`
-  }
-  if (op === 'input')     return `input(${n.name})`
-  if (op === 'param')     return `param(${n.name})`
-  if (op === 'binding')   return `$${n.name}`
-  if (op === 'sampleRate')  return 'sampleRate'
-  if (op === 'sampleIndex') return 'sampleIndex'
-  if (op === 'float' || op === 'int')  return String(n.value)
-  if (op === 'bool')  return String(n.value)
+    if (op === 'ref') {
+      const mod = n.instance as string
+      const out = n.output
+      const inst = instanceRegistry.get(mod)
+      const outName = inst && typeof out === 'number' ? (outputNames(inst)[out] ?? String(out)) : String(out)
+      return `${mod}.${outName}`
+    }
+    if (op === 'input')     return `input(${n.name})`
+    if (op === 'param')     return `param(${n.name})`
+    if (op === 'binding')   return `$${n.name}`
+    if (op === 'sampleRate')  return 'sampleRate'
+    if (op === 'sampleIndex') return 'sampleIndex'
+    if (op === 'float' || op === 'int')  return String(n.value)
+    if (op === 'bool')  return String(n.value)
 
-  if (BINARY_OPS.has(op)) {
-    const sym = BINARY_INFIX[op]
-    const l = prettyExpr(args[0], instanceRegistry)
-    const r = prettyExpr(args[1], instanceRegistry)
-    return sym ? `(${l} ${sym} ${r})` : `${op}(${l}, ${r})`
-  }
-  if (UNARY_OPS.has(op)) {
-    const pfx = UNARY_PREFIX[op]
-    const x = prettyExpr(args[0], instanceRegistry)
-    return pfx ? `${pfx}${x}` : `${op}(${x})`
-  }
+    if (BINARY_OPS.has(op)) {
+      const sym = BINARY_INFIX[op]
+      const l = go(args[0])
+      const r = go(args[1])
+      return sym ? `(${l} ${sym} ${r})` : `${op}(${l}, ${r})`
+    }
+    if (UNARY_OPS.has(op)) {
+      const pfx = UNARY_PREFIX[op]
+      const x = go(args[0])
+      return pfx ? `${pfx}${x}` : `${op}(${x})`
+    }
 
-  if (op === 'clamp')  return `clamp(${args.map(a => prettyExpr(a, instanceRegistry)).join(', ')})`
-  if (op === 'select') return `select(${args.map(a => prettyExpr(a, instanceRegistry)).join(', ')})`
-  if (op === 'index')  return `${prettyExpr(args[0], instanceRegistry)}[${prettyExpr(args[1], instanceRegistry)}]`
-  if (op === 'arraySet') return `array_set(${args.map(a => prettyExpr(a, instanceRegistry)).join(', ')})`
-  if (op === 'array') return `[${(n.items as ExprNode[]).map(i => prettyExpr(i, instanceRegistry)).join(', ')}]`
-  if (op === 'matrix') return `matrix(${JSON.stringify(n.rows)})`
-  if (op === 'delay') return `delay(${prettyExpr(args[0], instanceRegistry)}, ${n.init ?? 0})`
-  if (op === 'delayRef') return `delay_ref(${n.id})`
-  if (op === 'nestedOut') return `${n.ref}.${n.output}`
-  if (op === 'tag') {
-    const payload = n.payload as Record<string, ExprNode> | undefined
-    const fields = payload === undefined
-      ? ''
-      : `{${Object.entries(payload).map(([k, v]) => `${k}: ${prettyExpr(v, instanceRegistry)}`).join(', ')}}`
-    return `${n.type}::${n.variant}${fields}`
-  }
-  if (op === 'match') {
-    const arms = n.arms as Record<string, { bind?: string | string[]; body: ExprNode }>
-    const armStrs = Object.entries(arms).map(([variant, arm]) => {
-      const bindStr = arm.bind === undefined
+    if (op === 'clamp')  return `clamp(${args.map(go).join(', ')})`
+    if (op === 'select') return `select(${args.map(go).join(', ')})`
+    if (op === 'index')  return `${go(args[0])}[${go(args[1])}]`
+    if (op === 'arraySet') return `array_set(${args.map(go).join(', ')})`
+    if (op === 'array') return `[${(n.items as ExprNode[]).map(go).join(', ')}]`
+    if (op === 'matrix') return `matrix(${JSON.stringify(n.rows)})`
+    if (op === 'delay') return `delay(${go(args[0])}, ${n.init ?? 0})`
+    if (op === 'delayRef') return `delay_ref(${n.id})`
+    // Hoisted unit-delay slots (post-extractSessionDelays). Resolve the
+    // backing source from the registry when available so a feedback
+    // wire reads as `delay(lfo5.out)` rather than an opaque slot index.
+    if (op === 'sessionSlot') {
+      const idx = n.index as number
+      const entry = delaySlots?.find(e => !e.isArray && e.slotIdx === idx)
+      return entry ? `delay(${go(entry.sourceExpr)}, ${entry.init ?? 0})` : `delay(slot:${idx})`
+    }
+    if (op === 'sessionArraySlot') {
+      const idx = n.index as number
+      const entry = delaySlots?.find(e => e.isArray && e.arraySlot === idx)
+      return entry ? `delay(${go(entry.sourceExpr)}, ${entry.init ?? 0})` : `delay(array_slot:${idx})`
+    }
+    if (op === 'nestedOut') return `${n.ref}.${n.output}`
+    if (op === 'tag') {
+      const payload = n.payload as Record<string, ExprNode> | undefined
+      const fields = payload === undefined
         ? ''
-        : ` bind ${typeof arm.bind === 'string' ? arm.bind : `(${arm.bind.join(', ')})`}`
-      return `${variant}${bindStr}: ${prettyExpr(arm.body, instanceRegistry)}`
-    })
-    return `match(${prettyExpr(n.scrutinee as ExprNode, instanceRegistry)}, type=${n.type}){${armStrs.join(', ')}}`
+        : `{${Object.entries(payload).map(([k, v]) => `${k}: ${go(v)}`).join(', ')}}`
+      return `${n.type}::${n.variant}${fields}`
+    }
+    if (op === 'match') {
+      const arms = n.arms as Record<string, { bind?: string | string[]; body: ExprNode }>
+      const armStrs = Object.entries(arms).map(([variant, arm]) => {
+        const bindStr = arm.bind === undefined
+          ? ''
+          : ` bind ${typeof arm.bind === 'string' ? arm.bind : `(${arm.bind.join(', ')})`}`
+        return `${variant}${bindStr}: ${go(arm.body)}`
+      })
+      return `match(${go(n.scrutinee as ExprNode)}, type=${n.type}){${armStrs.join(', ')}}`
+    }
+    // Should never reach here given the finite op set, but keep a safe fallback
+    throw new Error(`prettyExpr: unhandled op '${op}'`)
   }
-  // Should never reach here given the finite op set, but keep a safe fallback
-  throw new Error(`prettyExpr: unhandled op '${op}'`)
+  return go(node)
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/compiler/walk.ts
+++ b/compiler/walk.ts
@@ -370,6 +370,11 @@ export function mapChildren<T extends ExprOpNodeStrict>(
     case 'sampleIndex':
     case 'param':
     case 'const':
+    // Hoisted unit-delay slots (post-extractSessionDelays). Leaves: the
+    // delayed source lives in `session.delaySlotRegistry`, not in child
+    // ExprNodes, so there is nothing to recurse into.
+    case 'sessionSlot':
+    case 'sessionArraySlot':
       return node
 
     // ── Exhaustiveness check ─────────────────────────────────

--- a/mcp/engine.ts
+++ b/mcp/engine.ts
@@ -802,7 +802,7 @@ function handleGetInfo(instanceName: string) {
           type: inputPortType(inst, i) ?? null,
           expr: expr ?? null,
           pretty: expr !== undefined
-            ? prettyExpr(expr, session.instanceRegistry)
+            ? prettyExpr(expr, session.instanceRegistry, session.delaySlotRegistry)
             : null,
         }
       }),
@@ -966,7 +966,7 @@ function handleListWiring(filterInstance?: string) {
     for (const [key, node] of session.inputExprNodes) {
       const { instance, port } = parseWireKey(key)
       if (filterInstance && instance !== filterInstance) continue
-      results.push({ instance, input: port, expr: prettyExpr(node, session.instanceRegistry) })
+      results.push({ instance, input: port, expr: prettyExpr(node, session.instanceRegistry, session.delaySlotRegistry) })
     }
     return results
   })

--- a/mcp/engine.ts
+++ b/mcp/engine.ts
@@ -11,6 +11,7 @@ import { readFileSync }        from 'node:fs'
 import {
   makeSession, nextName, loadJSON,
   prettyExpr, resolveProgramType, SessionState, ExprNode,
+  type DelaySlotEntry,
   normalizeProgramFile, v2NodeToFile,
   type Instance,
   instantiate,
@@ -713,16 +714,89 @@ function handleExportProgram(args: Record<string, unknown>) {
   })
 }
 
+/** Collect the hoisted-delay slot indices a wire reads, split by class
+ *  (scalar `sessionSlot` vs array `sessionArraySlot`). */
+function collectSlotRefs(expr: ExprNode, scalar: Set<number>, array: Set<number>): void {
+  if (typeof expr !== 'object' || expr === null) return
+  if (Array.isArray(expr)) { for (const e of expr) collectSlotRefs(e, scalar, array); return }
+  const n = expr as { op?: string; index?: unknown; [k: string]: unknown }
+  if (n.op === 'sessionSlot' && typeof n.index === 'number') { scalar.add(n.index); return }
+  if (n.op === 'sessionArraySlot' && typeof n.index === 'number') { array.add(n.index); return }
+  for (const v of Object.values(n)) {
+    if (typeof v === 'object' && v !== null) collectSlotRefs(v as ExprNode, scalar, array)
+  }
+}
+
+/** All instances a wire transitively references, resolving hoisted
+ *  `sessionSlot` / `sessionArraySlot` reads back through the delay
+ *  registry. After a compile, `extractSessionDelays` has rewritten
+ *  auto-delayed wires (e.g. a feedback ring) into slot reads whose real
+ *  source lives in `delaySlotRegistry`, so a plain `exprDependencies`
+ *  would miss the instances the delayed source touches. Cycle-safe via
+ *  the visited slot sets (feedback rings chain slot → source → slot). */
+function resolvedWireDeps(
+  expr: ExprNode,
+  registry: readonly DelaySlotEntry[],
+  acc: Set<string> = new Set(),
+  seenScalar: Set<number> = new Set(),
+  seenArray: Set<number> = new Set(),
+): Set<string> {
+  for (const d of exprDependencies(expr)) acc.add(d)
+  const scalar = new Set<number>()
+  const array = new Set<number>()
+  collectSlotRefs(expr, scalar, array)
+  for (const idx of scalar) {
+    if (seenScalar.has(idx)) continue
+    seenScalar.add(idx)
+    const e = registry.find(r => !r.isArray && r.slotIdx === idx)
+    if (e) resolvedWireDeps(e.sourceExpr, registry, acc, seenScalar, seenArray)
+  }
+  for (const idx of array) {
+    if (seenArray.has(idx)) continue
+    seenArray.add(idx)
+    const e = registry.find(r => r.isArray && r.arraySlot === idx)
+    if (e) resolvedWireDeps(e.sourceExpr, registry, acc, seenScalar, seenArray)
+  }
+  return acc
+}
+
 function handleRemoveInstance(instanceName: string) {
   return wrap(() => {
     requireInstance(instanceName, 'instance_name')
     session.instanceRegistry.delete(instanceName)
-    for (const key of [...session.inputExprNodes.keys()]) {
-      if (key.startsWith(`${instanceName}:`)) session.inputExprNodes.delete(key)
+
+    const reg = session.delaySlotRegistry
+
+    // Hoisted-delay slots whose (resolved) source touches the removed
+    // instance — e.g. a feedback ring's `lfo_i.freq = delay(… ref(lfoN) …)`
+    // that compiled to `sessionSlot` with the ref now living in the
+    // registry. Both their backing wires AND their registry entries must
+    // go, or the post-removal recompile materializes a ref to a missing
+    // instance (the dangling-wiring bug).
+    const taintedScalar = new Set<number>()
+    const taintedArray = new Set<number>()
+    for (const e of reg) {
+      if (!resolvedWireDeps(e.sourceExpr, reg).has(instanceName)) continue
+      if (e.isArray) { if (e.arraySlot !== undefined) taintedArray.add(e.arraySlot) }
+      else if (e.slotIdx !== undefined) taintedScalar.add(e.slotIdx)
     }
+
     for (const [key, expr] of [...session.inputExprNodes.entries()]) {
-      if (exprDependencies(expr).has(instanceName)) session.inputExprNodes.delete(key)
+      // A wire goes if it feeds the removed instance, or its source —
+      // resolved through any hoisted delay slots — references it.
+      if (key.startsWith(`${instanceName}:`) || resolvedWireDeps(expr, reg).has(instanceName)) {
+        session.inputExprNodes.delete(key)
+      }
     }
+
+    // Drop the tainted registry entries. `sessionSlot` reads index by the
+    // entry's `slotIdx` / `arraySlot` field (not array position), so
+    // filtering the array out is safe for the surviving slots.
+    session.delaySlotRegistry = reg.filter(e =>
+      e.isArray
+        ? !(e.arraySlot !== undefined && taintedArray.has(e.arraySlot))
+        : !(e.slotIdx !== undefined && taintedScalar.has(e.slotIdx)))
+
     session.graphOutputs = session.graphOutputs.filter(o => o.instance !== instanceName)
     return { removed: instanceName, ...wire() }
   })

--- a/mcp/remove_feedback.test.ts
+++ b/mcp/remove_feedback.test.ts
@@ -1,0 +1,69 @@
+/**
+ * remove_feedback.test.ts — removing an instance that participates in a
+ * feedback ring must not throw, and must not leave dangling wiring.
+ *
+ * Regression: every MCP wire is unit-delay-wrapped, and after a compile
+ * `extractSessionDelays` rewrites the ring's wires into `sessionSlot`
+ * reads (the delayed source moves into `delaySlotRegistry`).
+ * `remove_instance` then (a) crashed because `exprDependencies` →
+ * `mapChildren` threw on the unhandled `sessionSlot` op, and (b) even
+ * past that, could not see that a `sessionSlot` wire still referenced
+ * the removed instance, so it left a wire whose registry source pointed
+ * at a now-missing instance — the post-removal recompile then threw.
+ *
+ * Requires libtropical.dylib (the engine's session owns a runtime).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { handleTool, session } from './engine.js'
+import type { ExprNode } from '../compiler/expr.js'
+
+function call(name: string, args: Record<string, unknown>) {
+  const res = handleTool(name, args) as { content: { text: string }[]; isError?: boolean }
+  return JSON.parse(res.content[0].text) as { status: 'ok' | 'error'; data?: unknown; error?: unknown }
+}
+
+const ref = (instance: string): ExprNode => ({ op: 'ref', instance, output: 'sine' })
+const fm  = (base: number, from: string): ExprNode => ({ op: 'add', args: [base, ref(from)] })
+
+describe('remove_instance on a feedback ring', () => {
+  test('does not throw and clears wiring that fed off the removed instance', () => {
+    // 3-LFO feedback ring: lfo1 ← lfo3 ← lfo2 ← lfo1. Unique names so
+    // the engine's shared session stays clean across the suite.
+    for (const n of ['rfb1', 'rfb2', 'rfb3']) {
+      expect(call('add_instance', { program: 'SinOsc', instance_name: n }).status).toBe('ok')
+    }
+    // Close the ring (MCP auto-delay breaks the cycle) and tap one to dac.
+    const wired = call('wire', { set: [
+      { instance: 'rfb1', input: 'freq', expr: fm(0.3, 'rfb3') },
+      { instance: 'rfb2', input: 'freq', expr: fm(0.5, 'rfb1') },
+      { instance: 'rfb3', input: 'freq', expr: fm(0.7, 'rfb2') },
+      { instance: 'dac',  input: 'out',  expr: ref('rfb1') },
+    ]})
+    expect(wired.status).toBe('ok') // compiled → ring wires became sessionSlot
+
+    // Remove an instance in the ring. Must succeed (no throw), and the
+    // recompile inside it must succeed too.
+    const removed = call('remove_instance', { instance_name: 'rfb3' })
+    expect(removed.status).toBe('ok')
+
+    // No surviving wire may reference the removed instance — including
+    // through a hoisted sessionSlot (rfb1.freq fed off rfb3).
+    const wiring = call('list_wiring', {})
+    expect(wiring.status).toBe('ok')
+    const pretty = JSON.stringify(wiring.data)
+    expect(pretty).not.toContain('rfb3')
+
+    // And the removed instance's own wires are gone.
+    expect(session.instanceRegistry.has('rfb3')).toBe(false)
+    expect([...session.inputExprNodes.keys()].some(k => k.startsWith('rfb3:'))).toBe(false)
+
+    // Inspection tools work on the survivors (would have thrown on the
+    // sessionSlot op before the fix).
+    expect(call('get_info', { instance_name: 'rfb2' }).status).toBe('ok')
+
+    // Clean up so other tests in this shared-session suite aren't affected.
+    call('remove_instance', { instance_name: 'rfb1' })
+    call('remove_instance', { instance_name: 'rfb2' })
+  })
+})


### PR DESCRIPTION
Three MCP bugs, **one root cause**: after a compile, every unit-delay-wrapped
wire (e.g. a feedback ring) is rewritten by `extractSessionDelays` into
`sessionSlot` / `sessionArraySlot` reads (the delayed source moves into
`delaySlotRegistry`). Several wire-walking / serialization paths had no handling
for those ops, so inspecting, editing, or saving such a patch broke.

## 1. `prettyExpr` — `list_wiring` / `get_info` threw

`unhandled op 'sessionSlot'`. `prettyExpr` now takes an optional
`delaySlotRegistry` and renders a hoisted slot as `delay(<resolved source>)`
(falling back to `delay(slot:<i>)` without it) — a feedback wire reads as
`delay((0.3 + lfo2.sine), 0)`. Refactored to an inner closure so the registry
threads through recursion.

## 2. `remove_instance` on a feedback ring threw and left dangling wiring

- `mapChildren` threw `unhandled op 'sessionSlot'` (it's how `exprDependencies`
  walks wires). Added `sessionSlot` / `sessionArraySlot` as **leaves**, plus
  `SessionSlotNode` / `SessionArraySlotNode` in `expr.ts`'s `LeafNode` union.
- Even past the throw, the cleanup couldn't see that a `sessionSlot` wire still
  referenced the removed instance (the ref lives in the registry), so it kept a
  wire pointing at a now-missing instance → the recompile threw.
  `handleRemoveInstance` now resolves deps **through** the registry
  (`resolvedWireDeps`, cycle-safe) and drops the tainted registry entries.

## 3. `save` serialized raw `sessionSlot` indices

`saveProgramFromSession` emitted `session.inputExprNodes` verbatim, so a saved
feedback patch carried opaque `{op:'sessionSlot', index}` nodes — unloadable in a
fresh session. Added `reconstructWireDelays` (the inverse of
`extractSessionDelays`): rewrites the slot reads back into `delay(<source>, init)`
from the registry, recursively + cycle-safe. `save` now emits the authored
`delay()` form; a reload re-hoists the delays and recompiles cleanly (verified
end-to-end).

## Tests

- `compiler/pretty_expr.test.ts` — slot wires render as `delay(...)`.
- `mcp/remove_feedback.test.ts` — remove a ring member: no throw, no surviving
  reference (incl. through `sessionSlot`), `get_info` works on survivors.
- `compiler/save_round_trip.test.ts` — save a compiled ring: no `sessionSlot` in
  the output, reloads into a fresh session and recompiles without a cycle error.
- Full suite green (1042 pass); `tsc` clean.

## Known follow-up (out of scope)

`save` does not emit inline `programDecl`s for custom `define_program` types —
an orthogonal, pre-existing round-trip gap (needs a `ResolvedProgram → ProgramNode`
serializer), independent of the sessionSlot gap fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)