### PR TITLE
feat(voice): voice ports — generic effects as pointfree morphisms (Phase 0 + Phase 1 core)

### DIFF
--- a/design/voice-ports-handoff.md
+++ b/design/voice-ports-handoff.md
@@ -1,0 +1,131 @@
+# Voice-ports sprint — handoff
+
+Branch `feat/voice-ports` (PR #194), off `main` @ `13c51ea` (native-DAG merged).
+Worktree `/Users/willishoke/tropical-voice`. This doc lets a fresh session resume
+without re-deriving the design.
+
+## Where it stands
+
+**Phase 0 + Phase 1 core are DONE and proven.** The generic voice-bearing flanger
+compiles **byte-identical** to the hand-wired `FlangeSin`. Remaining: the session
+wire-binding (Phase 1 piece #2) + Phases 2–4.
+
+### Commits on the branch
+- `b3f8949` Phase 0: `FlangeSin` — golden reference (arbitrary clock-parametric
+  voice at 3 warped clocks; renders peak 0.039).
+- `a65b078` representation lock (voice ports = sugar over instances; no new IR node).
+- `158f7d8` `rw`/`desugarBody` — the voice-application desugar.
+- `2dcf29c` `desugarProgram` — desugar + strip consumed voice ports.
+- `a3f22fa` render-proof — `voice-desugar` verb + `flanger.md`; generic ≡ FlangeSin.
+
+### Reproduce the proof
+```
+cd /Users/willishoke/tropical-voice
+./lean/.lake/build/bin/diffcli parse-md tests/fixtures/voice/flanger.md \
+  | ./lean/.lake/build/bin/diffcli voice-desugar /dev/stdin > /tmp/d.json
+./lean/.lake/build/bin/diffcli emit-file /tmp/d.json > /tmp/a.json
+./lean/.lake/build/bin/diffcli emit-file stdlib/parsed/FlangeSin.json > /tmp/b.json
+diff /tmp/a.json /tmp/b.json   # byte-identical
+```
+
+## The design (settled — see `design/voice-ports-plan.md` for the full pass)
+
+tropical = **cartesian, untraced, multi-port** category of clock-indexed closed
+forms ("arrows at home" over a closed/pure/compilable base, not Hask). Effects are
+`Voice → Voice` morphisms; the one new primitive is **`warp`** (precompose a voice
+with a clock transform); **no `loop`** (no feedback). **There are no values** —
+`arr f` (clock-transparent) and `warp` (clock-bending) are both morphisms;
+"value consumption" is just apply-at-ambient-clock, surviving only as an emit-layer
+sharing optimization (hash-cons on `(closedform, clock)`).
+
+Decisive realizations:
+- The **warp core already works** — instantiate a clock-parametric voice at chosen
+  clocks (`ClockChord`, `ClockReverseProbe`, `ReversibleComb`). The sprint is the
+  **binding surface**.
+- **Voice ports are sugar over instances.** `v(clockExpr)` desugars to an instance
+  of the bound voice clocked at `clockExpr` + `nestedOut`. No new IR node, no
+  strata/emit change. (`VoiceDesugar.lean`.)
+- **Pointfree, not pointful.** The voice is the morphism's *domain*, bound by the
+  wire — not a `<V>` type param. (User chose this over the explicit-generic surface,
+  knowing the wire-binding is more work.)
+- The desugar **can't live in `resolveExpr`** (it returns an `Expr`, can't *add*
+  instances) — it's a pre-elaboration `ParsedProgram → ParsedProgram` pass.
+- `voice` parses as `PortTypeDecl.scalar "voice"` (no parser change); recognition
+  is in the desugar/elaborator. `desugarProgram` strips the voice port before
+  elaboration, so the elaborator never sees the unknown `"voice"` type.
+
+## REMAINING WORK
+
+### Phase 1 piece #2 — the session wire-binding (the crux, next up)
+Derive the `VoiceBinding` from an actual voice-port wire (`osc → flanger.v`)
+instead of the verb's hardcoded binding. The hard part: a voice-bearing program
+**can't resolve standalone** (its voice is unbound), so per-instance resolution
+must be **deferred** until the voice wire lands, then re-resolved on rewiring.
+
+Concrete plan:
+1. **Detect voice ports.** A program with an input typed `voice` (or, post-`v(...)`
+   usage). The session needs to know `flanger.v` is a voice port — read it off the
+   program's parsed/port metadata. (`Session.lean` instance/port info;
+   `Wiring.lean:56-82` port types.)
+2. **Hold the instance unresolved.** When a `Flanger` instance is added without its
+   voice bound, `resolveProgramType` (`Engine.lean` ~600-680) can't resolve it —
+   skip/defer rather than error.
+3. **Derive the binding from the wire.** When `osc.sine → flanger.v` is wired
+   (`handleWire`, `Engine.lean` ~875-955), build a `VoiceBinding` from the *source*:
+   `programName` = osc's program, `clkInput`/`output` from osc's signature, `params`
+   = osc's non-clock instance config. (3a = single clock-parametric source.)
+4. **Desugar + resolve then.** Run `VoiceDesugar.desugarProgram` on the Flanger
+   parsed form with the binding → concrete program → elaborate + strata → use as
+   the instance's resolved type. Needs the Flanger **parsed form retained** (voice
+   programs are resolved per-binding, like generics).
+5. **Re-resolve on rewiring.** Changing/removing the voice wire re-derives.
+6. **The source instance** (osc) is consumed as a voice — it should be absorbed
+   into the flanger's applications, not emitted standalone.
+
+Key files: `Engine.lean` (`syncCompile` ~301, `resolveProgramType` ~600,
+`handleWire` ~875), `Session.lean` (Wire ~94, instance/wire state ~153),
+`Lowering.lean` (`sessionToParsed` ~359). Gate: a session wiring
+`FixedSinOsc → Flanger.v` renders == `FlangeSin`.
+
+### Phase 2 — composition + cartesian goldens (mostly verification)
+`Flanger → Flanger` one flat kernel (native-DAG); two flangers on a shared sine,
+different δ ≡ two independent (the diagonal law). Same-clock consumers share a pure
+let, not a recompute.
+
+### Phase 3 — multi-instance cone-capture + clock abstraction
+3b: lift a multi-instance upstream cone (`osc → relu → flanger`) into one
+clock-parametric program — richer than `WireProgram.lift` (which only lifts a wire
+*expression*, refs→inputs; it does NOT inline the cone or touch the clock). Thread
+one `clk` input to all clock leaves. 3c: rewrite global `clock()` leaves → the
+supplied `clk` for upstreams that aren't already clock-parametric (β-abstract the
+clock). Value-port effects (relu) are clock-transparent — the warp propagates
+through them to the generators.
+
+### Phase 4 — cable UX + arrow-law goldens
+Wiring into a voice port triggers the capture automatically (MCP `wire`/`fan_*`
+tools, `Tools.lean`); the bound's signature validates cables. Arrow-law goldens:
+algebraically-equal patches render bit-identical.
+
+## Code map (from the exploration agents)
+- Surface port types: `Parse/Surface/Declarations.lean:59-110`; `PortTypeDecl` in
+  `Parse/Nodes.lean:171`. (No change needed — `voice` is a scalar type name.)
+- ParsedExpr / instance / block: `Parse/Nodes.lean:105` / `:243` / `:267`.
+- Elaborator: scope `:98-109`, `resolvePortType` `:230-242` (errors on unknown
+  type — moot once voice ports are stripped pre-elaborate), `resolveCall` `:348`,
+  `resolveNestedOut` `:336`.
+- Type-param/specialize machinery (if a pointful escape hatch is ever wanted):
+  `Strata/Specialize.lean`, `TypeArgs.lean`, `Nodes.lean` (`TypeParamDecl`,
+  `InstanceTypeArg`, `BodyDecl.inst`).
+- Clock-first-class (the warp foundation): `clock() = sampleIndex << 32`
+  (`Elaborator.lean:362`); instance clock inputs flow via `Emit.lean:510-550`;
+  examples `stdlib/reversible/{ClockChord,ClockReverseProbe,ReversibleComb}.md`.
+
+## Build & test (run binaries directly — never `lake exe`; see CLAUDE.md)
+```
+cd lean && PATH="$HOME/.elan/bin:$PATH" lake build diffcli tropicaltest
+./lean/.lake/build/bin/tropicaltest                     # 12/12, from repo root
+TROPICAL_ENGINE_CMD="./lean/.lake/build/bin/frontend --rpc" bun test tests/web/wasm_vs_jit.test.ts tests/web/web_plans_vs_jit.test.ts
+```
+Note: Bash `cd` resets between tool calls in this environment — use absolute paths
+or `cd … &&` chains. Submodules in a fresh worktree need
+`git submodule update --init --recursive` (rtaudio clone is slow).

--- a/design/voice-ports-plan.md
+++ b/design/voice-ports-plan.md
@@ -1,0 +1,136 @@
+# Voice ports — pointfree generic effects (sprint plan)
+
+Off origin/main (native-DAG merged, 13c51ea). The forcing example is the flanger;
+the goal is **generic effects wired like a DAW insert chain**: `osc → flanger`,
+`flanger → flanger`, `(osc, env) → vca → filter` — composition, no feedback.
+
+## Semantics (settled — the law layer)
+
+tropical denotes a **cartesian, untraced** category of **clock-indexed,
+multi-port** closed forms ("arrows at home" — the composition skeleton over a
+closed, compilable base, *not* Hask; no `arr`-of-arbitrary-function leak).
+
+- A **voice** is `Clock → Signal` (multi-port: `Clock → {named outs}`). Element
+  type ranges over the signal typeclass (primitives + arrays).
+- A **generator** is a point (`I → Voice`); an **effect** is a morphism
+  (`Voice → Voice`). Generator/effect is the closed-term/one-hole-context split —
+  UX taxonomy, **not** an IR category (the PM-osc sits on the line). One species
+  in the IR.
+- Combinators: `>>>` (compose = wire), `&&&`/`***` (fan-out/parallel = the
+  cartesian diagonal, compiled to a **pure let** — never a slot; there is no
+  per-sample state), and **`warp : (Clock→Clock) → Voice → Voice`** — the one
+  "stranger primitive", precompose a voice with a clock transform. `delay δ =
+  warp(·−δ)`, `reverse = warp(−·)`, `timescale k = warp(k·)`. **No `loop`** (no
+  trace, no feedback — the coherence axiom, not a restriction).
+- **There are no values.** `arr f` (clock-transparent) and `warp φ` (clock-bending)
+  are both `Voice → Voice`. "Value consumption" is just "apply at the ambient
+  clock" — the degenerate single-clock case. The value/voice split survives **only**
+  at the emit layer as a sharing optimization (same `(closedform, clock)` →
+  shared via hash-cons; different clock → its own eval), never as a type.
+
+**Pointfree, not pointful.** An effect is a morphism with a voice *domain*;
+genericity is **free by composition** (`osc >>> flanger`, `synth >>> flanger`
+reuse the same morphism). No program-valued type parameters — the binding is the
+wire, not a `<V>`.
+
+**The cost model** (one line for the doc): you pay one evaluation per distinct
+`(cone, clock)`; clock-transparent consumers pass the clock through (share),
+clock-bending consumers (voice ports) multiply it by their tap count; hash-cons
+dedups coincidences. A many-tap voice port re-evaluates its upstream cone per tap
+— O(taps × cone), embarrassingly parallel, the price of reversal/random-access.
+(The stateful effect-bus that amortizes many-tap delays is many sprints away and
+out of scope.)
+
+## What already exists (the warp core)
+
+- **Warp on a concrete voice**: instantiate a clock-parametric program at chosen
+  clocks. `ClockChord` instantiates `ModalVoice` at three clocks; `ClockReverseProbe`
+  at `−clk`. Clock is a first-class value (`clock() = sampleIndex << 32`), flows as
+  an expression into a child's clock input (`Emit.lean:510-550`).
+- **Depth without bloat**: native-DAG strata — `flanger → flanger → flanger`
+  stays one flat kernel, shared-id substitution.
+- **Fan-out as a pure let**: CSE / the cartesian diagonal. No slots in the signal
+  path (only param slots, which are control-plane inputs).
+
+So the missing piece is the **binding surface**: a `voice` port, an application
+form, and wire-composition that fills it.
+
+## The new work
+
+### 1. Surface (`Parse/Surface/`, `Parse/Nodes.lean`)
+- A **`voice` input port type** with a port-signature bound: `v: voice(out: float)`
+  (the bound is the typed interface the cable UX later reads — the principal type
+  the row-inference engine would derive; hand-written until that engine exists).
+- An **application form** `v(clockExpr)` in body exprs — evaluate the voice at a
+  clock. Closest existing construct: instance-call syntax + `nestedOut`.
+- A way to name **the effect's own clock** in the body (the ambient clock it is
+  evaluated at, which downstream drives) — likely `clock()` reused.
+
+Example:
+```tropical
+program Flanger(v: voice(out: float), depth: float = 0.0007) -> (out: float) {
+  out = v(clock()) + v(clock() - depth)
+}
+```
+
+### 2. IR + elaboration
+A voice input binds a **clock-parametric program**; each `v(clockExpr)` desugars
+to an **instance of that program clocked at clockExpr**. This reuses the instance
++ clock + native-DAG machinery wholesale — `v(clk−δ)` is "an instance of the
+bound voice, `clk: clk−δ`, take its `out`". The elaborator, knowing `v`'s bound
+program, lowers each application to an instance + `nestedOut`.
+
+### 3. The cone-capture binding (the one genuinely new pass — DE-RISK FIRST)
+Wiring `osc → flanger.v` must bind `v` to the upstream as a **clock-parametric
+program** the flanger instantiates. Phased by difficulty:
+- **3a (MVP): single clock-parametric program.** The wired upstream is one
+  program already authored with a `clk` input (the reversible-family convention —
+  `FixedSinOsc(freq, clk)`, `ClockPhasor(clk, …)`). Binding = attach that program
+  to the voice slot; no lifting, no abstraction. `v(clkE)` instantiates it at `clkE`.
+- **3b: multi-instance cone.** The upstream is a subpatch (`osc → relu → v`). Lift
+  the whole upstream cone into one clock-parametric program (richer than
+  `WireProgram.lift`, which only lifts a wire *expression* with refs→inputs — it
+  does **not** inline the cone or touch the clock). Clock-transparency propagates:
+  the lifted cone threads one `clk` input to all its clock leaves.
+- **3c: clock abstraction.** The upstream uses the global `clock()` (not a `clk`
+  input). Capture must rewrite `clock()` leaves → the supplied `clk` (β-abstract
+  the clock; the voice becomes `λθ. <cone with clock()→θ>`). General; needed for
+  arbitrary upstreams.
+
+### 4. Cable UX (`Engine.handleWire`, `Tools.lean`)
+Wiring into a voice-typed port triggers 3a–c automatically; the bound's signature
+is what the UI reads to validate cables. The user drags a cable; never writes a type.
+
+## Phases & gates
+
+| phase | deliverable | gate |
+|---|---|---|
+| 0 | **De-risk 3a**: spike a hand-written program with a `voice` input bound to one clock-parametric program, applied at two clocks; confirm it lowers + renders | renders; bit-exact vs a hand-wired two-tap flanger |
+| 1 | Surface + IR + elaboration for `voice` ports + `v(clkE)` application; binding 3a | **`Flanger` over `FixedSinOsc` ≡ hand-wired flanger** (hash) |
+| 2 | Composition + cartesian goldens | `Flanger→Flanger` one flat kernel; two flangers / shared sine / different δ ≡ two independent (the diagonal golden) |
+| 3 | Cone-capture 3b + clock-abstraction 3c | `(osc→relu)→flanger` ≡ hand-wired; arbitrary-upstream voices |
+| 4 | Cable UX (wire into voice port) + arrow-law goldens | dragging a cable binds the voice; algebraically-equal patches hash-identical |
+
+## Goldens = the arrow laws
+
+The equivalence spec is stronger than one hash: **every algebraically-equal patch
+must render bit-identical.** `arr id >>> f = f`; associativity of `>>>`;
+`(id &&& warp(·−δ)) >>> arr(+)` (the flanger) ≡ the hand-wired flanger; the
+diagonal law (shared upstream = independent copies). Plus the existing 12 goldens
++ wasm≡JIT, all bit-exact (relabeling from any of this is invisible to the audio).
+
+## Risks
+
+- **Cone-capture + clock-abstraction (3b/3c)** is the load-bearing new pass. De-risk
+  in phase 0 with the single-program case before building the surface around it.
+- **The effect's-own-clock surface** (`clock()` in an effect body meaning "my
+  ambient clock") needs care — when the effect is composed downstream, its clock is
+  driven; confirm the propagation matches the clock-transparency semantics.
+- **Bound surface ergonomics**: explicit signature is verbose (the C++-concepts
+  tradeoff). Acceptable because it's the metadata the cable reads and the principal
+  type inference would later derive; not user-facing.
+
+## Gate commands (per the native-DAG sprint)
+- build: `cd lean && PATH="$HOME/.elan/bin:$PATH" lake build diffcli tropicaltest`
+- goldens: `./lean/.lake/build/bin/tropicaltest` (from repo root)
+- web: `TROPICAL_ENGINE_CMD="./lean/.lake/build/bin/frontend --rpc" bun test tests/web/wasm_vs_jit.test.ts tests/web/web_plans_vs_jit.test.ts`

--- a/design/voice-ports-plan.md
+++ b/design/voice-ports-plan.md
@@ -73,12 +73,36 @@ program Flanger(v: voice(out: float), depth: float = 0.0007) -> (out: float) {
 }
 ```
 
-### 2. IR + elaboration
+### 2. IR + elaboration  (REPRESENTATION LOCKED — Phase 0 confirmed)
 A voice input binds a **clock-parametric program**; each `v(clockExpr)` desugars
 to an **instance of that program clocked at clockExpr**. This reuses the instance
 + clock + native-DAG machinery wholesale — `v(clk−δ)` is "an instance of the
 bound voice, `clk: clk−δ`, take its `out`". The elaborator, knowing `v`'s bound
 program, lowers each application to an instance + `nestedOut`.
+
+**The key simplification (verified against the parser/IR):** there is **no new
+IR node, no strata change, no emit change.** The pieces all already exist:
+- Application `v(clockExpr)` parses as the existing `ParsedExpr.call (nameRef "v")
+  [clockExpr]` — no new surface production.
+- Its desugar target is `BodyDecl.inst` + `ParsedExpr.nestedOut` — both existing.
+- Lowering is the proven FlangeSin shape (Phase 0): instances of a clock-parametric
+  voice at warped clocks, summed.
+
+So the novelty is concentrated in exactly two places:
+1. **Parse** — a `voice` port *type* (`PortTypeDecl.voice` carrying the output
+   signature/bound). The application reuses `call`.
+2. **Elaborate** — when a `call`'s callee resolves to a voice-typed input, desugar
+   it to a fresh instance of the bound program (clock = the call's arg, other
+   params threaded from the binding) + a `nestedOut` to that instance's output.
+
+Plus the **binding** (§3): how the voice input acquires its bound program. Phase 1
+takes the 3a path — the voice is wired to a single clock-parametric program; the
+binding records that program + its non-clock params; each application supplies the
+clock. `v` is the morphism's *domain* (pointfree), bound by the wire — not a `<V>`.
+
+Net: voice ports are **sugar over the program-at-warped-clocks shape Phase 0 already
+renders.** The hard part is the desugar + binding plumbing in the elaborator/session,
+not the IR.
 
 ### 3. The cone-capture binding (the one genuinely new pass — DE-RISK FIRST)
 Wiring `osc → flanger.v` must bind `v` to the upstream as a **clock-parametric

--- a/lean/Diffcli.lean
+++ b/lean/Diffcli.lean
@@ -1,5 +1,6 @@
 import Tropical.Ffi
 import Tropical.Parse.Raise
+import Tropical.Parse.VoiceDesugar
 import Tropical.Ir.Elaborator
 import Tropical.Ir.Codec
 import Tropical.Ir.Strata
@@ -124,6 +125,32 @@ def parsedRoundtripVerb (args : List String) : IO UInt32 := do
       match Tropical.Parse.decodeProgram jv with
       | .error msg => errorJson msg
       | .ok prog => prog.toJson
+  IO.println out.compress
+  return 0
+
+/-- Voice-ports render proof (Phase 1): desugar a voice-bearing parsed program
+    against a hardcoded `FixedSinOsc` voice binding and print the desugared
+    ParsedProgram JSON. The chain `parse-md flanger.md | voice-desugar |
+    emit-file` lowers the result; rendered, it must match FlangeSin. -/
+def voiceDesugarVerb (args : List String) : IO UInt32 := do
+  let some path := args.head?
+    | IO.eprintln "usage: diffcli voice-desugar <parsed.json>"
+      return 1
+  let text ← IO.FS.readFile path
+  let out : Lean.Json :=
+    match Tropical.Parse.JsonV.parse text with
+    | .error e => errorJson s!"JSON parse error: {e}"
+    | .ok jv =>
+      match Tropical.Parse.decodeProgram jv with
+      | .error msg => errorJson msg
+      | .ok prog =>
+        let vb : Tropical.Parse.VoiceDesugar.VoiceBinding :=
+          { voiceName := "v", programName := "FixedSinOsc",
+            clkInput := "clk", output := "sine",
+            params := #[("freq", .nameRef "freq")] }
+        match Tropical.Parse.VoiceDesugar.desugarProgram #[vb] prog with
+        | .error msg => errorJson msg
+        | .ok desugared => desugared.toJson
   IO.println out.compress
   return 0
 
@@ -551,6 +578,7 @@ def main (args : List String) : IO UInt32 := do
   | "raise" :: rest => raiseVerb rest
   | "parsed-roundtrip" :: rest => parsedRoundtripVerb rest
   | "parse-md" :: rest => parseMdVerb rest
+  | "voice-desugar" :: rest => voiceDesugarVerb rest
   | "parse-all" :: rest => parseAllVerb rest
   | "elab-stdlib" :: rest => elabStdlibVerb rest
   | "elab-file" :: rest => elabFileVerb rest

--- a/lean/Tropical/Parse/VoiceDesugar.lean
+++ b/lean/Tropical/Parse/VoiceDesugar.lean
@@ -115,6 +115,24 @@ def desugarBody (bs : Array VoiceBinding) (body : Block) : Except String Block :
   | .ok (block, _) => pure block
   | .error e => throw e
 
+private def portName : ProgramPort → String
+  | .bare n => n
+  | .spec s => s.name
+
+/-- Desugar voice applications in a program AND drop the now-consumed voice input
+    ports (each `v` is fully replaced by generated instances, so the port no
+    longer exists). The result is an ordinary program that elaborates + lowers
+    through the existing pipeline — the FlangeSin shape Phase 0 proved. -/
+def desugarProgram (bs : Array VoiceBinding) (prog : Program) : Except String Program := do
+  match prog with
+  | .mk name tps ports body bc =>
+    let body' ← desugarBody bs body
+    let voiceNames := bs.map (·.voiceName)
+    let ports' := ports.map fun pp =>
+      { pp with inputs := pp.inputs.map fun arr =>
+        arr.filter fun p => !voiceNames.contains (portName p) }
+    pure (.mk name tps ports' body' bc)
+
 end Tropical.Parse.VoiceDesugar
 
 

--- a/lean/Tropical/Parse/VoiceDesugar.lean
+++ b/lean/Tropical/Parse/VoiceDesugar.lean
@@ -1,0 +1,120 @@
+import Tropical.Parse.Nodes
+
+/-!
+# Voice-application desugar (voice-ports sprint, Phase 1)
+
+Rewrite voice applications `v(clockExpr)` into instances of the bound voice
+program clocked at `clockExpr`, plus a `nestedOut` reference to that instance's
+output. Pure `ParsedProgram → ParsedProgram`, given the per-voice bindings (the
+program wired into a voice port, its clock-input and output port names, and the
+non-clock params threaded from the binding).
+
+This is the whole novelty of voice ports at the IR level: `v(clk − δ)` is sugar
+for "a fresh instance of the bound voice, `clk: clk − δ`, take its output" — the
+FlangeSin shape Phase 0 proved renders. No new IR node downstream; the generated
+instances flow through elaborate → strata → emit unchanged.
+
+Scope note (Phase 1): voice applications are expected at expression position in
+output assigns / instance inputs, not inside a combinator binder — lifting a
+binder-scoped application to a top-level instance would escape its binder. The
+MVP effects (flanger) apply voices at the top level; binder-scoped voices are a
+later concern.
+-/
+
+namespace Tropical.Parse.VoiceDesugar
+
+open Lean (JsonNumber)
+open Tropical.Parse
+
+/-- One voice port's binding: the program wired into it, that program's
+    clock-input and output port names, and the non-clock params carried from the
+    binding site. -/
+structure VoiceBinding where
+  voiceName : String
+  programName : String
+  clkInput : String
+  output : String
+  params : Array (String × ParsedExpr) := #[]
+deriving Inhabited
+
+private structure St where
+  counter : Nat := 0
+  newInsts : Array BodyDecl := #[]
+
+private abbrev M := StateT St (Except String)
+
+private def findVoice (bs : Array VoiceBinding) (name : String) : Option VoiceBinding :=
+  bs.find? (·.voiceName == name)
+
+partial def rw (bs : Array VoiceBinding) : ParsedExpr → M ParsedExpr
+  | .call (.nameRef fname) args => do
+    match findVoice bs fname with
+    | some vb =>
+      unless args.size == 1 do
+        throw s!"voice application '{fname}(…)' takes exactly one clock argument, got {args.size}"
+      let clkArg ← rw bs args[0]!
+      let st ← get
+      let instName := s!"__{fname}_{st.counter}"
+      let inputs := #[(vb.clkInput, clkArg)] ++ vb.params
+      set { st with
+        counter := st.counter + 1
+        newInsts := st.newInsts.push (.inst instName vb.programName none (some inputs)) }
+      pure (.nestedOut instName vb.output)
+    | none =>
+      pure (.call (.nameRef fname) (← args.mapM (rw bs)))
+  | .call callee args => do pure (.call (← rw bs callee) (← args.mapM (rw bs)))
+  | .num n => do pure (.num n)
+  | .bool b => do pure (.bool b)
+  | .arr items => do pure (.arr (← items.mapM (rw bs)))
+  | .binary tag l r => do pure (.binary tag (← rw bs l) (← rw bs r))
+  | .unary tag a => do pure (.unary tag (← rw bs a))
+  | .nameRef n => do pure (.nameRef n)
+  | .binding n => do pure (.binding n)
+  | .nestedOut r o => do pure (.nestedOut r o)
+  | .index a i => do pure (.index (← rw bs a) (← rw bs i))
+  | .letIn binds body => do
+    let binds' ← binds.mapM fun (k, e) => do pure (k, ← rw bs e)
+    pure (.letIn binds' (← rw bs body))
+  | .fold over init av ev body => do
+    pure (.fold (← rw bs over) (← rw bs init) av ev (← rw bs body))
+  | .scan over init av ev body => do
+    pure (.scan (← rw bs over) (← rw bs init) av ev (← rw bs body))
+  | .generate count v body => do pure (.generate (← rw bs count) v (← rw bs body))
+  | .iterate count v init body => do
+    pure (.iterate (← rw bs count) v (← rw bs init) (← rw bs body))
+  | .chain count v init body => do
+    pure (.chain (← rw bs count) v (← rw bs init) (← rw bs body))
+  | .map2 over ev body => do pure (.map2 (← rw bs over) ev (← rw bs body))
+  | .zipWith a b xv yv body => do
+    pure (.zipWith (← rw bs a) (← rw bs b) xv yv (← rw bs body))
+  | .tag variant payload => do
+    match payload with
+    | none => do pure (.tag variant none)
+    | some entries =>
+      pure (.tag variant (some (← entries.mapM fun e => do
+        pure (TagPayloadEntry.mk e.field (← rw bs e.value)))))
+  | .match_ scrutinee arms => do
+    let arms' ← arms.mapM fun arm => do
+      pure (MatchArm.mk arm.variant arm.binds (← rw bs arm.body))
+    pure (.match_ (← rw bs scrutinee) arms')
+
+/-- Desugar every voice application in a program body, appending the generated
+    voice instances to the body's decls. -/
+def desugarBody (bs : Array VoiceBinding) (body : Block) : Except String Block := do
+  let walkAssign : BodyAssign → M BodyAssign := fun
+    | .output name e => do pure (.output name (← rw bs e))
+  let walkDecl : BodyDecl → M BodyDecl := fun
+    | .inst name prog ta (some inputs) => do
+      pure (.inst name prog ta (some (← inputs.mapM fun (k, e) => do pure (k, ← rw bs e))))
+    | d => pure d
+  let action : M Block := do
+    let assigns' ← body.assigns.mapM walkAssign
+    let decls' ← body.decls.mapM walkDecl
+    pure (Block.mk (decls' ++ (← get).newInsts) assigns')
+  match action.run {} with
+  | .ok (block, _) => pure block
+  | .error e => throw e
+
+end Tropical.Parse.VoiceDesugar
+
+

--- a/patches/flangesin_probe.json
+++ b/patches/flangesin_probe.json
@@ -1,0 +1,14 @@
+{
+  "schema": "tropical_program_2",
+  "name": "flangesin_probe",
+  "body": {
+    "op": "block",
+    "decls": [
+      { "op": "instanceDecl", "name": "f", "program": "FlangeSin", "inputs": {} }
+    ],
+    "assigns": []
+  },
+  "audio_outputs": [
+    { "instance": "f", "output": "out" }
+  ]
+}

--- a/stdlib/parsed/FlangeSin.json
+++ b/stdlib/parsed/FlangeSin.json
@@ -1,0 +1,101 @@
+{"ports":
+ {"outputs": [{"type": {"op": "nameRef", "name": "float"}, "name": "out"}],
+  "inputs":
+  [{"type": {"op": "nameRef", "name": "clock"},
+    "name": "clk",
+    "default":
+    {"op": "call", "callee": {"op": "nameRef", "name": "clock"}, "args": []}},
+   {"type": {"op": "nameRef", "name": "freq"},
+    "name": "freq",
+    "default":
+    {"op": "call",
+     "callee": {"op": "nameRef", "name": "select"},
+     "args": [{"op": "gt", "args": [220, 0]}, 220, 0]}},
+   {"type": {"op": "nameRef", "name": "float"},
+    "name": "depth",
+    "default": 0.0007}]},
+ "op": "program",
+ "name": "FlangeSin",
+ "body":
+ {"op": "block",
+  "decls":
+  [{"program": {"op": "nameRef", "name": "FixedSinOsc"},
+    "op": "instanceDecl",
+    "name": "dry",
+    "inputs":
+    [{"value": {"op": "nameRef", "name": "freq"},
+      "port": {"op": "nameRef", "name": "freq"}},
+     {"value": {"op": "nameRef", "name": "clk"},
+      "port": {"op": "nameRef", "name": "clk"}}]},
+   {"program": {"op": "nameRef", "name": "FixedSinOsc"},
+    "op": "instanceDecl",
+    "name": "past",
+    "inputs":
+    [{"value": {"op": "nameRef", "name": "freq"},
+      "port": {"op": "nameRef", "name": "freq"}},
+     {"value":
+      {"op": "sub",
+       "args":
+       [{"op": "nameRef", "name": "clk"},
+        {"op": "call",
+         "callee": {"op": "nameRef", "name": "toInt"},
+         "args":
+         [{"op": "mul",
+           "args":
+           [{"op": "mul",
+             "args":
+             [{"op": "nameRef", "name": "depth"},
+              {"op": "call",
+               "callee": {"op": "nameRef", "name": "sampleRate"},
+               "args": []}]},
+            4294967296]}]}]},
+      "port": {"op": "nameRef", "name": "clk"}}]},
+   {"program": {"op": "nameRef", "name": "FixedSinOsc"},
+    "op": "instanceDecl",
+    "name": "ahead",
+    "inputs":
+    [{"value": {"op": "nameRef", "name": "freq"},
+      "port": {"op": "nameRef", "name": "freq"}},
+     {"value":
+      {"op": "add",
+       "args":
+       [{"op": "nameRef", "name": "clk"},
+        {"op": "call",
+         "callee": {"op": "nameRef", "name": "toInt"},
+         "args":
+         [{"op": "mul",
+           "args":
+           [{"op": "mul",
+             "args":
+             [{"op": "nameRef", "name": "depth"},
+              {"op": "call",
+               "callee": {"op": "nameRef", "name": "sampleRate"},
+               "args": []}]},
+            4294967296]}]}]},
+      "port": {"op": "nameRef", "name": "clk"}}]}],
+  "assigns":
+  [{"op": "outputAssign",
+    "name": "out",
+    "expr":
+    {"op": "add",
+     "args":
+     [{"op": "add",
+       "args":
+       [{"op": "mul",
+         "args":
+         [0.5,
+          {"ref": {"op": "nameRef", "name": "dry"},
+           "output": {"op": "nameRef", "name": "sine"},
+           "op": "nestedOut"}]},
+        {"op": "mul",
+         "args":
+         [0.25,
+          {"ref": {"op": "nameRef", "name": "past"},
+           "output": {"op": "nameRef", "name": "sine"},
+           "op": "nestedOut"}]}]},
+      {"op": "mul",
+       "args":
+       [0.25,
+        {"ref": {"op": "nameRef", "name": "ahead"},
+         "output": {"op": "nameRef", "name": "sine"},
+         "op": "nestedOut"}]}]}}]}}

--- a/stdlib/parsed/manifest.json
+++ b/stdlib/parsed/manifest.json
@@ -26,4 +26,5 @@
   "ClockChord",
   "ClockPM",
   "ClockReverseProbe",
-  "FMBell"]}
+  "FMBell",
+  "FlangeSin"]}

--- a/stdlib/reversible/FlangeSin.md
+++ b/stdlib/reversible/FlangeSin.md
@@ -1,0 +1,34 @@
+# FlangeSin
+
+Phase-0 spike for the voice-ports sprint: the desugaring **target** of a generic
+`Flanger<V>` with `V = FixedSinOsc`. Structurally identical to `ReversibleComb`,
+but the voice is a `FixedSinOsc` instead of a `ModalVoice` — three instances of
+one clock-parametric voice, evaluated at the dry clock and at `±delta` warps of
+it, summed. It exists to prove the warp core works for an arbitrary
+clock-parametric voice before the surface (`voice` ports, `v(clk)` application)
+is built around it. No state anywhere — the taps are coordinate reads, so it
+scrubs and reverses exactly when `clk` does.
+
+## Signal flow
+
+```mermaid
+flowchart LR
+  clk([clk]) --> DRY
+  clk --> PAST
+  clk --> AHEAD
+  DRY["FixedSinOsc(clk)"] --> SUM["0.5·dry + 0.25·past + 0.25·ahead"]
+  PAST["FixedSinOsc(clk − δ)"] --> SUM
+  AHEAD["FixedSinOsc(clk + δ)"] --> SUM
+  SUM --> out([out])
+```
+
+## Source
+
+```tropical
+program FlangeSin(clk: clock = clock(), freq: freq = 220, depth: float = 0.0007) -> (out: float) {
+  dry = FixedSinOsc(freq: freq, clk: clk)
+  past = FixedSinOsc(freq: freq, clk: clk - toInt(depth * sampleRate() * 4294967296))
+  ahead = FixedSinOsc(freq: freq, clk: clk + toInt(depth * sampleRate() * 4294967296))
+  out = 0.5 * dry.sine + 0.25 * past.sine + 0.25 * ahead.sine
+}
+```

--- a/tests/fixtures/voice/flanger.md
+++ b/tests/fixtures/voice/flanger.md
@@ -1,0 +1,23 @@
+# Flanger
+
+Voice-ports render-proof fixture (Phase 1): the **generic** flanger as a
+pointfree morphism over a `voice` input — the same three-tap structure as
+`FlangeSin`, but the voice is the input `v` rather than a hardcoded
+`FixedSinOsc`. `diffcli voice-desugar` binds `v → FixedSinOsc` and must
+reproduce `FlangeSin` exactly.
+
+## Signal flow
+
+```mermaid
+flowchart LR
+  v([v: voice]) --> SUM["0.5·v(clk) + 0.25·v(clk−δ) + 0.25·v(clk+δ)"]
+  SUM --> out([out])
+```
+
+## Source
+
+```tropical
+program Flanger(v: voice, clk: clock = clock(), freq: freq = 220, depth: float = 0.0007) -> (out: float) {
+  out = 0.5 * v(clk) + 0.25 * v(clk - toInt(depth * sampleRate() * 4294967296)) + 0.25 * v(clk + toInt(depth * sampleRate() * 4294967296))
+}
+```


### PR DESCRIPTION
## Summary

Opens the **voice-ports** sprint: generic effects as pointfree morphisms over a
`voice` input (`osc → flanger`, composition not feedback). This PR lands **Phase 0
(de-risk) + Phase 1 core (the desugar)**, with the generic flanger proven to
compile *byte-identical* to the hand-wired one. The remaining Phase 1 piece — the
session wire-binding — is scoped in the handoff but not in this PR.

Full design + phasing in [`design/voice-ports-plan.md`](design/voice-ports-plan.md).

## The idea (settled over a long design pass)

tropical denotes a **cartesian, untraced, multi-port** category of clock-indexed
closed forms ("arrows at home" — the composition skeleton over a closed, pure,
compilable base, not Hask). An effect is a `Voice → Voice` morphism; the one
"stranger primitive" is `warp` (precompose a voice with a clock transform —
`delay`, `reverse`, `timescale`), and there is **no `loop`** (no feedback). The
key realization: the warp *core* already works (instantiate a clock-parametric
voice at chosen clocks — `ClockChord` does it), so the sprint is the **binding
surface**, and the only genuinely new pass is the voice desugar.

## What's in this PR

- **Phase 0 — `FlangeSin`** (`stdlib/reversible/FlangeSin.md`): the desugaring
  target — an arbitrary clock-parametric voice (`FixedSinOsc`) at three warped
  clocks, summed. Compiles + renders a real signal (peak 0.039); the **golden
  reference** the generic form must match.
- **Phase 1 core — the desugar** (`lean/Tropical/Parse/VoiceDesugar.lean`):
  - `rw` / `desugarBody` — rewrite each `v(clockExpr)` into a fresh instance of
    the bound voice clocked at `clockExpr` + a `nestedOut`. **No new IR node** —
    it's the FlangeSin shape, generated; flows through elaborate → strata → emit
    unchanged.
  - `desugarProgram` — also strips the consumed `voice` input ports, yielding an
    ordinary program.
- **Render proof** (`voice-desugar` diffcli verb + `tests/fixtures/voice/flanger.md`):
  the generic flanger as a morphism over `v: voice`. The chain

  ```
  parse-md flanger.md | voice-desugar | emit-file
  ```

  produces a compiled plan **byte-identical** to `emit-file stdlib/parsed/FlangeSin.json`
  (27016 bytes, `diff`-clean). So the generic voice-bearing flanger, with `v`
  bound to `FixedSinOsc`, lowers to *exactly* the hand-wired flanger.

## What's deliberately NOT here (the remaining Phase 1)

The **session wire-binding**: deriving the `VoiceBinding` from an actual
voice-port wire (`osc → flanger.v`) rather than the verb's hardcoded binding.
This needs **deferred per-instance resolution** — a voice-bearing program can't
resolve standalone (its voice is unbound until the wire lands), so the session
compiler must hold it, bind when the wire arrives, and re-resolve on rewiring.
Scoped in the handoff doc; it's the threaded, lifecycle-touching part best done
fresh.

## Verification

- `tropicaltest` **12/12** (literate gate green with `FlangeSin`; goldens unmoved).
- The render proof reproduces: generic `Flanger` ≡ `FlangeSin`, plan byte-identical.
- The engine/runtime is untouched — `VoiceDesugar` is consumed only by the diffcli
  verb; nothing in the audio path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
