### PR TITLE
refactor(ir): sources family — Tick/Rate as the dual of sinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ SessionState  (instances + wiring + dac.out + params)
   │          ExternalProgramResolver hook — LINK, not re-elaboration)
   │       → partitionKernel → tropical_plan_5
   ▼
-tropical_plan_5  (instance_functions[] + sinks[])
+tropical_plan_5  (instance_functions[] + sinks[] + sources[])
 ```
 
 **The IR is acyclic by construction.** Source-level cycles that
@@ -230,7 +230,7 @@ Two distinct JSON schemas; do not confuse them.
 | Schema | Produced by | Purpose |
 |--------|-------------|---------|
 | `tropical_program_2` | `compiler/program.ts`, `compiler/parse/raise.ts` | The high-detail input shape: a program with typed ports, a body block of decls/assigns, optionally generic in `type_params`. Authored by humans (in `.trop`) or by agents (over MCP). |
-| `tropical_plan_5`    | `compiler/ir/compile_session_slotted.ts` (`compiler/flat_plan.ts` schema) | The low-detail output: a root instruction stream (instances nested as `children`) plus `sinks[]` (device-bound outputs: sum input slots × gain → channel). The C++ JIT and the WASM emitter both consume this shape. The engine still accepts the older `tropical_plan_4` (single-kernel form, top-level `output_targets` temp-mix) for hand-crafted unit tests; it's lifted into a one-instance plan_5 at parse time. |
+| `tropical_plan_5`    | `compiler/ir/compile_session_slotted.ts` (`compiler/flat_plan.ts` schema) | The low-detail output: a root instruction stream (instances nested as `children`) plus `sinks[]` (device-bound outputs: sum input slots × gain → channel) and `sources[]` (runtime-bound inputs: canonical `[tick, rate]`; the dual of sinks). The C++ JIT and the WASM emitter both consume this shape. The engine still accepts the older `tropical_plan_4` (single-kernel form, top-level `output_targets` temp-mix) for hand-crafted unit tests; it's lifted into a one-instance plan_5 with the canonical sources at parse time. |
 
 Going from the first to the second without losing meaning is exactly
 what the strata pipeline does.

--- a/compiler/CLAUDE.md
+++ b/compiler/CLAUDE.md
@@ -56,7 +56,7 @@ program_types.ts      ProgramType / ProgramInstance — thin wrappers over a pos
                       slot-derived fields cache lazily. Wrapper is metadata; IR is the value.
 session.ts            SessionState, generic-program resolution, JSON ingest
 schema.ts             Zod validation for tropical_program_2
-flat_plan.ts          tropical_plan_5 schema (the boundary type with the engine; branded indices, instance_functions[] + sinks[])
+flat_plan.ts          tropical_plan_5 schema (the boundary type with the engine; branded indices, instance_functions[] + sinks[] (outputs) + sources[] (inputs: tick/rate))
 apply_plan.ts         compileSession → JSON.stringify → runtime.loadPlan
 compiler.ts           Dependency graph utilities (Kahn's, Tarjan's SCC); structural InstanceInfo
 term.ts               PortType, ScalarKind, shape algebra
@@ -262,8 +262,12 @@ compiler stage — they're parallel emits.
   structural id (interned via `${op}|${field=}|${child_id}` strings),
   not node identity, so duplicates introduced by clone-then-substitute
   passes still collapse. Operand kinds: `const`, `input`, `reg`,
-  `array_reg`, `state_reg`, `param`, `rate`, `tick`. Array-loop ops
-  carry `loop_count > 1` plus `strides` for broadcast vs. iterate.
+  `array_reg`, `state_reg`, `param`, `source`, `slot`. `source` carries an
+  index into `plan.sources[]` (the input family, canonical `[tick, rate]`);
+  the engine resolves it by switching on `sources[i].kind`. (Legacy `rate`
+  / `tick` operand kinds survive on the wire only — plan_4 fixtures; the
+  parser upgrades them to `source:1` / `source:0`.) Array-loop ops carry
+  `loop_count > 1` plus `strides` for broadcast vs. iterate.
 
 - **`emit_wasm.ts`** + **`wasm_memory_layout.ts`** — emits a
   standalone WASM module with a single exported

--- a/compiler/emit_wasm.ts
+++ b/compiler/emit_wasm.ts
@@ -24,7 +24,7 @@
  *   - slots        → f64 cells (inter-module shared array)
  */
 
-import type { FlatPlan, InstanceFunction } from './flat_plan'
+import type { FlatPlan, InstanceFunction, SourceSpec } from './flat_plan'
 import type { NInstr, NOperand, ScalarType } from './ir/emit_resolved'
 import { dstAsTemp, dstAsArray, dstAsModuleSlot } from './ir/emit_resolved'
 import { rawIdx, rawOffset } from './ir/slot_indices'
@@ -331,7 +331,7 @@ export function emitWasm(plan: FlatPlan, opts: EmitWasmOptions = {}): EmitWasmRe
     plan: flatProgram, inputCount, paramPtrs, maxBlockSize,
     slotCount: plan.slot_count ?? 0,
   })
-  const ctx: EmitCtx = { layout, paramIndex, sampleRate }
+  const ctx: EmitCtx = { layout, paramIndex, sampleRate, sources: plan.sources }
 
   const c = new Code()
 
@@ -449,6 +449,9 @@ type EmitCtx = {
   layout: WasmLayout
   paramIndex: Map<string, number>
   sampleRate: number
+  /** The plan's declared input sources. `source:i` operands resolve via
+   *  `sources[i].kind` — symmetric with the engine's resolution. */
+  sources: readonly SourceSpec[]
 }
 
 function emitInstruction(c: Code, instr: NInstr, ctx: EmitCtx): void {
@@ -517,11 +520,20 @@ function pushOperand(c: Code, op: NOperand, ctx: EmitCtx): ScalarType {
       c.i32c(0); c.f64Load(ctx.layout.paramTableOffset + idx * 8)
       return 'float'
     }
-    case 'rate': {
-      c.f64c(ctx.sampleRate); return 'float'
-    }
-    case 'tick': {
-      c.localGet(L_SIDX); return 'int'
+    case 'source': {
+      // Read input source `sources[op.index]`. The kind lookup tells us
+      // which kernel value to materialize: tick = sample_index (i64),
+      // rate = sample rate (f64). Mirrors the engine resolution.
+      const src = ctx.sources[op.index]
+      if (src === undefined) {
+        throw new Error(
+          `emit_wasm: source operand index ${op.index} out of range ` +
+          `(plan has ${ctx.sources.length} sources)`,
+        )
+      }
+      if (src.kind === 'tick') { c.localGet(L_SIDX); return 'int' }
+      if (src.kind === 'rate') { c.f64c(ctx.sampleRate); return 'float' }
+      throw new Error(`emit_wasm: unknown source kind '${src.kind}' at index ${op.index}`)
     }
     case 'slot': {
       // Inter-module slot read. Slots are stored as f64 in the
@@ -993,8 +1005,9 @@ function operandScalarType(op: NOperand): ScalarType {
       `remapInstancePlan must convert it to 'array_reg' before WASM emission.`,
     )
   }
-  if (op.kind === 'rate') return 'float'
-  if (op.kind === 'tick') return 'int'
+  // `source` carries its own coerced scalar_type from the emit pass;
+  // the operand's intrinsic kind (tick = int, rate = float) is recovered
+  // by looking up the plan's source declaration when needed downstream.
   return op.scalar_type
 }
 

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -231,6 +231,49 @@ export interface WireSinkSpec {
   target: number
 }
 
+// ─── SourceSpec: a runtime-bound input source (Tick/Rate, neutrally named) ───
+//
+// The dual of `SinkSpec` — the *entry* from the runtime to the pure signal
+// graph. Where sinks WRITE device outputs at the end of each sample, sources
+// PROVIDE values that the kernel reads (the sample index, the sample rate,
+// future external inputs like ADC or MIDI clock). Sources are a FAMILY: the
+// schema is N-source ready; v1 always emits the canonical pair in fixed order:
+//
+//     sources[0] = { kind: 'tick' }   // current sample index  (integer)
+//     sources[1] = { kind: 'rate' }   // current sample rate   (float)
+//
+// IR refs (`SampleIndex`, `SampleRate`) lower to `{kind:'source', index}`
+// operands at the plan boundary; the engine resolves each by switching on
+// `program.sources[index].kind` to the appropriate kernel argument. The plan
+// thus DECLARES what it consumes — symmetric with how it declares its outputs
+// in `sinks[]` — while the engine keeps the existing efficient kernel args.
+
+export type SourceKind = 'tick' | 'rate'
+
+export interface SourceSpec {
+  kind: SourceKind
+}
+
+export interface WireSourceSpec {
+  kind: SourceKind
+}
+
+/** Canonical source ordering. Sessions always emit the pair in this order
+ *  so emit-time and engine-time index agreement is mechanical. */
+export const SOURCE_TICK_INDEX = 0
+export const SOURCE_RATE_INDEX = 1
+export const DEFAULT_SOURCES: SourceSpec[] = [
+  { kind: 'tick' },
+  { kind: 'rate' },
+]
+
+/** Predicate used by `toWirePlan` to elide the `sources` field when its
+ *  value matches the canonical pair — keeps pre-sources wire goldens
+ *  byte-stable when nothing real has changed. */
+export const isDefaultSources = (s: readonly SourceSpec[]): boolean =>
+  s.length === DEFAULT_SOURCES.length
+  && s.every((sp, i) => sp.kind === DEFAULT_SOURCES[i]!.kind)
+
 // ─── FlatPlan: the runnable plan ────────────────────────────────────────────
 
 export interface FlatPlan {
@@ -253,6 +296,10 @@ export interface FlatPlan {
   instance_functions: InstanceFunction[]
   /** Device-bound output sinks (the plan_5 output path). */
   sinks: SinkSpec[]
+  /** Runtime-bound input sources. Dual of `sinks`. Canonical order:
+   *  `[{kind:'tick'}, {kind:'rate'}]`; `{op:'source', index:i}` operands
+   *  resolve via `sources[i].kind`. v1 always emits both. */
+  sources: SourceSpec[]
   /** Legacy temp-mix carrier — top-level output temps summed ÷20 by the
    *  engine when `sinks` is empty (the plan_4 / single-kernel path).
    *  Sessions never set this; they use `sinks`. */
@@ -309,6 +356,10 @@ export interface WireFlatPlan {
   instance_functions: WireInstanceFunction[]
   /** Device-bound output sinks (the plan_5 output path). */
   sinks?:        WireSinkSpec[]
+  /** Runtime-bound input sources. Optional in the wire for backcompat
+   *  with plan_4 / pre-sources fixtures; parsed as `DEFAULT_SOURCES`
+   *  (the canonical [tick, rate] pair) when missing. */
+  sources?:      WireSourceSpec[]
   /** Legacy temp-mix carrier (top-level, plan_4-style) — engine sums
    *  these output temps ÷20 when `sinks` is absent. */
   output_targets?: number[]
@@ -433,6 +484,12 @@ export function parseWirePlan(wire: WireFlatPlan): FlatPlan {
     slot_names:       wire.slot_names,
     slot_defaults:    wire.slot_defaults,
     instance_functions: wire.instance_functions.map(parseInstanceFn),
+    // Pre-sources plans get the canonical [tick, rate] pair so any `source`
+    // operands that may arrive (if a future plan layer emits them) still
+    // resolve. Plans that explicitly carry `sources` round-trip exactly.
+    sources: wire.sources !== undefined
+      ? wire.sources.map(s => ({ kind: s.kind }))
+      : [...DEFAULT_SOURCES],
     sinks: (wire.sinks ?? []).map(s => ({
       inputs: s.inputs.map(moduleSlotIdx),
       gain:   s.gain,
@@ -475,6 +532,12 @@ export function toWirePlan(plan: FlatPlan): WireFlatPlan {
     ...(plan.sinks.length > 0
       ? { sinks: plan.sinks.map(s => ({ inputs: s.inputs.map(rawIdx), gain: s.gain, target: s.target })) }
       : {}),
+    // Sources: always emit on the production path (sessions construct
+    // [tick, rate]). Omit when equal to the canonical default so existing
+    // golden JSON byte goldens (pre-sources) round-trip cleanly.
+    ...(isDefaultSources(plan.sources)
+      ? {}
+      : { sources: plan.sources.map(s => ({ kind: s.kind })) }),
     // Legacy temp-mix carrier (plan_4 / sink-less plans only).
     ...(plan.output_targets !== undefined
       ? { output_targets: plan.output_targets.map(rawIdx), outputs: plan.outputs ?? [] }

--- a/compiler/flat_plan.ts
+++ b/compiler/flat_plan.ts
@@ -404,9 +404,13 @@ const deriveLegacyDstKind = (i: WireNInstr): 'temp' | 'array' | 'moduleSlot' => 
 const parseOperand = (o: WireNOperand): NOperand => {
   switch (o.kind) {
     case 'const':     return o
-    case 'rate':      return o
-    case 'tick':      return o
     case 'param':     return o
+    // Legacy plan_4 / pre-sources fixtures emit `rate`/`tick` directly;
+    // upgrade them to indexed source operands so the internal type
+    // is fully migrated. Engine-side parser does the dual upgrade.
+    case 'rate':      return { kind: 'source', index: SOURCE_RATE_INDEX, scalar_type: o.scalar_type }
+    case 'tick':      return { kind: 'source', index: SOURCE_TICK_INDEX, scalar_type: o.scalar_type }
+    case 'source':    return { kind: 'source', index: o.index,            scalar_type: o.scalar_type }
     case 'input':     return { kind: 'input',     slot:  inputPortIdx(o.slot),   scalar_type: o.scalar_type }
     case 'reg':       return { kind: 'reg',       slot:  tempIdx(o.slot),        scalar_type: o.scalar_type }
     case 'array_reg': return { kind: 'array_reg', slot:  arraySlotIdx(o.slot) }

--- a/compiler/flat_plan_mode.test.ts
+++ b/compiler/flat_plan_mode.test.ts
@@ -40,6 +40,7 @@ function makeEmptyWirePlan(): WireFlatPlan {
     array_slot_sizes: [],
     instance_functions: [],
     sinks: [],
+    sources: [{ kind: 'tick' }, { kind: 'rate' }],
     slot_count:    0,
     slot_names:    [],
     slot_defaults: [],

--- a/compiler/ir/compile_session_slotted.ts
+++ b/compiler/ir/compile_session_slotted.ts
@@ -27,6 +27,7 @@ import {
   type InstanceName,
 } from './branded_names.js'
 import type { FlatPlan, InstanceFunction, CompilationMode } from '../flat_plan.js'
+import { DEFAULT_SOURCES } from '../flat_plan.js'
 import type { ResolvedProgram, InputIdx, ParamIdx } from './nodes.js'
 import { inputIdx, paramIdx } from './nodes.js'
 import { getInstanceType } from './decl_tables.js'
@@ -214,6 +215,7 @@ function compileSessionSlottedRoot(
     register_count:    acc.nextRegRaw,
     instance_functions: instanceFunctions,
     sinks:              emitSinks(session),
+    sources:            [...DEFAULT_SOURCES],
     ...buildSlotMetadata(session),
   }
 }

--- a/compiler/ir/compile_session_slotted_helpers.ts
+++ b/compiler/ir/compile_session_slotted_helpers.ts
@@ -42,6 +42,7 @@ import {
   instrScalar, instrArray, instrPack, instrSetElement, instrIndex,
   instrWriteSlot,
   opConst, opTemp, opSlot, opStateReg, opArray, opRate, opTick,
+  opSource, SOURCE_TICK, SOURCE_RATE,
 } from './emit_resolved.js'
 import {
   type TempIdx, type StateRegIdx, type ArraySlotIdx, type ModuleSlotIdx,
@@ -140,8 +141,8 @@ export function translateNode(
   }
 
   // ── builtins ──
-  if (op === 'sampleRate')  return { kind: 'rate', scalar_type: scalarType }
-  if (op === 'sampleIndex') return { kind: 'tick', scalar_type: scalarType }
+  if (op === 'sampleRate')  return opSource(SOURCE_RATE, scalarType)
+  if (op === 'sampleIndex') return opSource(SOURCE_TICK, scalarType)
 
   // ── session-internal slot read (emitted by extractSessionDelays) ──
   // The wire was a `delay()` that got hoisted to a module slot in the
@@ -364,10 +365,9 @@ export function remapInstancePlan(
 
   const remapOperand = (op: NOperand): NOperand => {
     switch (op.kind) {
-      case 'const': return op
-      case 'rate':  return op
-      case 'tick':  return op
-      case 'slot':  return op
+      case 'const':  return op
+      case 'source': return op
+      case 'slot':   return op
       case 'input': {
         const portName = ctx.inputPortNames[rawIdx(op.slot)]
         if (portName === undefined) {

--- a/compiler/ir/emit_resolved.ts
+++ b/compiler/ir/emit_resolved.ts
@@ -69,8 +69,13 @@ export type NOperand =
   | { kind: 'session_array_reg'; slot: ArraySlotIdx }
   | { kind: 'state_reg';         slot: StateRegIdx;    scalar_type: ScalarType }
   | { kind: 'param';             ptr:  string;         scalar_type: ScalarType }
-  | { kind: 'rate';                                    scalar_type: ScalarType }
-  | { kind: 'tick';                                    scalar_type: ScalarType }
+  /** Read an input source — the dual of a sink, materialized at the runtime
+   *  boundary. `index` keys into `FlatPlan.sources[]`; the engine switches
+   *  on the source's `kind` (tick / rate / future ADC) to the appropriate
+   *  kernel argument. v1: index 0 = tick, index 1 = rate. Replaces the
+   *  former `rate` / `tick` operand kinds, which survive only on the wire
+   *  format as plan_4 backcompat (parsed as `source:rate` / `source:tick`). */
+  | { kind: 'source';            index: number;        scalar_type: ScalarType }
   | { kind: 'slot';              index: ModuleSlotIdx; scalar_type: ScalarType }
 
 /** Discriminated dst — the namespace of an instruction's writeback. */
@@ -220,8 +225,14 @@ export const opSlot     = (index: ModuleSlotIdx, scalar_type: ScalarType): NOper
   ({ kind: 'slot', index, scalar_type })
 export const opParam    = (ptr: string, scalar_type: ScalarType = 'float'): NOperand =>
   ({ kind: 'param', ptr, scalar_type })
-export const opRate: NOperand = { kind: 'rate', scalar_type: 'float' }
-export const opTick: NOperand = { kind: 'tick', scalar_type: 'int' }
+export const opSource = (index: number, scalar_type: ScalarType): NOperand =>
+  ({ kind: 'source', index, scalar_type })
+/** Canonical source indices (mirrors `flat_plan.SOURCE_*_INDEX`).
+ *  Sessions always emit `[{kind:'tick'},{kind:'rate'}]` in this order. */
+export const SOURCE_TICK = 0
+export const SOURCE_RATE = 1
+export const opTick: NOperand = opSource(SOURCE_TICK, 'int')
+export const opRate: NOperand = opSource(SOURCE_RATE, 'float')
 
 // ─── Wire format ────────────────────────────────────────────────────────────
 // The C++ engine parses this shape from JSON. Brands erase at runtime
@@ -235,8 +246,12 @@ export type WireNOperand =
   | { kind: 'array_reg'; slot: number }
   | { kind: 'state_reg'; slot: number; scalar_type: ScalarType }
   | { kind: 'param';     ptr: string;  scalar_type: ScalarType }
+  /** Legacy plan_4 sentinel — production sessions emit `source` instead.
+   *  `parseOperand` upgrades these to `source` at parse time. */
   | { kind: 'rate';      scalar_type: ScalarType }
   | { kind: 'tick';      scalar_type: ScalarType }
+  /** Read input source `sources[index]`. */
+  | { kind: 'source';    index: number; scalar_type: ScalarType }
   | { kind: 'slot';      index: number; scalar_type: ScalarType }
 
 export type WireDstKind = 'temp' | 'array' | 'moduleSlot'

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -98,7 +98,8 @@ ResolvedProgram (post-strata)
     │   │       │ liftWiresToInstances → extractSessionDelays
     │   │       │     → assertSessionAcyclic → compileSessionSlotted
     │   │       │     (buildSessionRoot → partitionKernel →
-    │   │       │      instance_functions[] (root, nested children) + sinks[])
+    │   │       │      instance_functions[] (root, nested children)
+    │   │       │      + sinks[] (outputs) + sources[] (inputs))
     │   │       │
     │   │       │   ──── C API boundary (engine/c_api/tropical_c.h, koffi FFI) ────
     │   │       ▼
@@ -539,9 +540,13 @@ not node identity. This catches duplicates that strata's
 clone-then-substitute introduces.
 
 **Operand kinds.** `NOperand` discriminates: `const`, `input`, `reg`,
-`array_reg`, `state_reg`, `param`, `rate`, `tick`. Terminals
-(literals, sentinels, register reads) embed inline; non-terminal
-expressions get a temp register.
+`array_reg`, `state_reg`, `param`, `source`, `slot`. The `source` kind
+carries an index into `plan.sources[]` — the runtime-bound input family
+(canonical: `[tick, rate]`); the engine switches on `sources[i].kind` to
+the appropriate kernel arg. Terminals (literals, register reads, source
+reads) embed inline; non-terminal expressions get a temp register.
+(The former `tick` and `rate` operand kinds survive only on the wire as
+plan_4 legacy aliases; parser upgrades them to `source:0`/`source:1`.)
 
 **Array loops.** When `loop_count > 1` an instruction emits an
 elementwise loop. `strides[i]` controls whether each argument
@@ -700,7 +705,7 @@ Two distinct JSON schemas; do not confuse them.
 | Schema | Produced by | Purpose |
 |--------|-------------|---------|
 | `tropical_program_2` | `compiler/program.ts`, `compiler/parse/raise.ts` | The high-detail input shape: a program with typed ports, a body block of decls/assigns, optionally generic in `type_params`. Authored by humans (in `.trop`) or by agents (over MCP). |
-| `tropical_plan_5`    | `compiler/ir/compile_session_slotted.ts` (`compiler/flat_plan.ts` schema) | The low-detail output: a root instruction stream (`instance_functions[]`, instances nested as `children`) plus `sinks[]` (device-bound outputs). The C++ JIT and the WASM emitter both consume this shape. The engine still accepts the older `tropical_plan_4` (single-kernel, top-level temp-mix) for hand-crafted unit tests; it's lifted into a one-instance plan_5 at parse time. |
+| `tropical_plan_5`    | `compiler/ir/compile_session_slotted.ts` (`compiler/flat_plan.ts` schema) | The low-detail output: a root instruction stream (`instance_functions[]`, instances nested as `children`) plus `sinks[]` (device-bound outputs) and `sources[]` (runtime-bound inputs — canonical `[tick, rate]`). The C++ JIT and the WASM emitter both consume this shape. The engine still accepts the older `tropical_plan_4` (single-kernel, top-level temp-mix) for hand-crafted unit tests; it's lifted into a one-instance plan_5 with the canonical sources at parse time. |
 
 Schema validation: `compiler/schema.ts` (Zod) for input;
 `compiler/flat_plan.ts` (branded TypeScript types) for output.
@@ -747,15 +752,21 @@ what the strata pipeline does.
       gain:   number,    // output scale (was the engine's hardcoded ÷20)
       target: number },  // output channel/device (0 = default audio out)
     ...
+  ],
+  sources: [             // runtime-bound inputs — the dual of sinks.
+    { kind: "tick" },    //   index 0: current sample index (i64)
+    { kind: "rate" }     //   index 1: current sample rate (f64)
   ]
-  // (sink-less plan_4 / single-kernel fixtures instead carry top-level
+  // (omitted on the wire when equal to the canonical [tick, rate] pair;
+  //  sink-less plan_4 / single-kernel fixtures instead carry top-level
   //  `output_targets`/`outputs` for the legacy temp-mix ÷20.)
 }
 ```
 
 The `tropical_plan_5` shape is the C-API contract. Anything the
 backends need to know about the program — instance kernels, the output
-sinks, names, types, slot counts, init state — is in there; everything
+sinks, the input sources, names, types, slot counts, init state — is in
+there; everything
 the compiler decided to forget along the way is gone.
 
 ---

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -28,8 +28,8 @@ All external access (TypeScript FFI, tests) goes through here. Handles are opaqu
 
 `FlatRuntime::load_plan()` receives a `tropical_plan_5` JSON string:
 
-1. `NumericProgramParser::parse_plan5()` — thin deserializer, reads the instance functions plus `sinks[]` into a `FlatProgram` (multi-function) struct. A backcompat lift exists for single-kernel `plan_4` inputs (hand-crafted unit tests, legacy saved plans) — they parse into a one-instance plan_5 with a top-level temp-mix.
-2. `OrcJitEngine::compile_flat_program()` — JIT compiles the FlatProgram to a single native kernel function (instances then sinks, per sample).
+1. `NumericProgramParser::parse_plan5()` — thin deserializer, reads the instance functions plus `sinks[]` (outputs) and `sources[]` (inputs; defaults to canonical `[tick, rate]`) into a `FlatProgram` (multi-function) struct. A backcompat lift exists for single-kernel `plan_4` inputs — they parse into a one-instance plan_5 with a top-level temp-mix and the canonical source pair. Legacy `rate`/`tick` operand tags upgrade to `Source{kind:Rate/Tick}` at parse.
+2. `OrcJitEngine::compile_flat_program()` — JIT compiles the FlatProgram to a single native kernel function (instances then sinks, per sample). Source operands resolve to `sample_rate_arg` / `current_sample_idx` via `program.sources[i].kind`.
 3. State initialization — registers and module slots are type-aware bit-cast (`int64_t[]` backing store, with float/int/bool coercion).
 4. Named state transfer — matching registers, arrays, and slots are copied from the active kernel by name for click-free hot-swap.
 5. Atomic swap — new kernel published to audio thread via `active_state_` store-release.

--- a/engine/jit/OrcJitEngine.cpp
+++ b/engine/jit/OrcJitEngine.cpp
@@ -633,6 +633,24 @@ TypedVal EmitCtx::resolve_typed(const Operand & op) const
     case OperandKind::StateReg: return {load_reg_typed(op.slot, op.scalar_type), op.scalar_type};
     case OperandKind::Rate:     return {sample_rate_arg, ST::Float};
     case OperandKind::Tick:     return {current_sample_idx, ST::Int};
+    case OperandKind::Source: {
+      // Indexed source: dispatch on the declared source kind. Same kernel
+      // arg behind each case as the legacy Rate/Tick fall-through; the
+      // indirection through `sources[op.slot]` is what makes the plan
+      // genuinely N-source-ready while staying perf-equivalent.
+      if (program->sources.size() <= op.slot) {
+        // Defensive: a plan that emits source:i but didn't declare i.
+        // Treat as zero to keep the kernel valid; shouldn't reach here
+        // from production code (TS-side construction always emits the
+        // canonical pair).
+        return {llvm::ConstantFP::get(f64_ty, 0.0), ST::Float};
+      }
+      switch (program->sources[op.slot].kind) {
+        case tropical_jit::SourceKind::Tick: return {current_sample_idx, ST::Int};
+        case tropical_jit::SourceKind::Rate: return {sample_rate_arg,    ST::Float};
+      }
+      return {llvm::ConstantFP::get(f64_ty, 0.0), ST::Float};
+    }
     case OperandKind::Slot: {
       llvm::Value * v = load_slot_f64(op.slot);
       switch (op.scalar_type) {
@@ -1183,6 +1201,12 @@ llvm::Expected<NumericKernelFn> OrcJitEngine::compile_flat_program(
       append(&sink.gain, sizeof(double));
       append(&sink.target, sizeof(uint32_t));
     }
+    // Sources (the kind at each index determines which kernel arg the
+    // Source operand resolves to; identity of the mapping affects codegen).
+    uint32_t nsrc = static_cast<uint32_t>(program.sources.size());
+    append(&nsrc, sizeof(uint32_t));
+    for (const auto & src : program.sources)
+      append(&src.kind, sizeof(tropical_jit::SourceKind));
     // Register writebacks
     uint32_t nrt = static_cast<uint32_t>(program.register_targets.size());
     append(&nrt, sizeof(uint32_t));
@@ -1509,6 +1533,10 @@ llvm::Expected<MicrokernelKernels> OrcJitEngine::compile_microkernel(
       append(&sink.gain, sizeof(double));
       append(&sink.target, sizeof(uint32_t));
     }
+    uint32_t nsrc = static_cast<uint32_t>(program.sources.size());
+    append(&nsrc, sizeof(uint32_t));
+    for (const auto & src : program.sources)
+      append(&src.kind, sizeof(tropical_jit::SourceKind));
     uint32_t nrt = static_cast<uint32_t>(program.register_targets.size());
     append(&nrt, sizeof(uint32_t));
     for (int32_t rt : program.register_targets)

--- a/engine/jit/OrcJitEngine.hpp
+++ b/engine/jit/OrcJitEngine.hpp
@@ -64,8 +64,10 @@ enum class OperandKind : uint8_t
   ArrayReg, // virtual register — array result in arrays[slot]
   StateReg, // persistent module register in registers[slot]
   Param,    // ControlParam pointer (ptr field)
-  Rate,     // sample rate (runtime constant)
-  Tick,     // sample index (runtime counter)
+  Source,   // input source `sources[slot]` — resolved by kind at runtime
+            // (slot field holds the source index; sources[i].kind → tick|rate)
+  Rate,     // [legacy plan_4] sample rate (runtime constant)
+  Tick,     // [legacy plan_4] sample index (runtime counter)
   Slot,     // shared inter-module slot (slot field, indexes slots[]) — M6+
 };
 
@@ -93,6 +95,8 @@ struct Operand
   { Operand o; o.kind = OperandKind::Rate; o.scalar_type = JitScalarType::Float; return o; }
   static Operand make_tick()
   { Operand o; o.kind = OperandKind::Tick; o.scalar_type = JitScalarType::Float; return o; }
+  static Operand make_source(uint32_t index, JitScalarType t = JitScalarType::Float)
+  { Operand o; o.kind = OperandKind::Source; o.scalar_type = t; o.slot = index; return o; }
   // M6: slot operand reads from the shared slots[] arg passed to the
   // kernel. Stored as double, coerced at use site to match scalar_type.
   static Operand make_slot(uint32_t s, JitScalarType t = JitScalarType::Float)
@@ -178,6 +182,22 @@ struct Sink
   uint32_t              target = 0;    // output channel/device index
 };
 
+// A runtime-bound input source — the dual of `Sink`. The kernel reads source
+// values via `OperandKind::Source` operands carrying an index into the plan's
+// `sources` array; the engine switches on the source's `kind` to the
+// appropriate kernel argument (Tick → current_sample_idx, Rate →
+// sample_rate_arg). v1: sources[0] = Tick, sources[1] = Rate.
+enum class SourceKind : uint8_t
+{
+  Tick,  // current sample index (integer)
+  Rate,  // current sample rate (float)
+};
+
+struct Source
+{
+  SourceKind kind = SourceKind::Tick;
+};
+
 struct FlatProgram
 {
   // ── Plan-wide unified state (shared across all instance functions) ──
@@ -190,7 +210,8 @@ struct FlatProgram
 
   // ── Multi-function layout (tropical_plan_5) ──
   std::vector<InstanceProgram> instance_functions;
-  std::vector<Sink>            sinks;  // device-bound outputs (plan_5 mix path)
+  std::vector<Sink>            sinks;    // device-bound outputs (plan_5 mix path)
+  std::vector<Source>          sources;  // runtime-bound inputs (plan_5 source path)
 };
 
 // Engine realization strategy.

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -103,8 +103,13 @@ inline tropical_jit::Operand parse_operand(const nlohmann::json & j)
     const uint64_t ptr = std::stoull(j.at("ptr").get<std::string>());
     return tropical_jit::Operand::make_param(ptr);
   }
-  if (kind == "rate") return tropical_jit::Operand::make_rate();
-  if (kind == "tick") return tropical_jit::Operand::make_tick();
+  if (kind == "source")
+    return tropical_jit::Operand::make_source(j.at("index").get<uint32_t>(), st);
+  // Legacy plan_4 / pre-sources fixtures emit `rate`/`tick` directly;
+  // upgrade them to indexed source operands so the engine path is
+  // fully migrated. Canonical: sources[0] = tick, sources[1] = rate.
+  if (kind == "rate") return tropical_jit::Operand::make_source(1u, st);
+  if (kind == "tick") return tropical_jit::Operand::make_source(0u, st);
   if (kind == "slot")
     return tropical_jit::Operand::make_slot(j.at("index").get<uint32_t>(), st);
   throw std::runtime_error("NumericProgramParser: unknown operand kind '" + kind + "'");
@@ -324,6 +329,27 @@ inline ParsedPlan5 parse_plan5(const nlohmann::json & plan)
     }
   }
 
+  // ── sources: runtime-bound inputs (the dual of sinks). When absent,
+  //    default to the canonical pair [tick, rate] so plan_4 / pre-sources
+  //    fixtures using legacy `tick`/`rate` operands still resolve via the
+  //    upgrade in `parse_operand`. ──
+  if (plan.contains("sources"))
+  {
+    for (const auto & js : plan["sources"])
+    {
+      tropical_jit::Source src;
+      const std::string k = js.value("kind", std::string{"tick"});
+      src.kind = (k == "rate") ? tropical_jit::SourceKind::Rate
+                               : tropical_jit::SourceKind::Tick;
+      prog.sources.push_back(src);
+    }
+  }
+  else
+  {
+    prog.sources.push_back({ tropical_jit::SourceKind::Tick });
+    prog.sources.push_back({ tropical_jit::SourceKind::Rate });
+  }
+
   // ── Legacy temp-mix carrier (top-level, plan_4-style) — used when a
   //    plan has no `sinks` (hand fixtures / single-kernel plans). ──
   if (plan.contains("output_targets"))
@@ -391,6 +417,10 @@ inline ParsedPlan5 parse_plan4(const nlohmann::json & plan)
   auto & prog = result.program;
   prog.register_types = result.register_types;
   prog.register_count = plan.value("register_count", 0u);
+  // plan_4 predates `sources`; seed the canonical pair so legacy
+  // `tick`/`rate` operands (upgraded to `source:0/1`) resolve.
+  prog.sources.push_back({ tropical_jit::SourceKind::Tick });
+  prog.sources.push_back({ tropical_jit::SourceKind::Rate });
   if (plan.contains("array_slot_sizes"))
     for (const auto & s : plan["array_slot_sizes"])
       prog.array_slot_sizes.push_back(s.get<uint32_t>());


### PR DESCRIPTION
## What

Ships the **dual of sinks**: `sources[]` as a first-class plan-boundary
family in `tropical_plan_5`. Tick and Rate, which were sentinel operand
kinds resolved by the JIT from kernel args, are now indexed entries in
the plan's `sources` array; the `SampleIndex` / `SampleRate` IR sentinels
lower to a single `source` operand kind that the engine resolves by
switching on `sources[i].kind`.

```ts
interface SourceSpec { kind: 'tick' | 'rate' }
// canonical, always-emitted:
sources[0] = { kind: 'tick' }   // current sample index
sources[1] = { kind: 'rate' }   // current sample rate
```

This is the categorical counterpart to the DAC-as-sink work: sinks are
the *exit* from the pure trace-free PROP (effect at the device boundary),
sources are the *entry* (the runtime values the kernel reads). Both
declare themselves in the plan; both are N-ready families v1 realizes
minimally; both keep the runtime efficient (sinks reuse the existing
output_buffer, sources reuse the existing kernel args).

## Why now

Tick/Rate were already efficient kernel args, so this refactor's win is
**categorical / declarative**, not mechanical:
- The plan now *says* what sources it consumes (symmetric with sinks).
- The schema is genuinely N-source ready — future ADC, MIDI clock, or
  block-rate sources don't need a new operand kind, they're just new
  entries in `sources[]`.
- The IR's two ends are the same kind of thing.

This is the user's deliberate "build the abstraction now because v2 is
the planned second consumer" override — same call as DAC-as-sink, same
reasoning.

## Phased commits

| Phase | Commit | Summary |
|---|---|---|
| 1 | `9f9e8c2` | Declarative: `SourceSpec` + `FlatPlan.sources`. No operand or engine changes yet; sessions always emit canonical `[tick, rate]`. |
| 2+3 | `7052fce` | The protocol change: new `source` operand kind; emit lowers SampleRate/SampleIndex through it; engine + WASM resolve `source:i` via `sources[i].kind`. Legacy `tick`/`rate` operand tags survive on the wire only (parser upgrades them to `source:0`/`source:1`). Cache key includes sources. Shipped as one commit because the TS operand change and the engine recognition are two sides of one protocol step. |
| 4 | `07d089c` | Docs + artifact regen. Web/dist plans regenerate **byte-stable** — `toWirePlan` elides `sources` when equal to the canonical pair. |

## Verification

- **tsc** clean
- **ctest** 100% (1/1)
- **compiler** suite 870 pass
- **equiv** suite 88 pass (`wasm_vs_jit`, `microkernel_vs_fused`, `microkernel_deep`, `nested_vs_inlined`, `web_plans_vs_jit`, `migration_audio` — all byte-exact green; no goldens re-baselined)
- web/dist plans regenerate to **496 B**, identical to pre-sources

## Backcompat

The engine parser and `parseOperand` both upgrade legacy `rate`/`tick`
operand tags to the new `source:1`/`source:0` form, so plan_4 hand
fixtures and any legacy plan-JSON still load. `parse_plan4` seeds the
canonical source pair so the resolution finds them.

## Deferred (explicitly)

- **Multi-source engine plumbing.** Plan is N-source ready; engine
  realizes Tick / Rate via the existing kernel args. New source kinds
  (block-rate tick, external ADC, MIDI clock) require the plan to declare
  the new kind, the IR to gain a way to ref it (e.g. a specialized op or
  a typed binding), and the engine to plumb a new kernel arg or buffer.
- **Source `target`** (analogous to `sink.target`): would let multiple
  instances of the same source kind coexist (multiple audio rates, etc.).
  Not needed for v1's `[tick, rate]` singletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)