### PR TITLE
feat(api): the self-describing surface — vocabulary, realized-state report, host-contract dispatch

### DIFF
--- a/design/host-param-dispatch.md
+++ b/design/host-param-dispatch.md
@@ -1,0 +1,86 @@
+# Host param dispatch — the normative contract
+
+Every runtime host (the C++ FlatRuntime, a Swift/Metal host, the wasm player)
+implements param writes by reading `param_disciplines` from the plan manifest
+and dispatching per slot. **No client ever chooses a write verb** — the
+discipline is a fact about the compiled patch, carried by the plan, exactly
+like `slot_names` and `slot_defaults`. A host that implements this section is
+conformant; hosts are gated against each other differentially (same write
+sequence → identical slot trajectories → identical audio).
+
+The reference implementation is the Lean control plane
+(`lean/Tropical/Engine.lean`, `handleSetParamGlide` / `handleSetParamFreq` /
+`handleSetParamVelocity`). Where this document and that code disagree, this
+document is the intent and the code is the bug.
+
+## The manifest field
+
+```json
+"param_disciplines": [
+  { "name": "master.velocity", "discipline": "velocity",
+    "companions": ["master.tau_base"] },
+  { "name": "sf.depth", "discipline": "glide", "glide_dur_sec": 0.02,
+    "companions": ["sf.depth#v0", "sf.depth#v1", "sf.depth#t0"] },
+  { "name": "osc.freq", "discipline": "anchor",
+    "companions": ["osc.freq#phase"] },
+  { "name": "res.decay", "discipline": "raw" }
+]
+```
+
+Omitted when empty; a host that does not read it treats every write as `raw`
+(old plans, old hosts: both unaffected). Slot names are `param:<name>`.
+
+All disciplines below are **stateless re-anchorings**: the "state" they touch
+lives in param slots the kernel reads as pure functions of τ — navigable,
+transferable by name across hot-swap, exactly like everything else. A write
+needs two ambient values from the host: `now` (the current sample index the
+kernel will next read) and `SR` (the kernel's sample rate).
+
+## `raw`
+
+Write `value` to `param:<name>`. Nothing else.
+
+## `glide` — closed-form smoothstep re-anchor
+
+The kernel evaluates
+`f(τ) = v0 + (v1 − v0) · s²(3 − 2s)`, `s = clamp((τ − t0)/dur, 0, 1)`,
+`dur = glide_dur_sec · SR` samples, from the three companion slots. A write
+re-anchors the ramp so it departs from the CURRENT value (no jump):
+
+1. read `v0, v1, t0`;
+2. `curr = f(now)` (the formula above, evaluated at `now`);
+3. write `v0 := curr`, `v1 := target`, `t0 := now`.
+
+The base slot `param:<name>` is not written (glided knobs have no base slot;
+the companions are the value).
+
+## `anchor` — phase-anchored frequency
+
+The oscillator's phase is `f·τ + φ_off`; changing `f` alone jumps the phase by
+`Δf·τ` — a click that grows with τ. The write bumps the `#phase` companion by
+the phase the change would have jumped, using the phasor's own quantized
+increments so the correction is exact against the kernel's arithmetic:
+
+1. `inc₀ = ⌊f_current · 2³² / SR⌋`, `inc₁ = ⌊target · 2³² / SR⌋`;
+2. `Δφ = (inc₀ − inc₁) · now / 2³²` (cycles);
+3. `φ := frac(φ + Δφ)` (wrap to `[0, 1)`), then write `param:<name> := target`.
+
+If the `#phase` companion is absent from the loaded plan, degrade to `raw`.
+
+## `velocity` — master-clock re-base
+
+The master clock is `M(n) = tau_base·SR·2³² + velocity·2³²·n`; changing
+`velocity` alone jumps `M` by `Δv·n`. The write re-bases the origin so `M`
+stays value-continuous:
+
+1. `tau_base += (v_current − target) · now / SR` (the companion slot);
+2. write `param:<name> := target`.
+
+## Conformance
+
+- The Lean control plane and the C++ socket data-plane dispatch from the SAME
+  manifest table; a differential gate drives an identical write sequence
+  through both and requires identical slot trajectories.
+- A host that rounds differently, evaluates the glide with a different
+  polynomial, or applies the phase bump un-quantized will pass casual
+  listening and fail the differential — that is what the gate is for.

--- a/engine/c_api/tropical_socket.cpp
+++ b/engine/c_api/tropical_socket.cpp
@@ -195,6 +195,134 @@ void SocketServer::handle_line(int fd, uint64_t id, const std::string & line)
   enqueue_control(id, line, method);
 }
 
+// Host-contract param dispatch (design/host-param-dispatch.md): the write
+// discipline is a fact about the compiled patch, read from the plan's
+// param_disciplines table — the client never chooses a verb. Every branch is
+// a synchronous slot write off the audio thread, like the raw path; the whole
+// resolve-read-write runs under one lock so a concurrent hot-swap can never
+// land values at stale slot indices. The math mirrors the Lean reference
+// (Engine.lean handleSetParamGlide / handleSetParamFreq /
+// handleSetParamVelocity) exactly — including the quantized-increment floor
+// arithmetic — and the conformance differential
+// (tests/web/param_dispatch_conformance.test.ts) gates the agreement.
+static std::string dispatch_set_param(tropical_runtime::FlatRuntime * rt,
+                                      const json & id, const std::string & name,
+                                      double value)
+{
+  auto ok = [&] {
+    return json{{"jsonrpc", "2.0"}, {"id", id},
+                {"result", {{"name", name}, {"value", value}}}}.dump();
+  };
+  auto err = [&](const std::string & msg) {
+    return json{{"jsonrpc", "2.0"}, {"id", id},
+                {"error", {{"code", -32603}, {"message", msg}}}}.dump();
+  };
+
+  return rt->with_active_state_sync(
+    [&](tropical_runtime::KernelState & st) -> std::string
+  {
+    auto slot_of = [&st](const std::string & slot_name) -> uint32_t {
+      for (uint32_t i = 0; i < st.slot_names.size(); ++i)
+        if (st.slot_names[i] == slot_name) return i;
+      return UINT32_MAX;
+    };
+    // Missing companions read as 0.0 and write as no-ops, matching the Lean
+    // reference's per-slot defaults.
+    auto read  = [&st](uint32_t i) { return i < st.slots.size() ? st.slots[i] : 0.0; };
+    auto write = [&st](uint32_t i, double v) { if (i < st.slots.size()) st.slots[i] = v; };
+
+    const tropical_runtime::ParamDiscipline * pd = st.find_discipline(name);
+    const std::string disc = pd ? pd->discipline : std::string{"raw"};
+
+    if (disc == "glide")
+    {
+      // Re-anchor the closed-form smoothstep ramp so it departs from the
+      // CURRENT value (no jump): evaluate f(now) from the companions, then
+      // v0 := current, v1 := target, t0 := now. The base slot does not exist
+      // for glided params — only the companions are written.
+      const uint32_t v0i = slot_of("param:" + name + "#v0");
+      const uint32_t v1i = slot_of("param:" + name + "#v1");
+      const uint32_t t0i = slot_of("param:" + name + "#t0");
+      if (v0i == UINT32_MAX)
+        return err("set_param: no glide slots for '" + name + "'");
+      const double now = static_cast<double>(st.sample_index);
+      // dur matches the kernel's ramp window; the table carries it (0.02 s
+      // for playground knobs), with the kernel's 20 ms as the fallback.
+      const double dur_sec = pd->glide_dur_sec > 0.0 ? pd->glide_dur_sec : 0.02;
+      const double dur = st.sample_rate * dur_sec;
+      const double v0 = read(v0i);
+      const double v1 = read(v1i);
+      const double t0 = read(t0i);
+      const double r = (now - t0) / dur;
+      const double s = r < 0.0 ? 0.0 : (r > 1.0 ? 1.0 : r);
+      write(v0i, v0 + (v1 - v0) * (s * s * (3.0 - 2.0 * s)));
+      write(v1i, value);
+      write(t0i, now);
+      return ok();
+    }
+
+    if (disc == "anchor")
+    {
+      // Phase-anchored frequency: bump #phase by the phase the change would
+      // have jumped (Δφ = (inc0 − inc1)·now / 2^32 cycles, inc the phasor's
+      // own quantized increment), wrap to [0, 1), then write the base slot.
+      const uint32_t fi = slot_of("param:" + name);
+      if (fi == UINT32_MAX)
+        return err("set_param: unknown param '" + name + "'");
+      const uint32_t pi = slot_of("param:" + name + "#phase");
+      if (pi == UINT32_MAX)
+      {
+        // No #phase companion in the loaded plan: degrade to raw.
+        write(fi, value);
+        return ok();
+      }
+      const double now  = static_cast<double>(st.sample_index);
+      const double sr   = st.sample_rate;
+      const double inc0 = std::floor(read(fi) * 4294967296.0 / sr);
+      const double inc1 = std::floor(value * 4294967296.0 / sr);
+      const double dcyc = ((inc0 - inc1) * now) / 4294967296.0;
+      const double ph   = read(pi) + dcyc;
+      write(pi, ph - std::floor(ph));   // frac → [0, 1)
+      write(fi, value);
+      return ok();
+    }
+
+    if (disc == "velocity")
+    {
+      // Master-clock re-base: tau_base += (v_current − target)·now/SR keeps
+      // M(n) value-continuous across the velocity change.
+      const uint32_t vi = slot_of("param:" + name);
+      if (vi == UINT32_MAX)
+        return err("set_param: unknown param '" + name + "'");
+      // The origin slot is the declared companion; the Lean reference
+      // derives the same name by substitution ("velocity" → "tau_base").
+      std::string tau;
+      if (!pd->companions.empty()) tau = pd->companions.front();
+      else
+      {
+        tau = name;
+        const std::size_t pos = tau.find("velocity");
+        if (pos != std::string::npos) tau.replace(pos, 8, "tau_base");
+      }
+      const uint32_t ti = slot_of("param:" + tau);
+      if (ti == UINT32_MAX)
+        return err("set_param: no origin slot '" + tau + "'");
+      const double now = static_cast<double>(st.sample_index);
+      write(ti, read(ti) + (read(vi) - value) * now / st.sample_rate);
+      write(vi, value);
+      return ok();
+    }
+
+    // raw (or a name absent from the table): plain base-slot write —
+    // today's behavior, and the whole contract for old plans.
+    const uint32_t bi = slot_of("param:" + name);
+    if (bi == UINT32_MAX)
+      return err("set_param: unknown param '" + name + "'");
+    write(bi, value);
+    return ok();
+  });
+}
+
 std::string SocketServer::handle_data(const std::string & line)
 {
   json id = nullptr;
@@ -213,11 +341,7 @@ std::string SocketServer::handle_data(const std::string & line)
       if (!std::isfinite(value))
         return json{{"jsonrpc", "2.0"}, {"id", id},
                     {"error", {{"code", -32603}, {"message", "set_param: value must be finite"}}}}.dump();
-      if (!runtime_->set_slot_by_name_sync("param:" + name, value))
-        return json{{"jsonrpc", "2.0"}, {"id", id},
-                    {"error", {{"code", -32603}, {"message", "set_param: unknown param '" + name + "'"}}}}.dump();
-      return json{{"jsonrpc", "2.0"}, {"id", id},
-                  {"result", {{"name", name}, {"value", value}}}}.dump();
+      return dispatch_set_param(runtime_, id, name, value);
     }
 
     if (method == "get_telemetry")

--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -30,6 +30,14 @@ KernelState FlatRuntime::build_kernel_state(const tropical_plan5::ParsedPlan5 & 
     new_state.slots[i] = parsed.slot_defaults[i];
   }
 
+  // Host-contract dispatch table — swaps with the plan it describes, like
+  // slot_names. Field-copied because the runtime keeps its own struct (the
+  // header stays free of the parser header).
+  new_state.param_disciplines.reserve(parsed.param_disciplines.size());
+  for (const auto & d : parsed.param_disciplines)
+    new_state.param_disciplines.push_back(
+      { d.name, d.discipline, d.glide_dur_sec, d.companions });
+
   // CF-only: there are no per-sample state registers. The kernel's
   // `%registers` argument survives in the calling convention but is never
   // read or written, so the backing buffer is empty. The temp pool

--- a/engine/runtime/FlatRuntime.hpp
+++ b/engine/runtime/FlatRuntime.hpp
@@ -26,6 +26,18 @@ namespace tropical_plan5 { struct ParsedPlan5; }
 namespace tropical_runtime
 {
 
+// Host-contract param write discipline (design/host-param-dispatch.md),
+// carried by the plan manifest exactly like slot_names / slot_defaults.
+// Runtime copy of ParsedPlan5::ParamDiscipline so this header stays free
+// of the parser header.
+struct ParamDiscipline
+{
+  std::string              name;             // base param ("sf.depth"; slot "param:<name>")
+  std::string              discipline;       // raw | glide | anchor | velocity
+  double                   glide_dur_sec = 0.0;
+  std::vector<std::string> companions;       // #v0/#v1/#t0, #phase, tau_base sibling
+};
+
 struct KernelState
 {
   // ── Execution mode + kernel handles ──────────────────────────────────────
@@ -59,6 +71,22 @@ struct KernelState
   // control values set from outside persist across kernel rebuilds.
   std::vector<double>      slots;
   std::vector<std::string> slot_names;
+
+  // Host-contract dispatch table: which write discipline each base param
+  // carries. Lives here so a hot-swap replaces it together with the plan
+  // it describes (like slot_names); an empty table means every write is raw.
+  std::vector<ParamDiscipline> param_disciplines;
+
+  // Discipline lookup by base param name. Returns nullptr when the name is
+  // absent from the loaded plan's table (callers treat that as raw). The
+  // pointer is into this state — only valid while the state is held (e.g.
+  // under FlatRuntime::with_active_state_sync).
+  const ParamDiscipline * find_discipline(const std::string & name) const
+  {
+    for (const auto & d : param_disciplines)
+      if (d.name == name) return &d;
+    return nullptr;
+  }
 
   double sample_rate = 44100.0;
   uint64_t sample_index = 0;
@@ -271,6 +299,22 @@ public:
     for (uint32_t i = 0; i < state.slot_names.size(); ++i)
       if (state.slot_names[i] == name) { state.slots[i] = value; return true; }
     return false;
+  }
+
+  // Run `fn` against the active KernelState under build_mutex_ — the
+  // generalization of set_slot_by_name_sync for multi-slot writes. The
+  // discipline dispatches (glide/anchor/velocity re-anchorings) must
+  // resolve, read, and write several slots against ONE consistent plan;
+  // without the lock a concurrent hot-swap could flip the active state
+  // between resolve and write and land values at stale indices. Same
+  // contention profile as set_slot_by_name_sync: publish_state holds the
+  // lock only for the cheap transfer + flip, never the LLVM compile.
+  template <typename Fn>
+  auto with_active_state_sync(Fn && fn)
+  {
+    std::lock_guard<std::mutex> lock(build_mutex_);
+    const uint32_t state_idx = active_state_.load(std::memory_order_acquire);
+    return fn(states_[state_idx]);
   }
 
   // ── Random-access render (scope / slave consumers) ─────────────────────────

--- a/engine/runtime/NumericProgramParser.hpp
+++ b/engine/runtime/NumericProgramParser.hpp
@@ -183,6 +183,19 @@ struct ParsedPlan5
   uint32_t                 slot_count = 0;
   std::vector<std::string> slot_names;
   std::vector<double>      slot_defaults;
+
+  // Host-contract param write dispatch (design/host-param-dispatch.md): the
+  // discipline is a fact about the compiled patch, carried by the plan, so a
+  // host dispatches writes itself and no client ever chooses a verb. Absent
+  // field ⇒ empty table ⇒ every write is raw (old plans unaffected).
+  struct ParamDiscipline
+  {
+    std::string              name;             // base param ("sf.depth"; slot "param:<name>")
+    std::string              discipline;       // raw | glide | anchor | velocity
+    double                   glide_dur_sec = 0.0;
+    std::vector<std::string> companions;       // #v0/#v1/#t0, #phase, tau_base sibling
+  };
+  std::vector<ParamDiscipline> param_disciplines;
 };
 
 // Parse the optional `compilation_mode` JSON string. Fails closed on
@@ -324,6 +337,20 @@ inline ParsedPlan5 parse_plan5(const nlohmann::json & plan)
   if (plan.contains("slot_defaults"))
     for (const auto & v : plan["slot_defaults"])
       result.slot_defaults.push_back(v.get<double>());
+
+  // ── Host-contract dispatch table (contains-guarded: absent ⇒ all-raw) ──
+  if (plan.contains("param_disciplines"))
+    for (const auto & d : plan["param_disciplines"])
+    {
+      ParsedPlan5::ParamDiscipline pd;
+      pd.name       = d.value("name", std::string{});
+      pd.discipline = d.value("discipline", std::string{"raw"});
+      pd.glide_dur_sec = d.value("glide_dur_sec", 0.0);
+      if (d.contains("companions"))
+        for (const auto & c : d["companions"])
+          pd.companions.push_back(c.get<std::string>());
+      result.param_disciplines.push_back(std::move(pd));
+    }
 
   return result;
 }

--- a/lean/Tropical/Engine.lean
+++ b/lean/Tropical/Engine.lean
@@ -2018,6 +2018,9 @@ def handleSetParamGlide (env : Env) (args : Json) : EngineM Json := do
   write "v0" curr
   write "v1" target
   write "t0" now
+  -- the mirror tracks the ramp's TARGET (its settled value), like every
+  -- other write path — a glide previously skipped this, so list_params lied.
+  env.state.modify (·.setParamValue name (toJson target))
   pure <| Json.mkObj [("name", Json.str name), ("value", toJson target)]
 
 /-- `set_param_freq`: a PHASE-ANCHORED frequency change. `freq = f·τ + φ_off` — so
@@ -2048,6 +2051,7 @@ def handleSetParamFreq (env : Env) (args : Json) : EngineM Json := do
     env.runtime.setSlot phaseIdx (raw - Float.floor raw)   -- frac → [0, 1)
     env.runtime.setSlot freqIdx target
   | none => env.runtime.setSlot freqIdx target
+  env.state.modify (·.setParamValue name (toJson target))
   pure <| Json.mkObj [("name", Json.str name), ("value", toJson target)]
 
 /-- `set_param_velocity`: the GLOBAL TIME-WARP scrub. The master clock is
@@ -2078,6 +2082,26 @@ def handleSetParamVelocity (env : Env) (args : Json) : EngineM Json := do
   env.runtime.setSlot velIdx target
   env.state.modify (·.setParamValue name (toJson target))
   pure <| Json.mkObj [("name", Json.str name), ("value", toJson target)]
+
+/-- ONE `set_param`, dispatched by the plan's own discipline table (the host
+    contract, design/host-param-dispatch.md): the caller never chooses a write
+    verb. Raw for table-less names (session-model patches, old plans) — with
+    the one engine-owned exception that the reserved master-clock velocity
+    param always re-bases, table or no table (the engine consulting its own
+    reserved name is not a client choosing semantics). The old
+    `set_param_glide/freq/velocity` methods remain as aliases into the same
+    internal handlers until the surfaces migrate (deleted in a later phase). -/
+def handleSetParamDispatch (env : Env) (args : Json) : EngineM Json := do
+  let name := (argStr? args "name").getD ""
+  let st ← env.state.get
+  let disc := match st.paramDisciplines.find? (·.name == name) with
+    | some d => d.discipline
+    | none => if name == Tropical.Playground.masterVelocityParam then "velocity" else "raw"
+  match disc with
+  | "glide" => handleSetParamGlide env args
+  | "anchor" => handleSetParamFreq env args
+  | "velocity" => handleSetParamVelocity env args
+  | _ => handleSetParam env args
 
 def handleListParams (env : Env) : EngineM Json := do
   let st ← env.state.get
@@ -2133,7 +2157,8 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
   -- this graph's inspection points via `list_scope_taps` with no session wiring.
   env.state.modify (fun st => { st with
     params := Tropical.Playground.knobParams args
-    scopeTaps := taps })
+    scopeTaps := taps
+    paramDisciplines := plan.paramDisciplines })
   -- The realized-state report: facts about what compiled (active/excluded
   -- nodes, wired/normalled inputs, live params with disciplines, taps) —
   -- never warnings. `ok` stays for callers that only ever looked at it.
@@ -2167,7 +2192,10 @@ def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   | "start_audio"     => handleStartAudio env args
   | "stop_audio"      => handleStopAudio env
   | "audio_status"    => handleAudioStatus env
-  | "set_param"       => handleSetParam env args
+  -- ONE set_param: discipline-dispatched from the loaded plan's table
+  -- (raw for table-less names). The three verbs below are migration
+  -- aliases into the same internals.
+  | "set_param"       => handleSetParamDispatch env args
   | "set_param_glide" => handleSetParamGlide env args
   | "set_param_freq"  => handleSetParamFreq env args
   | "set_param_velocity" => handleSetParamVelocity env args

--- a/lean/Tropical/Engine.lean
+++ b/lean/Tropical/Engine.lean
@@ -2134,7 +2134,10 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
   env.state.modify (fun st => { st with
     params := Tropical.Playground.knobParams args
     scopeTaps := taps })
-  pure <| Json.mkObj [("ok", Json.bool true)]
+  -- The realized-state report: facts about what compiled (active/excluded
+  -- nodes, wired/normalled inputs, live params with disciplines, taps) —
+  -- never warnings. `ok` stays for callers that only ever looked at it.
+  pure <| Tropical.Playground.realizedReport args taps
 
 def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   wrap <| match name with

--- a/lean/Tropical/Engine.lean
+++ b/lean/Tropical/Engine.lean
@@ -2139,9 +2139,10 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
 def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   wrap <| match name with
   | "load_patch_graph" => handleLoadPatchGraph env args
-  -- The static node-port schema (inlets + accepted colors + outlet color) the
-  -- GUI validates connections against. Session-independent, so it just echoes.
-  | "node_schema" => pure Tropical.Playground.nodeSchema
+  -- The vocabulary (port-spec table as data: ports, accepts, defaults, write
+  -- disciplines, display metadata) — clients render it, never re-encode it.
+  -- Session-independent, so it just echoes.
+  | "get_vocabulary" => pure Tropical.Playground.vocabularyJson
   | "define_program"  => handleDefineProgram env args
   | "add_instance"    => handleAddInstance env args
   | "remove_instance" => handleRemoveInstance env args

--- a/lean/Tropical/Plan.lean
+++ b/lean/Tropical/Plan.lean
@@ -325,6 +325,30 @@ def CompilationMode.ofWire? : String → Option CompilationMode
 -- FlatPlan — the runnable plan
 -- ─────────────────────────────────────────────────────────────
 
+/-- Per-param write discipline — HOST-CONTRACT data. A runtime host (the C++
+    FlatRuntime, a Swift/Metal host, the wasm player) reads this from the
+    manifest and dispatches param writes itself, so no client ever chooses
+    semantics (see design/host-param-dispatch.md for the normative
+    re-anchoring math each discipline requires). `name` is the base param
+    (slot `param:<name>`); `companions` are the discipline's implementation
+    slots (`#v0/#v1/#t0` for glide, `#phase` for anchor, the `tau_base`
+    sibling for velocity). -/
+structure ParamDiscipline where
+  name : String
+  discipline : String
+  glideDurSec : Option JsonNumber := none
+  companions : Array String := #[]
+deriving Repr, Inhabited
+
+def ParamDiscipline.toWire (d : ParamDiscipline) : Json :=
+  let fields := #[("name", Json.str d.name), ("discipline", Json.str d.discipline)]
+  let fields := match d.glideDurSec with
+    | some n => fields.push ("glide_dur_sec", Json.num n)
+    | none => fields
+  let fields := if d.companions.isEmpty then fields
+    else fields.push ("companions", toJson d.companions)
+  Json.mkObj fields.toList
+
 structure FlatPlan where
   sampleRate : JsonNumber := (44100 : Nat)
   compilationMode : CompilationMode := .fused
@@ -340,6 +364,10 @@ structure FlatPlan where
   /-- Numbers in TS; delay-slot inits and param values land here
       verbatim (raw Json so lexical number forms survive). -/
   slotDefaults : Array Json
+  /-- Host-contract dispatch table (empty for plans with no live params;
+      omitted from the wire when empty, so old plans and old parsers are
+      both untouched). -/
+  paramDisciplines : Array ParamDiscipline := #[]
 deriving Inhabited
 
 /-- Mirrors `toWirePlan`'s omission rules. -/
@@ -357,6 +385,8 @@ def FlatPlan.toWire (p : FlatPlan) : Except String Json := do
       ("slot_names", toJson p.slotNames),
       ("slot_defaults", Json.arr p.slotDefaults),
       ("instance_functions", Json.arr (← p.instanceFunctions.mapM (·.toWire)))]
+  let fields := if p.paramDisciplines.isEmpty then fields
+    else fields.push ("param_disciplines", Json.arr (p.paramDisciplines.map (·.toWire)))
   let fields := if p.sinks.isEmpty then fields
     else fields.push ("sinks", Json.arr (p.sinks.map (·.toWire)))
   let fields := if isDefaultSources p.sources then fields

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -610,6 +610,61 @@ def decodeGraph (j : Json) : Except String (PatchGraph × Array (String × JsonN
   pnodes := pnodes.push { id := "__silence__", node := .mix #[] }
   pure ({ nodes := pnodes, output := "__out__" }, params)
 
+-- ── The realized-state report (the load_patch_graph reply) ──────────────────
+/-- FACTS about what compiled — never warnings (legal-but-incomplete states
+    compile to silence by contract; the report is how a surface renders truth
+    instead of guessing policy). Per user node: `active` (reachable from the
+    `out` node, walking inlet edges backwards) or `excluded`. Per inlet:
+    `wired` (with sources) or `normalled` (running on its default). Per live
+    param: the collected value and write discipline, base names only — the
+    glide/anchor companion slots are the discipline's implementation detail,
+    not surface. Plus the taps. The silence-with-`{ok:true}` class dies here:
+    a patch that gracefully compiled to nothing now SAYS so, as facts. -/
+def realizedReport (args : Json) (taps : Array (String × String × String)) : Json := Id.run do
+  let raws := rawsOf args
+  let outId := match (args.getObjVal? "out").toOption with
+    | some (.str s) => s
+    | _ => ""
+  -- reachability fixed point (≤ |nodes| rounds; GUI graphs are small)
+  let mut reach : Array String := #[outId]
+  for _ in [0:raws.size] do
+    for r in raws do
+      if reach.contains r.id then
+        for spec in portSpecs r.kind do
+          for src in portSources r.inObj spec.name do
+            if !reach.contains src then reach := reach.push src
+  let nodesJ := raws.map fun r =>
+    Json.mkObj [("id", Json.str r.id), ("kind", Json.str r.kind),
+      ("status", Json.str (if reach.contains r.id then "active" else "excluded"))]
+  let inputsJ := raws.foldl (init := #[]) fun acc r =>
+    (portSpecs r.kind).foldl (init := acc) fun acc spec =>
+      if spec.accepts.isEmpty then acc else
+      let srcs := portSources r.inObj spec.name
+      acc.push (Json.mkObj (
+        [("node", Json.str r.id), ("port", Json.str spec.name)] ++
+        (if srcs.isEmpty then [("state", Json.str "normalled")]
+         else [("state", Json.str "wired"),
+               ("sources", Json.arr (srcs.map Json.str))])))
+  let kindOf : String → Option String := fun id => (raws.find? (·.id == id)).map (·.kind)
+  let paramsJ := (collectParams raws).filterMap fun (nm, v) =>
+    if nm.endsWith "#v1" || nm.endsWith "#t0" || nm.endsWith "#phase" then none
+    else if nm.endsWith "#v0" then
+      some (Json.mkObj [("name", Json.str (nm.dropRight 3)),
+        ("value", Json.num v), ("discipline", Json.str "glide")])
+    else
+      let disc :=
+        if nm == masterVelocityParam then "velocity"
+        else match nm.splitOn "." with
+          | [id, kname] => (kindOf id).map (fun k => discStr (disciplineOf k kname)) |>.getD "raw"
+          | _ => "raw"
+      some (Json.mkObj [("name", Json.str nm),
+        ("value", Json.num v), ("discipline", Json.str disc)])
+  let tapsJ := taps.map fun (name, inst, out) =>
+    Json.mkObj [("name", Json.str name), ("slot", Json.str s!"{inst}.{out}")]
+  return Json.mkObj [("ok", Json.bool true), ("nodes", Json.arr nodesJ),
+    ("inputs", Json.arr inputsJ), ("params", Json.arr paramsJ),
+    ("taps", Json.arr tapsJ)]
+
 -- ── Scope taps ──────────────────────────────────────────────────────────────
 /-- A scope tap: `(name, srcInstance, srcOutput)` — the exact `scopeTaps` triple
     the session model uses, so `list_scope_taps` (which builds the slot as

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -610,6 +610,40 @@ def decodeGraph (j : Json) : Except String (PatchGraph × Array (String × JsonN
   pnodes := pnodes.push { id := "__silence__", node := .mix #[] }
   pure ({ nodes := pnodes, output := "__out__" }, params)
 
+-- ── Host-contract dispatch table (param_disciplines in the manifest) ────────
+/-- The per-param write-discipline table this graph's plan carries — the same
+    walk and skip rules as `collectParams`, projected to base names. A host
+    reads this from the manifest and dispatches param writes itself
+    (design/host-param-dispatch.md is the normative math); no client ever
+    chooses a write verb. -/
+private def paramDisciplinesOf (raws : Array Raw) :
+    Array Tropical.Plan.ParamDiscipline := Id.run do
+  let mut out : Array Tropical.Plan.ParamDiscipline := #[
+    { name := masterVelocityParam, discipline := "velocity",
+      companions := #[masterTauBaseParam] },
+    { name := masterTauBaseParam, discipline := "raw" }]
+  for r in raws do
+    if r.kind == "out" then continue
+    for spec in portSpecs r.kind do
+      if spec.knob.isNone then continue
+      let selfWired := !(portSources r.inObj spec.name).isEmpty
+      let ownerWired := match spec.ownerPort with
+        | some o => !(portSources r.inObj o).isEmpty
+        | none => false
+      if !selfWired && !ownerWired then
+        let base := s!"{r.id}.{spec.name}"
+        let d : Tropical.Plan.ParamDiscipline := match spec.discipline with
+          | .glide =>
+            -- 0.02 s: the engine's glide window
+            { name := base, discipline := "glide", glideDurSec := some ⟨2, 2⟩,
+              companions := #[s!"{base}#v0", s!"{base}#v1", s!"{base}#t0"] }
+          | .anchor =>
+            { name := base, discipline := "anchor", companions := #[s!"{base}#phase"] }
+          | .raw =>
+            { name := base, discipline := "raw" }
+        out := out.push d
+  return out
+
 -- ── The realized-state report (the load_patch_graph reply) ──────────────────
 /-- FACTS about what compiled — never warnings (legal-but-incomplete states
     compile to silence by contract; the report is how a surface renders truth
@@ -734,6 +768,10 @@ def compilePlanPure (arena : Arena) (resolved : Array (String × ProgramIdx)) (j
     arena := coreArena
     mode := .fused }
   let plan ← Tropical.Compile.compileSession input
+  -- The host-contract dispatch table rides the manifest: any runtime host
+  -- (C++ today, Swift/Metal or wasm tomorrow) reads per-slot disciplines from
+  -- the plan itself and dispatches param writes locally.
+  let plan := { plan with paramDisciplines := paramDisciplinesOf (rawsOf j) }
   -- The final mix (`out`) plus one tap per user node, all routed to the synthetic
   -- root's output slots (`__root__.<port>`), ready for `render_window`.
   let root := Tropical.Compile.rootInstancePath

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -180,19 +180,28 @@ inductive PortDomain where
   | signal | modal | control
 deriving BEq, Repr
 
+/-- Display metadata for a knob — semantics, not decoration: without it every
+    frontend reinvents ranges and scales, badly, and drifts (three copies of
+    this table have already existed). Served verbatim by `get_vocabulary`. -/
+structure KnobMeta where
+  min : Float
+  max : Float
+  log : Bool := false
+  unit : String := ""
+deriving Repr
+
 /-- One port of a node kind. A port with `accepts ≠ #[]` is an inlet; a port
     with `knob = some (m, e)` carries a continuous param slot whose
     compile-time fallback is `lit m e` (the value `buildNode` bakes only if the
     collector somehow skipped the slot). A port may be BOTH (source `freq`: a
-    control inlet that, unwired, is a knob) — wiring it supersedes the slot.
-    Phase 1: constant fallbacks only; default TERMS (normalled subgraphs) land
-    in the next phase. -/
+    control inlet that, unwired, is a knob) — wiring it supersedes the slot. -/
 structure PortSpec where
   name : String
   accepts : Array PortDomain := #[]
   multi : Bool := false
   knob : Option (Int × Nat) := none
   discipline : Discipline := .raw
+  display : Option KnobMeta := none
   /-- The port whose NORMAL this knob parameterizes (an input of the default
       subgraph, not of the node): sflange's `rate` is an input of `mod`'s
       normalled LFO. Wiring the owner replaces the whole default — circuit,
@@ -210,52 +219,80 @@ private def ctrlIn : Array PortDomain := #[.control]
     define the `ParamIdx` scan order (`collectParams`), and the whole layout is
     what `get_vocabulary` will serve. -/
 def portSpecs : String → Array PortSpec
-  | "knob" => #[{ name := "value", knob := some (0, 0) }]
+  | "knob" => #[
+      { name := "value", knob := some (0, 0),
+        display := some { min := 0, max := 1000 } }]
   | "source" => #[
-      { name := "freq", accepts := ctrlIn, knob := some (220, 0), discipline := .anchor },
-      { name := "morph", knob := some (0, 0), discipline := .glide },
+      { name := "freq", accepts := ctrlIn, knob := some (220, 0), discipline := .anchor,
+        display := some { min := 0.02, max := 2000, log := true, unit := "Hz" } },
+      { name := "morph", knob := some (0, 0), discipline := .glide,
+        display := some { min := 0, max := 1 } },
       { name := "pm", accepts := sigIn }]
   | "pluck" => #[
-      { name := "freq", accepts := ctrlIn, knob := some (110, 0), discipline := .anchor },
-      { name := "morph", knob := some (0, 0), discipline := .glide },
-      { name := "event_rate", knob := some (2, 0), discipline := .glide }]
+      { name := "freq", accepts := ctrlIn, knob := some (110, 0), discipline := .anchor,
+        display := some { min := 20, max := 2000, log := true, unit := "Hz" } },
+      { name := "morph", knob := some (0, 0), discipline := .glide,
+        display := some { min := 0, max := 1 } },
+      { name := "event_rate", knob := some (2, 0), discipline := .glide,
+        display := some { min := 0.1, max := 20, log := true, unit := "Hz" } }]
   | "comb" => #[
       { name := "in", accepts := sigIn },
-      { name := "delay", knob := some (12, 3), discipline := .glide },
-      { name := "decay", knob := some (7, 1), discipline := .glide }]
+      { name := "delay", knob := some (12, 3), discipline := .glide,
+        display := some { min := 0.0005, max := 0.05, log := true, unit := "s" } },
+      { name := "decay", knob := some (7, 1), discipline := .glide,
+        display := some { min := 0, max := 0.95 } }]
   | "flange" => #[
       { name := "in", accepts := sigIn },
-      { name := "depth", knob := some (7, 4), discipline := .glide }]
+      { name := "depth", knob := some (7, 4), discipline := .glide,
+        display := some { min := 0.0001, max := 0.01, log := true, unit := "s" } }]
   | "sflange" => #[
       { name := "in", accepts := sigIn },
       { name := "mod", accepts := sigIn },
-      { name := "depth", knob := some (2, 3), discipline := .glide },
+      { name := "depth", knob := some (2, 3), discipline := .glide,
+        display := some { min := 0.0002, max := 0.02, log := true, unit := "s" } },
       -- `rate` parameterizes `mod`'s normal (the built-in LFO): patch `mod`
       -- and the LFO, this knob, and its slot all vanish together.
-      { name := "rate", knob := some (3, 1), ownerPort := some "mod" }]
+      { name := "rate", knob := some (3, 1), ownerPort := some "mod",
+        display := some { min := 0.02, max := 12, log := true, unit := "Hz" } }]
   | "fm" => #[
       { name := "in", accepts := sigIn },
-      { name := "carrier", knob := some (330, 0), discipline := .anchor },
-      { name := "depth", knob := some (8, 0), discipline := .glide }]
+      { name := "carrier", knob := some (330, 0), discipline := .anchor,
+        display := some { min := 20, max := 2000, log := true, unit := "Hz" } },
+      { name := "depth", knob := some (8, 0), discipline := .glide,
+        display := some { min := 1, max := 400, log := true } }]
   | "delay" => #[
       { name := "in", accepts := sigIn },
-      { name := "amount", knob := some (4, 3), discipline := .glide }]
+      { name := "amount", knob := some (4, 3), discipline := .glide,
+        display := some { min := 0.0001, max := 0.02, log := true, unit := "s" } }]
   | "reverse" => #[{ name := "in", accepts := sigIn }]
   | "mix" => #[{ name := "in", accepts := sigIn, multi := true }]
   | "ring" => #[{ name := "in", accepts := sigIn, multi := true }]
   | "resonator" => #[
       { name := "addr", accepts := sigIn },
-      { name := "freq", knob := some (220, 0) },
-      { name := "decay", knob := some (4, 0) }]
+      { name := "freq", knob := some (220, 0),
+        display := some { min := 20, max := 2000, log := true, unit := "Hz" } },
+      { name := "decay", knob := some (4, 0),
+        display := some { min := 0.5, max := 50, log := true } }]
   | "reverb" => #[
       { name := "in", accepts := modalIn },
-      { name := "rt60", knob := some (2, 0) },
-      { name := "dir", knob := some (0, 0) },
-      { name := "sway", knob := some (0, 0) },
-      { name := "rate", knob := some (3, 1) }]
+      { name := "rt60", knob := some (2, 0),
+        display := some { min := 0.2, max := 12, log := true, unit := "sec" } },
+      { name := "dir", knob := some (0, 0),
+        display := some { min := 0, max := 1 } },
+      { name := "sway", knob := some (0, 0),
+        display := some { min := 0, max := 0.9 } },
+      { name := "rate", knob := some (3, 1),
+        display := some { min := 0.05, max := 8, log := true, unit := "Hz" } }]
   | "modalmix" => #[{ name := "in", accepts := modalIn, multi := true }]
   | "out" => #[{ name := "in", accepts := sigIn, multi := true }]
   | _ => #[]
+
+/-- Each kind's outlet color (`none` = no outlet, the dac sink). -/
+def outletOf : String → Option PortDomain
+  | "knob" => some .control
+  | "resonator" | "reverb" | "modalmix" => some .modal
+  | "out" => none
+  | _ => some .signal
 
 /-- The kinds the table covers, in schema order (`out` last — it has no outlet). -/
 def vocabularyKinds : Array String := #[
@@ -463,56 +500,50 @@ private def rawsOf (j : Json) : Array Raw :=
 def knobNamesOf (kind : String) : Array String :=
   (portSpecs kind).filterMap fun p => if p.knob.isSome then some p.name else none
 
--- ── Node-port schema (the connection-validation contract for the GUI) ─────────
-/-- The static node-port schema the playground GUI validates connections against.
-    For each node kind: its INLETS (name + the outlet colors it accepts, and
-    whether it fans in), its OUTLET color, and its continuous knobs. Colors:
+-- ── get_vocabulary: the port-spec table, served ──────────────────────────────
+private def domStr : PortDomain → String
+  | .signal => "signal" | .modal => "modal" | .control => "control"
+private def discStr : Discipline → String
+  | .raw => "raw" | .glide => "glide" | .anchor => "anchor"
 
-    * `signal`  — a per-sample stream (an oscillator/effect output);
-    * `modal`   — a pole bank (a resonator/reverb, composed by residue calculus);
-    * `control` — a knob (a live param slot).
-
-    A connection `outlet → inlet` is valid iff `outlet.color ∈ inlet.accepts`.
-    The asymmetry is real and enforced by the compiler: a `modal` outlet feeding a
-    `signal` inlet REALIZES at the seam (poles → stream), a `control` outlet is a
-    constant stream (so it also satisfies a `signal` inlet), but a `signal` into a
-    `modal` inlet is the one hard TYPE ERROR ("a Sig has no poles to compose").
-    There is no signal-port typing beyond this — every other mismatch was silently
-    dropped, which is what made osc→osc read as a dotted no-op.
-
-    Kept in sync with `buildNode` (the inlets it reads) and `knobNamesOf`. -/
-def nodeSchema : Json :=
-  let sig : Array String := #["signal", "modal", "control"]  -- a stream-consuming inlet
-  let modal : Array String := #["modal"]                     -- poles only
-  let ctrl : Array String := #["control"]                    -- a knob only
-  let inlet (name : String) (accepts : Array String) (multi : Bool := false) : Json :=
-    Json.mkObj [("name", Json.str name),
-      ("accepts", Json.arr (accepts.map Json.str)), ("multi", Json.bool multi)]
-  let node (kind : String) (inlets : Array Json) (outlet : Option String)
-      (knobs : Array String) : Json :=
-    Json.mkObj [("kind", Json.str kind), ("inlets", Json.arr inlets),
-      ("outlet", match outlet with | some c => Json.str c | none => Json.null),
-      ("knobs", Json.arr (knobs.map Json.str))]
+/-- The vocabulary as JSON — the ONE description of the node kinds, GENERATED
+    from the port-spec table (the hand-maintained `nodeSchema` this replaces
+    was the third copy, and the class of bug this file exists to kill). Per
+    kind: outlet color and ports; per port: inlet facts (accepts/multi), knob
+    facts (default, write discipline, display metadata), and `owner` when the
+    knob parameterizes another port's normal. Clients RENDER this — nothing
+    the engine knows may be re-encoded client-side. The connection rule rides
+    along: `outlet→inlet` valid iff `outlet.color ∈ inlet.accepts`; a modal
+    outlet into a signal inlet REALIZES at the seam; a control outlet is a
+    constant stream; signal into a modal inlet is the one hard type error. -/
+def vocabularyJson : Json :=
+  let portJson := fun (p : PortSpec) => Json.mkObj <|
+    [("name", Json.str p.name)]
+    ++ (if p.accepts.isEmpty then [] else
+        [("accepts", Json.arr (p.accepts.map (Json.str ∘ domStr))),
+         ("multi", Json.bool p.multi)])
+    ++ (match p.knob with
+        | some (m, e) => [("default", Json.num ⟨m, e⟩),
+                          ("discipline", Json.str (discStr p.discipline))]
+        | none => [])
+    ++ (match p.display with
+        | some md => [("min", Lean.toJson md.min), ("max", Lean.toJson md.max),
+                      ("log", Json.bool md.log), ("unit", Json.str md.unit)]
+        | none => [])
+    ++ (match p.ownerPort with
+        | some o => [("owner", Json.str o)]
+        | none => [])
   Json.mkObj [
     ("rule", Json.str
       "outlet→inlet valid iff outlet.color ∈ inlet.accepts; modal→signal realizes, signal→modal is a type error"),
     ("colors", Json.arr #[Json.str "signal", Json.str "modal", Json.str "control"]),
-    ("nodes", Json.arr #[
-      node "source"    #[inlet "freq" ctrl, inlet "pm" sig] (some "signal") #["freq", "morph"],
-      node "pluck"     #[inlet "freq" ctrl] (some "signal") #["freq", "morph", "event_rate"],
-      node "comb"      #[inlet "in" sig] (some "signal") #["delay", "decay"],
-      node "flange"    #[inlet "in" sig] (some "signal") #["depth"],
-      node "delay"     #[inlet "in" sig] (some "signal") #["amount"],
-      node "reverse"   #[inlet "in" sig] (some "signal") #[],
-      node "fm"        #[inlet "in" sig] (some "signal") #["carrier", "depth"],
-      node "sflange"   #[inlet "in" sig, inlet "mod" sig] (some "signal") #["depth", "rate"],
-      node "mix"       #[inlet "in" sig true] (some "signal") #[],
-      node "ring"      #[inlet "in" sig true] (some "signal") #[],
-      node "resonator" #[inlet "addr" sig] (some "modal") #["freq", "decay"],
-      node "reverb"    #[inlet "in" modal] (some "modal") #["rt60", "dir", "sway", "rate"],
-      node "modalmix"  #[inlet "in" modal true] (some "modal") #[],
-      node "knob"      #[] (some "control") #["value"],
-      node "out"       #[inlet "in" sig true] none #[] ])]
+    ("kinds", Json.arr (vocabularyKinds.map fun k =>
+      Json.mkObj [
+        ("kind", Json.str k),
+        ("outlet", match outletOf k with
+          | some d => Json.str (domStr d)
+          | none => Json.null),
+        ("ports", Json.arr ((portSpecs k).map portJson))]))]
 
 /-- The live param table: every node's continuous knobs as `(<id>.<knob>, default)`
     in scan order (node order, then knob order). The position IS the `ParamIdx` the

--- a/lean/Tropical/Session.lean
+++ b/lean/Tropical/Session.lean
@@ -2,6 +2,7 @@ import Std.Data.HashMap
 import Lean.Data.Json
 import Tropical.Expr
 import Tropical.Ir.Codec
+import Tropical.Plan
 
 /-!
 # Session state — the authoritative graph topology
@@ -115,6 +116,11 @@ structure SessionSt where
   /-- Param mirror: name → last-known value (raw Json to preserve lexical
       number forms). The service owns the live Param handles. -/
   params       : Array (String × Json) := #[]
+  /-- Host-contract dispatch table for the LOADED plan (name → discipline),
+      seeded from the plan's own `param_disciplines` at load — the unified
+      `set_param` dispatches from this, so no client ever chooses a verb.
+      Empty (a session-model patch, an old plan) ⇒ every write is raw. -/
+  paramDisciplines : Array Tropical.Plan.ParamDiscipline := #[]
   nameCounters : Std.HashMap String Nat := {}
   /-- The typed store (Phase 4 stage 4a): every adopted catalog entry's
       post-strata resolved IR, appended via `decodeResolvedInto`. The

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -1916,56 +1916,71 @@ def unreadParamSlots (plan : Tropical.Plan.FlatPlan) : Array String := Id.run do
   return dead
 
 open Tropical.Playground in
-/-- THE TABLE-COHERENCE gate. The static `nodeSchema` JSON (served as
-    `node_schema`, slated to become a generated view) must agree with the
-    port-spec table — same kinds, same inlets (name/accepts/multi), same knobs
-    in the same order. While both exist, this gate is what makes them ONE
-    description; when the schema becomes generated, the gate becomes a
-    tautology and can retire with it. -/
-private def runVocabCoherence : IO Bool := do
-  let domStr : PortDomain → String
-    | .signal => "signal" | .modal => "modal" | .control => "control"
-  let strArr := fun (j : Lean.Json) => match j.getArr? with
-    | .ok a => a.filterMap (·.getStr?.toOption)
-    | .error _ => #[]
+/-- THE VOCABULARY-DRIVENNESS gate (successor to the table-coherence gate,
+    which retired with the static `nodeSchema` it was pinning). `get_vocabulary`
+    is only honest if the served table can DRIVE a client: for every kind,
+    generate a minimal patch FROM the vocabulary alone (wire each `in` inlet
+    from a domain-matching helper; leave optional normals intact), compile it
+    through the real `compilePlanPure`, and assert every knob the table
+    declares registers a live slot and nothing registered goes unread. A kind
+    added to the table is covered here with no test edit. -/
+private def runVocabDriven (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
   let mut ok := true
+  let mut covered := 0
   let mut issues : Array String := #[]
-  let nodes := match nodeSchema.getObjVal? "nodes" with
-    | .ok (.arr a) => a
-    | _ => #[]
-  -- every schema node must match the table's projection, and cover all kinds
-  let mut schemaKinds : Array String := #[]
-  for nj in nodes do
-    let kind := ((nj.getObjVal? "kind").toOption.bind (·.getStr?.toOption)).getD "?"
-    schemaKinds := schemaKinds.push kind
-    let specs := portSpecs kind
-    -- knobs: names in declaration order
-    let tblKnobs := knobNamesOf kind
-    let schKnobs := strArr ((nj.getObjVal? "knobs").toOption.getD (Lean.Json.arr #[]))
-    if tblKnobs != schKnobs then
-      ok := false; issues := issues.push s!"{kind}: knobs {schKnobs} ≠ table {tblKnobs}"
-    -- inlets: name + accepts + multi
-    let tblInlets := specs.filter (!·.accepts.isEmpty)
-    let schInlets := match (nj.getObjVal? "inlets").toOption.getD (Lean.Json.arr #[]) with
-      | .arr a => a
-      | _ => #[]
-    if tblInlets.size != schInlets.size then
-      ok := false; issues := issues.push s!"{kind}: {schInlets.size} schema inlets ≠ table {tblInlets.size}"
+  for kind in vocabularyKinds do
+    if kind == "out" then continue
+    let mut nodes : Array Lean.Json := #[]
+    let mut inFields : List (String × Lean.Json) := []
+    for p in portSpecs kind do
+      if !p.accepts.isEmpty && p.name == "in" then
+        if p.accepts == #[PortDomain.modal] then
+          nodes := nodes.push (Lean.Json.mkObj
+            [("id", .str "helper_m"), ("kind", .str "resonator"), ("params", Lean.Json.mkObj [])])
+          inFields := inFields ++ [("in", Lean.Json.arr #[.str "helper_m"])]
+        else
+          nodes := nodes.push (Lean.Json.mkObj
+            [("id", .str "helper_s"), ("kind", .str "source"), ("params", Lean.Json.mkObj [])])
+          inFields := inFields ++ [("in", Lean.Json.arr #[.str "helper_s"])]
+    nodes := nodes.push (Lean.Json.mkObj
+      [("id", .str "dut"), ("kind", .str kind), ("params", Lean.Json.mkObj []),
+       ("in", Lean.Json.mkObj inFields)])
+    -- a control-outlet kind (a bare Knob) drives nothing by itself — its
+    -- natural minimal patch consumes it through a source's control inlet, so
+    -- the patch has a generator (and the master-clock slots have a reader).
+    if outletOf kind == some .control then
+      nodes := nodes.push (Lean.Json.mkObj
+        [("id", .str "consumer"), ("kind", .str "source"), ("params", Lean.Json.mkObj []),
+         ("in", Lean.Json.mkObj [("freq", Lean.Json.arr #[.str "dut"])])])
+      nodes := nodes.push (Lean.Json.mkObj
+        [("id", .str "outn"), ("kind", .str "out"),
+         ("in", Lean.Json.mkObj [("in", Lean.Json.arr #[.str "consumer"])])])
     else
-      for (spec, ij) in tblInlets.zip schInlets do
-        let nm := ((ij.getObjVal? "name").toOption.bind (·.getStr?.toOption)).getD "?"
-        let acc := strArr ((ij.getObjVal? "accepts").toOption.getD (Lean.Json.arr #[]))
-        let multi := ((ij.getObjVal? "multi").toOption.bind (·.getBool?.toOption)).getD false
-        if nm != spec.name || acc != spec.accepts.map domStr || multi != spec.multi then
-          ok := false; issues := issues.push s!"{kind}.{nm}: schema inlet ≠ table ({acc}, multi={multi})"
-  if schemaKinds != vocabularyKinds then
-    ok := false; issues := issues.push s!"kind coverage: schema {schemaKinds} ≠ table {vocabularyKinds}"
-  IO.println s!"        {nodes.size} schema kinds vs the port-spec table (inlets, accepts, multi, knob order):"
-  IO.println s!"        result   {if issues.isEmpty then "coherent" else toString issues}"
+      nodes := nodes.push (Lean.Json.mkObj
+        [("id", .str "outn"), ("kind", .str "out"),
+         ("in", Lean.Json.mkObj [("in", Lean.Json.arr #[.str "dut"])])])
+    let patch := Lean.Json.mkObj [("nodes", Lean.Json.arr nodes), ("out", .str "outn")]
+    match Tropical.Playground.compilePlanPure arena resolved patch with
+    | .error e => ok := false; issues := issues.push s!"{kind}: compile: {firstLine e}"
+    | .ok (plan, _) =>
+      covered := covered + 1
+      -- every table knob must land as a slot: raw/anchor knobs under the bare
+      -- name, glided knobs as their #v0 anchor triple.
+      for p in portSpecs kind do
+        if p.knob.isSome then
+          let base := s!"param:dut.{p.name}"
+          if !(plan.slotNames.any (fun s => s == base || s == s!"{base}#v0")) then
+            ok := false; issues := issues.push s!"{kind}: {base} not registered"
+      let dead := unreadParamSlots plan
+      if !dead.isEmpty then
+        ok := false; issues := issues.push s!"{kind}: unread {dead}"
+  IO.println s!"        {covered} kinds, each compiled from a vocabulary-generated minimal patch:"
+  IO.println s!"        result   {if issues.isEmpty then "every declared knob registers and is read" else toString issues}"
   if ok then
-    IO.println "  PASS  vocab-coherence  static nodeSchema ≡ port-spec table — one description, two views"; pure true
+    IO.println "  PASS  vocab-driven  the served vocabulary drives a compiling patch per kind — declared knobs live, nothing unread"; pure true
   else
-    IO.println s!"  FAIL  vocab-coherence  drift between nodeSchema and portSpecs: {issues}"; pure false
+    IO.println s!"  FAIL  vocab-driven  {issues}"; pure false
 
 /-- THE DEAD-SLOT LINT gate (the systemic net for the dead-knob class). Canonical
     patches covering every playground node kind compile through the real
@@ -2494,7 +2509,7 @@ def main (args : List String) : IO UInt32 := do
     if !(← runModalAddr arena resolved) then
       failed := failed + 1
     total := total + 1
-    if !(← runVocabCoherence) then
+    if !(← runVocabDriven arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runDeadSlotLint arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -2037,6 +2037,63 @@ private def runRealizedReport : IO Bool := do
       IO.println s!"  FAIL  realized-report  unwired={unwiredOk} wired={wiredOk} dangler={danglerOk} noWarn={noWarnOk}"; pure false
   | _, _, _ => IO.println "  FAIL  realized-report  patch json parse"; pure false
 
+open Tropical.Playground in
+/-- THE MANIFEST-DISCIPLINE gate. `param_disciplines` is host-contract data:
+    every entry must be consistent with the slots the same plan carries (glide
+    companions exist and the base slot doesn't; anchor/raw base slots exist;
+    the velocity entry names its tau_base companion), and a knob superseded by
+    a wired normal must be absent from the table exactly as it is from the
+    slots. A host dispatching from this table can then trust it blind. -/
+private def runManifestDisciplines (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let patch := fun (withMod : Bool) => "{\"nodes\":[" ++
+    "{\"id\":\"osc\",\"kind\":\"source\",\"params\":{\"freq\":220}}," ++
+    (if withMod then "{\"id\":\"lfo\",\"kind\":\"source\",\"params\":{\"freq\":0.4}}," else "") ++
+    "{\"id\":\"sfw\",\"kind\":\"sflange\",\"params\":{\"depth\":0.002,\"rate\":0.3},\"in\":{\"in\":[\"osc\"]" ++
+    (if withMod then ",\"mod\":[\"lfo\"]" else "") ++ "}}," ++
+    "{\"id\":\"outn\",\"kind\":\"out\",\"in\":{\"in\":[\"sfw\"]}}],\"out\":\"outn\"}"
+  let check := fun (label : String) (plan : Tropical.Plan.FlatPlan) => Id.run do
+    let mut issues : Array String := #[]
+    let names := plan.slotNames
+    for d in plan.paramDisciplines do
+      let base := s!"param:{d.name}"
+      for c in d.companions do
+        if !names.contains s!"param:{c}" then
+          issues := issues.push s!"{label}: {d.name} companion {c} has no slot"
+      match d.discipline with
+      | "glide" =>
+        if names.contains base then
+          issues := issues.push s!"{label}: glided {d.name} has a base slot (companions are the value)"
+        if d.glideDurSec.isNone then
+          issues := issues.push s!"{label}: glided {d.name} missing glide_dur_sec"
+      | "raw" | "anchor" | "velocity" =>
+        if !names.contains base then
+          issues := issues.push s!"{label}: {d.discipline} {d.name} has no base slot"
+      | other => issues := issues.push s!"{label}: unknown discipline {other}"
+    return issues
+  match Lean.Json.parse (patch false), Lean.Json.parse (patch true) with
+  | .ok ju, .ok jw =>
+    match Tropical.Playground.compilePlanPure arena resolved ju,
+          Tropical.Playground.compilePlanPure arena resolved jw with
+    | .ok (pu, _), .ok (pw, _) =>
+      let mut issues := check "unwired" pu ++ check "wired" pw
+      if !(pu.paramDisciplines.any (·.name == "sfw.rate")) then
+        issues := issues.push "unwired: sfw.rate missing from disciplines"
+      if pw.paramDisciplines.any (·.name == "sfw.rate") then
+        issues := issues.push "wired: superseded sfw.rate present in disciplines"
+      if !(pu.paramDisciplines.any fun d => d.name == "master.velocity"
+            && d.discipline == "velocity" && d.companions.contains "master.tau_base") then
+        issues := issues.push "master.velocity entry wrong"
+      IO.println s!"        {pu.paramDisciplines.size}+{pw.paramDisciplines.size} manifest entries checked against their plans' slots:"
+      IO.println s!"        result   {if issues.isEmpty then "consistent" else toString issues}"
+      if issues.isEmpty then
+        IO.println "  PASS  manifest-disciplines  param_disciplines ≡ the plan's slots — a host can dispatch from it blind"; pure true
+      else
+        IO.println s!"  FAIL  manifest-disciplines  {issues}"; pure false
+    | .error e, _ | _, .error e =>
+      IO.println s!"  FAIL  manifest-disciplines  compile: {firstLine e}"; pure false
+  | _, _ => IO.println "  FAIL  manifest-disciplines  json parse"; pure false
+
 /-- THE DEAD-SLOT LINT gate (the systemic net for the dead-knob class). Canonical
     patches covering every playground node kind compile through the real
     `compilePlanPure`, and every `param:*` slot each plan registers must be READ
@@ -2565,6 +2622,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runRealizedReport) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runManifestDisciplines arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runVocabDriven arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -1982,6 +1982,61 @@ private def runVocabDriven (arena : Arena)
   else
     IO.println s!"  FAIL  vocab-driven  {issues}"; pure false
 
+open Tropical.Playground in
+/-- THE REALIZED-STATE REPORT gate. The `load_patch_graph` reply must state
+    FACTS a surface can render — wired vs normalled inputs, live params with
+    disciplines, excluded nodes — and never a warning (house contract: legal-
+    but-incomplete compiles silently; the report tells, it does not scold).
+    This is the protocol-level net for the silence-with-`{ok:true}` class. -/
+private def runRealizedReport : IO Bool := do
+  let mkPatch := fun (withMod : Bool) (dangler : Bool) =>
+    let base := "{\"nodes\":[" ++
+      "{\"id\":\"osc\",\"kind\":\"source\",\"params\":{\"freq\":220}}," ++
+      (if withMod then "{\"id\":\"lfo\",\"kind\":\"source\",\"params\":{\"freq\":0.4}}," else "") ++
+      (if dangler then "{\"id\":\"orphan\",\"kind\":\"source\",\"params\":{\"freq\":99}}," else "") ++
+      "{\"id\":\"sfw\",\"kind\":\"sflange\",\"params\":{\"depth\":0.002,\"rate\":0.3},\"in\":{\"in\":[\"osc\"]" ++
+      (if withMod then ",\"mod\":[\"lfo\"]" else "") ++ "}}," ++
+      "{\"id\":\"outn\",\"kind\":\"out\",\"in\":{\"in\":[\"sfw\"]}}],\"out\":\"outn\"}"
+    base
+  let inputState := fun (rep : Lean.Json) (node port : String) =>
+    match rep.getObjVal? "inputs" with
+    | .ok (.arr a) => (a.find? fun ij =>
+        ((ij.getObjVal? "node").toOption.bind (·.getStr?.toOption)) == some node &&
+        ((ij.getObjVal? "port").toOption.bind (·.getStr?.toOption)) == some port).bind
+        fun ij => (ij.getObjVal? "state").toOption.bind (·.getStr?.toOption)
+    | _ => none
+  let paramNames := fun (rep : Lean.Json) =>
+    match rep.getObjVal? "params" with
+    | .ok (.arr a) => a.filterMap fun (pj : Lean.Json) =>
+        (pj.getObjVal? "name").toOption.bind (·.getStr?.toOption)
+    | _ => #[]
+  let nodeStatus := fun (rep : Lean.Json) (id : String) =>
+    match rep.getObjVal? "nodes" with
+    | .ok (.arr a) => (a.find? fun nj =>
+        ((nj.getObjVal? "id").toOption.bind (·.getStr?.toOption)) == some id).bind
+        fun nj => (nj.getObjVal? "status").toOption.bind (·.getStr?.toOption)
+    | _ => none
+  match Lean.Json.parse (mkPatch false false), Lean.Json.parse (mkPatch true false),
+        Lean.Json.parse (mkPatch false true) with
+  | .ok jUnwired, .ok jWired, .ok jDangler =>
+    let repU := realizedReport jUnwired #[]
+    let repW := realizedReport jWired #[]
+    let repD := realizedReport jDangler #[]
+    let unwiredOk := inputState repU "sfw" "mod" == some "normalled"
+      && (paramNames repU).contains "sfw.rate"
+    let wiredOk := inputState repW "sfw" "mod" == some "wired"
+      && !(paramNames repW).contains "sfw.rate"
+    let danglerOk := nodeStatus repD "orphan" == some "excluded"
+      && nodeStatus repD "osc" == some "active"
+    -- the no-warnings contract, checked on the wire form itself
+    let noWarnOk := ((repU.compress ++ repW.compress ++ repD.compress).toLower.splitOn "warn").length == 1
+    IO.println s!"        unwired: mod={inputState repU "sfw" "mod"} rate-param={((paramNames repU).contains "sfw.rate")} · wired: mod={inputState repW "sfw" "mod"} rate-param={((paramNames repW).contains "sfw.rate")} · orphan={nodeStatus repD "orphan"}"
+    if unwiredOk && wiredOk && danglerOk && noWarnOk then
+      IO.println "  PASS  realized-report  facts, not warnings: normalled/wired inputs, owned knobs absent when superseded, excluded nodes named"; pure true
+    else
+      IO.println s!"  FAIL  realized-report  unwired={unwiredOk} wired={wiredOk} dangler={danglerOk} noWarn={noWarnOk}"; pure false
+  | _, _, _ => IO.println "  FAIL  realized-report  patch json parse"; pure false
+
 /-- THE DEAD-SLOT LINT gate (the systemic net for the dead-knob class). Canonical
     patches covering every playground node kind compile through the real
     `compilePlanPure`, and every `param:*` slot each plan registers must be READ
@@ -2507,6 +2562,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runModalAddr arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runRealizedReport) then
       failed := failed + 1
     total := total + 1
     if !(← runVocabDriven arena resolved) then

--- a/tests/web/param_dispatch_conformance.test.ts
+++ b/tests/web/param_dispatch_conformance.test.ts
@@ -1,0 +1,299 @@
+/**
+ * param_dispatch_conformance.test.ts — the host-param-dispatch differential.
+ *
+ * design/host-param-dispatch.md: every runtime host dispatches param writes
+ * itself from the plan's `param_disciplines` table; no client ever chooses a
+ * write verb. Two implementations exist today:
+ *
+ *   - the Lean control plane (Engine.lean handleSetParamGlide / Freq /
+ *     Velocity — the reference), reached over the socket via the alias verbs
+ *     `set_param_glide` / `set_param_freq` / `set_param_velocity`;
+ *   - the C++ socket data-plane (tropical_socket.cpp `set_param`, dispatching
+ *     per the loaded plan's table against FlatRuntime's slots).
+ *
+ * This gate drives an IDENTICAL write sequence through both, on two separate
+ * engine instances, and requires the companion-slot values (v0/v1/t0, #phase,
+ * tau_base) and the audible output trajectory to match to near-identity.
+ * These are pure closed-form re-anchorings computed from the same inputs, so
+ * they should typically be EXACTLY equal; a material difference means the C++
+ * math diverged from the reference (fix the C++, do not widen the tolerance).
+ *
+ * TIMING: neither run starts audio, so current_sample_index is frozen at 0
+ * for both — `now` is identical and the trajectories are exactly comparable
+ * (verified via `playback_position` before driving writes). With now = 0 the
+ * anchor/velocity bumps multiply by zero by construction, so the glide's
+ * smoothstep is exercised numerically by pre-seeding its companions (t0 < 0:
+ * a ramp already in flight) through raw writes identical in both runs.
+ */
+
+import { describe, test, expect, setDefaultTimeout } from 'bun:test'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { connect, type Socket } from 'node:net'
+import { existsSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+// Each run spawns a full engine and compiles a patch through LLVM; give the
+// file integration-gate headroom, not unit-test headroom.
+setDefaultTimeout(120_000)
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../..')
+// The built binary, never `lake exe` (the lake wrapper's DYLD environment
+// shadows Homebrew's libLLVM by leaf name and the process dies at load).
+const frontendBin = resolve(repoRoot, 'lean/.lake/build/bin/frontend')
+
+// ── Minimal socket client (the tui/scope/client.ts pattern) ────────────────
+// Control-plane replies wrap an inner {status,data} in result.content[0].text;
+// data-plane replies (set_param, render_window, playback_position) are a
+// plain `result`. Unwraps both.
+type Pending = { resolve: (v: any) => void; reject: (e: any) => void }
+
+class EngineClient {
+  private proc: ChildProcess
+  private sock: Socket | null = null
+  private sockPath: string
+  private buf = ''
+  private pending = new Map<number, Pending>()
+  private outbox: string[] = []
+  private nextId = 1
+  private connected = false
+  private dead = false
+
+  constructor(tag: string) {
+    this.sockPath = join(tmpdir(), `tropical-conform-${process.pid}-${tag}.sock`)
+    this.proc = spawn(frontendBin, ['--serve', this.sockPath], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+    this.proc.on('exit', () => this.failAll(new Error('engine exited')))
+    void this.connectLoop()
+  }
+
+  // Wait for the engine to bind its socket node, then connect. Polling for
+  // the file first avoids racing connect() against the bind (bun raises the
+  // ENOENT synchronously, unlike node).
+  private async connectLoop() {
+    for (let attempt = 0; attempt < 300 && !this.dead; attempt++) {
+      if (existsSync(this.sockPath)) {
+        const ok = await new Promise<boolean>((res) => {
+          const s = connect({ path: this.sockPath })
+          s.on('connect', () => {
+            this.sock = s
+            this.connected = true
+            for (const l of this.outbox) s.write(l)
+            this.outbox = []
+            res(true)
+          })
+          s.on('data', (c: Buffer) => this.onData(c.toString()))
+          s.on('error', () => {
+            try { s.destroy() } catch {}
+            res(false)
+          })
+        })
+        if (ok) return
+      }
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    if (!this.dead) this.failAll(new Error(`could not connect to ${this.sockPath}`))
+  }
+
+  private failAll(e: Error) {
+    for (const { reject } of this.pending.values()) reject(e)
+    this.pending.clear()
+  }
+
+  private onData(s: string) {
+    this.buf += s
+    let i: number
+    while ((i = this.buf.indexOf('\n')) >= 0) {
+      const line = this.buf.slice(0, i).trim()
+      this.buf = this.buf.slice(i + 1)
+      if (!line) continue
+      let msg: any
+      try { msg = JSON.parse(line) } catch { continue }
+      if (typeof msg.id !== 'number') continue
+      const p = this.pending.get(msg.id)
+      if (!p) continue
+      this.pending.delete(msg.id)
+      if (msg.error) { p.reject(new Error(`RPC: ${JSON.stringify(msg.error)}`)); continue }
+      const r = msg.result
+      const text = r?.content?.[0]?.text
+      if (typeof text === 'string') {
+        try {
+          const inner = JSON.parse(text)
+          inner.status === 'ok'
+            ? p.resolve(inner.data)
+            : p.reject(new Error(`${inner.error?.code}: ${inner.error?.message}`))
+        } catch (e) { p.reject(e) }
+      } else p.resolve(r)
+    }
+  }
+
+  call(method: string, params: any = {}): Promise<any> {
+    const id = this.nextId++
+    const line = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      if (this.connected && this.sock) this.sock.write(line)
+      else this.outbox.push(line)
+      setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id)
+          reject(new Error(`timeout: ${method}`))
+        }
+      }, 60_000)
+    })
+  }
+
+  kill() {
+    this.dead = true
+    try { this.sock?.destroy() } catch {}
+    try { this.proc.kill() } catch {}
+  }
+}
+
+// ── The patch under test ────────────────────────────────────────────────────
+// source → sflange → out (playground vocabulary), covering all four
+// disciplines in the plan's table:
+//   src.freq        anchor    (#phase companion)
+//   sfl.depth       glide     (#v0/#v1/#t0 companions, no base slot)
+//   sfl.rate        raw
+//   master.velocity velocity  (master.tau_base companion; always in the table)
+const graph = {
+  nodes: [
+    { id: 'src', kind: 'source', params: { freq: 220, morph: 0 }, sel: {}, in: { freq: [] } },
+    { id: 'sfl', kind: 'sflange', params: { depth: 0.006, rate: 0.3 }, sel: {}, in: { in: ['src'], mod: [] } },
+    { id: 'out', kind: 'out', params: {}, sel: {}, in: { in: ['sfl'] } },
+  ],
+  out: 'out', // MANDATORY: the reachability root
+  taps: true, // materialize render_window-readable taps per node
+}
+
+// The companion/base slots whose post-sequence values the two runs must agree
+// on. All are param slots; render_window resolves ANY slot name via
+// slot_index, so a 1-sample window reads them directly.
+const observedSlots = [
+  'param:sfl.depth#v0',
+  'param:sfl.depth#v1',
+  'param:sfl.depth#t0',
+  'param:src.freq',
+  'param:src.freq#phase',
+  'param:master.velocity',
+  'param:master.tau_base',
+  'param:sfl.rate',
+]
+
+// Companion pre-seed: a glide ramp already in flight (t0 in the past — with
+// now frozen at 0 that means t0 < 0), and a nonzero phase offset, so the
+// smoothstep evaluation has a nontrivial value to re-anchor from. Companion
+// names are absent from the discipline table, so these dispatch as raw slot
+// writes — identical in both runs by construction (setup, not the gate).
+const seedWrites: Array<[string, number]> = [
+  ['sfl.depth#v0', 0.001],
+  ['sfl.depth#v1', 0.02],
+  ['sfl.depth#t0', -400],
+  ['src.freq#phase', 0.7],
+]
+
+// The write sequence under test (base names + targets).
+const driveValues = { 'sfl.depth': 0.012, 'src.freq': 440, 'master.velocity': -0.5, 'sfl.rate': 1.5 }
+
+async function loadAndSeed(c: EngineClient): Promise<string> {
+  const report = await c.call('load_patch_graph', graph)
+  expect(report.ok).toBe(true)
+  // No DAC is running, so the master clock is frozen: `now` = 0 for every
+  // write in both runs, making the re-anchorings exactly comparable.
+  const pos = await c.call('playback_position', {})
+  expect(pos.position).toBe(0)
+  for (const [name, value] of seedWrites) await c.call('set_param', { name, value })
+  // The out tap: the patch's final mix, render_window-readable.
+  const outTap = (report.taps as Array<{ name: string; slot: string }>).find((t) => t.name === 'out')
+  expect(outTap).toBeDefined()
+  return outTap!.slot
+}
+
+async function readSlots(c: EngineClient, names: string[]): Promise<number[]> {
+  const r = await c.call('render_window', { start: 0, count: 1, slots: names })
+  return (r.values as number[][]).map((ch) => ch[0])
+}
+
+describe('param dispatch conformance (C++ data-plane ≡ Lean reference)', () => {
+  test('identical write sequence → identical companion slots and audio', async () => {
+    if (!existsSync(frontendBin))
+      throw new Error(`frontend binary missing: ${frontendBin} (run \`make lean\`)`)
+
+    // Run A: the C++ socket data-plane. `set_param` over the socket never
+    // reaches Lean — handle_line routes it to handle_data, which dispatches
+    // per the loaded plan's param_disciplines table.
+    const a = new EngineClient('data')
+    // Run B: the Lean reference, via the control-plane alias verbs.
+    const b = new EngineClient('ctrl')
+    try {
+      const [tapA, tapB] = await Promise.all([loadAndSeed(a), loadAndSeed(b)])
+      expect(tapA).toBe(tapB)
+
+      // The glided param has NO base slot — only companions. render_window
+      // must reject it before AND after the write (the C++ dispatch must not
+      // create or write one).
+      await expect(readSlots(a, ['param:sfl.depth'])).rejects.toThrow(/unknown slot/)
+
+      // Drive the identical sequence.
+      await a.call('set_param', { name: 'sfl.depth', value: driveValues['sfl.depth'] })
+      await a.call('set_param', { name: 'src.freq', value: driveValues['src.freq'] })
+      await a.call('set_param', { name: 'master.velocity', value: driveValues['master.velocity'] })
+      await a.call('set_param', { name: 'sfl.rate', value: driveValues['sfl.rate'] })
+
+      await b.call('set_param_glide', { name: 'sfl.depth', value: driveValues['sfl.depth'] })
+      await b.call('set_param_freq', { name: 'src.freq', value: driveValues['src.freq'] })
+      await b.call('set_param_velocity', { name: 'master.velocity', value: driveValues['master.velocity'] })
+      // raw has no control-plane alias verb; the raw data-plane path is
+      // asserted against its own written value below.
+      await b.call('set_param', { name: 'sfl.rate', value: driveValues['sfl.rate'] })
+
+      // ── The differential: companion trajectories must match ──────────────
+      const [slotsA, slotsB] = await Promise.all([
+        readSlots(a, observedSlots),
+        readSlots(b, observedSlots),
+      ])
+      for (let i = 0; i < observedSlots.length; i++) {
+        // Closed-form re-anchorings from the same inputs: typically exactly
+        // equal; 1e-9 absorbs float noise only.
+        expect(Math.abs(slotsA[i] - slotsB[i]),
+          `${observedSlots[i]}: data-plane ${slotsA[i]} vs reference ${slotsB[i]}`,
+        ).toBeLessThanOrEqual(1e-9)
+      }
+
+      // ── Pin the values themselves (not just agreement) ────────────────────
+      const v = Object.fromEntries(observedSlots.map((n, i) => [n, slotsA[i]]))
+      // glide: dur = 0.02·SR (SR = 44100 for the arrow patch plan);
+      // s = clamp((0 − (−400))/882, 0, 1), curr = v0 + (v1−v0)·s²(3−2s).
+      const s = Math.min(1, Math.max(0, (0 - -400) / (0.02 * 44100)))
+      const expectedV0 = 0.001 + (0.02 - 0.001) * (s * s * (3 - 2 * s))
+      expect(Math.abs(v['param:sfl.depth#v0'] - expectedV0)).toBeLessThanOrEqual(1e-12)
+      expect(v['param:sfl.depth#v1']).toBe(driveValues['sfl.depth']) // target lands in v1
+      expect(v['param:sfl.depth#t0']).toBe(0) // re-anchored to now
+      // anchor: Δφ = (inc0 − inc1)·now/2³² = 0 at now = 0 — phase unchanged,
+      // base written after the bump.
+      expect(v['param:src.freq']).toBe(driveValues['src.freq'])
+      expect(v['param:src.freq#phase']).toBe(0.7)
+      // velocity: tau_base += (v0 − target)·now/SR = 0 at now = 0.
+      expect(v['param:master.velocity']).toBe(driveValues['master.velocity'])
+      expect(v['param:master.tau_base']).toBe(0)
+      // raw dispatches as a plain base-slot write, exactly as before.
+      expect(v['param:sfl.rate']).toBe(driveValues['sfl.rate'])
+
+      // Still no base slot for the glided param after the write.
+      await expect(readSlots(a, ['param:sfl.depth'])).rejects.toThrow(/unknown slot/)
+
+      // ── Audible trajectory: identical slot state ⇒ bit-identical audio ────
+      const winA = await a.call('render_window', { start: 0, count: 512, slots: [tapA] })
+      const winB = await b.call('render_window', { start: 0, count: 512, slots: [tapB] })
+      expect(winA.values[0]).toEqual(winB.values[0])
+    } finally {
+      a.kill()
+      b.kill()
+    }
+  })
+})

--- a/tui/scrub/app.tsx
+++ b/tui/scrub/app.tsx
@@ -30,9 +30,9 @@ const GROUP_LABEL: Record<string, string> = {
 // the global master clock (re-basing τ for continuity), the rest step.
 const METHOD: Record<ParamMode, string> = {
   live: 'set_param',
-  glide: 'set_param_glide',
-  freq: 'set_param_freq',
-  velocity: 'set_param_velocity',
+  glide: 'set_param',
+  freq: 'set_param',
+  velocity: 'set_param',
 }
 
 // The forward / freeze / reverse readout for the global time-warp knob.

--- a/tui/scrub/patch.ts
+++ b/tui/scrub/patch.ts
@@ -6,10 +6,10 @@
 // the EmitArrow patch-graph (see lean/Tropical/Playground.lean). So this is now
 // a fixed patch-GRAPH driven live over the same three RPCs the playground uses:
 //
-//   set_param          — a raw slot write (steps at block rate)
-//   set_param_glide    — a closed-form smoothstep ramp (click-free, stateless)
-//   set_param_freq     — a phase-anchored freq change (waveform stays continuous)
-//   set_param_velocity — the GLOBAL time-warp scrub (re-bases τ for continuity)
+//   set_param — ONE verb; the engine dispatches per the loaded plan's
+//   param_disciplines table (raw slot write / closed-form glide /
+//   phase-anchored freq / master-clock velocity re-base) — the caller
+//   never chooses semantics (design/host-param-dispatch.md).
 //
 // The graph (downstream-only, in the playground's node vocabulary):
 //

--- a/tui/scrub/smoke.ts
+++ b/tui/scrub/smoke.ts
@@ -5,9 +5,9 @@ import { buildGraph, PARAMS, type ParamMode } from './patch'
 
 const METHOD: Record<ParamMode, string> = {
   live: 'set_param',
-  glide: 'set_param_glide',
-  freq: 'set_param_freq',
-  velocity: 'set_param_velocity',
+  glide: 'set_param',
+  freq: 'set_param',
+  velocity: 'set_param',
 }
 // The seeded-slot name a mode's drive addresses: a glided knob lives in its
 // `#v0` ramp slot; a raw/anchored knob in the bare slot (see Playground.collectParams).
@@ -28,7 +28,7 @@ const main = async () => {
   for (const p of PARAMS) {
     await c.call(METHOD[p.mode], { name: p.slot, value: p.value })
   }
-  console.log('drive OK — set_param / set_param_glide / set_param_freq all live')
+  console.log('drive OK — unified set_param dispatches raw/glide/anchor/velocity engine-side')
   c.kill()
 }
 main().catch((e) => { console.error('FAIL:', e.message); c.kill(); process.exit(1) })


### PR DESCRIPTION
Phases 3-6 of the API rework (PR A = #199, phases 0-2). Validate fully green: tropicaltest 59/59, bun 77/0 (including the new conformance differential), ctest clean.

The organizing seam: **compiler API** (durable, survives any future runtime host) vs **host contract** (per-runtime, specified as manifest data + a normative spec, never as C++ socket features).

## Phase 3 — `get_vocabulary` (compiler API)
The port-spec table served as data: per kind, outlet color + ports; per port, inlet facts, knob facts (default, write discipline, display metadata min/max/log/unit), and `owner` for knobs that parameterize another port's normal. The static `nodeSchema` and its `node_schema` arm are deleted (zero consumers verified). New `vocab-driven` gate generates a minimal patch per kind FROM the served table and asserts every declared knob lands live — a new kind is covered with no test edit.

## Phase 4 — the realized-state report (compiler API)
`load_patch_graph` replies with facts: nodes active/excluded (reachability from `out`), inputs wired|normalled, live params with disciplines, tap slots. No warnings, ever — the report tells, it does not scold. The silence-with-`{ok:true}` class dies at the protocol. New `realized-report` gate.

## Phase 5 — `param_disciplines` in the manifest (host contract)
Per-param write discipline (raw|glide|anchor|velocity, glide duration, companion slots) rides the plan wire format next to `slot_names`/`slot_defaults` — a fact about the compiled patch, readable by any host. `design/host-param-dispatch.md` is the normative re-anchoring math (Lean control plane = reference implementation). Contains-guarded C++ parse; old plans and old parsers unaffected. New `manifest-disciplines` gate pins the table to the plan's actual slots.

## Phase 6 — one `set_param`, both dispatchers (host contract)
- **Lean**: `set_param` dispatches by the loaded table (glide/anchor/velocity internals; raw fallback; engine-owned exception for the reserved `master.velocity`). The three old verbs remain as migration aliases. Fixes the mirror bug — glide/freq writes now update `st.params`, so `list_params` stops lying. `tui/scrub` migrated to the single verb.
- **C++ data plane**: the socket's `set_param` dispatches from the same table (copied onto `KernelState` at build, hot-swapping with the plan), all multi-slot re-anchorings under one `with_active_state_sync` so a mid-dispatch swap can't land at stale indices.
- **Conformance differential** (`tests/web/param_dispatch_conformance.test.ts`): identical write sequences through the C++ data plane vs the Lean reference → companion-slot trajectories equal at 1e-9 and pinned to independently computed math; out-tap render bit-identical. Mutation-checked: corrupting the C++ smoothstep coefficient fails the gate with the exact slot diff.

Next: Phase 7 (Swift app: EngineHost protocol, socket transport, vocabulary consumption, report-driven UI, render_window scopes — separate repo) and Phase 8 (alias deletion after 7c).

Generated with [Claude Code](https://claude.com/claude-code)
