### PR TITLE
fix(playground): kill the engine on Cmd+Q, not just window-close

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -34,10 +34,22 @@ function startEngine() {
   })
   engine.stderr.on('data', (d) => process.stderr.write(`[engine] ${d}`))
   engine.on('exit', (code) => {
+    engine = null
     for (const { reject } of pending.values()) reject(new Error('engine exited'))
     pending.clear()
     if (!app.isQuitting) console.error(`engine exited (${code})`)
   })
+}
+
+// Kill the engine child. SIGTERM (the engine reaps it cleanly), with a SIGKILL
+// fallback in case it's wedged mid-compile. Idempotent: `engine` is nulled on
+// exit, so repeated calls are no-ops.
+function stopEngine() {
+  const child = engine
+  if (!child) return
+  try { child.kill('SIGTERM') } catch {}
+  const t = setTimeout(() => { try { child.kill('SIGKILL') } catch {} }, 2000)
+  child.on('exit', () => clearTimeout(t))
 }
 
 function tryConnect(attempt = 0) {
@@ -110,8 +122,23 @@ app.whenReady().then(() => {
   win.loadFile(join(__dirname, 'renderer/index.html'))
 })
 
-app.on('window-all-closed', () => {
+// Engine teardown lives in `before-quit`, NOT `window-all-closed`: the latter
+// is documented as *not emitted* when the app quits via Cmd+Q or app.quit(), so
+// cleanup hung there leaks the engine on the normal macOS quit path (it gets
+// reparented to launchd and orphaned). before-quit fires on every quit path.
+app.on('before-quit', () => {
   app.isQuitting = true
-  try { engine?.kill() } catch {}
+  stopEngine()
+})
+
+// Closing the window quits the app (single-window instrument); this in turn
+// fires before-quit, which does the actual engine kill.
+app.on('window-all-closed', () => {
   app.quit()
 })
+
+// If the main process itself is signalled (e.g. killed from a terminal), Electron
+// won't run before-quit — reap the child ourselves so it never outlives us.
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(sig, () => { stopEngine(); app.quit() })
+}


### PR DESCRIPTION
## Problem

The Electron demo spawns `frontend --serve` but only reaped it from a `window-all-closed` handler. That event is **not emitted** on the normal macOS quit path (Cmd+Q / `app.quit()`), so the kill never ran and the engine got reparented to launchd — an orphan holding the socket. (Confirmed live: PID 56260 reparented to launchd after its launcher died.)

## Fix

- Engine teardown moved into `before-quit` (fires on every quit path) via a new idempotent `stopEngine()` — SIGTERM with a SIGKILL fallback for a wedged mid-compile child.
- `window-all-closed` now just triggers `app.quit()`.
- Process-level `SIGINT`/`SIGTERM`/`SIGHUP` handlers reap the child if the main process is signalled directly from a terminal.

## Verification

Single-file change to `playground/main.js` (+29/−2). Verified by reasoning + by-hand SIGTERM proof that the signal kills the engine; not exercised headlessly (no display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)