### PR TITLE
feat(scope): explicit scope taps — opt-in inspection sink + tap-browser TUI

### DIFF
--- a/lean/Tropical/Engine.lean
+++ b/lean/Tropical/Engine.lean
@@ -725,9 +725,9 @@ def handleDefineProgram (env : Env) (args : Json) : EngineM Json := do
 def handleAddInstance (env : Env) (args : Json) : EngineM Json := do
   let programName := (argStr? args "program").getD ""
   let instanceName := (argStr? args "instance_name").getD ""
-  if instanceName == dacName then
+  if instanceName == dacName || instanceName == scopeName then
     throwBare .invalidValue
-      s!"'{dacName}' is a reserved instance name (audio output boundary). Choose a different name."
+      s!"'{instanceName}' is a reserved instance name ({dacName} = audio output, {scopeName} = inspection taps). Choose a different name."
       (param := some "instance_name") (value := some (Json.str instanceName))
   let st ← env.state.get
   if (st.findInstance? instanceName).isSome then
@@ -750,9 +750,9 @@ def handleReplicate (env : Env) (args : Json) : EngineM Json := do
         (some s!"count must be a positive integer, got {tsInterp countJ}")
   let namePrefix := argStr? args "name_prefix"
   let prefix' := namePrefix.getD programName.toLower
-  if prefix' == dacName then
+  if prefix' == dacName || prefix' == scopeName then
     throwBare .invalidValue
-      s!"'{dacName}' is a reserved instance name (audio output boundary). Choose a different name_prefix."
+      s!"'{prefix'}' is a reserved instance name ({dacName} = audio output, {scopeName} = inspection taps). Choose a different name_prefix."
       (param := some "name_prefix") (value := some (Json.str prefix'))
   let mut created : Array Json := #[]
   for _ in [0:count] do
@@ -777,7 +777,8 @@ def handleRemoveInstance (env : Env) (args : Json) : EngineM Json := do
     { st with
       wires := st.wires.filter fun w =>
         !(w.instName == instanceName || (exprDependencies w.expr).contains instanceName)
-      graphOutputs := st.graphOutputs.filter (·.1 != instanceName) }
+      graphOutputs := st.graphOutputs.filter (·.1 != instanceName)
+      scopeTaps := st.scopeTaps.filter (·.2.1 != instanceName) }
   syncCompile env
   pure <| Json.mkObj [("removed", Json.str instanceName)]
 
@@ -1783,6 +1784,13 @@ def handleDebugRender (env : Env) (args : Json) : EngineM Json := do
 
 -- ── Dispatcher ───────────────────────────────────────────────────────────────
 
+def handleListScopeTaps (env : Env) : EngineM Json := do
+  let st ← env.state.get
+  let taps := st.scopeTaps.map fun (name, inst, out) =>
+    Json.mkObj [("name", Json.str name), ("instance", Json.str inst),
+                ("output", Json.str out), ("slot", Json.str s!"{inst}.{out}")]
+  pure <| Json.mkObj [("taps", Json.arr taps)]
+
 def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   wrap <| match name with
   | "define_program"  => handleDefineProgram env args
@@ -1799,6 +1807,7 @@ def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   | "get_info"        => handleGetInfo env args
   | "wire"            => handleWire env args
   | "list_wiring"     => handleListWiring env args
+  | "list_scope_taps" => handleListScopeTaps env
   | "load"            => handleLoad env args
   | "save"            => handleSave env
   | "merge"           => handleMerge env args

--- a/lean/Tropical/Engine.lean
+++ b/lean/Tropical/Engine.lean
@@ -48,6 +48,7 @@ structure Env where
 -- Reserved audio-output boundary leaf.
 private def dacName : String := "dac"
 private def dacOut : String := "out"
+private def scopeName : String := "scope"
 
 -- ── Json access helpers ──────────────────────────────────────────────────────
 
@@ -204,6 +205,19 @@ def runStrataChecked (typeArgs : Array (String × Lean.JsonNumber))
     if let .error e := Tropical.Ir.Core.check arena rootIdx then
       throw s!"post-strata Core check failed (port bug): {e}"
   pure (arena, rootIdx)
+
+/-- Emit the (LLVM IR text, manifest JSON) for a compiled session plan
+    without loading it. Shared by the audio compile (`syncCompile`) and the
+    lazy inspection compile (Part II): both realizations go through the same
+    `toWire`/`emitKernel` path; only the originating `FlatPlan` differs. -/
+def buildKernelIr (plan : Tropical.Plan.FlatPlan) : EngineM (String × String) := do
+  let planJson ← match plan.toWire with
+    | .error msg => internalError msg
+    | .ok j => pure j.compress
+  let ir ← match Tropical.Ir.EmitLlvm.emitKernel plan with
+    | .error msg => internalError s!"EmitLlvm: {msg}"
+    | .ok s => pure s
+  pure (ir, planJson)
 
 -- ── Snapshot compile (`wire()` in TS) ────────────────────────────────────────
 
@@ -374,14 +388,9 @@ def syncCompile (env : Env) : EngineM Unit := do
       root := rootCore } with
     | .error msg => internalError msg
     | .ok p => pure p
-  let planJson ← match plan.toWire with
-    | .error msg => internalError msg
-    | .ok j => pure j.compress
   -- Lean owns codegen: emit LLVM IR from the in-memory plan and hand it to
   -- the engine (planJson is the metadata manifest). No C++ plan compiler.
-  let ir ← match Tropical.Ir.EmitLlvm.emitKernel plan with
-    | .error msg => internalError s!"EmitLlvm: {msg}"
-    | .ok s => pure s
+  let (ir, planJson) ← buildKernelIr plan
   env.runtime.loadIr ir planJson
 
 /-- Harness-only (diffcli `compile`): rebuild the plan from the current
@@ -889,6 +898,7 @@ def handleWire (env : Env) (args : Json) : EngineM Json := do
   -- Sets
   let mut results : Array Json := #[]
   let mut dacWires : Array Json := #[]
+  let mut scopeWires : Array Json := #[]
   for s in setOps do
     let sInst := (argStr? s "instance").getD ""
     let sInput := (getField? s "input").getD jsonNull
@@ -904,6 +914,19 @@ def handleWire (env : Env) (args : Json) : EngineM Json := do
       env.state.modify fun st =>
         { st with graphOutputs := st.graphOutputs.push (srcInst, srcOut) }
       dacWires := dacWires.push <| Json.mkObj
+        [("instance", Json.str sInst), ("input", sInput), ("expr", sExpr)]
+    else if sInst == scopeName then
+      let tapName := (argStr? s "input").getD ""
+      if tapName.isEmpty then
+        throwBare .invalidValue
+          s!"scope tap requires a string input name ({scopeName}.<name>)."
+          (param := some "set[].input") (value := some sInput)
+      validateOrInternal sExpr s!"{scopeName}.{tapName}"
+      let st ← env.state.get
+      let (srcInst, srcOut) ← resolveDacSource st sExpr
+      env.state.modify fun st =>
+        { st with scopeTaps := (st.scopeTaps.filter (·.1 != tapName)).push (tapName, srcInst, srcOut) }
+      scopeWires := scopeWires.push <| Json.mkObj
         [("instance", Json.str sInst), ("input", sInput), ("expr", sExpr)]
     else
       let st ← env.state.get
@@ -926,6 +949,7 @@ def handleWire (env : Env) (args : Json) : EngineM Json := do
   pure <| Json.mkObj <|
     [("set", Json.arr results)]
     ++ (if dacWires.isEmpty then [] else [("dac", Json.arr dacWires)])
+    ++ (if scopeWires.isEmpty then [] else [("scope", Json.arr scopeWires)])
     ++ [("removed", toJson removeOps.size)]
     ++ (if dacRemoved > 0 then [("dacRemoved", toJson dacRemoved)] else [])
 

--- a/lean/Tropical/Session.lean
+++ b/lean/Tropical/Session.lean
@@ -107,6 +107,11 @@ structure SessionSt where
   instances    : Array (String × InstanceInfo) := #[]
   wires        : Array Wire := #[]
   graphOutputs : Array (String × String) := #[]   -- (instance, output)
+  /-- Scope taps: (tapName, srcInstance, srcOutput). Opt-in observation
+      points — like `graphOutputs` (dac) but routed to a render_window-
+      readable slot instead of the audio output. The keep-set the collapse
+      honors: params ∪ dac ∪ scope-taps stay materialized. -/
+  scopeTaps    : Array (String × String × String) := #[]
   /-- Param mirror: name → last-known value (raw Json to preserve lexical
       number forms). The service owns the live Param handles. -/
   params       : Array (String × Json) := #[]

--- a/tui/launch-demo.sh
+++ b/tui/launch-demo.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# tropical demo — one engine, two TUIs side by side (requires tmux + bun).
+#
+# Starts a single `frontend --serve` engine, launches the scrub (which loads and
+# drives its patch) and the scope (which attaches, discovers the live patch's
+# nodes, and taps them) against the SAME socket. The scrub owns the patch and
+# drives params; the scope is a pure observer — wire-to-`scope`, read-only.
+#
+#   tui/launch-demo.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/lean/.lake/build/bin/frontend"
+SOCK="${TMPDIR:-/tmp}/tropical-demo-$$.sock"
+
+[ -x "$BIN" ] || { echo "engine not built: $BIN (run 'make lean')" >&2; exit 1; }
+command -v tmux >/dev/null || { echo "tmux required (brew install tmux)" >&2; exit 1; }
+
+"$BIN" --serve "$SOCK" &
+ENGINE=$!
+trap 'kill "$ENGINE" 2>/dev/null || true; rm -f "$SOCK"' EXIT
+
+# Wait for the socket to come up.
+for _ in $(seq 1 50); do [ -S "$SOCK" ] && break; sleep 0.1; done
+[ -S "$SOCK" ] || { echo "engine socket never appeared: $SOCK" >&2; exit 1; }
+
+# Scrub owns the patch (starts first); scope attaches and taps it.
+tmux new-session  -d -s tropical -c "$ROOT" "TROPICAL_SOCK=$SOCK bun tui/scrub/app.tsx"
+tmux split-window -h -t tropical -c "$ROOT" "TROPICAL_SOCK=$SOCK bun tui/scope/scope.tsx"
+tmux set -t tropical mouse on
+tmux attach -t tropical

--- a/tui/scope/client.ts
+++ b/tui/scope/client.ts
@@ -112,3 +112,39 @@ export async function setupMorphScope(
   ] })
   return ['osc1.out', 'osc2.out']
 }
+
+export type Tap = { name: string; slot: string }
+
+/**
+ * Set up the scope's tappable sources and return them.
+ *  - Standalone (own engine): build the morph demo and tap its nodes
+ *    (osc1.out, osc2.out, lfo.sine) — opt-in observation points wired to the
+ *    reserved `scope` sink.
+ *  - Attached (TROPICAL_SOCK set): the other TUI owns the live patch; discover
+ *    its instances (retrying while it loads) and tap every instance output.
+ * Either way the taps lower to existing module slots `<inst>.<out>` that
+ * `render_window` reads — no probe-everything, just what we opted into.
+ */
+export async function setupTapScope(c: EngineClient): Promise<Tap[]> {
+  const attached = !!process.env.TROPICAL_SOCK
+  if (!attached) {
+    await setupMorphScope(c)
+    await c.call('wire', { set: [
+      { instance: 'scope', input: 'osc1', expr: { op: 'ref', instance: 'osc1', output: 'out' } },
+      { instance: 'scope', input: 'osc2', expr: { op: 'ref', instance: 'osc2', output: 'out' } },
+      { instance: 'scope', input: 'lfo',  expr: { op: 'ref', instance: 'lfo',  output: 'sine' } },
+    ] })
+  } else {
+    let insts: any[] = []
+    for (let i = 0; i < 40 && insts.length === 0; i++) {
+      insts = (await c.call('list_instances', {})) as any[]
+      if (!Array.isArray(insts) || insts.length === 0) { insts = []; await new Promise((r) => setTimeout(r, 250)) }
+    }
+    for (const inst of insts)
+      for (const out of (inst.outputs ?? []))
+        await c.call('wire', { set: [{ instance: 'scope', input: `${inst.name}.${out}`,
+          expr: { op: 'ref', instance: inst.name, output: out } }] })
+  }
+  const res = await c.call('list_scope_taps', {})
+  return ((res.taps ?? []) as any[]).map((t) => ({ name: t.name as string, slot: t.slot as string }))
+}

--- a/tui/scope/scope.tsx
+++ b/tui/scope/scope.tsx
@@ -1,57 +1,55 @@
-// tropical · scope — a 2-channel oscilloscope TUI with basic scope controls.
+// tropical · scope — a tap browser. Anything wired to `scope.<name>` (a reserved
+// sink, like `dac`) is observable: pick a tap, render_window its module slot over
+// the window ending at the audio-paced master clock, trigger-lock, draw braille.
 //
-// Each frame: drive the morph param (auto-LFO unless grabbed), read
-// playback_position (the audio-paced master clock), render_window the two voice
-// slots over the window ending there, lock the trace to a rising zero-crossing
-// (the trigger), and draw braille. Cadence is the app's refresh; content is the
-// master position, so the trace tracks playback. Controls:
-//   ↑/↓ select · ←/→ adjust · space toggle (trigger / morph-auto) · q quit
+// Standalone it builds a morph demo and taps its nodes; attached (TROPICAL_SOCK)
+// it taps whatever patch the other TUI has live.
+//   ↑/↓ select control · ←/→ adjust (source cycles taps) · space trigger · q quit
 //
-//   bun tui/scope.tsx                  (spawns its own engine)
-//   TROPICAL_SOCK=/path bun scope.tsx  (attach to a running --serve engine)
+//   bun tui/scope/scope.tsx                       (spawns its own engine)
+//   TROPICAL_SOCK=/path bun tui/scope/scope.tsx   (attach to a running --serve engine)
 import React, { useEffect, useReducer, useRef, useState } from 'react'
 import { render, Box, Text, useApp, useInput } from 'ink'
 import { resolve } from 'node:path'
-import { EngineClient, setupMorphScope } from './client'
+import { EngineClient, setupTapScope, type Tap } from './client'
 import { renderWaveform } from './braille'
-import { findPhaseTrigger, slice } from './trigger'
+import { findTrigger, slice } from './trigger'
 
-const REPO = resolve(import.meta.dir, '..')
-const FREQS: [number, number] = [220, 330]
-const SR = 44100
+const REPO = resolve(import.meta.dir, '../..')
 const FPS = 30
-const BAND_H = 5
-const WARMUP = 64 // samples rendered before the window to prime the per-wire unit
-                  // delays the MCP session inserts (otherwise the window starts cold)
+const BAND_H = 7
+const WARMUP = 64 // CF-only is cold-start-exact (no per-wire delays), but a small
+                  // lead is harmless and robust if a patch ever reintroduces one.
 const TIMES = [256, 512, 1024, 2048, 4096]
 const TRIGS = ['off', 'rising']
-const SEARCH = Math.ceil(SR / Math.min(...FREQS)) + 8 // ≥ one period, so a rising edge always exists
 
 const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v)
 
-type Ctl = { sel: number; timeIdx: number; offset: number; trig: number }
+type Ctl = { sel: number; srcIdx: number; timeIdx: number; offset: number; trig: number }
 
 function Scope() {
   const { exit } = useApp()
-  const [rows1, setRows1] = useState<string[]>([])
-  const [rows2, setRows2] = useState<string[]>([])
+  const [rows, setRows] = useState<string[]>([])
   const [status, setStatus] = useState('connecting…')
   const [pos, setPos] = useState(0)
+  const tapsRef = useRef<Tap[]>([])
   const [, force] = useReducer((x: number) => x + 1, 0)
   const clientRef = useRef<EngineClient | null>(null)
-  const ctl = useRef<Ctl>({ sel: 0, timeIdx: 2, offset: 0, trig: 1 })
+  const ctl = useRef<Ctl>({ sel: 0, srcIdx: 0, timeIdx: 2, offset: 0, trig: 1 })
 
   useInput((input, key) => {
     const c = ctl.current
+    const nTaps = Math.max(1, tapsRef.current.length)
     if (input === 'q' || key.escape) { clientRef.current?.kill(); exit(); return }
-    if (key.upArrow) c.sel = (c.sel + 2) % 3
-    else if (key.downArrow) c.sel = (c.sel + 1) % 3
+    if (key.upArrow) c.sel = (c.sel + 3) % 4
+    else if (key.downArrow) c.sel = (c.sel + 1) % 4
     else if (key.leftArrow || key.rightArrow) {
       const d = key.rightArrow ? 1 : -1
-      if (c.sel === 0) c.timeIdx = clamp(c.timeIdx + d, 0, TIMES.length - 1)
-      else if (c.sel === 1) c.offset = clamp(Math.round((c.offset + d * 0.1) * 10) / 10, -1, 1)
+      if (c.sel === 0) c.srcIdx = (c.srcIdx + d + nTaps) % nTaps
+      else if (c.sel === 1) c.timeIdx = clamp(c.timeIdx + d, 0, TIMES.length - 1)
+      else if (c.sel === 2) c.offset = clamp(Math.round((c.offset + d * 0.1) * 10) / 10, -1, 1)
       else c.trig = clamp(c.trig + d, 0, TRIGS.length - 1)
-    } else if (input === ' ' && c.sel === 2) c.trig = 1 - c.trig
+    } else if (input === ' ' && c.sel === 3) c.trig = 1 - c.trig
     force()
   })
 
@@ -60,11 +58,11 @@ function Scope() {
     const c = new EngineClient({ repoRoot: REPO, onError: (e) => setStatus('engine error: ' + e.message) })
     clientRef.current = c
     ;(async () => {
-      let slots: string[]
       try {
-        slots = await setupMorphScope(c, FREQS)
-        try { await c.call('start_audio', {}); setStatus('▶ live · locked to audio') }
-        catch { setStatus('◼ no audio device · static window') }
+        tapsRef.current = await setupTapScope(c)
+        if (tapsRef.current.length === 0) { setStatus('no taps — wire something to scope.<name>'); return }
+        try { await c.call('start_audio', {}); setStatus(`▶ live · ${tapsRef.current.length} taps`) }
+        catch { setStatus(`◼ no audio device · static window · ${tapsRef.current.length} taps`) }
       } catch (e: any) { setStatus('setup failed: ' + e.message); return }
 
       const w = Math.max(20, (process.stdout.columns ?? 84) - 4)
@@ -72,30 +70,21 @@ function Scope() {
         if (stopped) return
         try {
           const k = ctl.current
+          const taps = tapsRef.current
+          const tap = taps[Math.min(k.srcIdx, taps.length - 1)]
           const display = TIMES[k.timeIdx]
-          const search = k.trig === 0 ? 0 : SEARCH
+          const search = k.trig === 0 ? 0 : display // up to one window to find a rising edge
           const count = display + search
-          // Render the window ending at the master position, with a warmup lead so
-          // the session's per-wire unit delays are primed (the patch is slightly
-          // stateful via those delays; a cold start gives garbage samples). Then
-          // discard the warmup and trigger-lock the rest.
           const p = (await c.call('playback_position', {})).position as number
           const desiredStart = Math.max(0, p - count)
           const renderStart = Math.max(0, desiredStart - WARMUP)
           const lead = desiredStart - renderStart
-          const res = await c.call('render_window', { start: renderStart, count: lead + count, slots })
-          const a = (res.values[0] as number[]).slice(lead)
-          const b = (res.values[1] as number[]).slice(lead)
-          // per-channel trigger on each oscillator's PHASE (its timebase) rather
-          // than the morphing output: the phasor wraps exactly once per period
-          // regardless of waveform, so the lock holds through the whole morph —
-          // a level trigger jitters mid-morph where the blend has two crossings.
-          const off1 = k.trig === 1 ? findPhaseTrigger(FREQS[0], SR, desiredStart, search) : 0
-          const off2 = k.trig === 1 ? findPhaseTrigger(FREQS[1], SR, desiredStart, search) : 0
-          setRows1(renderWaveform(slice(a, off1, display, k.offset), w, BAND_H))
-          setRows2(renderWaveform(slice(b, off2, display, k.offset), w, BAND_H))
+          const res = await c.call('render_window', { start: renderStart, count: lead + count, slots: [tap.slot] })
+          const v = (res.values[0] as number[]).slice(lead)
+          const off = k.trig === 1 ? Math.max(0, findTrigger(v, 0, search)) : 0
+          setRows(renderWaveform(slice(v, off, display, k.offset), w, BAND_H))
           setPos(p)
-        } catch { /* transient (mid hot-swap) — skip frame */ }
+        } catch { /* transient (mid hot-swap / patch reload) — skip frame */ }
         if (!stopped) setTimeout(tick, 1000 / FPS)
       }
       tick()
@@ -104,18 +93,14 @@ function Scope() {
   }, [])
 
   const k = ctl.current
+  const taps = tapsRef.current
+  const tapName = taps.length ? taps[Math.min(k.srcIdx, taps.length - 1)].name : '—'
   const items = [
+    ['source', `${tapName} (${k.srcIdx + 1}/${Math.max(1, taps.length)})`],
     ['timescale', String(TIMES[k.timeIdx])],
     ['offset', (k.offset >= 0 ? '+' : '') + k.offset.toFixed(1)],
     ['trigger', TRIGS[k.trig]],
   ] as const
-
-  const Band = ({ label, color, rows }: { label: string; color: string; rows: string[] }) => (
-    <Box flexDirection="column">
-      <Text color={color} bold>{label}</Text>
-      {rows.map((r, i) => (<Text key={i} color={color}>{r}</Text>))}
-    </Box>
-  )
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -124,9 +109,10 @@ function Scope() {
         <Text dimColor>{status}   ·   sample {pos}</Text>
       </Box>
       <Box height={1} />
-      <Band label={`CH1  ${FREQS[0]} Hz`} color="green" rows={rows1} />
-      <Box height={1} />
-      <Band label={`CH2  ${FREQS[1]} Hz`} color="magenta" rows={rows2} />
+      <Box flexDirection="column">
+        <Text color="green" bold>{`scope.${tapName}`}</Text>
+        {rows.map((r, i) => (<Text key={i} color="green">{r}</Text>))}
+      </Box>
       <Box height={1} />
       <Box>
         {items.map(([label, val], i) => (
@@ -136,7 +122,7 @@ function Scope() {
               : <Text dimColor>{` ${label} ‹${val}› `}</Text>}
           </Text>
         ))}
-        <Text dimColor>   ↑↓ select · ←→ adjust · space toggle · q quit</Text>
+        <Text dimColor>   ↑↓ select · ←→ adjust · space trigger · q quit</Text>
       </Box>
     </Box>
   )

--- a/tui/scope/test-frame.ts
+++ b/tui/scope/test-frame.ts
@@ -6,7 +6,7 @@ import { EngineClient, setupMorphScope } from './client'
 import { renderWaveform } from './braille'
 import { findPhaseTrigger } from './trigger'
 
-const repoRoot = resolve(import.meta.dir, '..')
+const repoRoot = resolve(import.meta.dir, '../..')
 const c = new EngineClient({ repoRoot, onError: (e) => { console.error('engine error:', e.message); process.exit(1) } })
 
 const FREQS = [220, 330], SR = 44100, SEARCH = 220

--- a/tui/scrub/client.ts
+++ b/tui/scrub/client.ts
@@ -127,4 +127,4 @@ export class EngineClient {
   }
 }
 
-export const repoRoot = resolve(import.meta.dir, '..')
+export const repoRoot = resolve(import.meta.dir, '../..')


### PR DESCRIPTION
## What

Adds **explicit scope taps** — a reserved `scope` sink, exactly like `dac`. You wire any value to `scope.<name>` and it becomes observable; the scope TUI browses the wired taps and renders any of them live. This is the opt-in alternative to probing the whole AST: only what you wire is materialized.

It also lands the two-TUI demo: one engine, the scrub driving a patch and the scope observing it side by side.

## Why this shape

The design converged on a single rule: **a value gets a materialized slot iff it is a param, a `dac` input, or an explicit `scope` tap** — everything else is just function composition and can fuse. `dac` and `scope` are the same animal (device-bound vs inspection-bound output); a scope tap is the explicit materialization you opted into. This dissolved an earlier dual-kernel / probe-everything design into one sink concept.

Named taps (source `scope.foo = …`) and ad-hoc taps (MCP `wire` to `scope`) are byte-identical after elaboration — sessions flow through the same `elaborate` front door — and a tap costs one store/sample of an already-computed value, so the audio output is bit-identical with or without taps.

## Engine

- `SessionSt.scopeTaps : (tapName, srcInstance, srcOutput)` — the opt-in observation keep-set, parallel to `graphOutputs` (dac).
- `wire` recognizes `scope` as a reserved target (resolves the ref via the existing `resolveDacSource`); `scope` joins `dac` in the add_instance/replicate reserved-name guard; removing an instance cascades to drop its taps.
- `list_scope_taps` enumerates the wired taps with the `render_window` slot name (`<inst>.<out>`), so a consumer can render any tap directly.
- `buildKernelIr` extracted from `syncCompile` (the shared `toWire`+`emitKernel` path; neutral refactor).

## TUI

- `scope.tsx` is now a **tap browser**: select any wired tap (←→ cycles), `render_window` its slot, generic rising-edge trigger (works for any signal — no known frequency needed).
- `client.ts` `setupTapScope`: standalone builds the morph demo and taps its nodes; **attached** (`TROPICAL_SOCK`) discovers the live patch's instances and taps every output.
- `tui/launch-demo.sh`: one `frontend --serve` engine + scrub (owns/drives the patch) + scope (attaches, taps it) side by side via tmux.
- Fixes a pre-existing path bug from the `tui/` subdir refactor: `repoRoot` resolved to `tui/` instead of the repo root, so standalone mode spawned the engine with the wrong cwd and hung (`resolve(import.meta.dir, '..')` → `'../..'`).

## Deferred — the collapse (Part I)

The matching "collapse the runtime" — materialize *only* the keep-set and fuse every other inter-instance wire to an SSA temp — is **not** in this PR. The analysis is done and recorded: the precondition is **verified sound** (each instance gets a disjoint, persistent temp range, so a consumer can read a producer's temp safely), but the change is a multi-site refactor of the core emitter (`emitResolvedProgram`'s input resolution + `perChildPreInput`, adjacent to a subtle existing array-alias path) with bit-identical-goldens stakes. It's cleanly separable — scope taps coexist with today's slots, so this works un-collapsed — and warrants a focused follow-up rather than a rushed core-emitter change. The collapse buys a leaner `f(n, params)` audio kernel (perf/honesty), not the demo.

## Verification

- `lake build` green; bun suites **74 / 0**.
- End-to-end over `--rpc`: `wire scope.foo = osc.sine` → `list_scope_taps` → `{name:foo, slot:"osc.sine"}`.
- Headless smokes: **standalone** (3 taps, render `osc1.out` peak 0.5) and **attached** (discovers `voice`, render `voice.sine` peak 1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)