### PR TITLE
Seam hardening: the modal-datapath rail fix (option E), surface seal, §5 gauge, and live poles across the bloom (WS-LP 0–1)

### DIFF
--- a/demos/bridge_verify.py
+++ b/demos/bridge_verify.py
@@ -1,0 +1,113 @@
+"""High-precision settling of the bloomComposedSig 'semantically invalid' claim.
+
+The docstring (Modal.lean:1212) says: at Re(a) ~ -1 (a near a negative integer)
+the Gamma-star bridge is 'semantically invalid, the two lane-totals disagree by
+~1e8'. The recon claims: the bridge is EXACT; only the float64 series-M Horner is
+garbage (catastrophic cancellation). Settle it with mpmath at 80 digits.
+
+Formulas transcribed from Modal.lean crossing bake (1121-1138) + bloomComposedSig
+(1216-1319, non-coincident crossing lanes 1302-1317) and the CplxB numerics.
+"""
+import mpmath as mp
+mp.mp.dps = 80
+
+TWO_PI = 2 * mp.pi
+g = mp.mpf('1.8')
+
+def cf_hp(a, z):
+    """CF(z) = Gamma(a,z)*e^z*z^{-a} at high precision (the code's bloomCF twin)."""
+    return mp.gammainc(a, z) * mp.e**z * z**(-a)
+
+def M_hp(a, z):
+    """M(1,a+1,z) = hyp1f1(1, a+1, z) at high precision."""
+    return mp.hyp1f1(1, a + 1, z)
+
+def gamma_star_hp(a, kappa):
+    """Gamma* = Gamma(a)*kappa^{-a}*e^kappa / g, via exp(lgamma - a log k + k)/g."""
+    return mp.e**(mp.loggamma(a) - a * mp.log(kappa) + kappa) / g
+
+def M_float_horner(a, z, nDepth):
+    """The code's FIXED-DEPTH float64 series Horner (bloomComposedSig:1303-1304):
+       mser = foldr (fun ik h => 1 + z*ik*h) 1  over invA = [1/(a+k+1)]."""
+    import cmath
+    a = complex(a); z = complex(z)
+    invA = [1.0 / (a + (k + 1)) for k in range(nDepth)]
+    h = complex(1, 0)
+    for ik in reversed(invA):
+        h = 1 + z * ik * h
+    return h
+
+def lanes(mu, nu, B, an_re, an_im, dprobe, nDepth, kDepth):
+    a = (nu - mu) / g
+    kappa = mu * B
+    # crossing bake
+    cfK = cf_hp(a, kappa)
+    gs = gamma_star_hp(a, kappa)
+    k1Ser = gs - cfK / g
+    k1Cf = -cfK / g
+    fSer = -1 / (nu - mu)
+    # at dprobe
+    d = mp.mpf(dprobe)
+    eg = mp.e**(-g * d)
+    z = kappa * eg
+    off = B * (1 - eg)
+    Env_nu = mp.e**(nu * d)
+    Env_mu = mp.e**(mu * (d + off))
+    # series lane (high precision M)
+    Mhp = M_hp(a, z)
+    k2ser_hp = Mhp * fSer
+    ser_hp = k1Ser * Env_nu + k2ser_hp * Env_mu
+    # CF lane (high precision)
+    k2cf = cf_hp(a, z) / g
+    cf_hp_total = k1Cf * Env_nu + k2cf * Env_mu
+    # series lane with the code's float64 Horner M
+    Mf = M_float_horner(a, z, nDepth)
+    k2ser_f = complex(Mf) * complex(fSer)
+    ser_f = complex(k1Ser) * complex(Env_nu) + k2ser_f * complex(Env_mu)
+    return dict(a=a, kappa=kappa, z=z, Mhp=Mhp, Mf=Mf,
+                ser_hp=ser_hp, cf_hp=cf_hp_total, ser_f=ser_f,
+                dSwitch=mp.log(abs(kappa) / abs(a + 1)) / g)
+
+def show(title, mu, nu, B, dprobe, nDepth, kDepth):
+    r = lanes(mu, nu, B, None, None, dprobe, nDepth, kDepth)
+    a, kappa, z = r['a'], r['kappa'], r['z']
+    ser_hp, cf_hp_v, ser_f = r['ser_hp'], r['cf_hp'], r['ser_f']
+    gap_hp = abs(ser_hp - cf_hp_v) / max(abs(ser_hp), abs(cf_hp_v))
+    print(f"\n== {title} ==")
+    print(f"   a = {mp.nstr(a,6)}   |a|={mp.nstr(abs(a),5)}  |kappa|={mp.nstr(abs(kappa),5)}  dSwitch={mp.nstr(r['dSwitch'],5)}  probe d={dprobe}")
+    print(f"   |z| at probe = {mp.nstr(abs(z),6)}")
+    print(f"   HP  M(1,a+1,z) = {mp.nstr(r['Mhp'],6)}   |M|={mp.nstr(abs(r['Mhp']),6)}")
+    print(f"   f64 M (Horner) = {r['Mf']}   |M|={abs(r['Mf']):.6e}")
+    print(f"   RELATIVE M error (f64 vs HP) = {mp.nstr(abs(r['Mf']-r['Mhp'])/abs(r['Mhp']),4)}")
+    print(f"   BRIDGE at d: |ser_hp|={mp.nstr(abs(ser_hp),6)}  |cf_hp|={mp.nstr(abs(cf_hp_v),6)}  RELGAP(HP)={mp.nstr(gap_hp,4)}")
+    print(f"   float64 series lane |ser_f|={abs(ser_f):.6e}  vs HP cf |cf_hp|={mp.nstr(abs(cf_hp_v),6)}")
+    fgap = abs(complex(ser_f) - complex(cf_hp_v)) / max(abs(complex(ser_f)), abs(complex(cf_hp_v)))
+    print(f"   float64-ser vs HP-cf RELGAP = {fgap:.4e}   <- what the render would 'see' at the switch")
+
+# ---- a benign moderate crossing (control): |a| ~ 7, Im a large ----
+mu = mp.mpc(-2.0, TWO_PI * 110)
+nu = mp.mpc(-5.0, TWO_PI * 112)
+show("benign crossing (|a|~7, Im a large)", mu, nu, mp.mpf('0.05')/g, 0.3, 40, 20)
+
+# ---- the hazard: a near -1, Im a small, but |kappa| SMALL enough to not depth-explode ----
+# choose mu with small |mu| so |kappa|=|mu|B is small; a.re ~ -0.98
+vSig = mp.mpf('0.5'); vOm = TWO_PI * 40    # a LOW partial -> small |kappa|
+mu2 = mp.mpc(-vSig, vOm)
+# a.re = (vSig - rSig)/g = -0.98 -> rSig = vSig + 0.98*g
+rSig = vSig + mp.mpf('0.98') * g
+rOm = vOm + mp.mpf('0.05') * g             # a.im ~ 0.05
+nu2 = mp.mpc(-rSig, rOm)
+a2 = (nu2 - mu2)/g
+k2 = mu2 * (mp.mpf('0.05')/g)
+print(f"\n[hazard config] a={mp.nstr(a2,6)} |kappa|={mp.nstr(abs(k2),5)} |a+1|={mp.nstr(abs(a2+1),5)}")
+show("hazard: a near -1, small |kappa|", mu2, nu2, mp.mpf('0.05')/g, 0.2, 60, 20)
+
+# ---- the hazard with LARGE |kappa| (the 'filter on its own partial' config) ----
+vSig3 = mp.mpf('0.5'); vOm3 = TWO_PI * 440
+mu3 = mp.mpc(-vSig3, vOm3)
+rSig3 = vSig3 + mp.mpf('0.98') * g
+rOm3 = vOm3 + mp.mpf('0.05') * g
+nu3 = mp.mpc(-rSig3, rOm3)
+a3 = (nu3 - mu3)/g; k3 = mu3 * (mp.mpf('0.05')/g)
+print(f"\n[hazard-largek config] a={mp.nstr(a3,6)} |kappa|={mp.nstr(abs(k3),5)} |a+1|={mp.nstr(abs(a3+1),5)}")
+show("hazard: a near -1, LARGE |kappa| (filter-on-partial)", mu3, nu3, mp.mpf('0.05')/g, 0.2, 120, 40)

--- a/design/seam-atom-contract.md
+++ b/design/seam-atom-contract.md
@@ -63,7 +63,20 @@ Everything load-bearing is in that sentence, so read it slowly.
   predicate's served region): these are outputs of a predicate the
   harness can probe, not inputs from a human squint. An atom and the harness
   consult the *same* predicate, so "where does this atom promise anything" has
-  one answer, in code.
+  one answer, in code. WS-CL sharpened the predicate into a **total classifier**:
+  `classifyBloomPair : (μ,ν,B,g) → SeamRegion`, where `SeamRegion` is a closed
+  partition (`serOnly | crossing | coincidentCrossing | coincidentSubtle |
+  excludedDepth`) and the atom's per-pair emit is an *exhaustive match* over it —
+  a region with no handler will not compile, so **types prove coverage** while the
+  sweep and the SNR threshold prove **accuracy** (that division of labor is the
+  design, not a compromise: an SNR is empirical and can never be typed). The
+  depth-cap drop is the named `excludedDepth` region, not a silent `continue`, and
+  the coverage gate (`runSeamCoverage`) Halton-classifies the legal config box to
+  report the admitted fraction as a number — turning "is the partition total over
+  the shipped surface" into `1.0` with the ≤300 cap shown as MEASURED headroom (a
+  sampled max over the Halton batch + a max-|κ| corner scan — empirical, not a typed
+  bound; only the exhaustive `SeamRegion` match is type-proven, per the same
+  division of labor above — an envelope depth, like an SNR, can never be typed).
 
 ## The four fields
 
@@ -102,7 +115,7 @@ apparatus is kept, not frozen.
 |---|---|---|---|
 | `residueComposeEC` | `id` | collected `ModalMode` bank · `modalBankSigTable` | separated poles (`|Δ|` above the coincidence floor — near-coincidence is `DD`'s region) |
 | `residueComposeDD` | `id` | `PairedMode` bank · `modalBankSigTableDD` | total (the `cexpm1` limit is the τ·e resonance, no branch) |
-| `bloomCompose` | `s + B(1−e^{−gs})` | `BloomPair` bank · `bloomComposedSig` | baked poles; envelope depth ≤ 300 — TOTAL over `|a|` (WS-A4: coincidence via the divided-difference branch; ½ is a scheme crossover) |
+| `bloomCompose` | `s + B(1−e^{−gs})` | `BloomPair` bank · `bloomComposedSig` | baked poles; `classifyBloomPair → SeamRegion` (WS-CL), exhaustive per-pair dispatch. TOTAL over `|a|` (WS-A4: coincidence via the divided-difference branch; ½ is a scheme crossover); `excludedDepth` (>300) is the only drop, counted by the coverage gate. Emit is region-indexed — coincident pairs carry no E1 lane, `coincidentSubtle` no CF lane (bit-clean, gated) |
 
 `bloomCompose` at `B→0` collapses to `residueComposeDD` (the Γ-bridge is the
 κ-extension of the divided difference), so the three are one family with a

--- a/engine/dac/TropicalDAC.hpp
+++ b/engine/dac/TropicalDAC.hpp
@@ -10,6 +10,53 @@
 
 static constexpr int kPrimeCycles = 4;
 
+/**
+ * C — the device-boundary output bound. The last thing between a computed
+ * value and a speaker: `out = clamp(sample, ±C)`.
+ *
+ * This is the first SAFETY-class gate in the project. Every other gate proves
+ * agreement (wasm ≡ JIT), preservation (goldens), or law-conformance (the seam
+ * atoms); none of them bounds MAGNITUDE, and two backends can bit-agree on a
+ * speaker-destroying burst. Stateless hard min/max is the whole mechanism —
+ * closed-form, bit-transparent below C, no state, no smoothing. NOT a limiter
+ * and NOT a softclip: the purity story is swap continuity, and a hard clamp
+ * downstream of the kernel does not touch it.
+ *
+ * WHY HERE AND NOT IN THE KERNEL. The emitted kernel's output buffer is not
+ * the device boundary — it is the value of `f(τ)`, and the whole system reads
+ * it as a number: `diffcli render-bytes`, the frozen goldens, the wasm≡JIT
+ * differential, and the numeric coverage gates all consume it. `bootstrap-exp`
+ * legitimately renders exp(x) out to e^10 ≈ 22026 through the sink to check the
+ * emitted polynomial against libm. Clamping in `emitSinks` would make the
+ * compiler lie about the value of the closed-form function, and would bake an
+ * audio-specific magnitude assumption into an evaluator that is meant to stay
+ * nature-agnostic (video, control-rate). The DAC callback is where a value
+ * becomes sound, so it is where a sound-safety bound belongs. `WasmKernel`
+ * mirrors this exactly: `render()` (the equivalence surface) is untouched and
+ * `process()` (the worklet feed) clamps — see `web/runtime/kernel.ts`.
+ *
+ * MEASURED at landing (2026-07-20): peak |sample| over the whole patch corpus —
+ * `patches/{reverse_reverb,scrub_reverb}` and `web/patches/{pure-sine-440,
+ * ring-mod,tz-flanger}`, 16384 samples each — is 1.807, so C = 4 is the
+ * smallest power of two comfortably above it, at 2.2× headroom. For scale: the
+ * i64 modal-datapath rail incident (design/modal-datapath-rail.local.md)
+ * produced peaks of 63.3, 16× past this bound. The clamp is what protects the
+ * interval between "this rail is fixed" and "the next rail is discovered."
+ *
+ * NaN maps to −C: the first comparison is false on NaN, so the low arm takes
+ * −C, which then passes the high arm. Ordered-compare + select rather than
+ * std::fmin/fmax, whose IEEE minNum semantics return the *other* operand on NaN
+ * and leave signed zero unspecified. Exact for every non-NaN value in [−C, C],
+ * including −0.0 and denormals.
+ */
+static constexpr double kDeviceOutputBound = 4.0;
+
+static inline double clamp_to_device_bound(double x)
+{
+  const double lo = x > -kDeviceOutputBound ? x : -kDeviceOutputBound;
+  return lo < kDeviceOutputBound ? lo : kDeviceOutputBound;
+}
+
 static inline void update_max(std::atomic<uint64_t>& cur, uint64_t val)
 {
   uint64_t prev = cur.load(std::memory_order_relaxed);
@@ -230,7 +277,11 @@ struct TropicalDACImpl
 
     for (unsigned int i = 0; i < n_buffer_frames; ++i)
     {
-      const double sample = i < buf.size() ? buf[i] : 0.0;
+      // The device-boundary clamp — the last thing before the speaker, applied
+      // AFTER the runtime's fade envelope (which is in [0,1] and so can never
+      // defeat it). See kDeviceOutputBound.
+      const double sample =
+          clamp_to_device_bound(i < buf.size() ? buf[i] : 0.0);
       for (unsigned int c = 0; c < self->channels; ++c)
         *out++ = sample;
     }

--- a/engine/dac/TropicalDAC.hpp
+++ b/engine/dac/TropicalDAC.hpp
@@ -35,13 +35,34 @@ static constexpr int kPrimeCycles = 4;
  * mirrors this exactly: `render()` (the equivalence surface) is untouched and
  * `process()` (the worklet feed) clamps — see `web/runtime/kernel.ts`.
  *
- * MEASURED at landing (2026-07-20): peak |sample| over the whole patch corpus —
+ * WHAT SETS C. Not the patch corpus. Peak |sample| over
  * `patches/{reverse_reverb,scrub_reverb}` and `web/patches/{pure-sine-440,
- * ring-mod,tz-flanger}`, 16384 samples each — is 1.807, so C = 4 is the
- * smallest power of two comfortably above it, at 2.2× headroom. For scale: the
- * i64 modal-datapath rail incident (design/modal-datapath-rail.local.md)
- * produced peaks of 63.3, 16× past this bound. The clamp is what protects the
- * interval between "this rail is fixed" and "the next rail is discovered."
+ * ring-mod,tz-flanger}` is only 1.807 (measured 2026-07-20, 16384 samples
+ * each), and C = 4 shipped on that basis — but that corpus contains no modal
+ * playground patches, and the modal vocabulary legitimately reaches far higher.
+ * A resonant lowpass has Q gain at resonance: `filterPair` maps
+ * `res ↦ Q = 0.55·80^res`, the composed modal coefficient is `|A| ≈ Q`, and the
+ * rendered peak is `≈ Q · master_gain`. At the top of the resonance knob
+ * (res = 1, Q = 44, master gain 3.7) that is ≈ 163 — spike-free, correct, and
+ * exactly the physics of a driven high-Q resonator. C = 4 would have hard-clipped
+ * the top of a shipped knob by 20×. C = 256 is the smallest power of two above
+ * the vocabulary's legitimate reach.
+ *
+ * C IS A HAZARD BOUND, NOT A LEVEL CONTROL. This follows `defaultSinkGain`'s
+ * own committed position — amplitude is a frontend concern; the backend invents
+ * no headroom scale of its own. C exists to stop the unbounded (∞, NaN, a 1e9
+ * excursion from a datapath defect), not to voice the instrument.
+ *
+ * AND IT CANNOT DISCRIMINATE THE MODAL RAIL — stated plainly because the
+ * temptation to believe otherwise is the whole hazard. The i64 modal-datapath
+ * incident (design/modal-datapath-rail.local.md) renders peaks of ≈ 234 on the
+ * production path, which is BELOW this C and therefore passes the clamp
+ * untouched. That is not a hole to close by lowering C: the incident's peak and
+ * the vocabulary's legitimate peak are the same order (234 vs 163, a factor of
+ * 1.4), because both are `≈ Q · gain` — no value of C admits the instrument and
+ * rejects the burst. The rail is fixed at its source (per-bank landing exponent);
+ * the clamp is defense in depth against the NEXT defect, whose magnitude is
+ * unknown and may be unbounded. Do not re-tune C to chase a known rail.
  *
  * NaN maps to −C: the first comparison is false on NaN, so the low arm takes
  * −C, which then passes the high arm. Ordered-compare + select rather than
@@ -49,7 +70,7 @@ static constexpr int kPrimeCycles = 4;
  * and leave signed zero unspecified. Exact for every non-NaN value in [−C, C],
  * including −0.0 and denormals.
  */
-static constexpr double kDeviceOutputBound = 4.0;
+static constexpr double kDeviceOutputBound = 256.0;
 
 static inline double clamp_to_device_bound(double x)
 {

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -11,11 +11,13 @@
  */
 
 #include "c_api/tropical_c.h"
+#include "dac/TropicalDAC.hpp"   // kDeviceOutputBound / clamp_to_device_bound
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <string>
 
 static int g_pass = 0;
@@ -151,12 +153,76 @@ static void test_ir_index_ramp()
   tropical_runtime_free(rt);
 }
 
+// ─────────────────────────────────────────────────────────────
+// The device-boundary clamp (the safety-class gate)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * `clamp_to_device_bound` is the last thing between a computed value and a
+ * speaker (TropicalDAC's callback applies it per sample, after the fade). Two
+ * properties, both load-bearing:
+ *
+ *   BOUNDEDNESS — nothing leaves the device boundary outside [−C, C], for any
+ *   input at all, including the rail-incident magnitudes (63.3) and non-finite
+ *   values. This is the property the gate exists for.
+ *
+ *   BIT-TRANSPARENCY — every non-NaN value already inside [−C, C] passes
+ *   through UNCHANGED, bit for bit: ±0.0 keep their signs, denormals survive,
+ *   and the endpoints themselves are fixed points. This is what makes the
+ *   clamp invisible to every existing golden.
+ *
+ * MUTATION: delete the clamp from TropicalDAC::fill_buffer (or widen
+ * kDeviceOutputBound past 63.3) and the boundedness assertions below fail.
+ */
+static void test_device_bound_clamp()
+{
+  const double C = kDeviceOutputBound;
+
+  // Bit-transparency below C — compare BITS, not values, so signed zero counts.
+  const double transparent[] = {
+    0.0, -0.0, 1.0, -1.0, 1.807261 /* the corpus peak */, -1.807261,
+    C, -C, 4.9406564584124654e-324 /* min denormal */, -2.2250738585072014e-308,
+  };
+  for (double v : transparent)
+  {
+    const double got = clamp_to_device_bound(v);
+    uint64_t vb, gb;
+    std::memcpy(&vb, &v, 8);
+    std::memcpy(&gb, &got, 8);
+    ASSERT(vb == gb);
+  }
+
+  // Boundedness above C — including the measured rail-incident peak.
+  const double over[] = { 4.0000001, 5.0, 63.3, 64.0, 1e9,
+                          std::numeric_limits<double>::infinity() };
+  for (double v : over)
+  {
+    ASSERT(clamp_to_device_bound(v) == C);
+    ASSERT(clamp_to_device_bound(-v) == -C);
+  }
+
+  // NaN is silenced to −C (ordered compare fails, so the low arm takes −C).
+  // Crucially it does NOT pass through: a NaN reaching a DAC is a click at
+  // best. This is the one input the clamp deliberately does not preserve.
+  const double got_nan =
+      clamp_to_device_bound(std::numeric_limits<double>::quiet_NaN());
+  ASSERT(!std::isnan(got_nan));
+  ASSERT(got_nan == -C);
+
+  // The bound itself: a power of two, above the measured corpus peak, and far
+  // below the rail incident it exists to catch.
+  ASSERT(C == 4.0);
+  ASSERT(C > 1.807261);
+  ASSERT(C < 63.3);
+}
+
 int main()
 {
   printf("test_module_process (load_ir engine)\n");
 
   run_test("constant kernel via load_ir",   test_ir_constant);
   run_test("closed-form index ramp",        test_ir_index_ramp);
+  run_test("device-boundary clamp",         test_device_bound_clamp);
 
   printf("\n  %d passed, %d failed\n", g_pass, g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -163,16 +163,24 @@ static void test_ir_index_ramp()
  * properties, both load-bearing:
  *
  *   BOUNDEDNESS — nothing leaves the device boundary outside [−C, C], for any
- *   input at all, including the rail-incident magnitudes (63.3) and non-finite
- *   values. This is the property the gate exists for.
+ *   input at all, including gross excursions and non-finite values. This is the
+ *   property the gate exists for.
  *
  *   BIT-TRANSPARENCY — every non-NaN value already inside [−C, C] passes
  *   through UNCHANGED, bit for bit: ±0.0 keep their signs, denormals survive,
  *   and the endpoints themselves are fixed points. This is what makes the
  *   clamp invisible to every existing golden.
  *
+ * The transparency list deliberately includes 163.5 (the modal vocabulary's
+ * legitimate peak at the top of the resonance knob, ≈ Q·master_gain) and 233.7
+ * (the measured i64 modal-datapath rail incident). BOTH pass through untouched
+ * at C = 256, and the second one is an asserted non-property, not an oversight:
+ * the clamp does not and cannot discriminate that rail, because the burst and
+ * the music are the same order of magnitude. See kDeviceOutputBound. The rail
+ * is fixed at its source; this gate bounds the unbounded.
+ *
  * MUTATION: delete the clamp from TropicalDAC::fill_buffer (or widen
- * kDeviceOutputBound past 63.3) and the boundedness assertions below fail.
+ * kDeviceOutputBound past 1e9) and the boundedness assertions below fail.
  */
 static void test_device_bound_clamp()
 {
@@ -181,6 +189,8 @@ static void test_device_bound_clamp()
   // Bit-transparency below C — compare BITS, not values, so signed zero counts.
   const double transparent[] = {
     0.0, -0.0, 1.0, -1.0, 1.807261 /* the corpus peak */, -1.807261,
+    163.5 /* the modal vocabulary at res = 1: legitimate, must survive */,
+    233.7 /* the rail incident: below C, passes through — see the docstring */,
     C, -C, 4.9406564584124654e-324 /* min denormal */, -2.2250738585072014e-308,
   };
   for (double v : transparent)
@@ -192,9 +202,10 @@ static void test_device_bound_clamp()
     ASSERT(vb == gb);
   }
 
-  // Boundedness above C — including the measured rail-incident peak.
-  const double over[] = { 4.0000001, 5.0, 63.3, 64.0, 1e9,
-                          std::numeric_limits<double>::infinity() };
+  // Boundedness above C.
+  const double over[] = { 256.0000001, 257.0, 1e3, 1e9, 6.8719476736e10 /* 2^36,
+                          the hard-wrap magnitude an unrecoverable i64 rail
+                          produces */, std::numeric_limits<double>::infinity() };
   for (double v : over)
   {
     ASSERT(clamp_to_device_bound(v) == C);
@@ -209,11 +220,12 @@ static void test_device_bound_clamp()
   ASSERT(!std::isnan(got_nan));
   ASSERT(got_nan == -C);
 
-  // The bound itself: a power of two, above the measured corpus peak, and far
-  // below the rail incident it exists to catch.
-  ASSERT(C == 4.0);
-  ASSERT(C > 1.807261);
-  ASSERT(C < 63.3);
+  // The bound itself: a power of two, above the vocabulary's legitimate reach
+  // (Q = 0.55·80^res peaks at 44, times the 3.7 master gain ≈ 163), and far
+  // below a hard i64 wrap.
+  ASSERT(C == 256.0);
+  ASSERT(C > 163.5);
+  ASSERT(C < 6.8719476736e10);
 }
 
 int main()

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -773,67 +773,125 @@ structure BloomPair where
   eKappa     : CplxB := ⟨0, 0⟩        -- e^κ (the secular coeff c·e^κ)
 deriving Inhabited
 
-/-- The per-pair BAKING PLAN and admission decision for one composed (μ, ν)
-    pair — the executable form of the bloom atom's admission region (the sprint's
-    epistemics fix: the boundary is an apparatus output, not a comment). `none`
-    ⟺ the pair is OUTSIDE admission (`|a| < ½`, or an envelope depth over the 300
-    cap); `some` carries the branch choice and the two depths `bloomCompose`
-    needs to size its coefficient arrays. `bloomCompose` and the seam-sweep
-    harness consult THIS predicate, so "where does the atom promise anything" has
-    one answer, in code. -/
+/-- The bloom crossing's region for one composed (μ, ν) pair — a TOTAL partition
+    of config space (`classifyBloomPair` is total, never `Option`). Dispatch is an
+    exhaustive match, so a region without a handler is a compile error, and the
+    depth-cap drop is a NAMED outcome (`excludedDepth`) the coverage gate tallies
+    rather than a silent `continue`. This is the type the island's totality claim
+    hangs off. The four served regions differ only in which per-pair lanes the
+    realizer emits; the two axes are coincidence (`|a| < ½`, the pole on the
+    settled partial, τ·e) and the CF/series boundary (`|κ|` vs `|a+1|`, whether the
+    continued fraction is reached). -/
+inductive SeamRegion where
+  /-- `¬coincident ∧ |a+1| ≥ |κ|`: the E1 Kummer series alone (`M` Horner over
+      `invA`). The CF is never reached — no CF lane emitted. -/
+  | serOnly
+  /-- `¬coincident ∧ |a+1| < |κ|`: the E1 series bridged to the continued fraction
+      at `dSwitch > 0` — both lanes emitted, `selectE` picks per sample. -/
+  | crossing
+  /-- `|a| < ½ ∧ |κ| ≥ |a+1|` (τ·e, WS-A4): the CF (large z) bridged to the
+      series-DD branch (small z) at `dSwitch > 0`, plus the τ·e secular. The E1
+      series lane (`invA`/`k1Ser`, singular at a = 0) is NOT emitted. -/
+  | coincidentCrossing
+  /-- `|a| < ½ ∧ |κ| < |a+1|` (a subtle bloom, `dSwitch < 0`): the per-sample path
+      starts on series-DD at d = 0 and never crosses, so the CF lane is dead (the
+      `selectE` is const-true) and is NOT emitted — the tightest region, series-DD
+      + secular only. -/
+  | coincidentSubtle
+  /-- Envelope depth over the 300 cap: a graceful drop (no lanes emitted). Counted,
+      never silent — the coverage gate reports the excluded fraction. -/
+  | excludedDepth
+deriving Inhabited, DecidableEq
+
+/-- Short label for the coverage gate's region histogram. -/
+def SeamRegion.label : SeamRegion → String
+  | .serOnly            => "serOnly"
+  | .crossing           => "crossing"
+  | .coincidentCrossing => "coincidentCrossing"
+  | .coincidentSubtle   => "coincidentSubtle"
+  | .excludedDepth      => "excludedDepth"
+
+/-- The per-pair classification + baking data for one composed (μ, ν) pair — the
+    executable form of the bloom atom's region partition (the sprint's epistemics
+    fix: the boundary is an apparatus output, not a comment). TOTAL: `region` is
+    always one of `SeamRegion`'s constructors (`excludedDepth` for a depth-cap
+    drop, never a `none`). `bloomCompose` matches on `region` exhaustively to emit
+    exactly that region's lanes; the seam-sweep harness and the coverage gate
+    consult the SAME classifier, so "which region is this pair, and does the atom
+    promise anything there" has one answer, in code. `nDepth`/`kDepth` size the
+    coefficient arrays (`kDepth = 0` where no CF is reached). -/
 structure BloomPairPlan where
   mu      : CplxB
   nu      : CplxB
   aC      : CplxB
   kappa   : CplxB
-  serOnly : Bool
-  /-- `|a| < ½` — the τ·e coincidence branch (CF + series-DD + secular, WS-A4). -/
-  coincident : Bool
+  region  : SeamRegion
   /-- `invA`/`dCoef` length / series depth (`nRaw + 8`). -/
   nDepth  : Nat
-  /-- CF depth (`kRaw + 8`); 0 when `serOnly`. -/
+  /-- CF depth (`kRaw + 8`); 0 where no CF lane is emitted. -/
   kDepth  : Nat
 deriving Inhabited
 
-def bloomPairPlan? (mu nu : CplxB) (B g : Float) : Option BloomPairPlan := Id.run do
+/-- Classify one composed (μ, ν) pair into its `SeamRegion` and size its depths —
+    TOTAL (replaces the `Option`-with-flags `bloomPairPlan?`: the depth-cap drop is
+    now the `excludedDepth` region, not a `none`). The control flow is preserved
+    byte-for-byte from the old predicate — same `zBnd`, same `nRaw`/`kRaw` depth
+    caps, same admission set — so the region label is the only new information; the
+    two axes (coincidence `|a| < ½` and the CF boundary `|κ|` vs `|a+1|`) name the
+    branches the old flags already encoded. -/
+def classifyBloomPair (mu nu : CplxB) (B g : Float) : BloomPairPlan := Id.run do
   let aC : CplxB := (nu.sub mu).scale (1.0 / g)
-  -- WS-A4 (atom four): the `|a| < ½` coincidence hole is CLAIMED admitted and
-  -- served by the coincident divided difference below. It is forced onto the
-  -- crossing shape (never series-only) so the coincidence-stable CF constants are
-  -- always baked; when `|κ| < |a+1|` (a subtle bloom — see `bloomPhiKappaOverG`)
-  -- `dSwitch < 0` and the per-sample path starts on the series-DD lane at d = 0.
+  -- WS-A4 (atom four): the `|a| < ½` coincidence is served by the coincident
+  -- divided difference; `|κ| < |a+1|` (a subtle bloom — see `bloomPhiKappaOverG`)
+  -- is `dSwitch < 0`, where the per-sample path starts on the series-DD lane at
+  -- d = 0 and the CF lane is dead.
   let coincident := aC.abs < 0.5
   let kappa := mu.scale B
   let aP1 := aC.add ⟨1, 0⟩
   let serOnly := !coincident && aP1.abs ≥ kappa.abs
+  let excluded : BloomPairPlan :=
+    { mu, nu, aC, kappa, region := .excludedDepth, nDepth := 0, kDepth := 0 }
   -- the worst z either per-sample branch evaluates: the branch boundary
   let zBnd := if serOnly then kappa else kappa.scale (aP1.abs / kappa.abs)
   let (_, nRaw) := bloomM1 aC zBnd
-  if nRaw + 8 > 300 then return none
+  if nRaw + 8 > 300 then return excluded
   if serOnly then
-    return some { mu, nu, aC, kappa, serOnly := true, coincident, nDepth := nRaw + 8, kDepth := 0 }
+    return { mu, nu, aC, kappa, region := .serOnly, nDepth := nRaw + 8, kDepth := 0 }
   else
     let (_, kRaw) := bloomCF aC zBnd
-    if kRaw + 8 > 300 then return none
-    return some { mu, nu, aC, kappa, serOnly := false, coincident, nDepth := nRaw + 8, kDepth := kRaw + 8 }
+    if kRaw + 8 > 300 then return excluded
+    -- non-coincident here is always the CF-bridged crossing; coincident splits on
+    -- the CF boundary (`dSwitch` sign = sign of `|κ| − |a+1|`): `|κ| ≥ |a+1|`
+    -- reaches the CF (coincidentCrossing), else the CF lane is dead (subtle).
+    let region : SeamRegion :=
+      if !coincident then .crossing
+      else if kappa.abs ≥ aP1.abs then .coincidentCrossing else .coincidentSubtle
+    return { mu, nu, aC, kappa, region, nDepth := nRaw + 8, kDepth := kRaw + 8 }
 
 /-- The bloom atom's admission predicate at the pair level: both envelope depths
-    within the 300 cap — exactly the region `bloomCompose` keeps a pair
-    (`bloomPairPlan?` is `some`). TOTAL over the `|a|` axis since WS-A4: the
-    `|a| < ½` coincidence is served by the divided-difference branch, and the ½
-    boundary is a scheme crossover, not an exclusion edge. Executable data the
-    sweep probes at its edges, not an annotation. -/
-def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool := (bloomPairPlan? mu nu B g).isSome
+    within the 300 cap — exactly the region `bloomCompose` keeps a pair (the
+    classifier lands in a served region, not `excludedDepth`). TOTAL over the `|a|`
+    axis since WS-A4: the `|a| < ½` coincidence is served by the divided-difference
+    branch, and the ½ boundary is a scheme crossover, not an exclusion edge.
+    Executable data the sweep probes at its edges, not an annotation. -/
+def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
+  match (classifyBloomPair mu nu B g).region with
+  | .excludedDepth => false
+  | _ => true
 
 /-- `bloomedVoice ⋙ reverb` as Γ-bridge pairs — the residue composition ACROSS a
     pitch-bloom warp (`B = β·scale/g` seconds of total clock advance, `g` the
     settle rate). Baked-pole contract (v1, `besselFuse` parity): every pole must
     fold to a constant (`none` if a live pole reaches this — the caller keeps
     live-pole banks on `residueComposeE`'s unbloomed path); amps stay live.
-    Admission drops (graceful exclusion, the documented v1 scope) route through
-    `bloomPairPlan?` and are now depth-only: pairs whose envelope depth exceeds
-    300 (cockpit-measured shipped max ≈ 250 incl. the coincident CF side; the cap
-    is headroom, not a tuning). Pairs with `|a| < ½` (the pole ON the settled
+    Admission drops (graceful exclusion, the documented v1 scope) are the
+    `classifyBloomPair` `excludedDepth` region and are now depth-only: pairs whose
+    envelope depth exceeds 300 (cockpit-measured shipped max ≈ 250 incl. the
+    coincident CF side; the cap is headroom, not a tuning). The per-pair emit is
+    REGION-INDEXED (WS-CL): the exhaustive `match plan.region` bakes exactly each
+    region's lanes — the coincident regions no longer carry the dead E1 (`invA`)
+    lane, and `coincidentSubtle` (`dSwitch < 0`) drops the whole CF lane the
+    per-sample `selectE` always discarded. Pairs with `|a| < ½` (the pole ON the settled
     partial — the τ·e resonance) are SERVED since WS-A4 by the coincident
     divided-difference branch (CF unchanged for large z; `Φ(a,z)` series-DD + the
     `cexpm1` secular below `dSwitch`), exactly as WS-B2 hardened
@@ -851,55 +909,86 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
       let some rOm  := sigConstF? r.omega | return none
       let mu : CplxB := ⟨-vSig, vOm⟩
       let nu : CplxB := ⟨-rSig, rOm⟩
-      -- the shared admission predicate: `none` ⇒ this pair is out of scope
-      -- (graceful exclusion), and it carries the two depths for the arrays.
-      let some plan := bloomPairPlan? mu nu B g | continue
+      -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope
+      -- (a COUNTED graceful drop — the coverage gate tallies it, not a silent
+      -- `continue`); every other region emits EXACTLY its own lanes (region-indexed
+      -- — the coincident regions no longer bake the dead E1/CF lanes). `bloomCompose`
+      -- and the seam-sweep harness consult THIS classifier, one answer in code.
+      let plan := classifyBloomPair mu nu B g
       let aC := plan.aC
       let kappa := plan.kappa
-      let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
-      let invA := (Array.range plan.nDepth).map (fun k =>
-        CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
+      let aP1 := aC.add ⟨1, 0⟩
       let c := cmulE v.ampE r.ampE
-      if plan.serOnly then
+      match plan.region with
+      | .excludedDepth => continue
+      | .serOnly =>
+        let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
+        let invA := (Array.range plan.nDepth).map (fun k =>
+          CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
         let (mK, _) := bloomM1 aC kappa
         out := out.push {
           muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
           bloomB := B, gRate := g, c, kappa
           k1Ser := mK.mul invNuMu, k1Cf := ⟨0, 0⟩, fSer := invNuMu.neg
           dSwitch := 0.0, invA, cfB := #[], cfN := #[] }
-      else
-        let kDepth := plan.kDepth
-        let aP1 := aC.add ⟨1, 0⟩
+      | .crossing =>
+        let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
+        let invA := (Array.range plan.nDepth).map (fun k =>
+          CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
         let (cfK, _) := bloomCF aC kappa
-        let cfB := (Array.range (kDepth + 1)).map (fun j =>
+        let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
           (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
-        let cfN := (Array.range kDepth).map (fun j =>
+        let cfN := (Array.range plan.kDepth).map (fun j =>
           let jf := (j + 1).toFloat
           (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
         let dSwitch := Float.log (kappa.abs / aP1.abs) / g
         let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
-        if plan.coincident then
-          -- WS-A4: the CF branch (large z, `k1Cf`/`cfB`/`cfN`) already coincidence-
-          -- stable; below `dSwitch` it bridges to the series-DD branch (`dCoef`,
-          -- `k1SerDD`) plus the τ·e secular `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`. The E1
-          -- series lane (`k1Ser`/`fSer`, singular at a=0) is UNUSED here.
-          let dCoef := bloomDCoef aC plan.nDepth
-          out := out.push {
-            muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-            bloomB := B, gRate := g, c, kappa
-            k1Ser := ⟨0, 0⟩, k1Cf, fSer := ⟨0, 0⟩
-            dSwitch, invA, cfB, cfN
-            coincident := true
-            dCoef
-            k1SerDD := bloomPhiKappaOverG aC kappa cfK dCoef g
-            eKappa := CplxB.exp kappa }
-        else
-          let gs := bloomGammaStar aC kappa g
-          out := out.push {
-            muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-            bloomB := B, gRate := g, c, kappa
-            k1Ser := gs.sub (cfK.scale (1.0 / g)), k1Cf, fSer := invNuMu.neg
-            dSwitch, invA, cfB, cfN }
+        let gs := bloomGammaStar aC kappa g
+        out := out.push {
+          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
+          bloomB := B, gRate := g, c, kappa
+          k1Ser := gs.sub (cfK.scale (1.0 / g)), k1Cf, fSer := invNuMu.neg
+          dSwitch, invA, cfB, cfN }
+      | .coincidentCrossing =>
+        -- WS-A4: the CF branch (large z, `k1Cf`/`cfB`/`cfN`), coincidence-stable,
+        -- bridges below `dSwitch` to the series-DD branch (`dCoef`/`k1SerDD`) plus
+        -- the τ·e secular `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`. The E1 series lane
+        -- (`invA`/`k1Ser`/`fSer`, singular at a=0) is NOT emitted (region-indexed).
+        let (cfK, _) := bloomCF aC kappa
+        let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
+          (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
+        let cfN := (Array.range plan.kDepth).map (fun j =>
+          let jf := (j + 1).toFloat
+          (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
+        let dSwitch := Float.log (kappa.abs / aP1.abs) / g
+        let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
+        let dCoef := bloomDCoef aC plan.nDepth
+        out := out.push {
+          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
+          bloomB := B, gRate := g, c, kappa
+          k1Ser := ⟨0, 0⟩, k1Cf, fSer := ⟨0, 0⟩
+          dSwitch, invA := #[], cfB, cfN
+          coincident := true
+          dCoef
+          k1SerDD := bloomPhiKappaOverG aC kappa cfK dCoef g
+          eKappa := CplxB.exp kappa }
+      | .coincidentSubtle =>
+        -- WS-A4 subtle bloom (`dSwitch < 0`): the per-sample path is series-DD from
+        -- d = 0, so the CF lane is DEAD (the `selectE` is const-true — LLVM `select`
+        -- ignores the unselected operand). Region-indexed: emit series-DD + the τ·e
+        -- secular ONLY — no CF lane (`k1Cf`/`cfB`/`cfN`, kept empty ⇒ `bloomComposedSig`
+        -- routes to the subtle sub-branch), no `invA`. `bloomPhiKappaOverG`'s subtle
+        -- branch reads only `dCoef`/κ (`cfK` unread), so a dummy `cfK` is bit-identical.
+        let dCoef := bloomDCoef aC plan.nDepth
+        out := out.push {
+          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
+          bloomB := B, gRate := g, c, kappa
+          k1Ser := ⟨0, 0⟩, k1Cf := ⟨0, 0⟩, fSer := ⟨0, 0⟩
+          dSwitch := Float.log (kappa.abs / aP1.abs) / g, invA := #[], cfB := #[], cfN := #[]
+          coincident := true
+          dCoef
+          k1SerDD := bloomPhiKappaOverG aC kappa ⟨0, 0⟩ dCoef g
+          eKappa := CplxB.exp kappa }
   return some out
 
 /-- The bloom-composed pair bank as a pure `Sig` over the clock: per pair, TWO
@@ -942,37 +1031,65 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
     let envNu := expSig (neg (mul (litF p.nuSigma) dPos))
     let envMu := expSig (neg (mul (litF p.muSigma) (add dPos off)))
     if p.coincident then
-      -- WS-A4: the τ·e coincidence pair. CF branch (large z, `onSer` false)
-      -- bridges at `dSwitch` to the series-DD branch (small z) + the secular.
-      let onSer := gt dPos (litF p.dSwitch)
-      let cf := cfEnv p z
-      let k2cf : CplxE := (div cf.1 (litF p.gRate), div cf.2 (litF p.gRate))   -- CF(z)/g
-      -- series-DD: Φ(a,z) = z·Σ dₙ z^{n−1} (Horner over `dCoef`); k2 = −Φ(a,z)/g.
-      let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE (cplxLitE dk) (cmulE z h)) (lit 0, lit 0))
-      let k2ser : CplxE := (div (neg phiZ.1) (litF p.gRate), div (neg phiZ.2) (litF p.gRate))
-      let k1 : CplxE := (selectE onSer (litF p.k1SerDD.re) (litF p.k1Cf.re),
-                         selectE onSer (litF p.k1SerDD.im) (litF p.k1Cf.im))
-      let k2 : CplxE := (selectE onSer k2ser.1 k2cf.1, selectE onSer k2ser.2 k2cf.2)
-      let w1 := cmulE p.c k1
-      let w2 := cmulE p.c k2
-      -- the τ·e secular `c·e^κ·e^{μd}·d·cexpm1((ν−μ)d)` on the STRAIGHT μ carrier
-      -- (= `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`), gated OFF on the CF side.
-      let phMuS := modePhaseQ (litF p.muOmega) clkRel
-      let envMuS := expSig (neg (mul (litF p.muSigma) dPos))
-      let zsec : CplxE := (mul (litF (p.muSigma - p.nuSigma)) dPos,     -- (ν−μ)d
-                           mul (litF (p.nuOmega - p.muOmega)) dPos)
-      let zsq := add (mul zsec.1 zsec.1) (mul zsec.2 zsec.2)
-      let big := gt zsq (litF 0.01)
-      let zsafe : CplxE := (selectE big zsec.1 (lit 1), selectE big zsec.2 (lit 0))
-      let ezr := expSig zsec.1
-      let ez : CplxE := (mul ezr (cosSig zsec.2), mul ezr (sinSig zsec.2))
-      let direct := cdivE (csubE ez one) zsafe
-      let series := cexpm1SeriesE zsec
-      let cxsec : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)
-      let cek := cmulE p.c (cplxLitE p.eKappa)
-      let wsecFull := cmulE cek (scaleRealE dPos cxsec)                -- c·e^κ·d·cexpm1
-      let wsec : CplxE := (selectE onSer wsecFull.1 (lit 0), selectE onSer wsecFull.2 (lit 0))
-      add acc (add (add (land envNu w1 phNu) (land envMu w2 phMu)) (land envMuS wsec phMuS))
+      if p.cfN.isEmpty then
+        -- WS-A4 / WS-CL: the subtle-bloom coincident pair (`dSwitch < 0`). The
+        -- per-sample path is series-DD from d = 0 — the CF lane is dead (region-
+        -- indexed: `cfN` is empty, so `cfEnv` is not even reached — it would index-
+        -- panic). Series-DD + the τ·e secular, ALWAYS on. Bit-identical to the old
+        -- coincident branch with the const-true `onSer` (the `selectE`s all picked
+        -- the series-DD/secular arm; the LLVM `select` ignored the CF operand).
+        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE (cplxLitE dk) (cmulE z h)) (lit 0, lit 0))
+        let k2ser : CplxE := (div (neg phiZ.1) (litF p.gRate), div (neg phiZ.2) (litF p.gRate))
+        let w1 := cmulE p.c ((litF p.k1SerDD.re, litF p.k1SerDD.im) : CplxE)
+        let w2 := cmulE p.c k2ser
+        let phMuS := modePhaseQ (litF p.muOmega) clkRel
+        let envMuS := expSig (neg (mul (litF p.muSigma) dPos))
+        let zsec : CplxE := (mul (litF (p.muSigma - p.nuSigma)) dPos,     -- (ν−μ)d
+                             mul (litF (p.nuOmega - p.muOmega)) dPos)
+        let zsq := add (mul zsec.1 zsec.1) (mul zsec.2 zsec.2)
+        let big := gt zsq (litF 0.01)
+        let zsafe : CplxE := (selectE big zsec.1 (lit 1), selectE big zsec.2 (lit 0))
+        let ezr := expSig zsec.1
+        let ez : CplxE := (mul ezr (cosSig zsec.2), mul ezr (sinSig zsec.2))
+        let direct := cdivE (csubE ez one) zsafe
+        let series := cexpm1SeriesE zsec
+        let cxsec : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)
+        let cek := cmulE p.c (cplxLitE p.eKappa)
+        let wsec := cmulE cek (scaleRealE dPos cxsec)                   -- c·e^κ·d·cexpm1
+        add acc (add (add (land envNu w1 phNu) (land envMu w2 phMu)) (land envMuS wsec phMuS))
+      else
+        -- WS-A4: the τ·e coincidence pair (`coincidentCrossing`). CF branch (large z,
+        -- `onSer` false) bridges at `dSwitch` to the series-DD branch (small z) + the
+        -- secular.
+        let onSer := gt dPos (litF p.dSwitch)
+        let cf := cfEnv p z
+        let k2cf : CplxE := (div cf.1 (litF p.gRate), div cf.2 (litF p.gRate))   -- CF(z)/g
+        -- series-DD: Φ(a,z) = z·Σ dₙ z^{n−1} (Horner over `dCoef`); k2 = −Φ(a,z)/g.
+        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE (cplxLitE dk) (cmulE z h)) (lit 0, lit 0))
+        let k2ser : CplxE := (div (neg phiZ.1) (litF p.gRate), div (neg phiZ.2) (litF p.gRate))
+        let k1 : CplxE := (selectE onSer (litF p.k1SerDD.re) (litF p.k1Cf.re),
+                           selectE onSer (litF p.k1SerDD.im) (litF p.k1Cf.im))
+        let k2 : CplxE := (selectE onSer k2ser.1 k2cf.1, selectE onSer k2ser.2 k2cf.2)
+        let w1 := cmulE p.c k1
+        let w2 := cmulE p.c k2
+        -- the τ·e secular `c·e^κ·e^{μd}·d·cexpm1((ν−μ)d)` on the STRAIGHT μ carrier
+        -- (= `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`), gated OFF on the CF side.
+        let phMuS := modePhaseQ (litF p.muOmega) clkRel
+        let envMuS := expSig (neg (mul (litF p.muSigma) dPos))
+        let zsec : CplxE := (mul (litF (p.muSigma - p.nuSigma)) dPos,     -- (ν−μ)d
+                             mul (litF (p.nuOmega - p.muOmega)) dPos)
+        let zsq := add (mul zsec.1 zsec.1) (mul zsec.2 zsec.2)
+        let big := gt zsq (litF 0.01)
+        let zsafe : CplxE := (selectE big zsec.1 (lit 1), selectE big zsec.2 (lit 0))
+        let ezr := expSig zsec.1
+        let ez : CplxE := (mul ezr (cosSig zsec.2), mul ezr (sinSig zsec.2))
+        let direct := cdivE (csubE ez one) zsafe
+        let series := cexpm1SeriesE zsec
+        let cxsec : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)
+        let cek := cmulE p.c (cplxLitE p.eKappa)
+        let wsecFull := cmulE cek (scaleRealE dPos cxsec)                -- c·e^κ·d·cexpm1
+        let wsec : CplxE := (selectE onSer wsecFull.1 (lit 0), selectE onSer wsecFull.2 (lit 0))
+        add acc (add (add (land envNu w1 phNu) (land envMu w2 phMu)) (land envMuS wsec phMuS))
     else
       let mser := p.invA.foldr
         (fun ik h => caddE one (cmulE (cmulE z (cplxLitE ik)) h)) one

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -444,6 +444,40 @@ def residueComposeEC (voice reverb : Array ModalMode) : Array ModalMode :=
     modeOfE r.poleE (cnegE (cmulE r.ampE coupling)))
   forced ++ ringing
 
+/-- The excitation-gauge adapter (§5): rescale every residue by the self-measured
+    `1/‖H‖^g`, with `g` a LIVE scalar. `‖H‖` is the p=8 norm of the bank's OWN
+    transfer function `H(iω) = Σᵢ Aᵢ/(iω − μᵢ)` sampled at its own pole frequencies
+    (each resonance peaks near its pole, so `max_k|H(iωₖ)|` tracks `‖H‖∞`, and the
+    smooth 8-norm — a summing fold, no `max` kink under a live sweep — approximates
+    it). `g = 0` is the IDENTITY (`‖H‖⁰ = 1`, unity-DC — the committed strike gauge:
+    strikes ping at a Q-independent level, `res` is ring time); `g = ½` the √Q trim;
+    `g = 1` unity-peak (`H/‖H‖` has unit peak, so a tuned tone is level-invariant
+    across a resonance sweep, pings fading as 1/Q). Self-measuring: the norm reads
+    pole/residue data ALONE (nothing about `filterPair`/`res`), so it applies
+    unchanged to any modal bank or composed segment — Modal ⇝ Modal. Coefficient-
+    time: the norm folds the mode `Sig`s DIRECTLY (never a `Sig.index`/clock read),
+    an s0 expression that hoists to the coefficient kernel and crosses to Metal as a
+    coef slot — `logSig`'s `floatExponent` never runs per sample (option E's
+    discipline). The scale is ONE real shared across the bank, so the render is
+    EXACTLY `scale · (bare render)` (linear in residues) — hence `g = 0` is a VALUE
+    no-op and any `g` is a pure re-level with no relower (a mid-ring sweep re-levels
+    the ongoing tail, closed-form, no click). An empty bank stays empty. -/
+def normalizePeak (g : Sig) (modes : Array ModalMode) : Array ModalMode :=
+  if modes.isEmpty then #[] else
+  -- H(iωₖ) = Σᵢ Aᵢ/(σᵢ + i(ωₖ − ωᵢ))   (iωₖ − μᵢ, with μᵢ = −σᵢ + iωᵢ)
+  let hAt := fun (wk : Sig) => modes.foldl (fun acc m =>
+      caddE acc (cdivE m.ampE ((m.sigma, sub wk m.omega) : CplxE))) ((lit 0, lit 0) : CplxE)
+  -- S = Σₖ |H(iωₖ)|⁸ = Σₖ (|H|²)⁴  (p = 8; even power ⇒ no sqrt)
+  let S := modes.foldl (fun acc m =>
+      let h := hAt m.omega
+      let h2 := add (mul h.1 h.1) (mul h.2 h.2)
+      add acc (mul (mul h2 h2) (mul h2 h2))) (lit 0)
+  -- ‖H‖⁻ᵍ = S^{−g/8} = exp(−(g/8)·ln S); floor S > 0 so a silent bank (S→0)
+  -- scales 0·anything = 0 with no log(0).
+  let scale := expSig (mul (mul (neg g) (lit 125 3))
+                           (logSig (clampE S (litF 1e-30) (litF 1e300))))
+  modes.map (fun m => { m with cre := mul m.cre scale, cim := mul m.cim scale })
+
 /-- `residueComposeEC` with the Cauchy inner sums BANKED (WS-F). Each output mode's
     amp (`Hlam`/`coupling`) becomes a scalar `Sig.bankSum` over the SOURCE columns
     rather than a meta-unrolled fold — same value (per-term identical to `cdivE`,

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -460,37 +460,42 @@ def residueComposeEC (voice reverb : Array ModalMode) : Array ModalMode :=
     re-level with no relower (a mid-ring sweep re-levels the ongoing tail, closed-
     form, no click). An empty bank stays empty.
 
-    **Two preconditions the caller (the future `gauge` node) MUST honour** — the norm
-    is by-ear approximate, but these two are correctness, not taste:
-    - **s0 poles.** The norm folds the mode `Sig`s; if the poles are s0 (const or a
-      settled knob) the whole scale is an s0 coefficient, hoisted once and crossed to
-      Metal as a coef slot — `logSig`'s `floatExponent` (f32≠f64 across backends) then
-      never runs per sample. But a GLIDED knob is `.s1` (`glideExpr` reads
-      `.sampleIndex`), so `normalizePeak (filterPair glidedCutoff …)` would emit a
-      per-sample `floatExponent` and DIVERGE on Metal. The gauge node must build the
-      norm from SETTLED (`#v1`) values, not the glided expression.
-    - **deg 0.** `H` here is the deg-0 form `Aᵢ/(iω−μᵢ)`; a deg-`p` mode's true
-      response is `Aᵢ·p!/(iω−μᵢ)^{p+1}`, so this under-weights higher-deg peaks. Exact
-      for the shipped `filterPair`/`reverbRoom`/`resonatorBank` (all deg-0); a mixed-
-      deg bank is mis-levelled. -/
-def normalizePeak (g : Sig) (modes : Array ModalMode) : Array ModalMode :=
-  if modes.isEmpty then #[] else
+    **s0 BY CONSTRUCTION** (`gaugeScale`): the norm is measured on the SETTLED poles
+    (`settle` collapses a glide to its `#v1` target), so `logSig`'s `floatExponent`
+    (f32≠f64 across backends) is coefficient-time and never runs per sample — the
+    Metal divergence is unreachable, not documented against. A pole that won't settle
+    (a genuine per-sample modulation, an LFO on a cutoff) makes `gaugeScale` `none`,
+    and the bank DECLINES (identity) rather than emit an s1 norm. **One remaining note
+    (taste-adjacent but a correctness caveat): deg 0.** `H` is the deg-0 form
+    `Aᵢ/(iω−μᵢ)`; a deg-`p` mode's `Aᵢ·p!/(iω−μᵢ)^{p+1}` is under-weighted (exact for
+    the shipped `filterPair`/`reverbRoom`/`resonatorBank`, all deg-0). -/
+def gaugeScale (g : Sig) (modes : Array ModalMode) : Option Sig := do
+  -- SETTLE every pole first — the whole scale then reads no clock (s0), so the
+  -- `floatExponent` inside `logSig` is coefficient-time. `none` if any won't settle.
+  let sm ← modes.mapM fun m => do
+    let sg ← settle m.sigma; let om ← settle m.omega
+    let cr ← settle m.cre;   let ci ← settle m.cim
+    pure ({ m with sigma := sg, omega := om, cre := cr, cim := ci } : ModalMode)
   -- H(iωₖ) = Σᵢ Aᵢ/(σᵢ + i(ωₖ − ωᵢ))   (iωₖ − μᵢ, with μᵢ = −σᵢ + iωᵢ)
-  let hAt := fun (wk : Sig) => modes.foldl (fun acc m =>
+  let hAt := fun (wk : Sig) => sm.foldl (fun acc m =>
       caddE acc (cdivE m.ampE ((m.sigma, sub wk m.omega) : CplxE))) ((lit 0, lit 0) : CplxE)
   -- S = Σₖ |H(iωₖ)|⁸ = Σₖ (|H|²)⁴  (p = 8; even power ⇒ no sqrt)
-  let S := modes.foldl (fun acc m =>
+  let S := sm.foldl (fun acc m =>
       let h := hAt m.omega
       let h2 := add (mul h.1 h.1) (mul h.2 h.2)
       add acc (mul (mul h2 h2) (mul h2 h2))) (lit 0)
   -- ‖H‖⁻ᵍ = S^{−g/8} = exp(−(g/8)·ln S). Floor S ∈ [1e−30, 1e30] (via `lit`, NOT
-  -- `litF` — `litF 1e−30` rounds to 0 and `litF 1e300` saturates to ≈1.8e7, which
-  -- would defeat the log(0) floor AND clamp every ‖H‖ ≳ 8): the floor guards a
-  -- silent bank (S→0 ⇒ logSig 0), the ceiling a non-finite one (S=∞ ⇒ logSig ∞ = NaN),
-  -- and 1e30 stays well under f32-max so Metal never overflows the clamp.
-  let scale := expSig (mul (mul (neg g) (lit 125 3))
-                           (logSig (clampE S (lit 1 30) (lit (10^30)))))
-  modes.map (fun m => { m with cre := mul m.cre scale, cim := mul m.cim scale })
+  -- `litF` — `litF 1e−30` rounds to 0, `litF 1e300` saturates to ≈1.8e7): the floor
+  -- guards a silent bank (S→0 ⇒ logSig 0), the ceiling a non-finite one (S=∞ ⇒
+  -- logSig ∞ = NaN), and 1e30 stays under f32-max so Metal never overflows the clamp.
+  pure (expSig (mul (mul (neg g) (lit 125 3))
+                    (logSig (clampE S (lit 1 30) (lit (10^30))))))
+
+def normalizePeak (g : Sig) (modes : Array ModalMode) : Array ModalMode :=
+  if modes.isEmpty then #[] else
+  match gaugeScale g modes with
+  | some scale => modes.map fun m => { m with cre := mul m.cre scale, cim := mul m.cim scale }
+  | none => modes   -- un-settleable poles: decline to identity, never an s1 norm
 
 /-- `residueComposeEC` with the Cauchy inner sums BANKED (WS-F). Each output mode's
     amp (`Hlam`/`coupling`) becomes a scalar `Sig.bankSum` over the SOURCE columns

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -454,14 +454,25 @@ def residueComposeEC (voice reverb : Array ModalMode) : Array ModalMode :=
     `g = 1` unity-peak (`H/‖H‖` has unit peak, so a tuned tone is level-invariant
     across a resonance sweep, pings fading as 1/Q). Self-measuring: the norm reads
     pole/residue data ALONE (nothing about `filterPair`/`res`), so it applies
-    unchanged to any modal bank or composed segment — Modal ⇝ Modal. Coefficient-
-    time: the norm folds the mode `Sig`s DIRECTLY (never a `Sig.index`/clock read),
-    an s0 expression that hoists to the coefficient kernel and crosses to Metal as a
-    coef slot — `logSig`'s `floatExponent` never runs per sample (option E's
-    discipline). The scale is ONE real shared across the bank, so the render is
-    EXACTLY `scale · (bare render)` (linear in residues) — hence `g = 0` is a VALUE
-    no-op and any `g` is a pure re-level with no relower (a mid-ring sweep re-levels
-    the ongoing tail, closed-form, no click). An empty bank stays empty. -/
+    unchanged to any modal bank or composed segment — Modal ⇝ Modal. The scale is ONE
+    real shared across the bank, so the render is EXACTLY `scale · (bare render)`
+    (linear in residues) — hence `g = 0` is a VALUE no-op and any `g` is a pure
+    re-level with no relower (a mid-ring sweep re-levels the ongoing tail, closed-
+    form, no click). An empty bank stays empty.
+
+    **Two preconditions the caller (the future `gauge` node) MUST honour** — the norm
+    is by-ear approximate, but these two are correctness, not taste:
+    - **s0 poles.** The norm folds the mode `Sig`s; if the poles are s0 (const or a
+      settled knob) the whole scale is an s0 coefficient, hoisted once and crossed to
+      Metal as a coef slot — `logSig`'s `floatExponent` (f32≠f64 across backends) then
+      never runs per sample. But a GLIDED knob is `.s1` (`glideExpr` reads
+      `.sampleIndex`), so `normalizePeak (filterPair glidedCutoff …)` would emit a
+      per-sample `floatExponent` and DIVERGE on Metal. The gauge node must build the
+      norm from SETTLED (`#v1`) values, not the glided expression.
+    - **deg 0.** `H` here is the deg-0 form `Aᵢ/(iω−μᵢ)`; a deg-`p` mode's true
+      response is `Aᵢ·p!/(iω−μᵢ)^{p+1}`, so this under-weights higher-deg peaks. Exact
+      for the shipped `filterPair`/`reverbRoom`/`resonatorBank` (all deg-0); a mixed-
+      deg bank is mis-levelled. -/
 def normalizePeak (g : Sig) (modes : Array ModalMode) : Array ModalMode :=
   if modes.isEmpty then #[] else
   -- H(iωₖ) = Σᵢ Aᵢ/(σᵢ + i(ωₖ − ωᵢ))   (iωₖ − μᵢ, with μᵢ = −σᵢ + iωᵢ)
@@ -472,10 +483,13 @@ def normalizePeak (g : Sig) (modes : Array ModalMode) : Array ModalMode :=
       let h := hAt m.omega
       let h2 := add (mul h.1 h.1) (mul h.2 h.2)
       add acc (mul (mul h2 h2) (mul h2 h2))) (lit 0)
-  -- ‖H‖⁻ᵍ = S^{−g/8} = exp(−(g/8)·ln S); floor S > 0 so a silent bank (S→0)
-  -- scales 0·anything = 0 with no log(0).
+  -- ‖H‖⁻ᵍ = S^{−g/8} = exp(−(g/8)·ln S). Floor S ∈ [1e−30, 1e30] (via `lit`, NOT
+  -- `litF` — `litF 1e−30` rounds to 0 and `litF 1e300` saturates to ≈1.8e7, which
+  -- would defeat the log(0) floor AND clamp every ‖H‖ ≳ 8): the floor guards a
+  -- silent bank (S→0 ⇒ logSig 0), the ceiling a non-finite one (S=∞ ⇒ logSig ∞ = NaN),
+  -- and 1e30 stays well under f32-max so Metal never overflows the clamp.
   let scale := expSig (mul (mul (neg g) (lit 125 3))
-                           (logSig (clampE S (litF 1e-30) (litF 1e300))))
+                           (logSig (clampE S (lit 1 30) (lit (10^30)))))
   modes.map (fun m => { m with cre := mul m.cre scale, cim := mul m.cim scale })
 
 /-- `residueComposeEC` with the Cauchy inner sums BANKED (WS-F). Each output mode's

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -1200,19 +1200,34 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
     at z=κ where the selected CF weight is ~0.2). **Reachable max at every config
     that fires today: ≪ 32** (measured: SeamSweep gong-reverb 0.005; WS-A4
     coincident 0.27–0.92; a baked filterPair(Q44) stress config 2.48), so this
-    site is **unprotected but not broken**, and option E at k=0 is a byte-identical
-    no-op for it. **Two reasons it is NOT landed in this pass, DEFERRED to the
-    factor-site follow-on**: (a) it is GUI-DARK — `bloomCompose` requires every
-    pole to `sigConstF?`, but the Playground makes rt60/cutoff/resonance LIVE
-    slots, so the live surface never emits this (only the SeamSweep gate and
-    authored/loaded literal-pole programs do); (b) there is a reachable-by-baked-
-    poles degenerate case option E CANNOT absorb — filtering a gong ON one of its
-    own partials with a heavily-damped pole (`Re(a) ≲ −1`, `a` near a negative
-    integer) makes the series-M lane ~5e12, past the k≤28 ceiling of 32·2²⁸≈8.6e9,
-    AND the Γ★ bridge is itself semantically invalid there (the two lane-totals
-    disagree by ~1e8). Its correct remedy is a new `classifyBloomPair` admission
-    guard rejecting `Re(a) ≲ −1` to `excludedDepth`, which the factor-site landing
-    adds ALONGSIDE the per-pair exponent — not a landing-scale fix. -/
+    site is **unprotected but not broken** at every config reachable today, and
+    option E at k=0 is a byte-identical no-op for it. **Two reasons it is NOT landed
+    in this pass, DEFERRED to the factor-site follow-on**: (a) it is UNREACHABLE from
+    the surface — `bloomgong` (its only surface producer) is a WITHHELD kind, rejected
+    by `Playground.checkServedKinds`; and even were it served, `bloomCompose` requires
+    every pole to `sigConstF?` while the Playground makes rt60/cutoff/resonance LIVE,
+    so only the SeamSweep gate and authored/loaded literal-pole programs emit it;
+    (b) there is a reachable-by-baked-poles case option E CANNOT absorb — filtering a
+    gong ON one of its own partials (room pole tuned to a voice partial: `Im a ≈ 0`)
+    with `a` near a negative integer `−n` (`Re a ≈ −(σ_ν−σ_μ)/g`, so a resonance
+    sweep walks `Re a` down the lattice −1,−2,…) AND large `|z|=|κ|`: there the
+    fixed-depth float64 series-M Horner catastrophically cancels (the `1/(a+k+1)`
+    factor at `k≈n−1` is near-singular — MEASURED rel error ~1e8, e.g. `|M_float|`
+    ≈ 3.7e11 vs true ≈ 971 at `a=−0.98, |κ|=76.8`), so the LANDED weight can reach
+    ~5e12–1e19, past the k≤28 ceiling of 32·2²⁸≈8.6e9. This is a CONDITIONING
+    failure of the series REALIZATION, **not** a defect in the Γ★ bridge, which is
+    EXACT there — the two lane-totals agree to 74+ digits at high precision (the
+    identity `−M(z)/(ga) − CF(z)/g = −Γ(a)z^{−a}eᶻ/g`, verified
+    `demos/bridge_verify.py`); the earlier "semantically invalid / lanes disagree by
+    ~1e8" reading conflated the float64 Horner's own cancellation error with a lane
+    disagreement. The near-integer configs are NOT incidentally depth-excluded
+    (`zBnd ≈ |a+1|` is small, so `classifyBloomPair` admits them as `crossing`). Its
+    correct remedy is a new `classifyBloomPair` admission guard rejecting a DISC
+    around each negative integer (`|a+n| ≲ ε`), NOT the half-plane `Re a ≲ −1` (which
+    excludes ~91% of the benign shipped register — measured), to a NEW `SeamRegion`
+    (not `excludedDepth`, which the coverage gate's totality assertion relies on),
+    landed ALONGSIDE the per-pair exponent — a correctness fix, not a landing-scale
+    one. -/
 def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -45,6 +45,100 @@ def powE (base : Sig) : Nat → Sig
   | 1 => base
   | n + 1 => mul (powE base n) base
 
+/-- Fold an authored-constant `Sig` back to its `Float` (the baked-pole read in
+    `bloomCompose`, and the static-`k` amplitude read in `bankLandExp`). Partial:
+    `none` on any live/unsupported node — a live pole is outside the v1 baked-pole
+    contract, not an error to paper over. (Hoisted above the landing sites so
+    `bankLandExp` can consult it.) -/
+private partial def sigConstF? : Sig → Option Float
+  | .num n            => some n.toFloat
+  | .unary .neg a     => (sigConstF? a).map (fun x => -x)
+  | .unary .toFloat a => sigConstF? a
+  | .binary .add a b  => do pure ((← sigConstF? a) + (← sigConstF? b))
+  | .binary .sub a b  => do pure ((← sigConstF? a) - (← sigConstF? b))
+  | .binary .mul a b  => do pure ((← sigConstF? a) * (← sigConstF? b))
+  | .binary .div a b  => do
+      let x ← sigConstF? a; let y ← sigConstF? b
+      pure (if y == 0.0 then 0.0 else x / y)
+  | _                 => none
+
+-- ── Option E: the per-bank Q-landing exponent (the modal-datapath rail fix) ────
+-- Every modal weight lands as Q4.28 (×2²⁸) and multiplies an exact Q2.30 rotator
+-- in i64, so `|w|·env·2²⁸·2³⁰ = |w|·env·2⁵⁸` wraps against i64's 2⁶³ once
+-- `|w|·env > 2⁵ = 32` — reachable from the shipped vocabulary (a resonant lowpass
+-- has `|A| ≈ Q = 0.55·80^res`, so the rail is a cap on filter Q at 32; the top
+-- ~8% of the resonance knob wraps). The cure: land the weight at `2^(28−k)` and
+-- shift back by `28−k`, with `k` chosen PER BANK from the coefficient-time
+-- amplitude so the product cannot wrap. The rendered VALUE is k-INVARIANT — the
+-- `>>(28−k)` undoes the `·2^(28−k)` exactly and `(28−k)+30−(28−k)=30` leaves the
+-- accumulator at Q2.30, so `fixedOutQ 30` is unchanged; only the quantization LSB
+-- moves. At `k=0` the emitted ops are `·2²⁸` / `>>28` verbatim — byte-identical.
+-- The i64 accumulator (`Σ oscQₘ`, each already `>>(28−k)` to Q2.30) never binds:
+-- it needs `Σₘ|Aₘ| < 2³³`, orders looser than the per-mode `32·2^k`.
+
+/-- `⌊log₂|x|⌋` for a finite nonzero `x` — the IEEE-754 unbiased exponent, the
+    exact Lean-Float mirror of the `floatExponent` op the DYNAMIC path emits (so a
+    bank that happens to be all-const and one that is live agree on `k`). -/
+private def floatExpZ (x : Float) : Int :=
+  (((x.abs.toBits >>> 52) &&& 0x7ff).toNat : Int) - 1023
+
+/-- `k = clamp(0, 28, ⌊log₂ maxAbs⌋ − 4)` as a `Nat` (the static path). Solves
+    `maxAbs < 32·2^k`, so `maxAbs < 32 ⇒ k = 0` (bit-identical). Non-finite or
+    `≤ 0` ⇒ `k = 0` — a silent (all-zero-amp) or degenerate bank lands verbatim,
+    and the residue calculus on finite baked poles cannot produce a non-finite amp. -/
+private def landK (maxAbs : Float) : Nat :=
+  if maxAbs ≤ 0.0 || !maxAbs.isFinite then 0
+  else
+    let e := floatExpZ maxAbs - 4
+    if e ≤ 0 then 0 else if e ≥ 28 then 28 else e.toNat
+
+/-- The per-bank Q-landing exponent `k`. STATIC when every amp answers
+    `sigConstF?` (⇒ `k` a compile-time `Nat`; `k=0` emits the landing literals
+    verbatim, a byte-identical plan and a reused kernel-cache object). DYNAMIC
+    otherwise (⇒ `k` an s0 `Sig`, hoisted to the coefficient kernel and crossing
+    to the audio kernel as a `coef:` slot). -/
+inductive LandExp where
+  | static (k : Nat)
+  | dynamic (kSig : Sig)
+
+/-- `2^(28−k)` — the Q-landing scale multiplied before `toInt`. `lit 268435456`
+    verbatim at `static 0`; `ldexp(1, 28−k)` (an exact power of two) when live. -/
+def LandExp.scale : LandExp → Sig
+  | .static k  => lit (Int.pow 2 (28 - k))
+  | .dynamic k => ldexpE (lit 1) (sub (lit 28) k)
+
+/-- `28−k` — the per-mode right shift (the operand of `rshift`). `lit 28` verbatim
+    at `static 0`. Always in `[0,28]` by construction, so the emitted `ashr`/`>>`
+    is never the out-of-range poison/UB LLVM and MSL leave undefined. -/
+def LandExp.shift : LandExp → Sig
+  | .static k  => lit (28 - k)
+  | .dynamic k => sub (lit 28) k
+
+/-- The per-bank landing exponent from a bank's mode amplitudes. The guarded
+    magnitude is `maxAbs = maxₘ(|creₘ|+|cimₘ|)`, the L1 amp norm — invariant under
+    the `modal-pair` 90° swap `(cre,cim)↦(cim,−cre)` (it just swaps the two terms),
+    so the paired Re/Im banks and the amp-rotated oracle land at one `k`. The
+    DYNAMIC `maxSig` folds the SAME per-mode amp subterms the columns are built
+    from (never a `Sig.index` column read — `Stage0` pins `arrayReg`/`loopIdx`
+    `.s1`, which would park the O(count) chain in the AUDIO kernel); its leaves are
+    `num`/`paramRef`, so it stages to fold/s0 and rides the coefficient kernel.
+    `floatExponent` is `⌊log₂⌋` and fails toward HEADROOM: `floatExponent 0 =
+    −1023 ⇒ k=0` (silent bank), `floatExponent NaN = 1024 ⇒ k=28` (max headroom),
+    never k=0-toward-the-wrap. Both paths clamp `k∈[0,28]`. -/
+def bankLandExp (modes : Array ModalMode) : LandExp := Id.run do
+  let mut mx : Float := 0.0
+  let mut allConst := true
+  for m in modes do
+    match sigConstF? m.cre, sigConstF? m.cim with
+    | some cr, some ci => let v := cr.abs + ci.abs; if v > mx then mx := v
+    | _, _ => allConst := false
+  if allConst then
+    return .static (landK mx)
+  let maxSig := modes.foldl (fun acc m =>
+    let a := add (.unary .abs m.cre) (.unary .abs m.cim)
+    selectE (gt acc a) acc a) (lit 0)
+  return .dynamic (clampE (sub (.unary .floatExponent maxSig) (lit 4)) (lit 0) (lit 28))
+
 /-- The RELATIVE clock `clkRel = clk − anchor·2³²` as an EXACT i64 subtract.
     (A float-relative clock — `toFloat(clk)/2³² − anchor` — loses mantissa bits
     as the absolute clock grows, drifting with τ.) Subtracting on
@@ -98,21 +192,23 @@ def modePhaseQFromIncr (incr clkRel : Sig) : Sig :=
 def modalBankSig (modes : Array ModalMode) (clkInt : Sig) (anchorSamples : Sig) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
-  -- Q datapath: per mode, the slow scalars (envelope × residue
-  -- weight) land ONCE as Q4.28 (headroom |w| < 32, quantum 3.7e-9 ≈ −168 dB —
-  -- a tail quieter than that truncates to true silence), the oscillator values
-  -- are exact Q2.30 off the integer phase, and the mode SUM is i64 — modular,
-  -- hence associative and commutative: reordering modes cannot move a bit,
-  -- which float summation never gave us. One float scale at the boundary.
+  -- Q datapath: per mode, the slow scalars (envelope × residue weight) land ONCE
+  -- as Q(4+k).(28−k) (`le`, option E — `k=0`/Q4.28 unless the bank's collected
+  -- `|A|` crosses the i64 rail of 32; quantum 3.7e-9·2^k ≈ −168 dB at k=0 — a
+  -- tail quieter than that truncates to true silence), the oscillator values are
+  -- exact Q2.30 off the integer phase, and the mode SUM is i64 — modular, hence
+  -- associative and commutative: reordering modes cannot move a bit, which float
+  -- summation never gave us. One float scale at the boundary.
+  let le := bankLandExp modes
   let bankQ := modes.foldl
     (fun acc m =>
       let phQ := modePhaseQ m.omega clkRel
       let env := expSig (neg (mul m.sigma dSec))
       let env2 := if m.deg == 0 then env else mul (powE dSec m.deg) env
-      let wCre := toIntE (mul (mul env2 m.cre) (lit 268435456))
-      let wCim := toIntE (mul (mul env2 m.cim) (lit 268435456))
+      let wCre := toIntE (mul (mul env2 m.cre) le.scale)
+      let wCim := toIntE (mul (mul env2 m.cim) le.scale)
       let oscQ := rshift (sub (mul wCre (fixedCosCycSig phQ))
-                              (mul wCim (fixedSinCycSig phQ))) (lit 28)
+                              (mul wCim (fixedSinCycSig phQ))) le.shift
       add acc oscQ)
     (litI 0)
   selectE (gt clkRel (lit 0)) (fixedOutQ 30 bankQ) (lit 0)
@@ -196,13 +292,14 @@ def modalBankSigTable (modes : Array ModalMode) (clkInt anchorSamples : Sig)
     (live? : Option Sig := none) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
+  let le := bankLandExp modes                                    -- option E: per-bank Q exponent
   let bankQ := bankFold (bankCols modes live?) fun m =>
     let phQ  := modePhaseQFromIncr (toIntE m.incr) clkRel
     let env  := expSig (neg (mul m.sigma dSec))
-    let wCre := toIntE (mul (mul env m.cre) (lit 268435456))
-    let wCim := toIntE (mul (mul env m.cim) (lit 268435456))
+    let wCre := toIntE (mul (mul env m.cre) le.scale)
+    let wCim := toIntE (mul (mul env m.cim) le.scale)
     rshift (sub (mul wCre (fixedCosCycSig phQ))
-                (mul wCim (fixedSinCycSig phQ))) (lit 28)
+                (mul wCim (fixedSinCycSig phQ))) le.shift
   selectE (gt clkRel (lit 0)) (fixedOutQ 30 bankQ) (lit 0)
 
 /-- The ANALYTIC bank: the `(Re, Im)` pair of `Σ A·e^{iφ}·env` over ONE column
@@ -221,17 +318,18 @@ def modalBankSigPairTable (modes : Array ModalMode) (clkInt anchorSamples : Sig)
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
   let cols := bankCols modes live?
+  let le := bankLandExp modes                                    -- option E: shared by Re and Im
   let body (imag : Bool) : ModeSym → Sig := fun m =>
     let phQ  := modePhaseQFromIncr (toIntE m.incr) clkRel
     let env  := expSig (neg (mul m.sigma dSec))
-    let wCre := toIntE (mul (mul env m.cre) (lit 268435456))
-    let wCim := toIntE (mul (mul env m.cim) (lit 268435456))
+    let wCre := toIntE (mul (mul env m.cre) le.scale)
+    let wCim := toIntE (mul (mul env m.cim) le.scale)
     if imag then
       rshift (add (mul wCre (fixedSinCycSig phQ))
-                  (mul wCim (fixedCosCycSig phQ))) (lit 28)
+                  (mul wCim (fixedCosCycSig phQ))) le.shift
     else
       rshift (sub (mul wCre (fixedCosCycSig phQ))
-                  (mul wCim (fixedSinCycSig phQ))) (lit 28)
+                  (mul wCim (fixedSinCycSig phQ))) le.shift
   let gate := fun q => selectE (gt clkRel (lit 0)) (fixedOutQ 30 q) (lit 0)
   (gate (bankFold cols (body false)), gate (bankFold cols (body true)))
 
@@ -505,7 +603,18 @@ def bankFoldPaired (cols : PairedBankCols) (body : PairedModeSym → Sig) : Sig 
     direct `(e^z−1)/z` (`|z|²≥thr²=0.01`, guarded so the unused branch never divides
     by ~0) and the Horner series (small `|z|`); the complex weight
     `Wc = c·(e^{νd}·d·cexpm1)` lands in Q4.28 and combines with the ν oscillator in
-    i64 — `modalBankSigTable`'s skeleton exactly, one float boundary scale. `envDf`
+    i64 — `modalBankSigTable`'s skeleton exactly, one float boundary scale.
+
+    RANGE (WS-AA range lens). **Rail**: the same i64 landing as the plain sites —
+    `|Wc|·2²⁸·2³⁰ < 2⁶³` ⇒ **per mode `|Wc| < 32`**. This is a FACTOR site: `Wc`
+    carries the per-sample `d·cexpm1(Δd)` secular, which is UNBOUNDED by a
+    coefficient-time `max|A|` (it needs the bake-time sup `min(2/|Δ|, 1/(e·σ_min))`),
+    so the plain `bankLandExp` does NOT reach it. **Reachable max**: not bounded by
+    admission (a pole-DISTANCE test). **DEFERRED, not fixed** (remainder-handoff §1):
+    this is a fixture-only site — no Playground surface routes through
+    `modalBankSigTableDD` (the DD dispatch is never wired into `lowerModal`), so it
+    lands nothing in production. Option E covers it when the DD wiring lands, with
+    its own measured sup and witness, per the role-split rule. `envDf`
     and `e^z` stay float (never landed); `z`'s imaginary part uses raw `ω_d·dSec`
     (the divisor needs only relative precision; the rotator phase is integer-reduced,
     consistent because `e^z` is periodic). -/
@@ -776,21 +885,6 @@ def bloomFoldQCoef (a1 a2 : CplxB) (n : Nat) : Array CplxB := Id.run do
 def bloomFoldDDaM (qcoef : Array CplxB) (x : CplxB) : CplxB :=
   x.mul (qcoef.foldr (fun q h => q.add (x.mul h)) ⟨0, 0⟩)
 
-/-- Fold an authored-constant `Sig` back to its `Float` (the baked-pole read in
-    `bloomCompose`). Partial: `none` on any live/unsupported node — a live pole
-    is outside the v1 baked-pole contract, not an error to paper over. -/
-private partial def sigConstF? : Sig → Option Float
-  | .num n            => some n.toFloat
-  | .unary .neg a     => (sigConstF? a).map (fun x => -x)
-  | .unary .toFloat a => sigConstF? a
-  | .binary .add a b  => do pure ((← sigConstF? a) + (← sigConstF? b))
-  | .binary .sub a b  => do pure ((← sigConstF? a) - (← sigConstF? b))
-  | .binary .mul a b  => do pure ((← sigConstF? a) * (← sigConstF? b))
-  | .binary .div a b  => do
-      let x ← sigConstF? a; let y ← sigConstF? b
-      pure (if y == 0.0 then 0.0 else x / y)
-  | _                 => none
-
 /-- One composed (voice μ, reverb ν) pair of the Γ-bridge atom. Everything but
     the amp is BAKED (`besselFuse`'s v1 contract: B, g and both pole sets baked —
     a change relowers; the amp `c = a_voice·r_reverb` stays a live `CplxE` and
@@ -1052,7 +1146,29 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
     select picks the cockpit-validated branch, the DD's guarded-`cexpm1`
     stance). Weights land Q4.28, carriers are exact Q2.30, the pair sum is i64
     (the `modalBankSigTableDD` skeleton). Unrolled per pair — envelope depths
-    are per-pair ragged, the non-uniform route. Causal gate on `clkRel > 0`. -/
+    are per-pair ragged, the non-uniform route. Causal gate on `clkRel > 0`.
+
+    RANGE (WS-AA range lens). **Rail**: `|env·w| < 32` PER CARRIER, PER pair (2
+    `land` calls for non-coincident pairs, 3 with the τ·e secular). A FACTOR site:
+    each `w` carries the region-selected series-M / continued-fraction / Γ★ / τ·e
+    factor, so the sup must be taken over d≥0 on the SELECTED lane only (a naive
+    both-lane sup over-estimates by ~1e10 — the unselected series-M reaches ~5e10
+    at z=κ where the selected CF weight is ~0.2). **Reachable max at every config
+    that fires today: ≪ 32** (measured: SeamSweep gong-reverb 0.005; WS-A4
+    coincident 0.27–0.92; a baked filterPair(Q44) stress config 2.48), so this
+    site is **unprotected but not broken**, and option E at k=0 is a byte-identical
+    no-op for it. **Two reasons it is NOT landed in this pass, DEFERRED to the
+    factor-site follow-on**: (a) it is GUI-DARK — `bloomCompose` requires every
+    pole to `sigConstF?`, but the Playground makes rt60/cutoff/resonance LIVE
+    slots, so the live surface never emits this (only the SeamSweep gate and
+    authored/loaded literal-pole programs do); (b) there is a reachable-by-baked-
+    poles degenerate case option E CANNOT absorb — filtering a gong ON one of its
+    own partials with a heavily-damped pole (`Re(a) ≲ −1`, `a` near a negative
+    integer) makes the series-M lane ~5e12, past the k≤28 ceiling of 32·2²⁸≈8.6e9,
+    AND the Γ★ bridge is itself semantically invalid there (the two lane-totals
+    disagree by ~1e8). Its correct remedy is a new `classifyBloomPair` admission
+    guard rejecting `Re(a) ≲ −1` to `excludedDepth`, which the factor-site landing
+    adds ALONGSIDE the per-pair exponent — not a landing-scale fix. -/
 def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
@@ -1390,11 +1506,16 @@ def modalBankSigDir (modes : Array ModalMode) (clkInt : Sig) (anchorSamples : Si
     (dir : Sig) (dampScale? : Option Sig := none) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
-  -- Q datapath, same ledger as `modalBankSig` (Q4.28 weight landings, exact
-  -- Q2.30 oscillators, i64 mode sums). The causal gates and the dir crossfade
-  -- hoist OUT of the per-mode fold: the gate condition is per-bank (same
-  -- clkRel for every mode) and the blend distributes over the sum — done once
-  -- at the float boundary instead of per mode.
+  -- Q datapath, same ledger as `modalBankSig` (Q(4+k).(28−k) weight landings via
+  -- option E's `le`, exact Q2.30 oscillators, i64 mode sums). The causal gates
+  -- and the dir crossfade hoist OUT of the per-mode fold. `le` is derived from
+  -- the AMP columns only (`bankLandExp` never reads env): the reverse arm's
+  -- `envR = e^{+σd}` is > 1 for d > 0, but that landing is DISCARDED by the
+  -- reverse `selectE` (active only for clkRel < 0, where envR ≤ 1) — its
+  -- non-taken poison must not force k upward, and the audible reverse tail is the
+  -- forward tail's time-mirror, equally |A|-bounded. So the same `le` serves both
+  -- arms and `dir=0` stays bit-identical to `modalBankSig`.
+  let le := bankLandExp modes
   let (fwdQ, revQ) := modes.foldl
     (fun (acc : Sig × Sig) m =>
       let phQ := modePhaseQ m.omega clkRel
@@ -1412,14 +1533,14 @@ def modalBankSigDir (modes : Array ModalMode) (clkInt : Sig) (anchorSamples : Si
       let envF := if m.deg == 0 then envF else mul (powE dSec m.deg) envF
       let envR := expSig sd
       let envR := if m.deg == 0 then envR else mul (powE (neg dSec) m.deg) envR
-      let wCreF := toIntE (mul (mul envF m.cre) (lit 268435456))
-      let wCimF := toIntE (mul (mul envF m.cim) (lit 268435456))
-      let wCreR := toIntE (mul (mul envR m.cre) (lit 268435456))
-      let wCimR := toIntE (mul (mul envR m.cim) (lit 268435456))
+      let wCreF := toIntE (mul (mul envF m.cre) le.scale)
+      let wCimF := toIntE (mul (mul envF m.cim) le.scale)
+      let wCreR := toIntE (mul (mul envR m.cre) le.scale)
+      let wCimR := toIntE (mul (mul envR m.cim) le.scale)
       let fwdM := rshift (sub (mul wCreF (fixedCosCycSig phQ))
-                              (mul wCimF (fixedSinCycSig phQ))) (lit 28)
+                              (mul wCimF (fixedSinCycSig phQ))) le.shift
       let revM := rshift (sub (mul wCreR (fixedCosCycSig phQN))
-                              (mul wCimR (fixedSinCycSig phQN))) (lit 28)
+                              (mul wCimR (fixedSinCycSig phQN))) le.shift
       (add acc.1 fwdM, add acc.2 revM))
     (litI 0, litI 0)
   let fwd := selectE (gt clkRel (lit 0)) (fixedOutQ 30 fwdQ) (lit 0)
@@ -1441,6 +1562,7 @@ def modalBankSigDirTable (modes : Array ModalMode) (clkInt anchorSamples : Sig)
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
   let cols := bankCols modes live?
+  let le := bankLandExp modes                 -- option E: amp-only, shared fwd/rev (see modalBankSigDir)
   -- σ·d, optionally sway-bent (decay clock only, pitch untouched) — the same
   -- subterm both sides read, per symbolic mode.
   let sdOf := fun (m : ModeSym) =>
@@ -1449,19 +1571,19 @@ def modalBankSigDirTable (modes : Array ModalMode) (clkInt anchorSamples : Sig)
   let fwdQ := bankFold cols fun m =>
     let phQ   := modePhaseQFromIncr (toIntE m.incr) clkRel
     let envF  := expSig (neg (sdOf m))
-    let wCreF := toIntE (mul (mul envF m.cre) (lit 268435456))
-    let wCimF := toIntE (mul (mul envF m.cim) (lit 268435456))
+    let wCreF := toIntE (mul (mul envF m.cre) le.scale)
+    let wCimF := toIntE (mul (mul envF m.cim) le.scale)
     rshift (sub (mul wCreF (fixedCosCycSig phQ))
-                (mul wCimF (fixedSinCycSig phQ))) (lit 28)
+                (mul wCimF (fixedSinCycSig phQ))) le.shift
   let revQ := bankFold cols fun m =>
     -- the mirrored phase spelled out on the NEGATED clock, as in the unrolled
     -- path (the fixed sine isn't bit-symmetric; see `modalBankSigDir`).
     let phQN  := modePhaseQFromIncr (toIntE m.incr) (neg clkRel)
     let envR  := expSig (sdOf m)
-    let wCreR := toIntE (mul (mul envR m.cre) (lit 268435456))
-    let wCimR := toIntE (mul (mul envR m.cim) (lit 268435456))
+    let wCreR := toIntE (mul (mul envR m.cre) le.scale)
+    let wCimR := toIntE (mul (mul envR m.cim) le.scale)
     rshift (sub (mul wCreR (fixedCosCycSig phQN))
-                (mul wCimR (fixedSinCycSig phQN))) (lit 28)
+                (mul wCimR (fixedSinCycSig phQN))) le.shift
   let fwd := selectE (gt clkRel (lit 0)) (fixedOutQ 30 fwdQ) (lit 0)
   let rev := selectE (gt (lit 0) clkRel) (fixedOutQ 30 revQ) (lit 0)
   add (mul (sub (lit 1) dir) fwd) (mul dir rev)

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -825,6 +825,61 @@ def lgammaB (z : CplxB) : CplxB :=
     (CplxB.sub ⟨Float.log pi, 0⟩ logsin).sub (core (CplxB.sub ⟨1, 0⟩ z))
   else core z
 
+-- ── The EMITTED complex transcendentals (WS-LP: the live Γ★ bridge) ────────────
+-- The bloom crossing's bake-time constants are lifted from build-time `CplxB` to
+-- emitted `CplxE` (Sig × Sig) so a LIVE pole survives the crossing. The one new
+-- op under this is `atan2E` (Numerics); everything else is mechanical CplxE.
+
+/-- Complex log at Sig level: `⟨½·log|z|², atan2(Im, Re)⟩` — `logSig` supplies the
+    modulus half, `atan2E` the phase. The live twin of `CplxB.log`. -/
+def clogE (z : CplxE) : CplxE :=
+  (mul (lit 5 1) (logSig (add (mul z.1 z.1) (mul z.2 z.2))), atan2E z.2 z.1)
+
+/-- Complex exp at Sig level: `e^{Re}·⟨cos Im, sin Im⟩`. The live twin of `CplxB.exp`. -/
+def cexpE (z : CplxE) : CplxE :=
+  let e := expSig z.1
+  (mul e (cosSig z.2), mul e (sinSig z.2))
+
+/-- Complex log-gamma at Sig level — the EMITTED twin of `lgammaB`. Same Lanczos
+    (g=7, n=9) core, same reflection for `Re z < ½` on the dominant half of
+    `log sin πz`; the build-time `if z.re<½` / `if z.im<0` branches become `selectE`s
+    (the unselected core lane may go non-finite off its region — the select discards
+    it, the bloom's established discipline). Both `clogE`/`cexpE` reachable. -/
+def lgammaE (z : CplxE) : CplxE :=
+  let lanczos : Array Float := #[0.99999999999980993, 676.5203681218851,
+    -1259.1392167224028, 771.32342877765313, -176.61502916214059,
+    12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6,
+    1.5056327351493116e-7]
+  let core : CplxE → CplxE := fun z =>
+    let zz := csubE z (lit 1, lit 0)
+    let x := (Array.range 8).foldl
+      (fun acc i => caddE acc (cdivE ((litF lanczos[i+1]!, lit 0) : CplxE)
+        (caddE zz ((litF (i+1).toFloat, lit 0) : CplxE))))
+      ((litF lanczos[0]!, lit 0) : CplxE)
+    let t := caddE zz ((litF 7.5, lit 0) : CplxE)
+    caddE (csubE (cmulE (caddE zz ((lit 5 1, lit 0) : CplxE)) (clogE t)) t)
+          (caddE (clogE x) ((litF (0.5 * Float.log (2.0 * 3.141592653589793)), lit 0) : CplxE))
+  let pi := lit 3141592653589793 15
+  let imNeg := gt (lit 0) z.2                                    -- Im z < 0
+  let s : CplxE := (selectE imNeg (neg (mul pi z.2)) (mul pi z.2),
+                    selectE imNeg (mul pi z.1) (neg (mul pi z.1)))
+  let log2i : CplxE := ((litF (Float.log 2.0) : Sig),
+                        selectE imNeg (lit 15707963267948966 16) (neg (lit 15707963267948966 16)))
+  let logsin := csubE (caddE s (clogE (csubE ((lit 1, lit 0) : CplxE)
+                  (cexpE (scaleRealE (lit (-2)) s))))) log2i
+  let reflected := csubE (csubE ((litF (Float.log 3.141592653589793), lit 0) : CplxE) logsin)
+                         (core (csubE ((lit 1, lit 0) : CplxE) z))
+  let base := core z
+  let useRefl := gt (lit 5 1) z.1                                -- Re z < ½
+  (selectE useRefl reflected.1 base.1, selectE useRefl reflected.2 base.2)
+
+/-- Γ★ = `exp(lgamma(a) − a·log κ + κ)/g` at Sig level — the live twin of
+    `bloomGammaStar`, the bloom crossing's d-constant bridge between the two envelope
+    branches (its `e^{±π|Im a|/2}` blowups cancel in the exponent). -/
+def bloomGammaStarE (a kappa : CplxE) (g : Sig) : CplxE :=
+  scaleRealE (div (lit 1) g)
+    (cexpE (caddE (csubE (lgammaE a) (cmulE a (clogE kappa))) kappa))
+
 /-- `M(1, a+1, z) = 1 + z/(a+1)(1 + z/(a+2)(…))` by forward recurrence —
     `(value, terms)`. Build-time (the κ-side constant + per-pair depth sizing);
     the per-sample twin is the fixed-depth Horner in `bloomComposedSig`. Stable

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -64,17 +64,30 @@ private partial def sigConstF? : Sig → Option Float
 
 -- ── Option E: the per-bank Q-landing exponent (the modal-datapath rail fix) ────
 -- Every modal weight lands as Q4.28 (×2²⁸) and multiplies an exact Q2.30 rotator
--- in i64, so `|w|·env·2²⁸·2³⁰ = |w|·env·2⁵⁸` wraps against i64's 2⁶³ once
--- `|w|·env > 2⁵ = 32` — reachable from the shipped vocabulary (a resonant lowpass
--- has `|A| ≈ Q = 0.55·80^res`, so the rail is a cap on filter Q at 32; the top
--- ~8% of the resonance knob wraps). The cure: land the weight at `2^(28−k)` and
--- shift back by `28−k`, with `k` chosen PER BANK from the coefficient-time
--- amplitude so the product cannot wrap. The rendered VALUE is k-INVARIANT — the
--- `>>(28−k)` undoes the `·2^(28−k)` exactly and `(28−k)+30−(28−k)=30` leaves the
--- accumulator at Q2.30, so `fixedOutQ 30` is unchanged; only the quantization LSB
--- moves. At `k=0` the emitted ops are `·2²⁸` / `>>28` verbatim — byte-identical.
--- The i64 accumulator (`Σ oscQₘ`, each already `>>(28−k)` to Q2.30) never binds:
--- it needs `Σₘ|Aₘ| < 2³³`, orders looser than the per-mode `32·2^k`.
+-- in i64, so `w·env·2²⁸·2³⁰ = w·env·2⁵⁸` wraps against i64's 2⁶³ once the LANDED
+-- magnitude `sup_d |env₂·A| > 2⁵ = 32` — reachable from the shipped vocabulary (a
+-- resonant lowpass has `|A| ≈ Q = 0.55·80^res`, so the rail is a cap on filter Q
+-- at 32; the top ~8% of the resonance knob wraps). The cure: land the weight at
+-- `2^(28−k)` and shift back by `28−k`, with `k` chosen PER BANK from the
+-- coefficient-time bound `maxAbs = maxₘ sup_d |env₂ₘ·Aₘ|`. For a deg-0 mode
+-- `env₂ = e^{−σd} ≤ 1`, so the bound is the amplitude `|creₘ|+|cimₘ|`; a deg-`p`
+-- mode's `env₂ = d^p·e^{−σd}` peaks at `(p/(σe))^p` (`bankLandExp` folds that
+-- factor in — so the fix is sound for deg > 0 too, not only the deg-0 plain
+-- vocabulary). The rendered VALUE is k-INVARIANT — the `>>(28−k)` undoes the
+-- `·2^(28−k)` exactly and `(28−k)+30−(28−k)=30` leaves the accumulator at Q2.30,
+-- so `fixedOutQ 30` is unchanged; only the quantization LSB moves. At `k=0` the
+-- emitted ops are `·2²⁸` / `>>28` verbatim — byte-identical.
+--
+-- TWO caveats, both at the +198 dB extreme (maxAbs ≥ 2³³), practically inert but
+-- stated for honesty. (1) THE k=28 CEILING: `k` clamps at 28 (a negative shift is
+-- UB), so the per-mode guarantee holds only for `maxAbs < 2³³ = 32·2²⁸`; above it
+-- `k` saturates and the product wraps. (2) THE ORTHOGONAL ACCUMULATOR RAIL: the
+-- i64 sum `Σ oscQₘ` (each `>>(28−k)` to Q2.30) needs `Σₘ|Aₘ| < 2³³` — orders
+-- looser than the per-mode `32·2^k` for any realistic bank, but NOT never: a
+-- collected weight reaching 2³³ (a live pole swept within ~6e-11 rad/s of exact
+-- coincidence, or absurd authored amps) binds it, and option E does not address
+-- this rail. Both extremes are past any musical level; the device clamp (C = 256)
+-- bounds their blast radius at the DAC.
 
 /-- `⌊log₂|x|⌋` for a finite nonzero `x` — the IEEE-754 unbiased exponent, the
     exact Lean-Float mirror of the `floatExponent` op the DYNAMIC path emits (so a
@@ -83,12 +96,15 @@ private def floatExpZ (x : Float) : Int :=
   (((x.abs.toBits >>> 52) &&& 0x7ff).toNat : Int) - 1023
 
 /-- `k = clamp(0, 28, ⌊log₂ maxAbs⌋ − 4)` as a `Nat` (the static path). Solves
-    `maxAbs < 32·2^k`, so `maxAbs < 32 ⇒ k = 0` (bit-identical). Non-finite or
-    `≤ 0` ⇒ `k = 0` — a silent (all-zero-amp) or degenerate bank lands verbatim,
-    and the residue calculus on finite baked poles cannot produce a non-finite amp. -/
+    `maxAbs < 32·2^k` for `maxAbs < 2³³` (the k=28 ceiling: above it `k` saturates
+    and the guarantee lapses — a +198 dB weight, practically inert). `maxAbs < 32
+    ⇒ k = 0` (bit-identical). Non-finite (`+∞` from a non-decaying deg>0 mode) ⇒
+    `k = 28` (max headroom); `≤ 0` ⇒ `k = 0` (a silent all-zero bank lands verbatim). -/
 private def landK (maxAbs : Float) : Nat :=
-  if maxAbs ≤ 0.0 || !maxAbs.isFinite then 0
+  if maxAbs ≤ 0.0 then 0            -- silent/all-zero bank: land verbatim (k=0)
   else
+    -- ∞/NaN reach here (¬(x ≤ 0)); floatExpZ reads their exponent field 2047 ⇒
+    -- 1024 ⇒ clamp 28 (max headroom, matching the dynamic floatExponent path).
     let e := floatExpZ maxAbs - 4
     if e ≤ 0 then 0 else if e ≥ 28 then 28 else e.toNat
 
@@ -114,28 +130,56 @@ def LandExp.shift : LandExp → Sig
   | .static k  => lit (28 - k)
   | .dynamic k => sub (lit 28) k
 
-/-- The per-bank landing exponent from a bank's mode amplitudes. The guarded
-    magnitude is `maxAbs = maxₘ(|creₘ|+|cimₘ|)`, the L1 amp norm — invariant under
-    the `modal-pair` 90° swap `(cre,cim)↦(cim,−cre)` (it just swaps the two terms),
-    so the paired Re/Im banks and the amp-rotated oracle land at one `k`. The
-    DYNAMIC `maxSig` folds the SAME per-mode amp subterms the columns are built
-    from (never a `Sig.index` column read — `Stage0` pins `arrayReg`/`loopIdx`
-    `.s1`, which would park the O(count) chain in the AUDIO kernel); its leaves are
-    `num`/`paramRef`, so it stages to fold/s0 and rides the coefficient kernel.
-    `floatExponent` is `⌊log₂⌋` and fails toward HEADROOM: `floatExponent 0 =
-    −1023 ⇒ k=0` (silent bank), `floatExponent NaN = 1024 ⇒ k=28` (max headroom),
-    never k=0-toward-the-wrap. Both paths clamp `k∈[0,28]`. -/
+/-- The envelope-peak factor `sup_{d≥0} d^p·e^{−σd} = (p/(σe))^p` for a mode of
+    degree `p` (the polynomial-order lift): `1` for `p=0` (`e^{−σd} ≤ 1`), else the
+    interior peak at `d = p/σ`. A non-decaying polynomial mode (`σ ≤ 0`, `p > 0`)
+    has no finite sup — `+∞`, which lands `k=28` (max headroom; it cannot be made
+    safe, and no residue calculus produces one). -/
+private def envPeakF (deg : Nat) (sigma : Float) : Float :=
+  if deg == 0 then 1.0
+  else if sigma ≤ 0.0 then (1.0 / 0.0)
+  else Float.pow (deg.toFloat / (sigma * 2.718281828459045)) deg.toFloat
+
+/-- The `Sig` mirror of `envPeakF` for the DYNAMIC max fold: `(p/(σe))^p·(|cre|+
+    |cim|)`. Reduces to exactly `|cre|+|cim|` at `deg=0`, so a deg-0 bank's `maxSig`
+    is unchanged (byte-identical dynamic path). -/
+private def modeWeightBoundSig (m : ModalMode) : Sig :=
+  let amp := add (.unary .abs m.cre) (.unary .abs m.cim)
+  if m.deg == 0 then amp
+  else mul (powE (div (litF m.deg.toFloat) (mul m.sigma (litF 2.718281828459045))) m.deg) amp
+
+/-- The per-bank landing exponent from a bank's mode weights. The guarded
+    magnitude is `maxAbs = maxₘ sup_d |env₂ₘ·Aₘ| = maxₘ (p/(σe))^p·(|creₘ|+|cimₘ|)`,
+    the deg-lifted L1 amp norm — invariant under the `modal-pair` 90° swap
+    `(cre,cim)↦(cim,−cre)` (it just swaps the two amp terms; the env factor is
+    amp-free), so the paired Re/Im banks and the amp-rotated oracle land at one
+    `k`. The DYNAMIC `maxSig` folds the SAME per-mode subterms the columns are
+    built from (never a `Sig.index` column read — `Stage0` pins `arrayReg`/
+    `loopIdx` `.s1`, which would park the O(count) chain in the AUDIO kernel); its
+    leaves are `num`/`paramRef`, so it stages to fold/s0 and rides the coefficient
+    kernel. `floatExponent` is `⌊log₂⌋` and fails toward HEADROOM: `floatExponent 0
+    = −1023 ⇒ k=0` (silent bank), `floatExponent NaN/∞ = 1024 ⇒ k=28` (max
+    headroom), never k=0-toward-the-wrap. Both paths clamp `k∈[0,28]`. -/
 def bankLandExp (modes : Array ModalMode) : LandExp := Id.run do
   let mut mx : Float := 0.0
   let mut allConst := true
   for m in modes do
-    match sigConstF? m.cre, sigConstF? m.cim with
-    | some cr, some ci => let v := cr.abs + ci.abs; if v > mx then mx := v
-    | _, _ => allConst := false
+    -- deg-0 (the whole plain vocabulary) never queries σ, so a live-σ deg-0 bank
+    -- still takes the static path when its amps const-fold.
+    if m.deg == 0 then
+      match sigConstF? m.cre, sigConstF? m.cim with
+      | some cr, some ci => let v := cr.abs + ci.abs; if v > mx then mx := v
+      | _, _ => allConst := false
+    else
+      match sigConstF? m.cre, sigConstF? m.cim, sigConstF? m.sigma with
+      | some cr, some ci, some sg =>
+        let v := (cr.abs + ci.abs) * envPeakF m.deg sg
+        if v > mx then mx := v
+      | _, _, _ => allConst := false
   if allConst then
     return .static (landK mx)
   let maxSig := modes.foldl (fun acc m =>
-    let a := add (.unary .abs m.cre) (.unary .abs m.cim)
+    let a := modeWeightBoundSig m
     selectE (gt acc a) acc a) (lit 0)
   return .dynamic (clampE (sub (.unary .floatExponent maxSig) (lit 4)) (lit 0) (lit 28))
 

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -727,6 +727,55 @@ def bloomPhiKappaOverG (aC kappa cfK : CplxB) (dCoef : Array CplxB) (g : Float) 
     let w := aC.mul waOverA
     ((((CplxB.exp kappa).mul (cexpm1B w)).mul waOverA).sub cfK).scale (1.0 / g)
 
+-- ── The ROOM-CHAIN FOLD divided difference (WS-DDF) ───────────────────────────
+-- A bloomed voice crossing a reverb CHAIN reassociates as (fold room1|>room2, then
+-- cross the bloom once). The fold's collected residues carry a 1/Δ over the ROOM
+-- poles (Δ = ν1−ν2); near-coincident rooms (two rooms sharing a mode region) drive
+-- the residue `c/Δ` out of Q4.28 range as a VALUE (|c/Δ| > 8). MEASURED QUALIFIER
+-- (the `ddfold` gate, arm A): at the BLOOMED site that does not yet break the
+-- render — the bloom's per-sample K factor (≈ M(κ)/(gα) ≈ 1e-3 for rooms far from
+-- the voice) divides the huge residue back down before anything lands, so the
+-- collected fold stays finite to Δ ~ 1e-5 rad/s. The premise holds unqualified only
+-- at the BARE-residue site (`modal_divdiff`'s D_dd2, where the residue lands with
+-- no K factor in front of it). The fix below is the correct, modestly-tighter
+-- form — and the transfer datum — not an urgent repair. The fix: the chain is
+-- the DIVIDED DIFFERENCE of the bloom cross over the two room poles,
+--   chain(d) = c·[Y0(μ,ν1;d) − Y0(μ,ν2;d)]/(ν1−ν2),
+-- and since ν1≈ν2 ⟹ a1≈a2 it decomposes (cockpit `demos/modal_ddfold.py`, D_df2/3):
+--   chain/c = e^{ν2 d}·[K1(a1)·d·cexpm1(Δd) + DDa(K1)/g] + DDa(K2)(z)/g·e^{μφ(d)}
+-- reusing atom four's KIND of machinery one axis over — cexpm1 on the ν2 carrier,
+-- an a-divided-difference on the Γ-bridge constants (SERIES side only: the rooms are
+-- separated from the voice, |a|≫0, so `|a+1| ≥ |z|` throughout; no CF branch, no Γ★).
+
+/-- The general-a a-divided-difference coefficients `Qₙ` (WS-DDF): `DDa(M(1,a+1,·))
+    = Σ_{n≥1} Qₙ xⁿ`, the divided difference over two nearby a-values `a1, a2`
+    (`aⱼ = (νⱼ−μ)/g` for a near-coincident ROOM pair). The stable recurrence never
+    forms `M(a1)−M(a2)`:
+      `Qₙ = Qₙ₋₁/(a2+n) − Pₙ₋₁/((a1+n)(a2+n))`, `Q₀ = 0`, `Pₙ = Pₙ₋₁/(a1+n)`, `P₀ = 1`.
+    → `−Pₙ·Hₙ` (the a-derivative) at `a1 = a2`. The WS-DDF sibling of `bloomDCoef`
+    (the a≈0, differ-against-`eˣ` instance); this is the general-a form for the
+    room-chain FOLD's divided difference. Cockpit `demos/modal_ddfold.py` (D_df3,
+    float64 vs mpmath ~8e-14). -/
+def bloomFoldQCoef (a1 a2 : CplxB) (n : Nat) : Array CplxB := Id.run do
+  let mut out : Array CplxB := #[]
+  let mut pPrev : CplxB := ⟨1, 0⟩   -- P₀
+  let mut qPrev : CplxB := ⟨0, 0⟩   -- Q₀
+  for k in [1:n+1] do
+    let kf := k.toFloat
+    let a1k := a1.add ⟨kf, 0⟩
+    let a2k := a2.add ⟨kf, 0⟩
+    let qk := (qPrev.div a2k).sub (pPrev.div (a1k.mul a2k))
+    out := out.push qk
+    pPrev := pPrev.div a1k
+    qPrev := qk
+  return out
+
+/-- `DDa(M(1,a+1,x)) = Σ_{n≥1} Qₙ xⁿ = x·Horner(Q)` over the baked `Qₙ`
+    (`bloomFoldQCoef`) — build-time at `x = κ` (the `ddK1` constant), per-sample at
+    `x = z(d)` in the realizer. -/
+def bloomFoldDDaM (qcoef : Array CplxB) (x : CplxB) : CplxB :=
+  x.mul (qcoef.foldr (fun q h => q.add (x.mul h)) ⟨0, 0⟩)
+
 /-- Fold an authored-constant `Sig` back to its `Float` (the baked-pole read in
     `bloomCompose`). Partial: `none` on any live/unsupported node — a live pole
     is outside the v1 baked-pole contract, not an error to paper over. -/
@@ -1115,6 +1164,155 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
     already-warped clock. -/
 def bloomComposedTerm (pairs : Array BloomPair) (anchor : Sig) (c : Clock) : ArrowTerm :=
   ArrowTerm.arrUn (fun clkSig => bloomComposedSig pairs clkSig anchor) (ArrowTerm.clk c)
+
+/-- One composed (voice μ, near-coincident room PAIR (ν1, ν2)) of the WS-DDF fold
+    atom — the divided difference of the bloom cross over the two room poles. All
+    baked but the amp `c = a_voice·r1·r2` (`a_voice` live). Series side only (the
+    rooms are separated from the voice, so `|a1+1| ≥ |κ|`; no CF branch, no Γ★). -/
+structure BloomFoldPair where
+  muSigma  : Float
+  muOmega  : Float
+  nu1Sigma : Float
+  nu1Omega : Float
+  nu2Sigma : Float
+  nu2Omega : Float
+  bloomB   : Float
+  gRate    : Float
+  c        : CplxE          -- a_voice · r1 · r2  (live amp)
+  kappa    : CplxB
+  k1a1     : CplxB          -- K1(a1) = M(1,a1+1,κ)/(g·a1)   (the ν2-carrier's baked coeff)
+  ddK1g    : CplxB          -- DDa(K1)/g = DDa(M/a;κ)/g²      (the ν2-carrier's const term)
+  invA1a2  : CplxB          -- 1/(a1·a2)   (per-sample DDa(K2) assembly)
+  invA2    : CplxB          -- 1/a2
+  invA     : Array CplxB    -- 1/(a1+k), k = 1..N   (M(a1;z) Horner, per-sample)
+  qCoef    : Array CplxB    -- Qₙ, n = 1..N         (DDa(M;z) Horner, per-sample)
+deriving Inhabited
+
+/-- `bloomedVoice ⋙ (room1 ⋙ room2)` for a NEAR-COINCIDENT room pair — the WS-DDF
+    fold atom. The chain is the divided difference of the bloom cross over the two
+    room poles; each voice mode μ crosses the pair (ν1, ν2) into a `BloomFoldPair`
+    carrying the `cexpm1`-carrier + a-DD constants (build-time; the a-DD is the
+    general-a `bloomFoldQCoef` sibling of atom four's `bloomDCoef`). `r1`, `r2` are
+    single baked room modes (the two filters folding); the voice bank's amps stay
+    live. `none` if a live pole reaches the baked-pole contract; a voice mode too
+    close to the rooms (`|a| < ½` or CF side `|a+1| < |κ|`) or over the 300 depth cap
+    is skipped (graceful — that mode is out of the series-side v1 scope). -/
+def bloomFoldCompose (voice : Array ModalMode) (r1 r2 : ModalMode) (B g : Float) :
+    Option (Array BloomFoldPair) := Id.run do
+  let some r1Sig := sigConstF? r1.sigma | return none
+  let some r1Om  := sigConstF? r1.omega | return none
+  let some r1Cre := sigConstF? r1.cre   | return none
+  let some r1Cim := sigConstF? r1.cim   | return none
+  let some r2Sig := sigConstF? r2.sigma | return none
+  let some r2Om  := sigConstF? r2.omega | return none
+  let some r2Cre := sigConstF? r2.cre   | return none
+  let some r2Cim := sigConstF? r2.cim   | return none
+  let nu1 : CplxB := ⟨-r1Sig, r1Om⟩
+  let nu2 : CplxB := ⟨-r2Sig, r2Om⟩
+  let r1r2 := (⟨r1Cre, r1Cim⟩ : CplxB).mul ⟨r2Cre, r2Cim⟩
+  let mut out : Array BloomFoldPair := #[]
+  for v in voice do
+    let some vSig := sigConstF? v.sigma | return none
+    let some vOm  := sigConstF? v.omega | return none
+    let mu : CplxB := ⟨-vSig, vOm⟩
+    let a1 := (nu1.sub mu).scale (1.0 / g)
+    let a2 := (nu2.sub mu).scale (1.0 / g)
+    let kappa := mu.scale B
+    let aP1 := a1.add ⟨1, 0⟩
+    -- series-side admission: rooms separated from the voice (no CF branch, no Γ★).
+    if a1.abs < 0.5 || a2.abs < 0.5 || aP1.abs < kappa.abs then continue
+    let (_, nRaw) := bloomM1 a1 kappa
+    let nDepth := nRaw + 8    -- M(a1;z) depth; the a-DD's Hₙ factor is a small (~log) tail
+    if nDepth > 300 then continue
+    let qCoef := bloomFoldQCoef a1 a2 nDepth
+    let invA := (Array.range nDepth).map (fun k => CplxB.div ⟨1, 0⟩ (a1.add ⟨(k + 1).toFloat, 0⟩))
+    let (mK1, _) := bloomM1 a1 kappa                     -- M(a1;κ)
+    let ddMκ := bloomFoldDDaM qCoef kappa                -- DDa(M;κ) = Σ κⁿ Qₙ
+    let invA1a2 := CplxB.div ⟨1, 0⟩ (a1.mul a2)
+    let invA2 := CplxB.div ⟨1, 0⟩ a2
+    -- DDa(M/a;κ) = −M(a1;κ)/(a1 a2) + DDa(M;κ)/a2 ; k1a1 = M(a1;κ)/(g a1)
+    let ddMaκ := (mK1.mul invA1a2).neg.add (ddMκ.mul invA2)
+    out := out.push {
+      muSigma := vSig, muOmega := vOm
+      nu1Sigma := r1Sig, nu1Omega := r1Om, nu2Sigma := r2Sig, nu2Omega := r2Om
+      bloomB := B, gRate := g
+      c := cmulE v.ampE (cplxLitE r1r2)
+      kappa
+      k1a1 := mK1.div (a1.scale g)
+      ddK1g := ddMaκ.scale (1.0 / (g * g))
+      invA1a2, invA2, invA, qCoef }
+  return some out
+
+/-- The WS-DDF fold-atom bank as a pure `Sig` over the clock: per pair, TWO carriers
+    (the ν2 ring `e^{ν2 d}` on the straight clock, the bloomed voice `e^{μφ(d)}` on
+    the offset clock — as `bloomComposedSig`), weighted by the divided-difference
+    form. The ν2-carrier weight is `K1(a1)·d·cexpm1(Δd) + ddK1/g` (the `cexpm1`
+    secular over Δ = ν1−ν2, the `modalBankSigTableDD` shape); the voice-carrier
+    weight is `DDa(K2)(z)/g = −DDa(M/a;z)/g²` per sample — `M(a1;z)` via the `invA`
+    Horner, `DDa(M;z) = Σ zⁿ Qₙ` via the `qCoef` Horner. Weights land Q4.28,
+    carriers exact Q2.30. Causal gate on `clkRel > 0`.
+
+    RANGE (the WS-AA range lens' standing obligation, adopted 2026-07-20 —
+    `design/seam-hardening-remainder-handoff.local.md` §2). **Rail**: the landing is
+    `|w|·env·2²⁸` against a Q2.30 rotator in i64, so `|w|·env·2⁵⁸ < 2⁶³` ⇒ **per
+    lane `|w|·env < 32`** — the shared modal-datapath rail
+    (`design/modal-datapath-rail.local.md`; note `|w| > 32` is *necessary, not
+    sufficient*: failure additionally needs differing per-mode wrap counts).
+    **Reachable max**: NOT bounded by this atom's admission, which is a
+    pole-DISTANCE test (`|a| ≥ ½`, `|a+1| ≥ |κ|`) — exactly the class the rail doc
+    §(3) declares unsound. `ddK1g` carries the Kummer a-poles at `a₁ = −2, −3, …`,
+    which admission does not exclude; an admitted config with `|a₁+3| = 0.002` lands
+    ≈ 2.8e3, ~87× past the rail (in two equal-and-opposite lanes that cancel to
+    ~1e-3 in the sum — a pure RANGE defect, not a math defect). Not reachable from
+    any surface today: `bloomFoldCompose` has no caller outside the `ddfold` gate,
+    and no Playground room bakes its poles into this shape. Routed to the option-E
+    landing (remainder-handoff §1) per the role-split rule — no red witness lands
+    before the fix. This predicate is `classifyBloomPair`'s shipped one transcribed
+    a site over, so the exposure is INHERITED, not introduced; the atom-specific
+    delta is that the divided difference is ~70× more exposed than its `k1a1`
+    sibling at the same pole distance. -/
+def bloomFoldComposedSig (pairs : Array BloomFoldPair) (clkInt anchorSamples : Sig) : Sig :=
+  let clkRel := relClockQ clkInt anchorSamples
+  let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
+  let dPos := clampE dSec (lit 0) (lit 1000000)
+  let one : CplxE := (lit 1, lit 0)
+  let land := fun (env : Sig) (w : CplxE) (ph : Sig) =>
+    rshift (sub (mul (toIntE (mul (mul env w.1) (lit 268435456))) (fixedCosCycSig ph))
+                (mul (toIntE (mul (mul env w.2) (lit 268435456))) (fixedSinCycSig ph))) (lit 28)
+  let bankQ := pairs.foldl (fun acc p =>
+    let eg := expSig (neg (mul (litF p.gRate) dPos))
+    let z : CplxE := (mul (litF p.kappa.re) eg, mul (litF p.kappa.im) eg)
+    let off := mul (litF p.bloomB) (sub (lit 1) eg)
+    let clkW := add clkRel (toIntE (mul (mul off .sampleRate) (lit 4294967296)))
+    let phNu2 := modePhaseQ (litF p.nu2Omega) clkRel
+    let phMu := modePhaseQ (litF p.muOmega) clkW
+    let envNu2 := expSig (neg (mul (litF p.nu2Sigma) dPos))
+    let envMu := expSig (neg (mul (litF p.muSigma) (add dPos off)))
+    -- ν2-carrier weight: K1(a1)·d·cexpm1(Δd) + ddK1/g. Δ = ν1−ν2 (pole difference).
+    let w : CplxE := (mul (litF (p.nu2Sigma - p.nu1Sigma)) dPos,     -- Δ.re·d = (σ2−σ1)d
+                      mul (litF (p.nu1Omega - p.nu2Omega)) dPos)      -- Δ.im·d = (ω1−ω2)d
+    let wsq := add (mul w.1 w.1) (mul w.2 w.2)
+    let big := gt wsq (litF 0.01)
+    let wsafe : CplxE := (selectE big w.1 (lit 1), selectE big w.2 (lit 0))
+    let ewr := expSig w.1
+    let ew : CplxE := (mul ewr (cosSig w.2), mul ewr (sinSig w.2))
+    let direct := cdivE (csubE ew one) wsafe
+    let series := cexpm1SeriesE w
+    let cxΔ : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)   -- cexpm1(Δd)
+    let wNu := cmulE p.c (caddE (cmulE (cplxLitE p.k1a1) (scaleRealE dPos cxΔ)) (cplxLitE p.ddK1g))
+    -- voice-carrier weight: DDa(K2)(z)/g = −DDa(M/a;z)/g², M(a1;z) & DDa(M;z) Horners.
+    let mser := p.invA.foldr (fun ik h => caddE one (cmulE (cmulE z (cplxLitE ik)) h)) one   -- M(a1;z)
+    let ddMz := cmulE z (p.qCoef.foldr (fun q h => caddE (cplxLitE q) (cmulE z h)) (lit 0, lit 0))
+    let ddMaz := caddE (cnegE (cmulE mser (cplxLitE p.invA1a2))) (cmulE ddMz (cplxLitE p.invA2))
+    let wMu := cmulE p.c (scaleRealE (litF (-1.0 / (p.gRate * p.gRate))) ddMaz)
+    add acc (add (land envNu2 wNu phNu2) (land envMu wMu phMu)))
+    (litI 0)
+  selectE (gt clkRel (lit 0)) (fixedOutQ 30 bankQ) (lit 0)
+
+/-- The WS-DDF fold-atom bank as a TERM over the clock leaf (rides `arrUn … (.clk c)`
+    like `bloomComposedTerm`, so master warps reach the carriers). -/
+def bloomFoldComposedTerm (pairs : Array BloomFoldPair) (anchor : Sig) (c : Clock) : ArrowTerm :=
+  ArrowTerm.arrUn (fun clkSig => bloomFoldComposedSig pairs clkSig anchor) (ArrowTerm.clk c)
 
 /-- The pitch-bloom clock warp for a BARE bloomed source (no room to cross): the
     offset `B·(1−e^{−g·d⁺})` added to the untouched integer clock — `B` already

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -33,6 +33,13 @@ structure ModalMode where
   cre   : Sig           -- Re A
   cim   : Sig := lit 0   -- Im A
   deg   : Nat := 0
+  /-- WS-LP: the closed interval a LIVE `sigma` ranges over (the knob's span,
+      supplied by the authoring site — e.g. the rt60 knob's display range mapped
+      through σ = 6.91/rt60). The region classifier's input when `sigma` doesn't
+      fold to a constant; the lifted kernel clamps the live σ to this interval,
+      so the classification is sound by construction. `none` + live σ ⇒ the
+      baked-pole fallback (bare bloom). -/
+  sigmaRange : Option (Float × Float) := none
 
 /-- Authored mode from (freq Hz, decay σ, real amp): `ω = 2π·f`, `c_re = amp`,
     `c_im = 0`. Any of `fHz`/`sigma`/`amp` may be a live `paramRef`. -/
@@ -47,10 +54,11 @@ def powE (base : Sig) : Nat → Sig
 
 /-- Fold an authored-constant `Sig` back to its `Float` (the baked-pole read in
     `bloomCompose`, and the static-`k` amplitude read in `bankLandExp`). Partial:
-    `none` on any live/unsupported node — a live pole is outside the v1 baked-pole
+    `none` on any live/unsupported node — a live pole is outside the baked-pole
     contract, not an error to paper over. (Hoisted above the landing sites so
-    `bankLandExp` can consult it.) -/
-private partial def sigConstF? : Sig → Option Float
+    `bankLandExp` can consult it; public so the test witnesses can read baked
+    `BloomPair` fields back as Floats.) -/
+partial def sigConstF? : Sig → Option Float
   | .num n            => some n.toFloat
   | .unary .neg a     => (sigConstF? a).map (fun x => -x)
   | .unary .toFloat a => sigConstF? a
@@ -798,6 +806,34 @@ end CplxB
 /-- A build-time complex constant as a `CplxE` literal pair. -/
 def cplxLitE (x : CplxB) : CplxE := (litF x.re, litF x.im)
 
+/-- The `CplxE` unit — the Kummer Horner's seed and the CF's numerator. -/
+def cOneE : CplxE := (lit 1, lit 0)
+
+/-- The fixed-depth Kummer `M(1, a+1, z)` Horner over the emitted reciprocals
+    `invA[k] = 1/(a+k+1)` — THE series lane's expression, shared verbatim by the
+    per-sample lane in `bloomComposedSig` (z live) and the live-pole lift's
+    `mK = M(1,a+1,κ)` constant in `bloomCompose` (z = κ, a coefficient — s0), so
+    the constant is computed by the SAME arithmetic the lane renders with. -/
+def bloomM1E (invA : Array CplxE) (z : CplxE) : CplxE :=
+  invA.foldr (fun ik h => caddE cOneE (cmulE (cmulE z ik) h)) cOneE
+
+/-- Is this `Sig` a pure s0 value — a function of knob slots and constants only
+    (no `τ`/tick, no input, no bank machinery)? The live-pole lift's admission
+    check: the lifted pair constants are correct (and Stage0-hoistable) only if
+    the pole read is knob-invariant per sample. A GLIDED pole (`.sampleIndex`
+    inside `glideExpr`) fails here — `settle` it first (the recorded WS-LP
+    discipline; reverb rt60 is raw ⇒ s0, filter cutoff/resonance are glided).
+    UNMEMOIZED structural walk (like `sigConstF?`): call it only on SHALLOW
+    authored expressions (a pole read), never on combinator-built values whose
+    subterms share by reference — their TREE is exponential in the DAG depth
+    (a Horner like `bloomM1E`'s output would never return). -/
+partial def sigIsS0 : Sig → Bool
+  | .num _ | .paramRef _ | .sampleRate => true
+  | .unary _ a => sigIsS0 a
+  | .binary _ a b => sigIsS0 a && sigIsS0 b
+  | .clamp a b c | .select a b c => sigIsS0 a && sigIsS0 b && sigIsS0 c
+  | _ => false
+
 /-- Complex log-gamma: Lanczos (g=7, n=9) on `Re z ≥ ½`, reflection below with
     `log sin(πz)` taken on the DOMINANT exponential (`s + log(1−e^{−2s})`, so
     large |Im z| never overflows). Build-time only (the Γ★ bridge). Gated at
@@ -1037,35 +1073,43 @@ def bloomFoldQCoef (a1 a2 : CplxB) (n : Nat) : Array CplxB := Id.run do
 def bloomFoldDDaM (qcoef : Array CplxB) (x : CplxB) : CplxB :=
   x.mul (qcoef.foldr (fun q h => q.add (x.mul h)) ⟨0, 0⟩)
 
-/-- One composed (voice μ, reverb ν) pair of the Γ-bridge atom. Everything but
-    the amp is BAKED (`besselFuse`'s v1 contract: B, g and both pole sets baked —
-    a change relowers; the amp `c = a_voice·r_reverb` stays a live `CplxE` and
-    enters linearly). `cfN.isEmpty` ⟺ series-only (the CF branch is not emitted
-    at all); otherwise `dSwitch > 0` and the per-sample select bridges at it. -/
+/-- One composed (voice μ, reverb ν) pair of the Γ-bridge atom. Every per-pair
+    constant is a `CplxE`/`Sig` (WS-LP): the BAKED path (`besselFuse` parity — B,
+    g, both pole sets fold to Floats; a change relowers) fills them with
+    `cplxLitE`/`litF`, byte-identical to the old `CplxB` fields; the LIVE-σ path
+    (a live-rt60 reverb pole) fills them with s0 expressions of the pole's knob
+    slot, so Stage0 hoists them to the coefficient kernel and turning rt60 never
+    relowers. B and g stay structural Floats (the bloom's shape, not a pole).
+    The amp `c = a_voice·r_reverb` is live as always and enters linearly.
+    `cfN.isEmpty` ⟺ series-only (the CF branch is not emitted at all);
+    otherwise `dSwitch > 0` and the per-sample select bridges at it. -/
 structure BloomPair where
-  muSigma  : Float
-  muOmega  : Float
-  nuSigma  : Float
-  nuOmega  : Float
+  muSigma  : Sig
+  muOmega  : Sig
+  nuSigma  : Sig
+  nuOmega  : Sig
   bloomB   : Float
   gRate    : Float
   c        : CplxE
-  kappa    : CplxB
-  k1Ser    : CplxB          -- C  (the κ-side constant)
-  k1Cf     : CplxB          -- C − Γ★  (= −CF(κ)/g)
-  fSer     : CplxB          -- −1/(ν−μ)  (the series envelope's factor)
-  dSwitch  : Float          -- 0 ⇒ series-only
-  invA     : Array CplxB    -- 1/(a+k), k = 1..N (series Horner reciprocals)
-  cfB      : Array CplxB    -- (2j+1)−a, j = 0..K (CF b-constants; z is added per sample)
-  cfN      : Array CplxB    -- (j+1)((j+1)−a), j = 0..K−1 (CF numerators)
+  kappa    : CplxE
+  k1Ser    : CplxE          -- C  (the κ-side constant)
+  k1Cf     : CplxE          -- C − Γ★  (= −CF(κ)/g)
+  fSer     : CplxE          -- −1/(ν−μ)  (the series envelope's factor)
+  dSwitch  : Sig            -- 0 ⇒ series-only
+  invA     : Array CplxE    -- 1/(a+k), k = 1..N (series Horner reciprocals)
+  cfB      : Array CplxE    -- (2j+1)−a, j = 0..K (CF b-constants; z is added per sample)
+  cfN      : Array CplxE    -- (j+1)((j+1)−a), j = 0..K−1 (CF numerators)
   -- coincidence (`|a| < ½`, WS-A4). `coincident = false` ⇒ the fields below are
   -- unused and the crossing/series-only per-sample body runs. When true: the CF
   -- branch (large z, `k1Cf`/`cfB`/`cfN`) bridges to the series-DD branch (small z)
   -- across `dSwitch`, and the τ·e secular rides a straight-μ carrier.
   coincident : Bool := false
-  dCoef      : Array CplxB := #[]     -- dₙ, n = 1..N (the a-divided-difference Horner coeffs)
-  k1SerDD    : CplxB := ⟨0, 0⟩        -- Φ(a,κ)/g (series-DD e^{νd} const, via the lgamma(a+1) bridge)
-  eKappa     : CplxB := ⟨0, 0⟩        -- e^κ (the secular coeff c·e^κ)
+  dCoef      : Array CplxE := #[]     -- dₙ, n = 1..N (the a-divided-difference Horner coeffs)
+  k1SerDD    : CplxE := (lit 0, lit 0)  -- Φ(a,κ)/g (series-DD e^{νd} const, via the lgamma(a+1) bridge)
+  eKappa     : CplxE := (lit 0, lit 0)  -- e^κ (the secular coeff c·e^κ)
+  -- (μ−ν as the τ·e secular's z-coefficients: (Re, −Im) — a FIELD so the baked
+  -- path emits the same single literals as before the CplxE lift.)
+  secCoef    : CplxE := (lit 0, lit 0)
 deriving Inhabited
 
 /-- The bloom crossing's region for one composed (μ, ν) pair — a TOTAL partition
@@ -1174,11 +1218,48 @@ def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
   | .excludedDepth => false
   | _ => true
 
+/-- WS-LP Phase 1: classify a live-σ pair over its whole σ interval — `some
+    nDepth` iff the pair is `serOnly` at EVERY σ ∈ `[sigLo, sigHi]`, else `none`
+    (the pair drops gracefully; region-crossing pairs are Phase 3's union emit).
+    Only `Re a = (σ_μ − σ_ν)/g` moves with σ_ν (`Im a` and `κ = μ·B` are
+    σ_ν-independent), so the two region conditions reduce to interval minima of
+    `|a + c|` along a horizontal segment — attained at `Re a = −c` clamped to the
+    segment. The depth is sized at the interval's worst case: `bloomM1`'s
+    convergence slows as `|a+1|` falls toward `|κ|`, so sample both endpoints
+    and the closest approach to `−1`; same `+8` guard and `≤ 300` cap as the
+    baked classifier. -/
+def classifyBloomPairLiveSer (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
+    (B g : Float) : Option Nat := Id.run do
+  let kappa := mu.scale B
+  let imA := (nuOmega - mu.im) / g
+  -- Re a = (−σ_ν − Re μ)/g, decreasing in σ_ν
+  let reLo := (-sigHi - mu.re) / g
+  let reHi := (-sigLo - mu.re) / g
+  let minAbsAt := fun (c : Float) =>
+    let t := max reLo (min reHi (-c))
+    Float.sqrt ((t + c) * (t + c) + imA * imA)
+  -- ¬coincident throughout (min |a| ≥ ½) ∧ serOnly throughout (min |a+1| ≥ |κ|)
+  if minAbsAt 0.0 < 0.5 then return none
+  if minAbsAt 1.0 < kappa.abs then return none
+  let depthAt := fun (re : Float) => (bloomM1 ⟨re, imA⟩ kappa).2
+  let tStar := max reLo (min reHi (-1.0))
+  let nRaw := max (depthAt reLo) (max (depthAt reHi) (depthAt tStar))
+  if nRaw + 8 > 300 then return none
+  return some (nRaw + 8)
+
 /-- `bloomedVoice ⋙ reverb` as Γ-bridge pairs — the residue composition ACROSS a
     pitch-bloom warp (`B = β·scale/g` seconds of total clock advance, `g` the
-    settle rate). Baked-pole contract (v1, `besselFuse` parity): every pole must
-    fold to a constant (`none` if a live pole reaches this — the caller keeps
-    live-pole banks on `residueComposeE`'s unbloomed path); amps stay live.
+    settle rate). Pole contract (WS-LP Phase 1): VOICE poles and reverb ω must
+    fold to constants (`none` if not — the caller keeps such banks on
+    `residueComposeE`'s unbloomed path); a reverb σ may be LIVE (the rt60 knob)
+    when it is s0 (`sigIsS0` — raw slot reads, not glides) and carries a
+    `sigmaRange` from the authoring site: the pair's constants are then built as
+    s0 `CplxE` expressions of the live pole (Stage0 hoists them; rt60 turns with
+    no relower), the live σ clamped to the classified interval so the region
+    choice is sound by construction. A live pair must be `serOnly` over the
+    WHOLE interval (`classifyBloomPairLiveSer`) — a pair that crosses a region
+    boundary across the rt60 range drops gracefully (per pair, `continue`; the
+    Phase 3 region-union emit removes this limit). Amps stay live as always.
     Admission drops (graceful exclusion, the documented v1 scope) are the
     `classifyBloomPair` `excludedDepth` region and are now depth-only: pairs whose
     envelope depth exceeds 300 (cockpit-measured shipped max ≈ 250 incl. the
@@ -1200,90 +1281,131 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
     let some vSig := sigConstF? v.sigma | return none
     let some vOm  := sigConstF? v.omega | return none
     for r in reverb do
-      let some rSig := sigConstF? r.sigma | return none
       let some rOm  := sigConstF? r.omega | return none
       let mu : CplxB := ⟨-vSig, vOm⟩
-      let nu : CplxB := ⟨-rSig, rOm⟩
-      -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope
-      -- (a COUNTED graceful drop — the coverage gate tallies it, not a silent
-      -- `continue`); every other region emits EXACTLY its own lanes (region-indexed
-      -- — the coincident regions no longer bake the dead E1/CF lanes). `bloomCompose`
-      -- and the seam-sweep harness consult THIS classifier, one answer in code.
-      let plan := classifyBloomPair mu nu B g
-      let aC := plan.aC
-      let kappa := plan.kappa
-      let aP1 := aC.add ⟨1, 0⟩
       let c := cmulE v.ampE r.ampE
-      match plan.region with
-      | .excludedDepth => continue
-      | .serOnly =>
-        let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
-        let invA := (Array.range plan.nDepth).map (fun k =>
-          CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
-        let (mK, _) := bloomM1 aC kappa
-        out := out.push {
-          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-          bloomB := B, gRate := g, c, kappa
-          k1Ser := mK.mul invNuMu, k1Cf := ⟨0, 0⟩, fSer := invNuMu.neg
-          dSwitch := 0.0, invA, cfB := #[], cfN := #[] }
-      | .crossing =>
-        let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
-        let invA := (Array.range plan.nDepth).map (fun k =>
-          CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
-        let (cfK, _) := bloomCF aC kappa
-        let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
-          (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
-        let cfN := (Array.range plan.kDepth).map (fun j =>
-          let jf := (j + 1).toFloat
-          (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
-        let dSwitch := Float.log (kappa.abs / aP1.abs) / g
-        let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
-        let gs := bloomGammaStar aC kappa g
-        out := out.push {
-          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-          bloomB := B, gRate := g, c, kappa
-          k1Ser := gs.sub (cfK.scale (1.0 / g)), k1Cf, fSer := invNuMu.neg
-          dSwitch, invA, cfB, cfN }
-      | .coincidentCrossing =>
-        -- WS-A4: the CF branch (large z, `k1Cf`/`cfB`/`cfN`), coincidence-stable,
-        -- bridges below `dSwitch` to the series-DD branch (`dCoef`/`k1SerDD`) plus
-        -- the τ·e secular `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`. The E1 series lane
-        -- (`invA`/`k1Ser`/`fSer`, singular at a=0) is NOT emitted (region-indexed).
-        let (cfK, _) := bloomCF aC kappa
-        let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
-          (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
-        let cfN := (Array.range plan.kDepth).map (fun j =>
-          let jf := (j + 1).toFloat
-          (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
-        let dSwitch := Float.log (kappa.abs / aP1.abs) / g
-        let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
-        let dCoef := bloomDCoef aC plan.nDepth
-        out := out.push {
-          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-          bloomB := B, gRate := g, c, kappa
-          k1Ser := ⟨0, 0⟩, k1Cf, fSer := ⟨0, 0⟩
-          dSwitch, invA := #[], cfB, cfN
-          coincident := true
-          dCoef
-          k1SerDD := bloomPhiKappaOverG aC kappa cfK dCoef g
-          eKappa := CplxB.exp kappa }
-      | .coincidentSubtle =>
-        -- WS-A4 subtle bloom (`dSwitch < 0`): the per-sample path is series-DD from
-        -- d = 0, so the CF lane is DEAD (the `selectE` is const-true — LLVM `select`
-        -- ignores the unselected operand). Region-indexed: emit series-DD + the τ·e
-        -- secular ONLY — no CF lane (`k1Cf`/`cfB`/`cfN`, kept empty ⇒ `bloomComposedSig`
-        -- routes to the subtle sub-branch), no `invA`. `bloomPhiKappaOverG`'s subtle
-        -- branch reads only `dCoef`/κ (`cfK` unread), so a dummy `cfK` is bit-identical.
-        let dCoef := bloomDCoef aC plan.nDepth
-        out := out.push {
-          muSigma := vSig, muOmega := vOm, nuSigma := rSig, nuOmega := rOm
-          bloomB := B, gRate := g, c, kappa
-          k1Ser := ⟨0, 0⟩, k1Cf := ⟨0, 0⟩, fSer := ⟨0, 0⟩
-          dSwitch := Float.log (kappa.abs / aP1.abs) / g, invA := #[], cfB := #[], cfN := #[]
-          coincident := true
-          dCoef
-          k1SerDD := bloomPhiKappaOverG aC kappa ⟨0, 0⟩ dCoef g
-          eKappa := CplxB.exp kappa }
+      match sigConstF? r.sigma with
+      | none =>
+        -- WS-LP Phase 1: a LIVE reverb σ (the rt60 pole). Admissible only when
+        -- the pole read is s0 (a raw slot, not a glide — `settle` a glided pole
+        -- first) and the authoring site declared its interval; otherwise the
+        -- pre-WS-LP baked-pole fallback (`none` ⇒ the caller's bare bloom).
+        let some (sLo, sHi) := r.sigmaRange | return none
+        if !(sigIsS0 r.sigma) then return none
+        match classifyBloomPairLiveSer mu rOm sLo sHi B g with
+        | none => continue   -- not serOnly over the whole interval: graceful per-pair drop (Phase 3 widens)
+        | some nDepth =>
+          -- the lift: every baked constant re-expressed as an s0 `CplxE` of the
+          -- live pole. The clamp ENFORCES the classified interval in-kernel, so
+          -- an out-of-range slot write saturates the crossing's σ instead of
+          -- walking off the classified region. κ = μ·B is σ_ν-independent (baked).
+          let sigC := clampE r.sigma (litF sLo) (litF sHi)
+          let nuE : CplxE := (neg sigC, litF rOm)
+          let dNuMu := csubE nuE (cplxLitE mu)
+          let aE := scaleRealE (litF (1.0 / g)) dNuMu
+          let invNuMuE := cdivE cOneE dNuMu
+          let invA := (Array.range nDepth).map (fun k =>
+            cdivE cOneE (caddE aE (litF (k + 1).toFloat, lit 0)))
+          let kE := cplxLitE (mu.scale B)
+          out := out.push {
+            muSigma := litF vSig, muOmega := litF vOm
+            nuSigma := sigC, nuOmega := litF rOm
+            bloomB := B, gRate := g, c, kappa := kE
+            k1Ser := cmulE (bloomM1E invA kE) invNuMuE
+            k1Cf := (lit 0, lit 0), fSer := cnegE invNuMuE
+            dSwitch := lit 0, invA, cfB := #[], cfN := #[] }
+      | some rSig =>
+        let nu : CplxB := ⟨-rSig, rOm⟩
+        -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope
+        -- (a COUNTED graceful drop — the coverage gate tallies it, not a silent
+        -- `continue`); every other region emits EXACTLY its own lanes (region-indexed
+        -- — the coincident regions no longer bake the dead E1/CF lanes). `bloomCompose`
+        -- and the seam-sweep harness consult THIS classifier, one answer in code.
+        let plan := classifyBloomPair mu nu B g
+        let aC := plan.aC
+        let kappa := plan.kappa
+        let aP1 := aC.add ⟨1, 0⟩
+        match plan.region with
+        | .excludedDepth => continue
+        | .serOnly =>
+          let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
+          let invA := (Array.range plan.nDepth).map (fun k =>
+            CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
+          let (mK, _) := bloomM1 aC kappa
+          out := out.push {
+            muSigma := litF vSig, muOmega := litF vOm
+            nuSigma := litF rSig, nuOmega := litF rOm
+            bloomB := B, gRate := g, c, kappa := cplxLitE kappa
+            k1Ser := cplxLitE (mK.mul invNuMu), k1Cf := (lit 0, lit 0)
+            fSer := cplxLitE invNuMu.neg
+            dSwitch := lit 0, invA := invA.map cplxLitE, cfB := #[], cfN := #[] }
+        | .crossing =>
+          let invNuMu := CplxB.div ⟨1, 0⟩ (nu.sub mu)
+          let invA := (Array.range plan.nDepth).map (fun k =>
+            CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
+          let (cfK, _) := bloomCF aC kappa
+          let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
+            (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
+          let cfN := (Array.range plan.kDepth).map (fun j =>
+            let jf := (j + 1).toFloat
+            (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
+          let dSwitch := Float.log (kappa.abs / aP1.abs) / g
+          let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
+          let gs := bloomGammaStar aC kappa g
+          out := out.push {
+            muSigma := litF vSig, muOmega := litF vOm
+            nuSigma := litF rSig, nuOmega := litF rOm
+            bloomB := B, gRate := g, c, kappa := cplxLitE kappa
+            k1Ser := cplxLitE (gs.sub (cfK.scale (1.0 / g))), k1Cf := cplxLitE k1Cf
+            fSer := cplxLitE invNuMu.neg
+            dSwitch := litF dSwitch, invA := invA.map cplxLitE
+            cfB := cfB.map cplxLitE, cfN := cfN.map cplxLitE }
+        | .coincidentCrossing =>
+          -- WS-A4: the CF branch (large z, `k1Cf`/`cfB`/`cfN`), coincidence-stable,
+          -- bridges below `dSwitch` to the series-DD branch (`dCoef`/`k1SerDD`) plus
+          -- the τ·e secular `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`. The E1 series lane
+          -- (`invA`/`k1Ser`/`fSer`, singular at a=0) is NOT emitted (region-indexed).
+          let (cfK, _) := bloomCF aC kappa
+          let cfB := (Array.range (plan.kDepth + 1)).map (fun j =>
+            (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
+          let cfN := (Array.range plan.kDepth).map (fun j =>
+            let jf := (j + 1).toFloat
+            (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
+          let dSwitch := Float.log (kappa.abs / aP1.abs) / g
+          let k1Cf := (cfK.scale (1.0 / g)).neg      -- −CF(κ)/g (CF-side e^{νd} const)
+          let dCoef := bloomDCoef aC plan.nDepth
+          out := out.push {
+            muSigma := litF vSig, muOmega := litF vOm
+            nuSigma := litF rSig, nuOmega := litF rOm
+            bloomB := B, gRate := g, c, kappa := cplxLitE kappa
+            k1Ser := (lit 0, lit 0), k1Cf := cplxLitE k1Cf, fSer := (lit 0, lit 0)
+            dSwitch := litF dSwitch, invA := #[]
+            cfB := cfB.map cplxLitE, cfN := cfN.map cplxLitE
+            coincident := true
+            dCoef := (dCoef.map cplxLitE)
+            k1SerDD := cplxLitE (bloomPhiKappaOverG aC kappa cfK dCoef g)
+            eKappa := cplxLitE (CplxB.exp kappa)
+            secCoef := (litF (vSig - rSig), litF (rOm - vOm)) }
+        | .coincidentSubtle =>
+          -- WS-A4 subtle bloom (`dSwitch < 0`): the per-sample path is series-DD from
+          -- d = 0, so the CF lane is DEAD (the `selectE` is const-true — LLVM `select`
+          -- ignores the unselected operand). Region-indexed: emit series-DD + the τ·e
+          -- secular ONLY — no CF lane (`k1Cf`/`cfB`/`cfN`, kept empty ⇒ `bloomComposedSig`
+          -- routes to the subtle sub-branch), no `invA`. `bloomPhiKappaOverG`'s subtle
+          -- branch reads only `dCoef`/κ (`cfK` unread), so a dummy `cfK` is bit-identical.
+          let dCoef := bloomDCoef aC plan.nDepth
+          out := out.push {
+            muSigma := litF vSig, muOmega := litF vOm
+            nuSigma := litF rSig, nuOmega := litF rOm
+            bloomB := B, gRate := g, c, kappa := cplxLitE kappa
+            k1Ser := (lit 0, lit 0), k1Cf := (lit 0, lit 0), fSer := (lit 0, lit 0)
+            dSwitch := litF (Float.log (kappa.abs / aP1.abs) / g)
+            invA := #[], cfB := #[], cfN := #[]
+            coincident := true
+            dCoef := (dCoef.map cplxLitE)
+            k1SerDD := cplxLitE (bloomPhiKappaOverG aC kappa ⟨0, 0⟩ dCoef g)
+            eKappa := cplxLitE (CplxB.exp kappa)
+            secCoef := (litF (vSig - rSig), litF (rOm - vOm)) }
   return some out
 
 /-- The bloom-composed pair bank as a pure `Sig` over the clock: per pair, TWO
@@ -1312,9 +1434,9 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
     option E at k=0 is a byte-identical no-op for it. **Two reasons it is NOT landed
     in this pass, DEFERRED to the factor-site follow-on**: (a) it is UNREACHABLE from
     the surface — `bloomgong` (its only surface producer) is a WITHHELD kind, rejected
-    by `Playground.checkServedKinds`; and even were it served, `bloomCompose` requires
-    every pole to `sigConstF?` while the Playground makes rt60/cutoff/resonance LIVE,
-    so only the SeamSweep gate and authored/loaded literal-pole programs emit it;
+    by `Playground.checkServedKinds` (WS-LP made the live-rt60 CROSSING compile, but
+    the surface stays sealed until this factor site carries the per-pair `k`), so
+    only the tropicaltest gates and authored/loaded literal-pole programs emit it;
     (b) there is a reachable-by-baked-poles case option E CANNOT absorb — filtering a
     gong ON one of its own partials (room pole tuned to a voice partial: `Im a ≈ 0`)
     with `a` near a negative integer `−n` (`Re a ≈ −(σ_ν−σ_μ)/g`, so a resonance
@@ -1348,20 +1470,20 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
   -- depth), shared by the crossing and coincident branches (both large-z sides).
   let cfEnv := fun (p : BloomPair) (z : CplxE) => Id.run do
     let kk := p.cfN.size
-    let mut h : CplxE := caddE z (cplxLitE p.cfB[kk]!)
+    let mut h : CplxE := caddE z p.cfB[kk]!
     for jr in [0:kk] do
       let j := kk - 1 - jr
-      h := csubE (caddE z (cplxLitE p.cfB[j]!)) (cdivE (cplxLitE p.cfN[j]!) h)
+      h := csubE (caddE z p.cfB[j]!) (cdivE p.cfN[j]! h)
     return cdivE one h
   let bankQ := pairs.foldl (fun acc p =>
     let eg := expSig (neg (mul (litF p.gRate) dPos))
-    let z : CplxE := (mul (litF p.kappa.re) eg, mul (litF p.kappa.im) eg)
+    let z : CplxE := (mul p.kappa.1 eg, mul p.kappa.2 eg)
     let off := mul (litF p.bloomB) (sub (lit 1) eg)
     let clkW := add clkRel (toIntE (mul (mul off .sampleRate) (lit 4294967296)))
-    let phNu := modePhaseQ (litF p.nuOmega) clkRel
-    let phMu := modePhaseQ (litF p.muOmega) clkW
-    let envNu := expSig (neg (mul (litF p.nuSigma) dPos))
-    let envMu := expSig (neg (mul (litF p.muSigma) (add dPos off)))
+    let phNu := modePhaseQ p.nuOmega clkRel
+    let phMu := modePhaseQ p.muOmega clkW
+    let envNu := expSig (neg (mul p.nuSigma dPos))
+    let envMu := expSig (neg (mul p.muSigma (add dPos off)))
     if p.coincident then
       if p.cfN.isEmpty then
         -- WS-A4 / WS-CL: the subtle-bloom coincident pair (`dSwitch < 0`). The
@@ -1370,14 +1492,14 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
         -- panic). Series-DD + the τ·e secular, ALWAYS on. Bit-identical to the old
         -- coincident branch with the const-true `onSer` (the `selectE`s all picked
         -- the series-DD/secular arm; the LLVM `select` ignored the CF operand).
-        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE (cplxLitE dk) (cmulE z h)) (lit 0, lit 0))
+        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE dk (cmulE z h)) (lit 0, lit 0))
         let k2ser : CplxE := (div (neg phiZ.1) (litF p.gRate), div (neg phiZ.2) (litF p.gRate))
-        let w1 := cmulE p.c ((litF p.k1SerDD.re, litF p.k1SerDD.im) : CplxE)
+        let w1 := cmulE p.c p.k1SerDD
         let w2 := cmulE p.c k2ser
-        let phMuS := modePhaseQ (litF p.muOmega) clkRel
-        let envMuS := expSig (neg (mul (litF p.muSigma) dPos))
-        let zsec : CplxE := (mul (litF (p.muSigma - p.nuSigma)) dPos,     -- (ν−μ)d
-                             mul (litF (p.nuOmega - p.muOmega)) dPos)
+        let phMuS := modePhaseQ p.muOmega clkRel
+        let envMuS := expSig (neg (mul p.muSigma dPos))
+        let zsec : CplxE := (mul p.secCoef.1 dPos,     -- (ν−μ)d
+                             mul p.secCoef.2 dPos)
         let zsq := add (mul zsec.1 zsec.1) (mul zsec.2 zsec.2)
         let big := gt zsq (litF 0.01)
         let zsafe : CplxE := (selectE big zsec.1 (lit 1), selectE big zsec.2 (lit 0))
@@ -1386,30 +1508,30 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
         let direct := cdivE (csubE ez one) zsafe
         let series := cexpm1SeriesE zsec
         let cxsec : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)
-        let cek := cmulE p.c (cplxLitE p.eKappa)
+        let cek := cmulE p.c p.eKappa
         let wsec := cmulE cek (scaleRealE dPos cxsec)                   -- c·e^κ·d·cexpm1
         add acc (add (add (land envNu w1 phNu) (land envMu w2 phMu)) (land envMuS wsec phMuS))
       else
         -- WS-A4: the τ·e coincidence pair (`coincidentCrossing`). CF branch (large z,
         -- `onSer` false) bridges at `dSwitch` to the series-DD branch (small z) + the
         -- secular.
-        let onSer := gt dPos (litF p.dSwitch)
+        let onSer := gt dPos p.dSwitch
         let cf := cfEnv p z
         let k2cf : CplxE := (div cf.1 (litF p.gRate), div cf.2 (litF p.gRate))   -- CF(z)/g
         -- series-DD: Φ(a,z) = z·Σ dₙ z^{n−1} (Horner over `dCoef`); k2 = −Φ(a,z)/g.
-        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE (cplxLitE dk) (cmulE z h)) (lit 0, lit 0))
+        let phiZ := cmulE z (p.dCoef.foldr (fun dk h => caddE dk (cmulE z h)) (lit 0, lit 0))
         let k2ser : CplxE := (div (neg phiZ.1) (litF p.gRate), div (neg phiZ.2) (litF p.gRate))
-        let k1 : CplxE := (selectE onSer (litF p.k1SerDD.re) (litF p.k1Cf.re),
-                           selectE onSer (litF p.k1SerDD.im) (litF p.k1Cf.im))
+        let k1 : CplxE := (selectE onSer p.k1SerDD.1 p.k1Cf.1,
+                           selectE onSer p.k1SerDD.2 p.k1Cf.2)
         let k2 : CplxE := (selectE onSer k2ser.1 k2cf.1, selectE onSer k2ser.2 k2cf.2)
         let w1 := cmulE p.c k1
         let w2 := cmulE p.c k2
         -- the τ·e secular `c·e^κ·e^{μd}·d·cexpm1((ν−μ)d)` on the STRAIGHT μ carrier
         -- (= `c·e^κ·(e^{νd}−e^{μd})/(ν−μ)`), gated OFF on the CF side.
-        let phMuS := modePhaseQ (litF p.muOmega) clkRel
-        let envMuS := expSig (neg (mul (litF p.muSigma) dPos))
-        let zsec : CplxE := (mul (litF (p.muSigma - p.nuSigma)) dPos,     -- (ν−μ)d
-                             mul (litF (p.nuOmega - p.muOmega)) dPos)
+        let phMuS := modePhaseQ p.muOmega clkRel
+        let envMuS := expSig (neg (mul p.muSigma dPos))
+        let zsec : CplxE := (mul p.secCoef.1 dPos,     -- (ν−μ)d
+                             mul p.secCoef.2 dPos)
         let zsq := add (mul zsec.1 zsec.1) (mul zsec.2 zsec.2)
         let big := gt zsq (litF 0.01)
         let zsafe : CplxE := (selectE big zsec.1 (lit 1), selectE big zsec.2 (lit 0))
@@ -1418,22 +1540,21 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
         let direct := cdivE (csubE ez one) zsafe
         let series := cexpm1SeriesE zsec
         let cxsec : CplxE := (selectE big direct.1 series.1, selectE big direct.2 series.2)
-        let cek := cmulE p.c (cplxLitE p.eKappa)
+        let cek := cmulE p.c p.eKappa
         let wsecFull := cmulE cek (scaleRealE dPos cxsec)                -- c·e^κ·d·cexpm1
         let wsec : CplxE := (selectE onSer wsecFull.1 (lit 0), selectE onSer wsecFull.2 (lit 0))
         add acc (add (add (land envNu w1 phNu) (land envMu w2 phMu)) (land envMuS wsec phMuS))
     else
-      let mser := p.invA.foldr
-        (fun ik h => caddE one (cmulE (cmulE z (cplxLitE ik)) h)) one
-      let k2ser := cmulE mser (cplxLitE p.fSer)
+      let mser := bloomM1E p.invA z
+      let k2ser := cmulE mser p.fSer
       let (k1, k2) : CplxE × CplxE :=
-        if p.cfN.isEmpty then (cplxLitE p.k1Ser, k2ser)
+        if p.cfN.isEmpty then (p.k1Ser, k2ser)
         else
           let cf := cfEnv p z
           let k2cf : CplxE := (div cf.1 (litF p.gRate), div cf.2 (litF p.gRate))
-          let onSer := gt dPos (litF p.dSwitch)
-          ((selectE onSer (litF p.k1Ser.re) (litF p.k1Cf.re),
-            selectE onSer (litF p.k1Ser.im) (litF p.k1Cf.im)),
+          let onSer := gt dPos p.dSwitch
+          ((selectE onSer p.k1Ser.1 p.k1Cf.1,
+            selectE onSer p.k1Ser.2 p.k1Cf.2),
            (selectE onSer k2ser.1 k2cf.1, selectE onSer k2ser.2 k2cf.2))
       let w1 := cmulE p.c k1
       let w2 := cmulE p.c k2

--- a/lean/Tropical/EmitArrow/Numerics.lean
+++ b/lean/Tropical/EmitArrow/Numerics.lean
@@ -145,6 +145,42 @@ def logSig (x : Sig) : Sig :=
         lit 1111111111111111 16))))))))
   add (mul e (lit 6931471805599453 16)) (mul (mul (lit 2) s) p)
 
+/-- `atan(a)` for `a ∈ [0, 1]` — octant-reduced to `[0, tan(π/12)]` (a value above
+    `tan(π/12)` folds by the `atan a = π/6 + atan((a−tan π/6)/(1+tan(π/6)·a))`
+    identity), then a 6-term Taylor in `a²` (|a_reduced| ≤ 0.268 ⇒ the tail < 1e-8).
+    Private helper for `atan2E`. -/
+private def atanUnit (a : Sig) : Sig :=
+  let hi := gt a (lit 2679491924311227 16)                         -- a > tan(π/12) = 2−√3
+  let ar := selectE hi (div (sub a (lit 5773502691896257 16))      -- (a − tan π/6)/(1 + tan(π/6)·a)
+                            (add (lit 1) (mul (lit 5773502691896257 16) a))) a
+  let bias := selectE hi (lit 5235987755982988 16) (lit 0)         -- π/6
+  let s := mul ar ar
+  -- atan(ar)/ar = 1 − s/3 + s²/5 − s³/7 + s⁴/9 − s⁵/11  (Horner over the coeffs)
+  let coeffs : Array Sig := #[lit 1, neg (lit 3333333333333333 16), lit 2 1,
+    neg (lit 14285714285714285 17), lit 1111111111111111 16, neg (lit 9090909090909091 17)]
+  let p := coeffs.foldr (fun c acc => add c (mul s acc)) (lit 0)
+  add bias (mul ar p)
+
+/-- `atan2(y, x) ∈ [−π, π]` — the angle of the point `(x, y)`. Reduce to the first
+    octant (`a = min(|x|,|y|)/max`, `atanUnit a ∈ [0, π/4]`), undo the min/max swap
+    (`|y| > |x| ⇒ π/2 − ·`), then place the quadrant from the signs of `x` and `y`.
+    `atan2(0,0) = 0` (`max` is floored above 0 so `0/0 → 0`). The ONE op the emitted
+    complex `log`/`lgamma` (WS-LP's live Γ★ bridge) need past `logSig` — no `atan` was
+    in the vocabulary; like `logSig`/`expSig` it is a pure combinator (no backend op),
+    and coefficient-time in its bloom use, so its `select`s never split a backend per
+    sample. -/
+def atan2E (y x : Sig) : Sig :=
+  let ax := Sig.unary .abs x
+  let ay := Sig.unary .abs y
+  let swap := gt ay ax
+  let num := selectE swap ax ay
+  let den := selectE swap ay ax
+  let a := div num (clampE den (lit 1 30) (lit (10^30)))     -- floor > 0 so origin → 0
+  let r0 := atanUnit a
+  let r1 := selectE swap (sub (lit 15707963267948966 16) r0) r0   -- |y|>|x| ⇒ atan(|y|/|x|)
+  let r2 := selectE (gt (lit 0) x) (sub (lit 3141592653589793 15) r1) r1   -- x<0 ⇒ π − r
+  selectE (gt (lit 0) y) (neg r2) r2                         -- y<0 ⇒ −r
+
 /-- 2π and π/2 as `Sig` literals; `cos x = sin(x + π/2)` reuses the gated `sinSig`. -/
 def twoPiE : Sig := lit 6283185307179586 15
 def halfPiE : Sig := lit 15707963267948966 16

--- a/lean/Tropical/EmitArrow/Numerics.lean
+++ b/lean/Tropical/EmitArrow/Numerics.lean
@@ -6,9 +6,11 @@ import Tropical.EmitArrow.Sig
 The numeric datapaths every generator/envelope is built from, as pure `Sig`
 functions: the exact Q2.30 fixed-point sine/cosine over a Q0.32 cycles phase,
 the integer split-multiply phasor (`phasorPhaseSig`), and the float
-polynomial transcendentals (`sinSig`, `cosSig`, `expSig`). Every
-transcendental is a polynomial — the op set never grows past
-`{+, ×, round, clamp, ldexp}`.
+polynomial transcendentals (`sinSig`, `cosSig`, `expSig`). `sin`/`cos`/`exp`
+are pure polynomials — that op set never grows past `{+, ×, round, clamp,
+ldexp}`. `logSig` (the gauge norm's inverse of `exp`) adds exactly two: the
+`floatExponent` exponent-extract (option E's op) and one `div` (the `atanh`
+argument) — coefficient-time only in its modal uses, so no per-sample cost.
 -/
 
 namespace Tropical.EmitArrow
@@ -113,6 +115,35 @@ def expSig (x : Sig) : Sig :=
     add (lit 13981999507 13) (mul (lit 198756915 12) r)) r)) r)) r)) r)
   let exp_r := add (lit 1) (mul r (add (lit 1) (mul r p)))
   ldexpE exp_r n
+
+/-- `ln x` for `x > 0` — `expSig`'s mirror, the second float transcendental the
+    modal island needs (the self-measuring excitation gauge's `‖H‖^{−g}` wants a
+    live `log`; `norm^{−g} = exp(−g·ln norm)`). Range-reduce by the IEEE exponent
+    to the mantissa `m ∈ [√½, √2)` (`e = ⌊log₂ x⌋`, `m = x·2^{−e}`, halved when
+    `m > √2` so the series stays centred), then `ln m = 2·atanh s`, `s = (m−1)/(m+1)`
+    — a 5-term series (`|s| ≤ 0.172`, so the `s¹⁰` tail is < 1e-8). `ln x = e·ln2
+    + ln m`. Two ops past the `{+,×,round,clamp,ldexp}` sine/exp set — `floatExponent`
+    (the exponent extract) and `div` (the `atanh` argument); both already in the Sig
+    vocabulary (`floatExponent` is option E's dynamic-`k` op). COEFFICIENT-TIME only
+    in its modal uses (the gauge norm folds pole/residue slots, an s0 expression), so
+    `floatExponent`'s f32-vs-f64 Metal split never runs per sample — the same
+    discipline that keeps option E's dynamic `k` Metal-safe. Domain `x > 0` (like
+    `Float.log`); the gauge floors its norm above 0 before calling. -/
+def logSig (x : Sig) : Sig :=
+  let e0 := Sig.unary .floatExponent x              -- ⌊log₂ x⌋ (float)
+  let m0 := ldexpE x (neg e0)                       -- x·2^{−e0} ∈ [1, 2)
+  let big := gt m0 (lit 14142135623730951 16)       -- m0 > √2 ⇒ halve, bump the exponent
+  let m := selectE big (mul m0 (lit 5 1)) m0        -- m ∈ [√½, √2)
+  let e := selectE big (add e0 (lit 1)) e0
+  let s := div (sub m (lit 1)) (add m (lit 1))      -- |s| ≤ 0.172
+  let s2 := mul s s
+  let p :=                                          -- atanh(s)/s = 1 + s²/3 + s⁴/5 + s⁶/7 + s⁸/9
+    add (lit 1) (mul s2 (
+    add (lit 3333333333333333 16) (mul s2 (
+    add (lit 2 1) (mul s2 (
+    add (lit 14285714285714285 17) (mul s2 (
+        lit 1111111111111111 16))))))))
+  add (mul e (lit 6931471805599453 16)) (mul (mul (lit 2) s) p)
 
 /-- 2π and π/2 as `Sig` literals; `cos x = sin(x + π/2)` reuses the gated `sinSig`. -/
 def twoPiE : Sig := lit 6283185307179586 15

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -118,6 +118,11 @@ inductive Node where
       (bloom : Option (Float × Float) := none)
   | modalReverb (input : String) (room : Array ModalMode) (dir : Option ModalDir)
   | modalMix (inputs : Array String)
+  -- `modalGauge` is the excitation-gauge adapter (§5): it re-levels its modal input's
+  -- residues by the self-measured `‖H‖^{−g}` (`normalizePeak`), a pure Modal ⇝ Modal
+  -- effect. `g` is a live slot. The norm is measured on the SETTLED poles, so an
+  -- un-settleable (per-sample-modulated) input DECLINES to identity, never an s1 norm.
+  | modalGauge (input : String) (g : Sig)
 
 structure PatchNode where
   id : String
@@ -144,6 +149,7 @@ def nodeIsModal (g : PatchGraph) (id : String) : Bool :=
     | .modalSource .. => true
     | .modalReverb .. => true
     | .modalMix .. => true
+    | .modalGauge .. => true
     | _ => false
 
 /-- The lowered modal value: a PLAIN composed bank (realized directly at the
@@ -198,6 +204,17 @@ partial def lowerModal (g : PatchGraph) (id : String) :
       -- identity (the first reverb in a chain).
       let folded := if acc.isEmpty then room else residueComposeEC acc room
       .ok (.bloomed voice folded B gr, a, clk, addr, dir.orElse (fun _ => dirIn), none)
+  | .modalGauge inId gExpr => do
+    let (bank, a, clk, addr, dirIn, count) ← lowerModal g inId
+    -- re-level in place: `normalizePeak` scales residues by the SETTLED norm (s0),
+    -- preserving the pole set — so `count` (the live mode count) survives, unlike a
+    -- reverb's composition. An un-settleable input declines to identity inside
+    -- `normalizePeak`. A bloomed source gauges its VOICE modes; the folded room and
+    -- the uncrossed bloom are untouched.
+    match bank with
+    | .plain v => .ok (.plain (normalizePeak gExpr v), a, clk, addr, dirIn, count)
+    | .bloomed voice acc B gr =>
+      .ok (.bloomed (normalizePeak gExpr voice) acc B gr, a, clk, addr, dirIn, count)
   | .modalMix inputs => do
     let parts ← inputs.mapM (lowerModal g)
     match parts.toList with

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -283,8 +283,11 @@ partial def lowerInput (g : PatchGraph) (id : String) : Except String ArrowTerm 
       | .bloomed voice room B gr =>
         -- the bare bloomed source: the bloom-warped bank (identical to a gong
         -- register's `warpFx`-around-`modalSource`). Also the graceful fallback
-        -- when the crossing produces nothing (a live pole hit the baked-pole
-        -- contract, or every pair fell outside admission) — legal, no warning.
+        -- when the crossing produces nothing (a live pole outside WS-LP's lift —
+        -- live voice/ω, live σ without a declared range, a glided σ — or every
+        -- pair fell outside admission) — legal, no warning. A live-rt60 room
+        -- with `sigmaRange` DOES cross (WS-LP): its serOnly pairs lift to s0
+        -- expressions of the live pole.
         let bare := ArrowTerm.warp (bloomWarpClock a B gr) (modalBankTerm voice a clk count?)
         if room.isEmpty then .ok bare
         else match bloomCompose voice room B gr with

--- a/lean/Tropical/EmitArrow/Sig.lean
+++ b/lean/Tropical/EmitArrow/Sig.lean
@@ -233,6 +233,55 @@ def selectE (cond then_ else_ : Sig) : Sig := .select cond then_ else_
     integer part of range reduction. `n` is an integer-valued float (`round …`). -/
 def ldexpE (m n : Sig) : Sig := .binary .ldexp m n
 
+/-- Does this expression read the sample clock (`.sampleIndex`)? That read is the
+    authoring layer's source of per-sample (s1) τ-dependence — a value with none is
+    a function of settled parameters alone (s0). -/
+partial def readsSampleIndex : Sig → Bool
+  | .sampleIndex        => true
+  | .binary _ a b       => readsSampleIndex a || readsSampleIndex b
+  | .unary _ a          => readsSampleIndex a
+  | .clamp v lo hi      => readsSampleIndex v || readsSampleIndex lo || readsSampleIndex hi
+  | .select c t e       => readsSampleIndex c || readsSampleIndex t || readsSampleIndex e
+  | .index a b          => readsSampleIndex a || readsSampleIndex b
+  | .arr items          => items.any readsSampleIndex
+  | .bankSum _ ts b _ _  => ts.any readsSampleIndex || readsSampleIndex b
+  | _                   => false
+
+private def isZeroLit : Sig → Bool | .num n => n.mantissa == 0 | _ => false
+private def isOneLit  : Sig → Bool | .num n => n.mantissa == 1 && n.exponent == 0 | _ => false
+
+/-- Collapse every SATURATING glide ramp to its terminal value — a `clampE(r, 0, 1)`
+    whose ramp `r` reads the clock (`glideExpr`'s smoothstep parameter, the only
+    converging τ-dependent construct authored today) reaches `1` as the clock runs,
+    so it settles to its ceiling. Every other subterm settles pointwise. This is the
+    mechanical half of `settle`; use `settle` for the totality contract. -/
+partial def settleRamps : Sig → Sig
+  | .clamp v lo hi =>
+    if isZeroLit lo && isOneLit hi && readsSampleIndex v then lit 1
+    else .clamp (settleRamps v) (settleRamps lo) (settleRamps hi)
+  | .binary t a b       => .binary t (settleRamps a) (settleRamps b)
+  | .unary t a          => .unary t (settleRamps a)
+  | .select c t e       => .select (settleRamps c) (settleRamps t) (settleRamps e)
+  | .index a b          => .index (settleRamps a) (settleRamps b)
+  | .arr items          => .arr (items.map settleRamps)
+  | .bankSum c ts b dc ii => .bankSum c (ts.map settleRamps) (settleRamps b) dc ii
+  | s                   => s
+
+/-- `settle e` — the τ-independent (s0) value `e` converges to as the clock runs,
+    when that value exists; `none` otherwise. The one converging τ-dependent
+    construct today is `glideExpr`'s saturating ramp, which `settleRamps` collapses
+    to its ceiling; a `.sampleIndex` that SURVIVES that collapse is a genuine
+    modulation (an LFO on a pole never settles — it has no fixed point), so `settle`
+    returns `none` and the caller must DECLINE rather than measure a value the signal
+    never sits at. The guarantee that makes this a contract, not a hope: a `some`
+    result reads no clock — **s0 by construction**. So a coefficient built through
+    `settle` (a self-measuring gauge norm) cannot emit a per-sample op, and the
+    f32≠f64 `floatExponent` split across backends is unREACHABLE, not merely
+    documented against. -/
+def settle (s : Sig) : Option Sig :=
+  let s' := settleRamps s
+  if readsSampleIndex s' then none else some s'
+
 /-- Mirror the elaborator's `registerInstanceDecl` over a sequence of
     instantiated program names: each adds `(name, idx)` then merges that
     program's own registry (skipping keys already present), in declaration

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -401,11 +401,39 @@ def outletOf : String → Option PortDomain
   | "out" => none
   | _ => some .signal
 
-/-- The kinds the table covers, in schema order (`out` last — it has no outlet). -/
+/-- The kinds the table covers, in schema order (`out` last — it has no outlet).
+    The SERVED surface vocabulary: `checkServedKinds` admits exactly these; a
+    client renders them from `vocabularyJson`. -/
 def vocabularyKinds : Array String := #[
   "source", "pluck", "comb", "flange", "delay", "reverse", "fm", "sflange",
   "mix", "ring", "gong", "string", "resonator", "reverb", "filter",
   "modalmix", "knob", "out"]
+
+/-- Every kind `buildNode` actually constructs (its match arms — the AUTHORITATIVE
+    list, read straight off the arms below). The classification-drift gate and
+    `checkServedKinds` both derive from THIS, so `buildNode` cannot grow a kind the
+    vocabulary/withholding machinery has not accounted for: the drift gate asserts
+    `buildNodeKinds ⊆ vocabularyKinds ∪ withheldKinds` (every built kind is served
+    or explicitly withheld) and that no served kind drifts. (`out` is a dac sink,
+    not a `buildNode` arm — it is in `vocabularyKinds`, not here.) -/
+def buildNodeKinds : Array String := #[
+  "knob", "source", "pluck", "comb", "flange", "sflange", "fm", "delay",
+  "reverse", "mix", "ring", "resonator", "reverb", "filter", "modalmix",
+  "gong", "bloomgong", "string"]
+
+/-- Kinds `buildNode` builds but which are WITHHELD from the served surface. Their
+    modal factor-site landing (`bloomComposedSig`) still lands `lit 268435456`
+    unconditionally — no per-region sup, no admission guard for the conditioning
+    hazard when `a` is near a negative integer (the fixed-depth float64 series-M
+    Horner catastrophically cancels; see that def's RANGE block). `checkServedKinds`
+    rejects a withheld kind with an honest message rather than letting it die
+    downstream as a MISLEADING `signal→modal` type error: `outletOf` falls through
+    to `signal` for it, which DRIFTS from its modal constructed node — the exact
+    drift the `modal-class-agreement` gate now sees because it drives off
+    `buildNodeKinds`. Un-withholding one is NOT a one-line `outletOf` edit: it
+    re-admits the unguarded factor site, so it waits on the per-region-sup landing
+    (`design/seam-hardening-optionE-handoff.local.md`, the factor-site follow-on). -/
+def withheldKinds : Array String := #["bloomgong"]
 
 -- Derived views — the ONLY readers of glide/anchor/knob facts from here down.
 private def portOf (kind kname : String) : Option PortSpec :=
@@ -721,6 +749,13 @@ private def discStr : Discipline → String
 private def checkEdgeTypes (raws : Array Raw) : Except String Unit := do
   for r in raws do
     for p in portSpecs r.kind do
+      -- A knob-only port (`accepts = #[]`, `knob` set — `rt60`, `decay`, `cutoff`,
+      -- …) is a SET value, never a wired inlet. A wire into it slips past the
+      -- color loop below (empty accepts) yet makes `collectParams`' `selfWired`
+      -- SUPPRESS the slot — a silently dead knob. Reject a non-empty wire here
+      -- (an empty `in[knob]` entry is a harmless surface convention, kept legal).
+      if p.accepts.isEmpty && p.knob.isSome && !(portSources r.inObj p.name).isEmpty then
+        throw s!"connection error: '{r.id}' ({r.kind}) has a wire into '{p.name}', which is a knob (a set value), not an inlet — set it via its param slot (or wire its owner port), do not wire the knob itself"
       unless p.accepts.isEmpty do
         for srcId in portSources r.inObj p.name do
           match raws.find? (·.id == srcId) with
@@ -796,18 +831,40 @@ private def checkOutTarget (j : Json) (raws : Array Raw) : Except String Unit :=
     else throw s!"output target error: the top-level \"out\" names node '{outId}', which is not in the patch — route the dac from an existing node (or omit \"out\" for a silent patch)"
   | _ => pure ()
 
+/-- Reject a node the served surface does not cover, at the surface boundary —
+    BEFORE `checkEdgeTypes`, so the honest message wins over the misleading
+    `signal→modal` type error a WITHHELD modal kind (whose `outletOf` falls through
+    to `signal`) would otherwise die as downstream. A withheld kind (`withheldKinds`
+    — built by `buildNode` but not yet surface-ready) and a genuinely UNKNOWN kind
+    (a typo, which `buildNode`'s `_ => .mix` fallthrough would otherwise turn into
+    silent silence) each get their own message. Distinct from a legal-incomplete
+    state (an unwired inlet → silence, no error): an unknown/withheld kind is a
+    broken/unavailable document. A valid patch is untouched — every `vocabularyKinds`
+    entry (incl. `out`) passes. -/
+private def checkServedKinds (raws : Array Raw) : Except String Unit := do
+  for r in raws do
+    if withheldKinds.contains r.kind then
+      throw s!"unserved kind: '{r.id}' has kind '{r.kind}', which the engine builds but WITHHOLDS from the surface vocabulary (its modal factor-site landing has no admission guard yet) — not available as a patch node"
+    unless vocabularyKinds.contains r.kind do
+      throw s!"unknown kind: '{r.id}' has kind '{r.kind}', which is not a served node kind — see get_vocabulary for the {vocabularyKinds.size} kinds the surface builds"
+  pure ()
+
 /-- Finding-2 agreement: the connection-typing rule is decided at TWO sites.
     `checkEdgeTypes` colors an outlet through `outletOf`; the lowering decides
     modal-ness through `nodeIsModal` on the CONSTRUCTED node. Nothing forces them
     to agree, so a future kind whose `buildNode` returns a modal node but which
     lacks a modal `outletOf` case would be silently signal-colored — the checker
     would then reject modal wiring the lowering accepts (or vice-versa). This
-    builds each vocabulary kind's DEFAULT node and reports the kinds where
-    `nodeIsModal` disagrees with `outletOf … == some .modal`; `tropicaltest`
-    asserts the result empty. (`out` has no outlet and is never built — skipped.) -/
+    builds every kind `buildNode` constructs (`buildNodeKinds`, NOT just the
+    served `vocabularyKinds` — so a served-but-unlisted kind like a withheld
+    `bloomgong` is SEEN, not invisible) and reports the kinds where `nodeIsModal`
+    disagrees with `outletOf … == some .modal`. The gate then asserts no SERVED
+    kind drifts; a withheld kind may drift (that drift is why it is withheld —
+    `checkServedKinds` rejects it pre-lowering, so it can never mis-type an edge).
+    (`out` is a dac sink, never built — not in `buildNodeKinds`.) -/
 def modalClassificationDrift : Array String := Id.run do
   let mut drift : Array String := #[]
-  for kind in vocabularyKinds do
+  for kind in buildNodeKinds do
     if kind == "out" then continue
     let (node, _) := buildNode (fun _ => none) "n" kind
       (Json.mkObj []) (Json.mkObj []) (Json.mkObj [])
@@ -1056,7 +1113,8 @@ def compilePlanPure (arena : Arena) (resolved : Array (String × ProgramIdx)) (j
     Except String (Tropical.Plan.FlatPlan × Array Tap
       × Array (Array (Option Tropical.Ir.Stage))) := do
   let raws := rawsOf j
-  checkEdgeTypes raws                                -- reject ill-typed / dangling edges pre-lowering
+  checkServedKinds raws                              -- reject withheld/unknown kinds FIRST (honest msg over the misleading type error)
+  checkEdgeTypes raws                                -- reject ill-typed / dangling / wire-into-knob edges pre-lowering
   checkAcyclic raws                                  -- reject cycles BEFORE the unbounded lowering recursion
   checkOutTarget j raws                              -- reject an "out" id that names no node
   let (g, paramTable) ← decodeGraph j

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -382,6 +382,13 @@ def portSpecs : String → Array PortSpec
       { name := "resonance", knob := some (5, 1), discipline := .glide,
         display := some { min := 0, max := 1 } }]
   | "modalmix" => #[{ name := "in", accepts := modalIn, multi := true }]
+  -- gauge: the §5 excitation-gauge adapter — re-levels its modal input's peak by the
+  -- self-measured ‖H‖^{−g}. `g` is the gauge: 0 = unity-DC (strike, the identity),
+  -- ½ = √Q trim, 1 = unity-peak (tuned-tone level-invariant). Glided (smooth sweep).
+  | "gauge" => #[
+      { name := "in", accepts := modalIn },
+      { name := "g", knob := some (0, 0), discipline := .glide,
+        display := some { min := 0, max := 1 } }]
   -- gong: a struck resonator whose strike data (`t`, `g`, `modes_full`,
   -- `modes_half`) is structural (carried in `params`), EXCEPT the pitch-bloom
   -- depth `beta` — promoted to a LIVE slot, so the bloom deepens/relaxes under a
@@ -397,7 +404,7 @@ def portSpecs : String → Array PortSpec
 /-- Each kind's outlet color (`none` = no outlet, the dac sink). -/
 def outletOf : String → Option PortDomain
   | "knob" => some .control
-  | "resonator" | "reverb" | "filter" | "modalmix" | "string" => some .modal
+  | "resonator" | "reverb" | "filter" | "modalmix" | "string" | "gauge" => some .modal
   | "out" => none
   | _ => some .signal
 
@@ -407,7 +414,7 @@ def outletOf : String → Option PortDomain
 def vocabularyKinds : Array String := #[
   "source", "pluck", "comb", "flange", "delay", "reverse", "fm", "sflange",
   "mix", "ring", "gong", "string", "resonator", "reverb", "filter",
-  "modalmix", "knob", "out"]
+  "modalmix", "gauge", "knob", "out"]
 
 /-- Every kind `buildNode` actually constructs (its match arms — the AUTHORITATIVE
     list, read straight off the arms below). The classification-drift gate and
@@ -419,7 +426,7 @@ def vocabularyKinds : Array String := #[
 def buildNodeKinds : Array String := #[
   "knob", "source", "pluck", "comb", "flange", "sflange", "fm", "delay",
   "reverse", "mix", "ring", "resonator", "reverb", "filter", "modalmix",
-  "gong", "bloomgong", "string"]
+  "gauge", "gong", "bloomgong", "string"]
 
 /-- Kinds `buildNode` builds but which are WITHHELD from the served surface. Their
     modal factor-site landing (`bloomComposedSig`) still lands `lit 268435456`
@@ -642,6 +649,13 @@ private def buildNode (pidx : String → Option Nat) (id kind : String)
     (.modalReverb sig
       (filterPair (p "cutoff" (dv "cutoff")) (p "resonance" (dv "resonance"))) none, #[])
   | "modalmix" => (.modalMix (portSources inObj "in"), #[])
+  | "gauge" =>
+    -- §5 excitation gauge: re-level the modal input's peak. g=0 identity (unity-DC,
+    -- the strike gauge), g=1 unity-peak. A pure Modal ⇝ Modal effect (`normalizePeak`);
+    -- the norm is self-measured on the SETTLED poles, so a glided filter input is
+    -- Metal-safe and an un-settleable input declines to identity.
+    let inId := (portSources inObj "in")[0]?.getD "__silence__"
+    (.modalGauge inId (p "g" (dv "g")), #[])
   | "gong" =>
     -- One STRIKE of the struck nonlinear resonator: two anchored modal banks
     -- (full-glide + stiff half-glide registers) behind per-strike pitch-bloom

--- a/lean/Tropical/Playground.lean
+++ b/lean/Tropical/Playground.lean
@@ -192,15 +192,20 @@ def defaultStringModes (f0 rho : Float) : Array ModalMode := Id.run do
 /-- A reverb room as a `ModalMode` bank (pole + residue-as-coeff): `nmode`
     log-spaced modes over `[flo,fhi]` with damping `σ = 6.91/rt60` (live), unit
     residues at golden-ratio phases so the tail isn't a pure comb. Freqs and count
-    are structural (baked); only the damping is a live knob. -/
-private def reverbRoom (rt60 : Sig) (nmode : Nat) (flo fhi : Float) : Array ModalMode :=
+    are structural (baked); only the damping is a live knob. `rtRange` (the rt60
+    knob's declared span) maps through σ = 6.91/rt60 to each mode's `sigmaRange` —
+    what lets a bloomed source CROSS this room with the rt60 still live (WS-LP:
+    `bloomCompose` classifies the live pole over that interval). -/
+private def reverbRoom (rt60 : Sig) (rtRange : Option (Float × Float))
+    (nmode : Nat) (flo fhi : Float) : Array ModalMode :=
   let sigma := div (lit 691 2) rt60           -- 6.91 / rt60
+  let sigmaRange := rtRange.map (fun (lo, hi) => (6.91 / hi, 6.91 / lo))
   let denom : Float := if nmode ≤ 1 then 1.0 else (nmode - 1).toFloat
   (Array.range nmode).map fun j =>
     let fq := flo * Float.pow (fhi / flo) (j.toFloat / denom)
     let ph := 6.283185307179586 * (0.6180339887 * j.toFloat)
     { sigma, omega := mul twoPiE (litF fq),
-      cre := litF (Float.cos ph), cim := litF (Float.sin ph) }
+      cre := litF (Float.cos ph), cim := litF (Float.sin ph), sigmaRange }
 
 /-- A 2-pole resonant filter as its EXACT complex-conjugate pole pair — the
     modal island's filter (the Serge-VCFQ move). "Filtering" a modal source is
@@ -454,6 +459,12 @@ private def fallbackOf (kind kname : String) : Sig :=
   match (portOf kind kname).bind (·.knob) with
   | some (m, e) => lit m e
   | none => lit 0
+/-- A knob's display span from the table — the interval a live value is DECLARED
+    to range over (WS-LP feeds it to the live-pole region classifier; the lifted
+    kernel clamps the live read to it, so the declaration is enforced, not
+    advisory). -/
+private def displayRangeOf (kind kname : String) : Option (Float × Float) :=
+  ((portOf kind kname).bind (·.display)).map (fun d => (d.min, d.max))
 
 /-- A closed-form smoothstep GLIDE of τ from three slots: `v0 + (v1−v0)·s²(3−2s)`,
     `s = clamp((τ − t0)/dur, 0, 1)`, `dur = 0.02·sampleRate` samples (20 ms at any
@@ -642,7 +653,7 @@ private def buildNode (pidx : String → Option Nat) (id kind : String)
     let sway := p "sway" (dv "sway")
     let swayRate := p "rate" (dv "rate")   -- 0.3 Hz: a slow breath
     let dir : ModalDir := { dir := dirX, damp := some (sway, swayRate) }
-    (.modalReverb sig (reverbRoom rt60 32 60.0 6000.0) (some dir), #[])
+    (.modalReverb sig (reverbRoom rt60 (displayRangeOf "reverb" "rt60") 32 60.0 6000.0) (some dir), #[])
   | "filter" =>
     -- the filter IS a modalReverb with a computed 2-mode room: the residue
     -- calculus does the "filtering" at build time, knobs stay live through it.
@@ -686,8 +697,9 @@ private def buildNode (pidx : String → Option Nat) (id kind : String)
     -- lowering folds the room chain first and crosses the bloom ONCE. Baked-pole-
     -- bloom contract (besselFuse parity): β, g, scale baked (a change relowers);
     -- amps stay live. Wired to `out` it plays the bare bloom-warped register;
-    -- wired to a BAKED-pole reverb it crosses. A live-pole (rt60) reverb
-    -- gracefully drops to the bare bloom (the recorded baked-pole-bloom v1 limit).
+    -- wired to a reverb it crosses — including a LIVE-rt60 reverb since WS-LP
+    -- (serOnly pairs lift to s0 CplxE of the live pole; region-crossing pairs
+    -- drop gracefully per pair until the Phase 3 region-union emit).
     let t := jFloat params "t" 0.0
     let beta := jFloat params "beta" 0.05
     let gRate := jFloat params "g" 1.8

--- a/lean/Tropical/Testing/ArrowFixtures.lean
+++ b/lean/Tropical/Testing/ArrowFixtures.lean
@@ -958,6 +958,14 @@ def buildLogProbe (name : String) (arena : Arena) : Arena × ProgramIdx :=
   let x := add (lit 2 2) (mul sIdxF (lit 9765625 8))
   buildExprCarrier name (logSig x) arena
 
+/-- `atan2E(sin θ, cos θ)` over a ramp `θ ∈ [−3.1, 3.096]` (all four quadrants across
+    2048 samples, inside `(−π, π)` so no wrap) — must recover `θ`. The reference side
+    of the `bootstrap-atan2` gate: rendered `atan2E` vs the known angle. -/
+def buildAtan2Probe (name : String) (arena : Arena) : Arena × ProgramIdx :=
+  let sIdxF := toFloatE (rshift clockLit (lit 32))
+  let theta := sub (mul sIdxF (lit 302734375 11)) (lit 31 1)
+  buildExprCarrier name (atan2E (sinSig theta) (cosSig theta)) arena
+
 /-- Emit the modal bank through the ARROW path (`arrUn`/`clk`, then `emitTerm`) —
     the term side of the `modal-bank` gate. -/
 def buildModalBankArrow (name : String) (modes : Array ModalMode) (anchor : Sig)

--- a/lean/Tropical/Testing/ArrowFixtures.lean
+++ b/lean/Tropical/Testing/ArrowFixtures.lean
@@ -949,6 +949,15 @@ def buildExpProbe (name : String) (arena : Arena) : Arena × ProgramIdx :=
   let x := sub (mul sIdxF (lit 9765625 9)) (lit 10)
   buildExprCarrier name (expSig x) arena
 
+/-- `logSig(x)` over a positive ramp `x ∈ [0.02, 200]` (`x = 0.02 + i·0.0977`,
+    ~4 decades across 2048 samples, exercising both range-reduction branches and
+    ~13 exponent octaves). The reference side of the `bootstrap-log` gate:
+    rendered `logSig(x)` vs libm `log(x)`. -/
+def buildLogProbe (name : String) (arena : Arena) : Arena × ProgramIdx :=
+  let sIdxF := toFloatE (rshift clockLit (lit 32))
+  let x := add (lit 2 2) (mul sIdxF (lit 9765625 8))
+  buildExprCarrier name (logSig x) arena
+
 /-- Emit the modal bank through the ARROW path (`arrUn`/`clk`, then `emitTerm`) —
     the term side of the `modal-bank` gate. -/
 def buildModalBankArrow (name : String) (modes : Array ModalMode) (anchor : Sig)

--- a/lean/Tropical/Tropicaltest/BanksStaging.lean
+++ b/lean/Tropical/Tropicaltest/BanksStaging.lean
@@ -658,11 +658,18 @@ def runModalRailIdentity (arena : Arena)
     ModalMode.hz (lit (Int.ofNat (220 + 40 * i))) (lit 30 1) amp
   let small := mkModes (lit 2 1)      -- amp 0.2 ⇒ maxAbs 0.2 < 32 ⇒ k = 0
   let large := mkModes (lit 100)      -- amp 100  ⇒ maxAbs 100    ⇒ k = 2
+  -- a deg-1 bank with small σ: |A|=10 < 32 (amp-only would give k=0), but env₂ =
+  -- d·e^{−σd} peaks at (1/(σe)) ≈ 3.68, so the LANDED sup ≈ 36.8 > 32 ⇒ the
+  -- envelope-aware bound bumps k to 1. Proves the deg>0 lift is not amp-only.
+  let degBank := (Array.range 3).map fun i =>
+    ({ sigma := litF 0.1, omega := mul twoPiE (lit (Int.ofNat (300 + 40 * i))),
+       cre := litF 10.0, cim := lit 0, deg := 1 } : ModalMode)
   let hasSub := fun (s sub : String) => (s.splitOn sub).length != 1
   let land2p28 := "0x41b0000000000000"   -- 2²⁸, the verbatim Q4.28 landing (lowercase hex)
   let land2p26 := "0x4190000000000000"   -- 2²⁶, the k=2 landing
   let kSmall := match bankLandExp small with | .static k => some k | .dynamic _ => none
   let kLarge := match bankLandExp large with | .static k => some k | .dynamic _ => none
+  let kDeg   := match bankLandExp degBank with | .static k => some k | .dynamic _ => none
   match buildAndFinish (.ok (buildModalBankTable "id_small" small (lit 200) arena)),
         buildAndFinish (.ok (buildModalBankTable "id_large" large (lit 200) arena)) with
   | .ok pSmall, .ok pLarge =>
@@ -670,12 +677,13 @@ def runModalRailIdentity (arena : Arena)
     | .ok irSmall, .ok irLarge =>
       let smallVerbatim := hasSub irSmall land2p28    -- k=0 keeps 2²⁸
       let largeRescaled := hasSub irLarge land2p26 && !(hasSub irLarge land2p28)  -- k=2 ⇒ 2²⁶, no 2²⁸
-      IO.println s!"        static banks: small amp 0.2 ⇒ k={kSmall} (want 0), large amp 100 ⇒ k={kLarge} (want 2):"
-      IO.println s!"        small IR keeps 2²⁸ landing={smallVerbatim} · large IR rescales to 2²⁶ & drops 2²⁸={largeRescaled}"
-      if kSmall == some 0 && kLarge == some 2 && smallVerbatim && largeRescaled then
-        passGate "modal-rail-identity" "k=0 emits the Q4.28 landing VERBATIM (byte-identical plan, reused kernel-cache); a loud static bank rescales to 2²⁶ (option E fires) — the 'nothing moves at k=0' claim is now pinned both ways"
+      let degLifts := kDeg == some 1    -- env₂-aware bound bumps a small-|A| deg-1 bank
+      IO.println s!"        static banks: small amp 0.2 ⇒ k={kSmall} (want 0), large amp 100 ⇒ k={kLarge} (want 2), deg-1 σ=0.1 amp=10 ⇒ k={kDeg} (want 1, env-lifted):"
+      IO.println s!"        small IR keeps 2²⁸ landing={smallVerbatim} · large IR rescales to 2²⁶ & drops 2²⁸={largeRescaled} · deg-1 env₂ lift={degLifts}"
+      if kSmall == some 0 && kLarge == some 2 && degLifts && smallVerbatim && largeRescaled then
+        passGate "modal-rail-identity" "k=0 emits the Q4.28 landing VERBATIM (byte-identical, reused kernel-cache); a loud static bank rescales to 2²⁶ (option E fires); a small-|A| deg-1 bank still lifts k via its env₂ peak (deg>0 is not amp-only) — pinned every way"
       else
-        failGate "modal-rail-identity" s!"kSmall={kSmall} (want 0) kLarge={kLarge} (want 2) smallVerbatim={smallVerbatim} largeRescaled={largeRescaled}"
+        failGate "modal-rail-identity" s!"kSmall={kSmall} (want 0) kLarge={kLarge} (want 2) kDeg={kDeg} (want 1) smallVerbatim={smallVerbatim} largeRescaled={largeRescaled}"
     | .error e, _ | _, .error e => failGate "modal-rail-identity" s!"emit: {firstLine e}"
   | .error e, _ | _, .error e => failGate "modal-rail-identity" s!"build: {firstLine e}"
 

--- a/lean/Tropical/Tropicaltest/BanksStaging.lean
+++ b/lean/Tropical/Tropicaltest/BanksStaging.lean
@@ -512,6 +512,63 @@ def runModalFilter (arena : Arena)
       | .error e, _ | _, .error e =>
         failGate "modal-filter" s!"(C) emit: {firstLine e}"
 
+/-- Oracle-free spike count: samples deviating from the mean of their neighbours by
+    more than 25% of peak. The rail probe's discriminator (design/prod-rail-probe):
+    a modal signal is a sum of decaying sinusoids ≤ 4.8 kHz on a 44.1 kHz grid, so
+    it is smooth by construction, while the i64 wrap's signature is ISOLATED
+    single-sample glitches. Reads 0 for every benign config INCLUDING loud ones
+    (peak 91), and jumps to hundreds exactly at the rail. Returns (peak, spikes). -/
+private def spikeStats (s : Array Float) : Float × Nat := Id.run do
+  let mut peak : Float := 0.0
+  for x in s do
+    if x.isFinite && x.abs > peak then peak := x.abs
+  let mut spikes : Nat := 0
+  if s.size ≥ 3 then
+    for i in [1:s.size-1] do
+      let d := (s[i]! - 0.5 * (s[i-1]! + s[i+1]!)).abs
+      if d > 0.25 * peak && peak > 1e-9 then spikes := spikes + 1
+  pure (peak, spikes)
+
+/-- THE MODAL RAIL WITNESS (option E, the production-path red witness). The exact
+    gesture the rail incident named: `resonator(800,4) ⋙ filter(cutoff 800, res) ⋙
+    out`, compiled through `compilePlanPure` on the PRODUCTION path (master clock,
+    anchor 0, master gain 3.7), the SAME path the shipped GUI drives. The filter's
+    amplitudes are LIVE param slots (`resonance` is a `pref` slot), so this
+    exercises option E's DYNAMIC (kernel-time) per-bank exponent — the case the
+    static path cannot reach, and the one the rail actually lives on.
+
+    Two arms on ONE knob, both MEASURED (design/prod-rail-probe.local.lean.txt):
+    - GREEN CONTROL res 0.91 — peak ≈ 91, spikes 0. Loud-but-correct: it proves
+      the discriminator distinguishes *loud* from *broken* and is not trivially
+      satisfied by silence (a peak floor guards that).
+    - RED ARM res 0.95 — pre-fix peak 234 with 211 spikes (the i64 wrap: `|A| ≈ Q =
+      0.55·80^0.95 ≈ 35` collected past the rail of 32 wraps to a ±64 full-scale
+      burst); post-fix `k = ⌊log₂ 35⌋−4 = 1` lands at Q3.27 and the ring renders
+      SMOOTH — peak ≈ 130 (the true driven-resonator output, legitimately louder
+      than the control) and spikes 0.
+
+    Discriminator is spikes, NOT peak: the correct high-Q output is LOUDER than the
+    control, so an amplitude bound would false-fail it. MUTATION-VERIFIED: revert
+    any plain-site landing to `lit 268435456`/`lit 28` and the res-0.95 arm returns
+    to hundreds of spikes → RED. -/
+def runModalRail (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  match ← renderFilterPatch arena resolved (filterPatchJson 800 91 2 800 4) 4096,
+        ← renderFilterPatch arena resolved (filterPatchJson 800 95 2 800 4) 4096 with
+  | .error e, _ | _, .error e => failGate "modal-rail" s!"render: {e}"
+  | .ok green, .ok red =>
+    let (pkG, spG) := spikeStats green
+    let (pkR, spR) := spikeStats red
+    let finiteG := green.all (·.isFinite)
+    let finiteR := red.all (·.isFinite)
+    IO.println s!"        resonator(800,4) ⋙ filter(800, res) ⋙ out, production path (live amps ⇒ dynamic k):"
+    IO.println s!"        res 0.91 (green control): peak={pkG} spikes={spG} finite={finiteG}"
+    IO.println s!"        res 0.95 (red arm)      : peak={pkR} spikes={spR} finite={finiteR}"
+    if spG == 0 && spR == 0 && finiteG && finiteR && pkG > 50.0 then
+      passGate "modal-rail" s!"the top of the resonance knob renders SMOOTH through the fix (res 0.91 & 0.95 both spike-free; control peak {pkG} proves the discriminator sees loud≠broken) — the i64 landing rail is gone on the production path"
+    else
+      failGate "modal-rail" s!"spikes green={spG} red={spR} (want 0/0), finite {finiteG}/{finiteR}, control peak {pkG} (want >50) — the datapath wraps or the render is trivial"
+
 open Tropical.EmitArrow in
 /-- THE MODAL ADDRESS gate. A resonator's `addr` inlet: a patched CF signal BECOMES
     the bank's absolute time-coordinate (`modalAddrWarp`), so the causal gate — the

--- a/lean/Tropical/Tropicaltest/BanksStaging.lean
+++ b/lean/Tropical/Tropicaltest/BanksStaging.lean
@@ -409,6 +409,24 @@ def runBanksCountCache (arena : Arena)
     else
       failGate "banks-count-cache" s!"knobInvariant={knobInvariant} capMoves={capMoves}"
 
+/-- Build the resonator → reverb → out patch graph as Json (the dir-landing path:
+    a `reverb` node attaches a `ModalDir` unconditionally, so it routes through
+    `modalBankSigDirTable`). `rt60` is a `.raw` slot, so the value sets its default. -/
+private def reverbPatchJson (srcF srcDecay : Int) (rtM : Int) (rtE : Nat) : Lean.Json :=
+  let node := fun (id kind : String) (params : List (String × Lean.Json))
+                  (ins : List (String × Lean.Json)) =>
+    Lean.Json.mkObj <|
+      [("id", Lean.Json.str id), ("kind", Lean.Json.str kind),
+       ("params", Lean.Json.mkObj params)] ++
+      (if ins.isEmpty then [] else [("in", Lean.Json.mkObj ins)])
+  Lean.Json.mkObj [
+    ("nodes", Lean.Json.arr #[
+      node "res" "resonator" [("freq", Lean.Json.num (jn srcF)), ("decay", Lean.Json.num (jn srcDecay))] [],
+      node "rev" "reverb" [("rt60", Lean.Json.num (jn rtM rtE))]
+        [("in", Lean.Json.arr #[Lean.Json.str "res"])],
+      node "out" "out" [] [("in", Lean.Json.arr #[Lean.Json.str "rev"])]]),
+    ("out", Lean.Json.str "out")]
+
 /-- Build the resonator → filter → out patch graph as Json. -/
 private def filterPatchJson (fc : Int) (resM : Int) (resE : Nat) (srcF srcDecay : Int) : Lean.Json :=
   let node := fun (id kind : String) (params : List (String × Lean.Json))
@@ -568,6 +586,98 @@ def runModalRail (arena : Arena)
       passGate "modal-rail" s!"the top of the resonance knob renders SMOOTH through the fix (res 0.91 & 0.95 both spike-free; control peak {pkG} proves the discriminator sees loud≠broken) — the i64 landing rail is gone on the production path"
     else
       failGate "modal-rail" s!"spikes green={spG} red={spR} (want 0/0), finite {finiteG}/{finiteR}, control peak {pkG} (want >50) — the datapath wraps or the render is trivial"
+
+/-- THE MODAL DIR-RAIL WITNESS (option E, the reverb/dir-path red witness). The
+    `modalBankSigDirTable` landing had ZERO rail coverage, yet every `reverb` node
+    in the vocabulary routes through it (`reverb` attaches a `ModalDir`
+    unconditionally, unlike `filter`), so the same i64 wrap lived there unwitnessed.
+    At the default dir knob (0) the dir table reduces to its forward accumulator,
+    whose per-mode Q4.28 landing is the SAME overflow site as the plain table.
+
+    The gesture: `resonator(60,4) ⋙ reverb(rt60) ⋙ out`. The reverb room mode 0
+    sits at EXACTLY 60 Hz and resonator partial 1 at 1·60 Hz, so the poles coincide
+    in frequency and |Δ| collapses to |Δσ|; sweeping rt60 through the punctured
+    neighbourhood of the coincidence (σ_room = 6.91/rt60 crossing σ_res = decay·1.4
+    = 5.6 at rt60 ≈ 1.234) drives the collected |A| past the rail.
+
+    MEASURED on the production dir path (the derivation lab, fix forced off):
+    the red set is ERRATIC — the wrap needs differing per-mode wrap counts, so it
+    is necessary-not-sufficient and fires only at some rt60 in the neighbourhood
+    (rt60 1.230/1.236/1.238 → peak ≈237 with 15/3/21 spikes; the exact-coincidence
+    1.232/1.234 stay benign — the point itself yields a deg-1 mode on the unrolled
+    path, and benign wrap-parity pockets sit between). So the red arm is a
+    MEASURED rt60 (1.238, the strongest), never a derived threshold.
+
+    - GREEN CONTROL rt60 = 2.0 — peak ≈0.30, spikes 0 (far from coincidence).
+    - RED ARM rt60 = 1.238 — pre-fix peak 237 / 21 spikes; post-fix peak ≈0.28 / 0
+      spikes. Near coincidence the CORRECT reverb output is quiet (the ±c/Δ
+      residues cancel in the sum), so unlike the filter witness a peak bound is a
+      safe secondary catch here (the wrap's 237 is the anomaly, not the music).
+
+    MUTATION-VERIFIED: revert the dir landing to `lit 268435456`/`lit 28` and the
+    rt60-1.238 arm returns to 21 spikes / peak 237 → RED. -/
+def runModalRailDir (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  match ← renderFilterPatch arena resolved (reverbPatchJson 60 4 2 0) 4096,
+        ← renderFilterPatch arena resolved (reverbPatchJson 60 4 1238 3) 4096 with
+  | .error e, _ | _, .error e => failGate "modal-rail-dir" s!"render: {e}"
+  | .ok green, .ok red =>
+    let (pkG, spG) := spikeStats green
+    let (pkR, spR) := spikeStats red
+    let finiteG := green.all (·.isFinite)
+    let finiteR := red.all (·.isFinite)
+    IO.println s!"        resonator(60,4) ⋙ reverb(rt60) ⋙ out, production dir path (60 Hz pole coincidence):"
+    IO.println s!"        rt60 2.0 (green control)  : peak={pkG} spikes={spG} finite={finiteG}"
+    IO.println s!"        rt60 1.238 (red arm)      : peak={pkR} spikes={spR} finite={finiteR}"
+    if spG == 0 && spR == 0 && finiteG && finiteR && pkG > 0.05 && pkR < 10.0 then
+      passGate "modal-rail-dir" s!"the reverb dir landing survives the 60 Hz pole coincidence (rt60 1.238 spike-free, peak {pkR} — the pre-fix ±237 wrap is gone; control rt60 2.0 renders) — the i64 rail is fixed on the dir path too"
+    else
+      failGate "modal-rail-dir" s!"spikes green={spG} red={spR} (want 0/0), finite {finiteG}/{finiteR}, control peak {pkG} (>0.05), red peak {pkR} (want <10 — the wrap is ≈237)"
+
+open Tropical.EmitArrow in
+/-- THE OPTION-E STRUCTURAL-IDENTITY gate — the anchor that makes "when max|A| < 32,
+    k = 0 and NOTHING moves" TESTABLE (no frozen plan/IR hash exists on the
+    EmitArrow modal-island path, so nothing else would catch a k=0 drift). Two
+    ALL-LITERAL-amp banks, so `bankLandExp` takes the STATIC path and `k` is a
+    compile-time `Nat` decided here — no dynamic machinery, no live slots:
+
+    - SMALL amps (L1 max 0.2 < 32) ⇒ `k = 0` ⇒ the landing is `·2²⁸` / `>>28`
+      VERBATIM: the emitted IR carries the pre-fix double `0x41B0000000000000`
+      (= 2²⁸) at the weight multiply — byte-identical structure, so the JIT reuses
+      the pre-fix kernel-cache object (the cache keys on md5 of the IR text).
+    - LARGE amps (L1 max 100) ⇒ `k = ⌊log₂ 100⌋ − 4 = 2` ⇒ the landing rescales to
+      `·2²⁶` (`0x4190000000000000`) and the 2²⁸ constant is ABSENT: option E fires
+      statically, exactly as the dynamic path does at knob rate.
+
+    Pins both directions at once. MUTATION-VERIFIED: force `bankLandExp` to
+    `.static 0` and the large bank keeps the 2²⁸ landing (option E stops firing) →
+    the `k=2`/`2²⁶` assertions go RED. -/
+def runModalRailIdentity (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let mkModes := fun (amp : Sig) => (Array.range 6).map fun i =>
+    ModalMode.hz (lit (Int.ofNat (220 + 40 * i))) (lit 30 1) amp
+  let small := mkModes (lit 2 1)      -- amp 0.2 ⇒ maxAbs 0.2 < 32 ⇒ k = 0
+  let large := mkModes (lit 100)      -- amp 100  ⇒ maxAbs 100    ⇒ k = 2
+  let hasSub := fun (s sub : String) => (s.splitOn sub).length != 1
+  let land2p28 := "0x41b0000000000000"   -- 2²⁸, the verbatim Q4.28 landing (lowercase hex)
+  let land2p26 := "0x4190000000000000"   -- 2²⁶, the k=2 landing
+  let kSmall := match bankLandExp small with | .static k => some k | .dynamic _ => none
+  let kLarge := match bankLandExp large with | .static k => some k | .dynamic _ => none
+  match buildAndFinish (.ok (buildModalBankTable "id_small" small (lit 200) arena)),
+        buildAndFinish (.ok (buildModalBankTable "id_large" large (lit 200) arena)) with
+  | .ok pSmall, .ok pLarge =>
+    match Tropical.Ir.EmitLlvm.emitKernel pSmall, Tropical.Ir.EmitLlvm.emitKernel pLarge with
+    | .ok irSmall, .ok irLarge =>
+      let smallVerbatim := hasSub irSmall land2p28    -- k=0 keeps 2²⁸
+      let largeRescaled := hasSub irLarge land2p26 && !(hasSub irLarge land2p28)  -- k=2 ⇒ 2²⁶, no 2²⁸
+      IO.println s!"        static banks: small amp 0.2 ⇒ k={kSmall} (want 0), large amp 100 ⇒ k={kLarge} (want 2):"
+      IO.println s!"        small IR keeps 2²⁸ landing={smallVerbatim} · large IR rescales to 2²⁶ & drops 2²⁸={largeRescaled}"
+      if kSmall == some 0 && kLarge == some 2 && smallVerbatim && largeRescaled then
+        passGate "modal-rail-identity" "k=0 emits the Q4.28 landing VERBATIM (byte-identical plan, reused kernel-cache); a loud static bank rescales to 2²⁶ (option E fires) — the 'nothing moves at k=0' claim is now pinned both ways"
+      else
+        failGate "modal-rail-identity" s!"kSmall={kSmall} (want 0) kLarge={kLarge} (want 2) smallVerbatim={smallVerbatim} largeRescaled={largeRescaled}"
+    | .error e, _ | _, .error e => failGate "modal-rail-identity" s!"emit: {firstLine e}"
+  | .error e, _ | _, .error e => failGate "modal-rail-identity" s!"build: {firstLine e}"
 
 open Tropical.EmitArrow in
 /-- THE MODAL ADDRESS gate. A resonator's `addr` inlet: a patched CF signal BECOMES

--- a/lean/Tropical/Tropicaltest/BanksStaging.lean
+++ b/lean/Tropical/Tropicaltest/BanksStaging.lean
@@ -741,3 +741,46 @@ def runModalAddr (arena : Arena)
         failGate "modal-addr" s!"maxErr={maxErr} preMax={preMax} postPeak={postPeak} decodeOk={decodeOk}"
     | .error e, _, _ | _, .error e, _ | _, _, .error e => failGate "modal-addr" s!"render: {firstLine e}"
   | _, _, _ => failGate "modal-addr" "build"
+
+/-- THE GAUGE-STAGE gate (§5, Hamilton's "make the s0 contract mechanical"). The
+    gauge's self-measured norm uses `logSig` → `floatExponent`; `settle` measures it
+    on the SETTLED poles, so that op is s0 (the coefficient kernel), NOT per-sample.
+    Proven by DELTA against `resonator ⋙ filter(glided cutoff/res) ⋙ out` without the
+    gauge: the filter's own option-E landing already emits `FloatExponent` in the
+    audio kernel (a glided-amp bank), so the invariant is not "zero in audio" but
+    "the GAUGE adds zero": with `settle`, inserting the gauge leaves the audio
+    kernel's `FloatExponent` count UNCHANGED and moves its norm's `FloatExponent`
+    into the s0 coeff kernel. Remove `settle` from `gaugeScale` (the norm folds the
+    live glided poles) and the gauge's `FloatExponent` lands per-sample → the audio
+    delta jumps → red. Contract enforced by the compiler's own stage split, not a
+    docstring. -/
+def runGaugeStage (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let mk := fun (withGauge : Bool) =>
+    "{\"nodes\":[" ++
+    "{\"id\":\"res\",\"kind\":\"resonator\",\"params\":{\"freq\":220,\"decay\":4}}," ++
+    "{\"id\":\"flt\",\"kind\":\"filter\",\"params\":{\"cutoff\":800,\"resonance\":0.5},\"in\":{\"in\":[\"res\"]}}," ++
+    (if withGauge then "{\"id\":\"gau\",\"kind\":\"gauge\",\"params\":{\"g\":1},\"in\":{\"in\":[\"flt\"]}}," else "") ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"" ++ (if withGauge then "gau" else "flt") ++ "\"]}}],\"out\":\"out\"}"
+  let feOf : Bool → IO (Option (Nat × Nat)) := fun withGauge => do
+    match Lean.Json.parse (mk withGauge) with
+    | .error e => IO.println s!"        gauge-stage json: {e}"; pure none
+    | .ok j => match Tropical.Playground.compilePlanPure arena resolved j with
+      | .error e => IO.println s!"        gauge-stage compile: {firstLine e}"; pure none
+      | .ok (plan, _, sb) => match Tropical.Ir.Stage0.hoistTyped plan sb with
+        | .error e => IO.println s!"        gauge-stage split: {firstLine e}"; pure none
+        | .ok split =>
+          let a := planFloatExponents split.audio
+          let c := match split.coeff? with | some k => planFloatExponents k | none => 0
+          pure (some (a, c))
+  let some (aBare, cBare) ← feOf false | return (← failGate "gauge-stage" "bare compile")
+  let some (aGauge, cGauge) ← feOf true | return (← failGate "gauge-stage" "gauge compile")
+  IO.println s!"        resonator ⋙ filter(glided) ⋙ [gauge] ⋙ out — FloatExponent (audio, coeff):"
+  IO.println s!"        result   without gauge ({aBare}, {cBare}) · with gauge ({aGauge}, {cGauge})"
+  -- the gauge adds ZERO per-sample FloatExponent (its norm is s0), and DOES add its
+  -- norm's FloatExponent to the coeff kernel (so the gauge is genuinely present).
+  if aGauge == aBare && cGauge > cBare then
+    passGate "gauge-stage" s!"settle keeps the gauge norm s0: the gauge adds 0 FloatExponent to the audio kernel (stays {aBare}) and {cGauge - cBare} to the s0 coeff kernel — Metal-safe by construction"
+  else
+    failGate "gauge-stage" s!"audio {aBare}→{aGauge} (want equal), coeff {cBare}→{cGauge} (want grow) — the gauge norm leaked into the per-sample kernel"
+

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1699,3 +1699,43 @@ def runGaugeAdapter (arena : Arena)
     passGate "gauge-adapter" s!"the self-measured excitation gauge: g=0 no-op, g=1 unity-peak (÷‖H‖), g=½ √Q trim — render ≡ norm^(-g) to {worst} rel, ‖H‖ grows {norms}"
   else
     failGate "gauge-adapter" s!"ok={ok} grows={grows} worst={worst}"
+
+open Tropical.EmitArrow in
+/-- THE OPTION-E k-INVARIANCE gate. Option E's whole correctness rests on the landed
+    value being INVARIANT under the per-bank exponent `k` (the `·2^(28−k)` land and the
+    `>>(28−k)` shift cancel; only the quantization LSB moves). Every equivalence gate
+    only ever exercised `k = 0` (all shipped configs land there), so the k≠0 branch's
+    value-preservation was inferred, never witnessed. This pins it directly: a single
+    cosine mode at a SWEEP of amplitudes that crosses the `k` boundaries (|A|=32→k1,
+    64→k2, 128→k3), rendered through the real datapath — the peak must stay LINEAR in
+    the amplitude (peak/amp constant), i.e. NO jump as `k` steps. Consequence (why the
+    handoff's earlier "glided-bank floatExponent is a Metal risk" note is retracted): a
+    backend that computes a different `k` (f32 maxAbs vs f64 near a power-of-2 boundary)
+    lands the SAME value to within one quantization LSB — not a 2× divergence, and
+    wasm≡jit (both f64 ⇒ same k) is bit-identical regardless. -/
+def runKInvariance (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let amps := #[10.0, 30.0, 40.0, 60.0, 70.0, 130.0]   -- k = 0,0,1,1,2,3 (crosses 32/64/128)
+  let peakOf := fun (amp : Float) => do
+    let modes := #[ModalMode.hz (litF 300.0) (litF 5.0) (litF amp)]
+    match buildAndFinish (.ok (buildExprCarrier "kinv" (modalBankSig modes clockLit (lit 200)) arena)) with
+    | .ok p => match ← renderPlanSamples p 2048 with
+      | .ok s => do
+          let mut mx := 0.0
+          for i in [201:s.size] do mx := max mx s[i]!.abs
+          pure (some mx)
+      | .error e => IO.println s!"        kinv render: {firstLine e}"; pure none
+    | .error e => IO.println s!"        kinv build: {firstLine e}"; pure none
+  let mut ratios : Array Float := #[]
+  for amp in amps do
+    let some pk ← peakOf amp | return (← failGate "k-invariance" s!"render amp={amp}")
+    ratios := ratios.push (pk / amp)
+  -- peak/amp must be one constant across the sweep — no jump at a k boundary
+  let mean := ratios.foldl (· + ·) 0.0 / ratios.size.toFloat
+  let worst := ratios.foldl (fun w r => max w ((r - mean).abs / mean)) 0.0
+  IO.println s!"        single cosine mode, |A| sweep {amps} (k = 0,0,1,1,2,3):"
+  IO.println s!"        result   peak/amp {ratios} · worst deviation from constant {worst}"
+  if worst < 1e-5 then
+    passGate "k-invariance" s!"the landed value is k-invariant: peak/amp constant to {worst} across the k=0→3 boundaries (32/64/128) — the ·2^(28−k)/>>(28−k) cancel, a k-flip moves only the quantization LSB"
+  else
+    failGate "k-invariance" s!"peak/amp NOT constant (worst {worst}) — a k boundary jumped the value; option E's k-invariance is broken"

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1604,3 +1604,76 @@ def planArrayFills (p : Tropical.Plan.FlatPlan) : Nat :=
 /-- Reduce regions (banked mode loops). -/
 def planReduces (p : Tropical.Plan.FlatPlan) : Nat :=
   countInstrs (fun i => i.tag == "ReduceBegin") p
+
+open Tropical.EmitArrow in
+/-- THE EXCITATION-GAUGE gate (§5). `normalizePeak g` rescales a bank's residues by
+    the self-measured `1/‖H‖^g` (`‖H‖` = the p=8 norm of the bank's own transfer
+    function over its pole frequencies). Because the scale is ONE real shared across
+    the bank, the render is EXACTLY `scale · (bare render)` — so
+    `peak(normalizePeak g) / peak(bare) = ‖H‖^{−g}` (linearity; option E keeps the
+    value identical across the `k` the rescale moves). An INDEPENDENT Float oracle
+    recomputes `‖H‖₈` from the raw pole/residue Floats — independent of the emitted
+    `logSig`/`expSig`, so a mis-scaled adapter shows as ratio ≠ oracle. Asserts, over
+    a 2-resonance bank with the damping σ swept (lower σ ⇒ higher Q ⇒ higher ‖H‖):
+    (1) g=0 is a no-op (ratio 1 — strike-invariance / unity-DC); (2) g=1 applies
+    1/‖H‖ (ratio = ‖H‖⁻¹), and since ‖H‖ GROWS across the sweep, the normalized
+    FREQUENCY peak ‖H‖·scale = 1 is level-invariant (unity-peak); (3) g=½ the √Q
+    trim (ratio = ‖H‖^{−½}). -/
+def runGaugeAdapter (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let f1 := 300.0; let f2 := 520.0; let a1 := 1.0; let a2 := 0.7
+  let tp := 6.283185307179586
+  let ws := #[tp * f1, tp * f2]; let amps := #[a1, a2]
+  let sigmas := #[40.0, 10.0, 3.0]                    -- the damping sweep (Q ↑ as σ ↓)
+  -- INDEPENDENT oracle: ‖H‖₈ over the two pole freqs, H(iω) = Σⱼ aⱼ/(σ + i(ω−ωⱼ)).
+  let normOf := fun (sig : Float) => Id.run do
+    let mut S := 0.0
+    for wk in ws do
+      let mut hr := 0.0; let mut hi := 0.0
+      for j in [0:2] do
+        let dr := sig; let di := wk - ws[j]!
+        let dn := dr * dr + di * di
+        hr := hr + amps[j]! * dr / dn
+        hi := hi - amps[j]! * di / dn
+      let h2 := hr * hr + hi * hi
+      S := S + h2 * h2 * h2 * h2
+    return Float.exp (Float.log S / 8.0)              -- S^{1/8}
+  let mkModes := fun (sig : Float) => #[
+    ModalMode.hz (litF f1) (litF sig) (litF a1),
+    ModalMode.hz (litF f2) (litF sig) (litF a2)]
+  let peakOf := fun (modes : Array ModalMode) => do
+    match buildAndFinish (.ok (buildExprCarrier "gauge_probe"
+        (modalBankSig modes clockLit (lit 200)) arena)) with
+    | .ok p => match ← renderPlanSamples p 2048 with
+      | .ok s => do
+          let mut mx := 0.0
+          for i in [201:s.size] do mx := max mx s[i]!.abs
+          pure (some mx)
+      | .error e => IO.println s!"        gauge render: {firstLine e}"; pure none
+    | .error e => IO.println s!"        gauge build: {firstLine e}"; pure none
+  let mut ok := true
+  let mut worst := 0.0
+  let mut norms : Array Float := #[]
+  for sig in sigmas do
+    let nrm := normOf sig
+    norms := norms.push nrm
+    let some pBare ← peakOf (mkModes sig) | return (← failGate "gauge-adapter" "bare render")
+    for g in #[(0.0, "0"), (0.5, "½"), (1.0, "1")] do
+      let some pG ← peakOf (normalizePeak (litF g.1) (mkModes sig))
+        | return (← failGate "gauge-adapter" s!"g={g.2} render")
+      let ratio := pG / pBare
+      let oracle := Float.exp (Float.log nrm * (-g.1))   -- ‖H‖^{−g}
+      let rel := (ratio - oracle).abs / (max oracle 1e-9)
+      if rel > worst then worst := rel
+      if rel > 5e-3 then
+        IO.println s!"        GAUGE MISMATCH σ={sig} g={g.2}: render ratio {ratio} vs oracle norm^(-g) {oracle} (rel {rel})"
+        ok := false
+  -- level-invariance: ‖H‖ must GROW across the sweep (else the adapter faces no
+  -- level change and unity-peak is vacuous); the g=1 case above then re-levels it.
+  let grows := norms.size == 3 && norms[0]! < norms[1]! && norms[1]! < norms[2]!
+  IO.println s!"        normalizePeak: render ratio ≡ norm^(-g) over σ∈{sigmas}, g∈0/½/1:"
+  IO.println s!"        result   worst rel {worst} · ‖H‖ {norms} (grows across the sweep: {grows})"
+  if ok && grows then
+    passGate "gauge-adapter" s!"the self-measured excitation gauge: g=0 no-op, g=1 unity-peak (÷‖H‖), g=½ √Q trim — render ≡ norm^(-g) to {worst} rel, ‖H‖ grows {norms}"
+  else
+    failGate "gauge-adapter" s!"ok={ok} grows={grows} worst={worst}"

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1250,10 +1250,12 @@ def runModalBloomGamma (arena : Arena)
   | none, _ | _, none =>
     failGate "modal-bloom-gamma" "bloomCompose: a live pole reached the baked-pole contract"
   | some pairs, some pairs0 =>
-    -- (o) the lgamma recurrence on the actual a values
+    -- (o) the lgamma recurrence on the actual a values (the pairs are BAKED, so
+    -- the `Sig` fields fold back to their Floats via `sigConstF?`)
+    let cf := fun (s : Tropical.EmitArrow.Sig) => (Tropical.EmitArrow.sigConstF? s).getD 0.0
     let mut lgErr : Float := 0.0
     for p in pairs do
-      let aC : CplxB := ⟨(p.nuSigma - p.muSigma) / g * (-1.0), (p.nuOmega - p.muOmega) / g⟩
+      let aC : CplxB := ⟨(cf p.nuSigma - cf p.muSigma) / g * (-1.0), (cf p.nuOmega - cf p.muOmega) / g⟩
       let ratio := (CplxB.exp ((lgammaB (aC.add ⟨1, 0⟩)).sub (lgammaB aC))).div aC
       lgErr := max lgErr ((ratio.sub ⟨1, 0⟩).abs)
     match buildAndFinish (.ok (buildBloomComposed "bloomg" pairs anchor arena)),
@@ -1311,10 +1313,10 @@ def runModalBloomGamma (arena : Arena)
         let eT := relL2 ref1 ref2 (anchorN + 1) n
         let e0 := relL2 dut0 ref0 (anchorN + 1) 4096
         -- (3) seam continuity around the crossing pair's switch sample
-        let crossing := pairs.filter (fun p => p.dSwitch > 0.0)
+        let crossing := pairs.filter (fun p => cf p.dSwitch > 0.0)
         let seamOk := Id.run do
           if crossing.isEmpty then return false
-          let iSw := anchorN + (crossing[0]!.dSwitch * sr).toUInt64.toNat
+          let iSw := anchorN + (cf crossing[0]!.dSwitch * sr).toUInt64.toNat
           if iSw + 1000 ≥ n then return false
           let maxStep := fun (lo hi : Nat) => Id.run do
             let mut m := 0.0

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1624,7 +1624,10 @@ def runGaugeAdapter (arena : Arena)
   let f1 := 300.0; let f2 := 520.0; let a1 := 1.0; let a2 := 0.7
   let tp := 6.283185307179586
   let ws := #[tp * f1, tp * f2]; let amps := #[a1, a2]
-  let sigmas := #[40.0, 10.0, 3.0]                    -- the damping sweep (Q ↑ as σ ↓)
+  -- the damping sweep (Q ↑ as σ ↓); the small-σ tail drives ‖H‖ to ~33 ⇒ S ~ 1e12,
+  -- PAST the pre-fix clamp ceiling (litF 1e300 saturated to ≈1.8e7), so this gate
+  -- catches a collapsed-clamp regression: with the old ceiling, high-Q leveling failed.
+  let sigmas := #[40.0, 10.0, 3.0, 0.5, 0.1, 0.03]
   -- INDEPENDENT oracle: ‖H‖₈ over the two pole freqs, H(iω) = Σⱼ aⱼ/(σ + i(ω−ωⱼ)).
   let normOf := fun (sig : Float) => Id.run do
     let mut S := 0.0
@@ -1668,9 +1671,23 @@ def runGaugeAdapter (arena : Arena)
       if rel > 5e-3 then
         IO.println s!"        GAUGE MISMATCH σ={sig} g={g.2}: render ratio {ratio} vs oracle norm^(-g) {oracle} (rel {rel})"
         ok := false
-  -- level-invariance: ‖H‖ must GROW across the sweep (else the adapter faces no
-  -- level change and unity-peak is vacuous); the g=1 case above then re-levels it.
-  let grows := norms.size == 3 && norms[0]! < norms[1]! && norms[1]! < norms[2]!
+  -- level-invariance: ‖H‖ must GROW monotonically across the sweep (a non-vacuity
+  -- guard — the exact invariance is the ratio ≡ ‖H‖^{−g} assertion above, which
+  -- proves normalizePeak divides by precisely the self-measured norm); the g=1 case
+  -- then re-levels a norm that spans ~0.025 → ~33 (three decades incl. the ceiling).
+  let grows := norms.size == sigmas.size &&
+    (Array.range (norms.size - 1)).all (fun i => norms[i]! < norms[i+1]!)
+  -- the floor path (S→0): an all-zero-residue bank has S = 0, clamped to 1e-30 (not
+  -- to `litF 1e-30`'s collapsed 0, which would send logSig(0) ≈ −712 → scale ≈ e⁸⁸);
+  -- the render must stay silent (0·anything = 0), never amplified numerical dust.
+  let silentBank := #[ModalMode.hz (litF f1) (litF 3.0) (lit 0),
+                       ModalMode.hz (litF f2) (litF 3.0) (lit 0)]
+  let some pSilent ← peakOf (normalizePeak (litF 1.0) silentBank)
+    | return (← failGate "gauge-adapter" "silent render")
+  let silentOk := pSilent < 1e-9
+  if !silentOk then
+    IO.println s!"        GAUGE: silent bank amplified to {pSilent} at g=1 — the S→0 floor is broken"
+    ok := false
   IO.println s!"        normalizePeak: render ratio ≡ norm^(-g) over σ∈{sigmas}, g∈0/½/1:"
   IO.println s!"        result   worst rel {worst} · ‖H‖ {norms} (grows across the sweep: {grows})"
   if ok && grows then

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1605,6 +1605,11 @@ def planArrayFills (p : Tropical.Plan.FlatPlan) : Nat :=
 def planReduces (p : Tropical.Plan.FlatPlan) : Nat :=
   countInstrs (fun i => i.tag == "ReduceBegin") p
 
+/-- `FloatExponent` ops (the one op whose f32/f64 result differs at 0/subnormal) in a
+    plan's instruction tree — the gauge-stage gate reads this per kernel. -/
+def planFloatExponents (p : Tropical.Plan.FlatPlan) : Nat :=
+  countInstrs (fun i => i.tag == "FloatExponent") p
+
 open Tropical.EmitArrow in
 /-- THE EXCITATION-GAUGE gate (§5). `normalizePeak g` rescales a bank's residues by
     the self-measured `1/‖H‖^g` (`‖H‖` = the p=8 norm of the bank's own transfer

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1701,6 +1701,44 @@ def runGaugeAdapter (arena : Arena)
     failGate "gauge-adapter" s!"ok={ok} grows={grows} worst={worst}"
 
 open Tropical.EmitArrow in
+/-- THE EMITTED-LGAMMA gate (WS-LP foundation). `lgammaE` — the emitted complex
+    log-gamma (via `atan2E`/`logSig`), the live twin of build-time `lgammaB` — must
+    match `lgammaB` over a `Re z ∈ [−5, 5]` sweep (crossing the reflection boundary
+    Re = ½) at both `Im z` signs (`+1`, `−2.5`, exercising the dominant-half select).
+    Independent oracle: the build-time Lanczos itself, rendered vs computed. Relative
+    error (lgamma grows near the negative reals). This is the primitive under WS-LP's
+    live Γ★ bridge; without it the crossing stays baked-pole. -/
+def runLgammaEmit (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let sinkGain : Float := Tropical.Plan.defaultSinkGain.toFloat
+  let step := 10.0 / 2048.0
+  let reRamp := sub (mul (toFloatE (rshift clockLit (lit 32))) (litF step)) (lit 5)
+  let mut worst : Float := 0.0
+  let mut worstAt : String := ""
+  let mut ok := true
+  for imVal in #[1.0, -2.5] do
+    let lg := lgammaE (reRamp, litF imVal)
+    match buildAndFinish (.ok (buildExprCarrier "lg_re" lg.1 arena)),
+          buildAndFinish (.ok (buildExprCarrier "lg_im" lg.2 arena)) with
+    | .ok pRe, .ok pIm =>
+      match ← renderPlanSamples pRe 2048, ← renderPlanSamples pIm 2048 with
+      | .ok sRe, .ok sIm =>
+        for i in [0:min sRe.size sIm.size] do
+          let re := -5.0 + i.toFloat * step
+          let ref := lgammaB ⟨re, imVal⟩
+          let scale := max (ref.re.abs + ref.im.abs) 1.0
+          let e := (max (sRe[i]! / sinkGain - ref.re).abs (sIm[i]! / sinkGain - ref.im).abs) / scale
+          if e > worst then worst := e; worstAt := s!"z=({re},{imVal})"
+      | .error e, _ | _, .error e => IO.println s!"        lgammaE render: {firstLine e}"; ok := false
+    | .error e, _ | _, .error e => IO.println s!"        lgammaE build: {firstLine e}"; ok := false
+  IO.println s!"        emitted lgammaE vs build-time lgammaB, Re∈[−5,5] (crosses ½), Im = 1 and −2.5:"
+  IO.println s!"        result   worst relative error {worst}  (at {worstAt})"
+  if ok && worst < 1e-4 then
+    passGate "lgamma-emit" s!"emitted complex lgamma ≡ build-time Lanczos to {worst} rel across the reflection boundary and both Im signs — WS-LP's live Γ★ bridge is sound"
+  else
+    failGate "lgamma-emit" s!"ok={ok} worst={worst} at {worstAt}"
+
+open Tropical.EmitArrow in
 /-- THE OPTION-E k-INVARIANCE gate. Option E's whole correctness rests on the landed
     value being INVARIANT under the per-bank exponent `k` (the `·2^(28−k)` land and the
     `>>(28−k)` shift cancel; only the quantization LSB moves). Every equivalence gate

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -855,4 +855,141 @@ def runSeamLaneClean (arena : Arena)
       failGate "seam-laneclean" s!"the CF-drop changed {bd} samples — the lane was NOT dead (or the render is non-finite)"
   | _, _ => failGate "seam-laneclean" "build/render failed for the lane-clean witness"
 
+-- ── WS-DDF: the near-coincident room-chain fold ───────────────────────────────
+
+/-- The STABLE oracle for the bloomed room-CHAIN: `c·∫₀^d [(e^{ν1(d−s)}−e^{ν2(d−s)})/Δ]
+    ·e^{μφ(s)} ds` per voice mode, summed, Re, sink-gained. The deg-1 folded kernel
+    (`room1 ⋙ room2` impulse response) quadratured directly — the `(·−·)/Δ` is
+    float64-accurate for the witness's MODERATE Δ (no huge residue). Composite
+    Simpson, ω on the rotator grid, matching the DUT carrier. -/
+private def oracleFoldChain (voice : Array SeamMode) (nu1p nu2p r1r2 : CplxB)
+    (B g : Float) (hdiv : Nat) (nLen : Nat := nProbe) : Array Float := Id.run do
+  let mut y : Array Float := Array.replicate nLen 0.0
+  -- match the DUT's convention: the ν2 carrier is on the rotator grid (`modePhaseQ`),
+  -- but the divided difference uses the RAW Δ (`cexpm1` divisor + slow oscillation),
+  -- so the effective ν1 = qOm(ω2) + (ω1−ω2)_raw. Quantizing ω1, ω2 SEPARATELY would
+  -- inject a ~res/Δ error into the 1/Δ-sensitive divided difference.
+  let om2 := qOm nu2p.im
+  let nu2 : CplxB := ⟨nu2p.re, om2⟩
+  let nu1 : CplxB := ⟨nu1p.re, om2 + (nu1p.im - nu2p.im)⟩
+  let dlt := nu1.sub nu2
+  for v in voice do
+    let mu : CplxB := ⟨-v.sigma, qOm v.omega⟩
+    let a  : CplxB := ⟨v.are, v.aim⟩
+    let c := (a.mul r1r2).scale sinkGain
+    let h := 1.0 / (srF * hdiv.toFloat)
+    let fint := fun (nu : CplxB) (s : Float) =>
+      CplxB.exp ((mu.scale (s + B * (1.0 - Float.exp (-g * s)))).sub (nu.scale s))
+    let mut j1 : CplxB := ⟨0, 0⟩
+    let mut j2 : CplxB := ⟨0, 0⟩
+    for i in [anchorNat + 1 : nLen] do
+      let dBase := (i - 1 - anchorNat).toFloat / srF
+      let mut s1 : CplxB := ⟨0, 0⟩
+      let mut s2 : CplxB := ⟨0, 0⟩
+      for k in [0:hdiv + 1] do
+        let w := if k == 0 || k == hdiv then 1.0 else if k % 2 == 1 then 4.0 else 2.0
+        let s := dBase + k.toFloat * h
+        s1 := s1.add ((fint nu1 s).scale w)
+        s2 := s2.add ((fint nu2 s).scale w)
+      j1 := j1.add (s1.scale (h / 3.0))
+      j2 := j2.add (s2.scale (h / 3.0))
+      let d := (i - anchorNat).toFloat / srF
+      let yc := (((CplxB.exp (nu1.scale d)).mul j1).sub ((CplxB.exp (nu2.scale d)).mul j2)).div dlt
+      y := y.set! i (y[i]! + (c.mul yc).re)
+  return y
+
+/-- Arm B's accuracy floor — MEASURED, not derived (set from the observed value at
+    landing, rounded up). Arm B carries the same Q4.28 absolute landing floor as arm
+    A against a signal of the same order (`K₁·2/|Δ| ≈ 5e-5` vs arm A's `K₁·d ≈
+    7e-5`), so the two floors sit in the same decade — but "same decade" is an
+    expectation, and the number below is an observation: arm B renders at **3.22e-3**
+    (2026-07-20), and the fail line is set at 5e-3 — ~1.5× margin, tight enough that
+    every structural mutation of the Δ-secular moves it by O(1) and trips it. -/
+private def ddfoldSeparatedFloor : Float := 5e-3
+
+/-- THE WS-DDF FOLD GATE, in TWO ARMS over one atom.
+
+    **Arm A — near-coincident** (Δ = 0.005 rad/s): the regime the atom is named
+    for. The collected fold (`residueComposeEC`) bakes a residue `c/Δ` that is out
+    of Q4.28 range as a *value* (`|c/Δ| ≈ 60 > 8`, printed below); the DD fold
+    removes it entirely. This arm asserts only that the DD form holds its law and
+    never loses to the collected form — it does **not** assert that the collected
+    form is broken. See the FINDING in the body, which measures that it is not, at
+    reachable Δ.
+
+    **Arm B — separated** (Δ = 30 rad/s, and `σ₁ ≠ σ₂` so `Δ.re ≠ 0`): the arm
+    that makes the divided-difference *structure* observable. Arm A alone cannot
+    see it: over the render window `|Δ|·d ≤ 4.4e-4`, so `cexpm1(Δd)` departs from
+    the constant `1` by only ~2e-4 while arm A's own error floor is ~2.1e-3 of
+    Q4.28 landing noise — flipping the Δ sign convention moves arm A by 3.3e-4 and
+    deleting the whole `cexpm1` select moves it by 1.7e-4, both invisible. Arm A
+    catches term *deletions*; it cannot catch the secular the atom exists to carry.
+    Arm B reaches `|Δ|·d ≈ 2.65`, so it selects the `big`/direct lane (dead in arm
+    A, which never leaves the series branch) and drives `expSig w.1` off zero for
+    the first time in any witness. MUTATION-VERIFIED on arm B: flip the Δ sign
+    convention (`Modal.lean` `w`), replace `cxΔ` by `1`, or force the series arm
+    (`big := gt wsq (litF 1e9)`) → each turns arm B RED by O(1); the last leaves
+    arm A green, which is what proves arm B is the coverage and not incidental.
+
+    Same divided-difference cure as atom four, at the fold site (WS-DDF; cockpit
+    `demos/modal_ddfold.py`; audit `design/seam-hardening-remainder-handoff` §0). -/
+def runFoldChain (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let lo := anchorNat + 1
+  let hi := nProbe
+  let (B, g) := bloomBg
+  let voice : Array SeamMode := #[mkMode 110 0.2 1.0, mkMode 353 0.56 0.6]
+  let r1 : SeamMode := mkMode 300 1.0 0.6
+  -- Arm A: the near-coincident pair (Δ = i·0.005 exactly — σ shared, so Δ.re = 0).
+  let r2 : SeamMode := { sigma := 1.0, omega := tp * 300 + 0.005, are := 0.5 }
+  -- Arm B: separated in BOTH components — Δ = (−0.7) + i·(−30), so |Δ|·d reaches
+  -- ≈ 2.65 at the window edge and the direct `cexpm1` lane is genuinely selected.
+  let r2s : SeamMode := { sigma := 1.7, omega := tp * 300 + 30.0, are := 0.5 }
+  let vM := voice.map (·.toModal)
+  let r1M := r1.toModal
+  -- One arm: the DD-fold DUT for a room pair against that pair's own stable
+  -- oracle. `oracleSelf` is the Simpson self-distance (hdiv 4 vs 8) — a QUADRATURE
+  -- convergence check, not a bound on the oracle's `1/Δ` cancellation error.
+  let runArm : String → SeamMode → IO (Option (Float × Float × Bool)) := fun tag r2m => do
+    let r1r2 := r1.amp.mul r2m.amp
+    let dut := match bloomFoldCompose vM r1M r2m.toModal B g with
+      | some pairs => bloomFoldComposedSig pairs clockLit anchorSig
+      | none => litI 0
+    let ref  := oracleFoldChain voice r1.pole r2m.pole r1r2 B g 8
+    let ref4 := oracleFoldChain voice r1.pole r2m.pole r1r2 B g 4
+    match ← renderConfig arena s!"seam_ddfold_{tag}" dut with
+    | .ok d => pure (some (relL2Win d ref lo hi, relL2Win ref4 ref lo hi, allFinite d))
+    | .error _ => pure none
+  let r1r2 := r1.amp.mul r2.amp
+  let coll := match bloomCompose vM (residueComposeEC #[r1M] #[r2.toModal]) B g with
+    | some pairs => bloomComposedSig pairs clockLit anchorSig
+    | none => litI 0
+  let refA := oracleFoldChain voice r1.pole r2.pole r1r2 B g 8
+  let resMag := (r1r2.div (r1.pole.sub r2.pole)).abs
+  match ← runArm "a" r2, ← runArm "b" r2s, ← renderConfig arena "seam_ddfold_coll" coll with
+  | some (eD, selfA, finA), some (eS, selfB, finB), .ok dC =>
+    let eC := relL2Win dC refA lo hi
+    IO.println s!"WS-DDF room-chain fold, two arms (collected residue |c/Δ|≈{resMag}):"
+    IO.println s!"        A near-coincident (Δ=0.005): DD rel {eD} · collected rel {eC} (oracle self {selfA})"
+    IO.println s!"        B separated (Δ=30, Δ.re≠0, direct cexpm1 lane): DD rel {eS} (oracle self {selfB})"
+    -- The atom's LAW: the DD fold ≡ the stable oracle within the divided-difference
+    -- floor (≈2e-3 — the chain signal is ≈ ∂Y0/∂ν, far weaker than the O(1) bloom
+    -- cross, so Q4.28's absolute floor costs more relative precision, the chain's
+    -- looser model). And it is at least as good as the collected fold. FINDING
+    -- (WS-DDF): the collected bloomed chain does NOT catastrophically break at
+    -- reachable Δ — the bloom's per-sample K factor (≈ M(κ)/(gα) ≈ 1e-3, rooms far
+    -- from the voice) scales the huge residue c/Δ DOWN before landing, so the Q4.28
+    -- overflow (modal_divdiff's D_dd2, where the residue lands directly) does not
+    -- reach the bloom cross until Δ < ~1e-5 rad/s (~1.6e-6 Hz). The DD fold is the
+    -- correct, modestly-tighter alternative; the a-DD machinery TRANSFERS (the datum).
+    if !finA || eD ≥ 3e-3 then
+      failGate "ddfold" s!"arm A (near-coincident) is off the law (rel {eD}, oracle self {selfA})"
+    else if eD > eC * 1.5 + 3e-4 then
+      failGate "ddfold" s!"arm A's DD fold ({eD}) is WORSE than the collected ({eC}) — the stable form should never lose"
+    else if !finB || eS ≥ ddfoldSeparatedFloor then
+      failGate "ddfold" s!"arm B (separated Δ, the direct cexpm1 lane) is off the law (rel {eS} ≥ {ddfoldSeparatedFloor}, oracle self {selfB}) — the Δ-secular's sign/branch is wrong"
+    else
+      passGate "ddfold" s!"the room-chain fold holds its law in both arms (A near-coincident DD {eD} ≤ collected {eC}; B separated DD {eS} on the direct cexpm1 lane); the a-DD machinery transferred to the fold site (WS-DDF datum). Finding: the bloom's K factor keeps the collected fold from breaking at reachable Δ — the wound is narrower than assumed"
+  | _, _, _ => failGate "ddfold" "build/render failed for the WS-DDF fold witness"
+
 end Tropical.Tropicaltest.SeamSweep

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -193,14 +193,32 @@ private def idWarp : Float → Float := fun s => s
 
 /-- `residueComposeEC` — the collected residue bank (`voice ⋙ reverb`, m+n
     modes), realized through the default banked lowering. Total composition; the
-    admission predicate marks where the collected `1/Δ` amp stays inside the
-    Q4.28 headroom (`|a·r/Δ| < 8` ⟺ `|Δ|·8 > |a·r|`) — below it is
-    `residueComposeDD`'s region, not EC's promise (passive exclusion). -/
+    admission predicate marks where EC's `1/Δ` residue stays ACCURATE — below it
+    is `residueComposeDD`'s region, not EC's promise (passive exclusion).
+
+    RE-DERIVED (option E, the modal-datapath rail fix). This predicate ONCE
+    conflated two boundaries under one `|a·r/Δ| < 8` threshold: the i64 Q4.28
+    WRAP (a collected weight past 32 — `modalBankSigTable`'s landing) and the
+    near-coincidence ACCURACY floor (EC's `1/Δ` forms two huge opposite-sign
+    residues whose landed cancellation loses precision). Option E's per-bank
+    exponent (`bankLandExp`) removed the wrap for ALL |A|, so this predicate no
+    longer guards it — that boundary is now covered on the PRODUCTION path by the
+    `modal-rail`/`modal-rail-dir` witnesses (the real gesture, stronger than a
+    sweep probe). What remains is the accuracy boundary, and that is genuinely
+    PER-PAIR-LOCAL — accuracy degrades when ONE voice pole nears ONE room pole
+    (`λ_j → ν` ⇒ residue `a_j·r/(λ_j−ν) → ∞`, its cancellation error growing with
+    the landed magnitude even at zero wrap), unlike the wrap which was collective.
+    So the rail doc's collected-sum unsoundness applied to the WRAP (now fixed);
+    the per-pair form is SOUND for the accuracy purpose it now serves alone. The
+    `8` stays as the empirical EC-accurate edge (where DD takes over), no longer
+    a Q4.28-headroom number. -/
 private def ecAtom : SeamAtom :=
   { name := "residueEC"
     phi := idWarp
     realize := fun v r => modalBankSigTable (residueComposeEC (v.map (·.toModal)) (r.map (·.toModal))) clockLit anchorSig
     admitsPair := fun v r =>
+      -- EC's accuracy edge: the per-pair 1/Δ residue below DD's coincidence region
+      -- (`|a·r/Δ| < 8`). NOT a wrap bound — option E removed that (see the header).
       let dpole := (v.pole.sub r.pole).abs
       let amp := (v.amp.mul r.amp).abs
       dpole * 8.0 > amp

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -247,7 +247,10 @@ private def bloomWarp : Float → Float := fun s => s + bloomBg.1 * (1.0 - Float
     live poles. Baked-pole v1 (the sweep pole set is all literal). NOTE: the 0.09 s
     interior/boundary window only exercises the CF branch (which is accidentally
     stable at coincidence); the series-DD resonance lives in the tail, witnessed by
-    the long-render `coincidence deep-tail` check in `runSeamSweep`. -/
+    the long-render checks in `runSeamSweep` — the `coincidence deep-tail` (a = 0
+    EXACT, the `euler` limit branch) AND the `a≠0 coincidentCrossing tail` (the
+    general `lgamma(a+1)/a` bridge, WS-AA audit) — plus the `small-κ` subtle-bloom
+    direct-sum branch. -/
 private def bloomAtom : SeamAtom :=
   let B := bloomBg.1
   let g := bloomBg.2
@@ -435,7 +438,28 @@ def runSeamSweep (arena : Arena)
     if !(allFinite dut) || eS ≥ 3e-4 then
       IO.println s!"        bloomGamma SMALL-κ VIOLATION: rel {eS} — Φ(a,κ) bridge cancellation not caught by the direct-sum fallback"
       ok := false
-  if ok then passGate "seam-sweep" "every registered atom holds its law over its admission region (incl. the τ·e coincidence deep-tail AND small-κ direct-sum region); composition laws (EC-commute, assoc) pinned"
+  -- ── coincidence a≠0 series-DD tail (WS-AA audit): the a=0 deep-tail above hits
+  -- bloomPhiKappaOverG's `euler` special case (aC.normSq < 1e-12, the removable-
+  -- singularity limit); the GENERAL lgamma(a+1)/a divided-difference bridge — baked
+  -- into k1SerDD for EVERY a≠0 coincidentCrossing pair (a room pole tuned NEAR but
+  -- not ON a settled partial, the generic coincidence, a=0 being measure-zero) — was
+  -- witnessed by no oracle. Render an a≠0 coincidentCrossing pair (0<|a|<½, |κ|≥|a+1|)
+  -- PAST its dSwitch (≈1.69 s) and re-check the series-DD tail where k1SerDD (via the
+  -- lgamma bridge) is the selected e^{νd} constant.
+  let vAC : Array SeamMode := #[mkMode 110 0.2 1.0]                                  -- μ, σ small ⇒ rings long
+  let rAC : Array SeamMode := #[{ sigma := 0.35, omega := tp * 110, are := 0.5 }]   -- ν≈μ ⇒ a≈−0.083 (real, ≠0)
+  let acLo : Nat := 76000                                                            -- ≈1.72 s > dSwitch≈1.69 s
+  match ← renderConfig arena "seam_bloom_coinc_aneq0" (bloomAtom.realize vAC rAC) nDeep with
+  | .error e => IO.println s!"        bloomGamma a≠0 tail BUILD/RENDER: {firstLine e}"; ok := false
+  | .ok dut =>
+    let refAC := oracleSeam vAC rAC bloomWarp admD 8 nDeep
+    let eAC := relL2Win dut refAC acLo nDeep
+    let eFullAC := relL2Win dut refAC lo nDeep
+    IO.println s!"        bloomGamma a≠0 coincidentCrossing tail (|a|≈0.083, |κ|≈19, general lgamma(a+1)/a bridge, ~2.2 s): series-DD region rel {eAC}, full rel {eFullAC}"
+    if !(allFinite dut) || eAC ≥ 1e-3 || eFullAC ≥ 1e-4 then
+      IO.println s!"        bloomGamma a≠0 TAIL VIOLATION: series-DD rel {eAC} (full {eFullAC}) — the general lgamma-bridge k1SerDD is off the law"
+      ok := false
+  if ok then passGate "seam-sweep" "every registered atom holds its law over its admission region (incl. the τ·e coincidence deep-tail, small-κ direct-sum, AND the a≠0 general lgamma-bridge tail); composition laws (EC-commute, assoc) pinned"
   else failGate "seam-sweep" "a registered seam atom drifted off its stated law — see the per-config lines above"
 
 -- ── Deliverable A: gong⋙reverb(⋙reverb) audible from the patch surface ────────
@@ -648,5 +672,187 @@ def runGammaCoeff (_arena : Arena)
     passGate "gamma-coeff" s!"E1 series ≡ the composition integral coefficient-for-coefficient to d^{n} (max |Δ| {worst}) — the resummation algebra, not points"
   else
     failGate "gamma-coeff" s!"E1/integral coefficient mismatch: max |Δ| {worst} at |κ|={kappa.abs}"
+
+-- ── WS-CL: the region-coverage gate (totality as a number) ────────────────────
+-- The types prove COVERAGE (the `SeamRegion` match is exhaustive — a config with
+-- no handler won't compile); this gate turns "is the partition total over the
+-- shipped register" into a reported number, and the depth cap into MEASURED
+-- headroom (a sampled max over the Halton batch + the max-|κ| corner scan —
+-- empirical, never a typed bound; only the exhaustive match is type-proven).
+-- Per-region ACCURACY stays the seam-sweep's job (the contract's division of
+-- labor: types for coverage, the sweep + SNR for the law). Depth-cap drops are
+-- counted and printed — never a silent cap.
+
+/-- Per-region tally + worst envelope depth over a Halton batch. -/
+private structure RegionTally where
+  serOnly  : Nat := 0
+  crossing : Nat := 0
+  coincX   : Nat := 0        -- coincidentCrossing
+  coincS   : Nat := 0        -- coincidentSubtle
+  excl     : Nat := 0        -- excludedDepth
+  maxN     : Nat := 0        -- worst series depth (admitted samples; excluded carry 0)
+  maxK     : Nat := 0        -- worst CF depth
+  total    : Nat := 0
+
+/-- Classify a Halton batch of legal (voice pole, room pole) pairs and tally the
+    region histogram. Voice poles over the shipped full-register box (σ ∈ [0.2,
+    3.3], f ∈ [110, 1023] Hz — the register `bloomgong` DEFAULTS to; `freq` is an
+    unclamped knob, so higher user registers push |κ| up and legitimately reach
+    `excludedDepth` — the coverage below is scoped to the shipped register); room
+    poles either uniform over the reverb box (σ ∈ [0.58, 34.5], f ∈ [60, 6000] Hz)
+    or, when `near`, placed within `|ν−μ| < 0.9` of the voice pole (a shrinking
+    Halton offset) so `|a| < ½` and the coincident regions are actually exercised —
+    uniform sampling almost never lands on coincidence. -/
+private def tallyBatch (count : Nat) (B g : Float) (near : Bool) : RegionTally := Id.run do
+  let mut t : RegionTally := {}
+  for i in [1:count + 1] do
+    let sV := 0.2 + 3.1 * haltonF 3 i
+    let fV := 110.0 + 913.0 * haltonF 2 i
+    let mu : CplxB := ⟨-sV, tp * fV⟩
+    let nu : CplxB :=
+      if near then
+        ⟨-(sV + (haltonF 5 i - 0.5) * 0.8), tp * fV + (haltonF 7 i - 0.5) * 1.6⟩
+      else
+        ⟨-(0.58 + 33.97 * haltonF 5 i), tp * (60.0 + 5940.0 * haltonF 7 i)⟩
+    let plan := classifyBloomPair mu nu B g
+    t := { t with total := t.total + 1, maxN := max t.maxN plan.nDepth, maxK := max t.maxK plan.kDepth }
+    match plan.region with
+    | .serOnly            => t := { t with serOnly  := t.serOnly  + 1 }
+    | .crossing           => t := { t with crossing := t.crossing + 1 }
+    | .coincidentCrossing => t := { t with coincX   := t.coincX   + 1 }
+    | .coincidentSubtle   => t := { t with coincS   := t.coincS   + 1 }
+    | .excludedDepth      => t := { t with excl     := t.excl     + 1 }
+  return t
+
+/-- The worst envelope depth over the max-|κ| corner (the top of the register,
+    where `|zBnd| = |κ|` is largest and `bloomM1`/`bloomCF` converge slowest): voice
+    pinned at f = 1023 Hz (σ swept), room swept over the reverb box. The Halton
+    interior only approximates this corner, so a random sample UNDERSHOOTS the true
+    worst depth (measured ≈204 vs a boundary config's ≈226); this deterministic
+    corner scan is folded into the reported max so the headroom is a trustworthy
+    sup, not an undershoot. Still empirical (depth is a convergence count, not
+    analytic) — the reason the gate says MEASURED, never "provable". -/
+private def cornerMaxDepth (B g : Float) : Nat := Id.run do
+  let mut d : Nat := 0
+  for i in [1:800] do
+    let sV := 0.2 + 3.1 * haltonF 3 i
+    let mu : CplxB := ⟨-sV, tp * 1023.0⟩                                    -- the top partial ⇒ max |κ|
+    let nu : CplxB := ⟨-(0.58 + 33.97 * haltonF 5 i), tp * (60.0 + 5940.0 * haltonF 7 i)⟩
+    let plan := classifyBloomPair mu nu B g
+    d := max d (max plan.nDepth plan.kDepth)
+  return d
+
+/-- THE REGION-COVERAGE GATE (WS-CL). Halton-classify the shipped bloom register
+    and report totality as a number: the region histogram, the admitted fraction,
+    and the worst envelope depth vs the 300 cap. Asserts (1) the SHIPPED surface
+    (β = 0.05, the default register) is depth-total — zero drops, worst SAMPLED
+    depth (Halton interior + the max-|κ| corner scan) < 300, so the cap is MEASURED
+    headroom (empirical, not proven — a config in a sampling gap could differ, but
+    would still become a counted `excludedDepth`, never a silent error); (2) all
+    FOUR served regions are reachable — serOnly, crossing, coincidentCrossing,
+    coincidentSubtle (the partition claims no region nothing lands in); (3)
+    `excludedDepth` IS reachable off-surface (β = 0.5, knob max) and is COUNTED, not
+    silently dropped. Accuracy per region is the seam-sweep's job (types for
+    coverage, the sweep for the law). -/
+def runSeamCoverage (_arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let g := bloomBg.2
+  let Bship := bloomBg.1                         -- shipped bloom advance (β = 0.05)
+  let Bover := 0.5 / 1.8                         -- knob-max β = 0.5, scale 1
+  let bSmall : Float := 1.67e-6                  -- a subtle bloom (matches the small-κ witness)
+  let uni    := tallyBatch 1000 Bship g false    -- shipped, uniform room → serOnly + crossing
+  let near   := tallyBatch 1000 Bship g true     -- shipped, near-coincident → coincidentCrossing
+  let subtle := tallyBatch 1000 bSmall g true    -- subtle bloom, near-coincident → coincidentSubtle
+  let over   := tallyBatch 1000 Bover g false    -- knob-max β → the depth cap bites
+  let corner    := cornerMaxDepth Bship g        -- the max-|κ| worst-corner scan
+  let shipTotal := uni.total + near.total
+  let shipExcl  := uni.excl + near.excl
+  let admitFrac := (shipTotal - shipExcl).toFloat / shipTotal.toFloat
+  let maxDepth  := max (max (max uni.maxN uni.maxK) (max near.maxN near.maxK)) corner
+  IO.println "seam region coverage (classify the shipped register — totality as a number):"
+  IO.println s!"        shipped register (β=0.05): serOnly {uni.serOnly + near.serOnly}, crossing {uni.crossing + near.crossing}, coincidentCrossing {near.coincX}, excludedDepth {shipExcl} / {shipTotal}"
+  IO.println s!"        admitted fraction {admitFrac} · worst SAMPLED depth {maxDepth} of cap 300 (measured headroom {300 - maxDepth}; Halton interior + max-|κ| corner scan {corner})"
+  IO.println s!"        subtle-bloom box (B={bSmall}): coincidentSubtle {subtle.coincS} / {subtle.total} reachable"
+  IO.println s!"        knob-max box (β=0.5): excludedDepth {over.excl} / {over.total} — COUNTED, a graceful drop, not a silent cap"
+  let mut ok := true
+  -- (1) the shipped register is depth-total: the ≤300 cap is measured headroom
+  --     (sampled max incl. the worst corner; empirical, never a typed bound)
+  if shipExcl != 0 || maxDepth ≥ 300 then
+    IO.println s!"        COVERAGE VIOLATION: the shipped register hit the depth cap (excl {shipExcl}, maxDepth {maxDepth}) — the ≤300 bound is not headroom for the shipped surface"
+    ok := false
+  -- (2) all FOUR served regions the box reaches are actually reached (crossing too —
+  --     it has its own bloomGammaStar emit lane, so a dead crossing must fail here)
+  if uni.serOnly == 0 || uni.crossing + near.crossing == 0 || near.coincX == 0 || subtle.coincS == 0 then
+    IO.println s!"        COVERAGE VIOLATION: a served region is unreachable (serOnly {uni.serOnly}, crossing {uni.crossing + near.crossing}, coincidentCrossing {near.coincX}, coincidentSubtle {subtle.coincS}) — the partition claims a region nothing lands in"
+    ok := false
+  -- (3) excludedDepth is reachable off-surface AND counted (the drop is named).
+  --     Graceful SILENCE for an excluded pair is structural, not rendered here: the
+  --     `| .excludedDepth => continue` (Modal.lean) drops the pair from the bank
+  --     entirely, so a mixed bank is byte-identical to the bank without it — nothing
+  --     to render. This gate proves the region is reachable and counted, not silent.
+  if over.excl == 0 then
+    IO.println s!"        COVERAGE VIOLATION: knob-max β did not exceed the depth cap — excludedDepth is never exercised, so 'counted not silent' is untested"
+    ok := false
+  if ok then
+    passGate "seam-coverage" s!"the shipped register classifies TOTALLY: admitted fraction {admitFrac} (0 depth drops, worst SAMPLED depth {maxDepth} < 300 — measured headroom, Halton + corner scan), all four served regions reachable, excludedDepth counted off-surface ({over.excl}/{over.total})"
+  else
+    failGate "seam-coverage" "the region partition is not total over the shipped register — see the lines above"
+
+-- ── WS-CL: the lane-tidying bit-clean witness ─────────────────────────────────
+
+/-- Re-bake BOTH dropped lanes onto a `coincidentSubtle` `BloomPair` — reconstructs
+    the FULL pre-refactor coincident emit (the `cfB`/`cfN`/`k1Cf` CF lane AND the
+    nonempty `invA` E1 lane, both baked at the coincident `nDepth`/`kDepth`) so the
+    bit-clean witness compares the region-indexed emit against a faithful old pair,
+    not one that happens to share the new pair's empty lanes (no circularity: the
+    witness independently tests that BOTH dropped lanes are dead). The re-baked CF
+    values are the crossing arm's; the pair is subtle (`dSwitch < 0`) so the
+    per-sample `selectE` always discards the CF lane, and the coincident branch
+    never reads `invA` — the render must be byte-identical regardless. -/
+private def withCfLane (p : BloomPair) : BloomPair := Id.run do
+  let mu : CplxB := ⟨-p.muSigma, p.muOmega⟩
+  let nu : CplxB := ⟨-p.nuSigma, p.nuOmega⟩
+  let aC := (nu.sub mu).scale (1.0 / p.gRate)
+  let plan := classifyBloomPair mu nu p.bloomB p.gRate
+  let (cfK, _) := bloomCF aC p.kappa
+  let cfB := (Array.range (plan.kDepth + 1)).map (fun j => (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
+  let cfN := (Array.range plan.kDepth).map (fun j =>
+    let jf := (j + 1).toFloat
+    (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
+  let invA := (Array.range plan.nDepth).map (fun k => CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
+  return { p with k1Cf := (cfK.scale (1.0 / p.gRate)).neg, cfB, cfN, invA }
+
+/-- THE LANE-CLEAN GATE (WS-CL). The region-indexed `coincidentSubtle` emit (the
+    whole CF lane DROPPED) is BYTE-IDENTICAL to the pre-refactor emit (which always
+    baked the CF lane and let the const-true `selectE` discard it). Builds the same
+    subtle pair BOTH ways — the new empty-CF pair and the same pair with the CF lane
+    re-baked (`withCfLane`) — renders both, and asserts `bitDiffCount = 0`. The
+    lane-tidying's proof: the plan shrank, the samples did not move (the dropped
+    lane was truly dead, LLVM `select` ignoring the unselected operand). -/
+def runSeamLaneClean (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let g := bloomBg.2
+  let bSmall : Float := 1.67e-6
+  -- a subtle-bloom coincident pair (dSwitch < 0): |κ| ≪ |a+1|, |a| < ½
+  let v : Array SeamMode := #[mkMode 55 0.8 1.0]
+  let r : Array SeamMode := #[{ sigma := 0.5, omega := tp * 55 + 0.74, are := 0.5 }]
+  let vM := v.map (·.toModal)
+  let rM := r.map (·.toModal)
+  let newSig := match bloomCompose vM rM bSmall g with
+    | some pairs => bloomComposedSig pairs clockLit anchorSig
+    | none => litI 0
+  let oldSig := match bloomCompose vM rM bSmall g with
+    | some pairs => bloomComposedSig (pairs.map withCfLane) clockLit anchorSig
+    | none => litI 0
+  match ← renderConfig arena "seam_laneclean_new" newSig,
+        ← renderConfig arena "seam_laneclean_old" oldSig with
+  | .ok dNew, .ok dOld =>
+    let bd := bitDiffCount dNew dOld
+    IO.println s!"seam lane-clean (WS-CL): coincidentSubtle CF-drop bitDiff {bd} (region-indexed emit vs pre-refactor baked-CF emit)"
+    if bd == 0 && allFinite dNew then
+      passGate "seam-laneclean" "the region-indexed coincidentSubtle emit is BYTE-IDENTICAL to the pre-refactor always-bake-CF emit — the dropped CF lane was truly dead (const-true selectE)"
+    else
+      failGate "seam-laneclean" s!"the CF-drop changed {bd} samples — the lane was NOT dead (or the render is non-finite)"
+  | _, _ => failGate "seam-laneclean" "build/render failed for the lane-clean witness"
 
 end Tropical.Tropicaltest.SeamSweep

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -599,6 +599,92 @@ def runGongReverb (arena : Arena)
   | .ok pS, .ok pC, .ok dS, .ok dC => gongVerdict voice room1 room2 pS pC dS dC
   | _, _, _, _ => failGate "gong-reverb" "build/render failed for a gong⋙reverb graph"
 
+-- ── WS-LP Phase 1: the live-pole crossing witness ─────────────────────────────
+
+/-- THE LIVE-POLE CROSSING GATE (WS-LP Phase 1). A bloomed source crosses a
+    reverb whose σ is a LIVE rt60 pole — the pole a Sig the folder can NOT
+    constant-fold (the surface shape: `6.91/rt60` with rt60 a slot read; here the
+    un-foldable stand-in is the same expression over a clamped literal, so the
+    carrier path can render it without a param table). Asserts:
+    (1) `bloomCompose` LIFTS the pairs instead of dropping to the bare bloom
+        (all voice×room pairs present, and their constants are genuinely live —
+        `sigConstF?` fails on them — and genuinely s0 — `sigIsS0` holds, the
+        Stage0-hoist precondition);
+    (2) the rendered live crossing ≈ the BAKED crossing at the same rt60 value
+        (the lift computes the same constants, by kernel arithmetic instead of
+        build-time arithmetic — identical up to last-bit float noise);
+    (3) the live crossing ≈ `oracleSeam` under the bloom warp (the law, not just
+        self-consistency), causal and finite;
+    (4) a pair that is NOT serOnly over the whole rt60 range (a room mode ON a
+        voice partial) drops gracefully PER PAIR — the rest of the bank lifts. -/
+def runBloomLivePole (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let (B, g) := bloomBg
+  let rt60Val : Float := 2.0
+  let (rtLo, rtHi) : Float × Float := (0.2, 12.0)     -- the reverb knob's declared span
+  let sigLive : Float := 6.91 / rt60Val
+  let voice : Array SeamMode := #[mkMode 220 1.0 1.0, mkMode 610 1.3 0.6, mkMode 1050 1.6 0.4]
+  let room  : Array SeamMode := #[mkMode 200 sigLive 1.0, mkMode 380 sigLive 0.8]
+  let vM := voice.map (·.toModal)
+  -- the live room: σ = 6.91/rt60 with rt60 NOT a foldable literal (clamp is
+  -- outside `sigConstF?`'s vocabulary, exactly like a `paramRef` slot read),
+  -- range declared as the knob span mapped through σ = 6.91/rt60
+  let rt60E : Sig := clampE (litF rt60Val) (litF rtLo) (litF rtHi)
+  let liveRoom := fun (rm : Array SeamMode) => rm.map (fun m =>
+    { m.toModal with sigma := div (lit 691 2) rt60E
+                     sigmaRange := some (6.91 / rtHi, 6.91 / rtLo) })
+  let rMLive  := liveRoom room
+  let rMBaked := room.map (·.toModal)
+  -- (1) the lift engages: all 6 pairs, live and s0
+  let some pairsLive := bloomCompose vM rMLive B g
+    | failGate "bloom-live-pole" "bloomCompose returned none for the live-rt60 room (dropped to bare bloom)"
+  -- NOT `k1Ser`: the lifted Horner shares subterms by REFERENCE, so its DAG is
+  -- small but its TREE is exponential in depth — a structural walk (`sigConstF?`
+  -- / `sigIsS0`, unmemoized) would never return. Its leaves are exactly the
+  -- constituents checked here (`nuSigma`, `fSer`, `invA`, `dSwitch` — plus
+  -- literals), so shallow checks carry the same s0/liveness claim.
+  let liveConsts := pairsLive.foldl (fun acc p =>
+    acc ++ #[p.fSer.1, p.fSer.2, p.nuSigma, p.dSwitch] ++
+    p.invA.foldl (fun a ik => a ++ #[ik.1, ik.2]) #[]) #[]
+  let genuinelyLive := pairsLive.all (fun p => (sigConstF? p.nuSigma).isNone)
+  let allS0 := liveConsts.all sigIsS0
+  -- (4) graceful per-pair drop: a room mode ON the 220 Hz partial is not
+  -- serOnly anywhere on the interval (|a+1| dips below |κ| at Re a = −1)
+  let nearRoom := liveRoom #[mkMode 220.5 sigLive 0.5]
+  let dropCount := match bloomCompose vM nearRoom B g with
+    | some ps => ps.size
+    | none => 1000
+  -- (2)+(3) render the live crossing, the baked crossing, and the oracle
+  let clk : Clock := clockLit
+  let mkGraph := fun (rm : Array ModalMode) =>
+    ({ nodes := #[ { id := "src", node := .modalSource vM anchorSig clk none none (some (B, g)) }
+                 , { id := "rev", node := .modalReverb "src" rm none } ]
+       output := "rev" } : PatchGraph)
+  let rLive ← renderGraph arena "wslp_live" (mkGraph rMLive)
+  let rBaked ← renderGraph arena "wslp_baked" (mkGraph rMBaked)
+  match rLive, rBaked with
+  | .ok pL, .ok pB =>
+    let lo := anchorNat + 1
+    let hi := nProbe
+    let adm := fun (v r : SeamMode) => bloomAdmitsPair v.pole r.pole B g
+    let eBaked := relL2Win pL pB lo hi
+    let eOracle := relL2Win pL (oracleSeam voice room bloomWarp adm 8) lo hi
+    let preE := energyWin pL 0 lo
+    let e := energyWin pL lo hi
+    IO.println s!"bloom live-pole crossing (WS-LP Phase 1: serOnly, live rt60):"
+    IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · near-partial pair drops to {dropCount}/3"
+    IO.println s!"        render   live ≡ baked crossing {eBaked * 1e9}e-9 · live ≡ oracle {eOracle} · pre-E {preE} · E {e}"
+    -- live ≡ baked is a CONSISTENCY check, not the law (the oracle is): the
+    -- baked `mK` comes from build-time forward summation (`bloomM1`), the lifted
+    -- one from the emitted Horner (`bloomM1E`) — a real reassociation of a
+    -- ~200-term series, so the honest bar is ~1e-6, not bit-identity.
+    if pairsLive.size == 6 && genuinelyLive && allS0 && dropCount == 2
+        && eBaked < 1e-6 && eOracle < 3e-4 && preE < 1e-18 && e > 1e-9 && allFinite pL then
+      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom (no bare-bloom drop): 6/6 pairs lifted s0, live ≡ baked {eBaked * 1e9}e-9, ≡ oracle {eOracle}, non-serOnly pair drops per-pair"
+    else
+      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL}"
+  | .error e, _ | _, .error e => failGate "bloom-live-pole" s!"build/render: {e}"
+
 -- ── The Γ-bridge coefficient comparator (per-identity, series-shaped) ──────────
 -- Truncated power-series (Taylor-in-d) arithmetic over `CplxB`, depth N. The
 -- witness compares the ALGEBRA (every coefficient) rather than points of it: the
@@ -828,17 +914,23 @@ def runSeamCoverage (_arena : Arena)
     per-sample `selectE` always discards the CF lane, and the coincident branch
     never reads `invA` — the render must be byte-identical regardless. -/
 private def withCfLane (p : BloomPair) : BloomPair := Id.run do
-  let mu : CplxB := ⟨-p.muSigma, p.muOmega⟩
-  let nu : CplxB := ⟨-p.nuSigma, p.nuOmega⟩
+  -- the pair is BAKED (built from literal poles), so its `Sig` fields fold back
+  -- to Floats via `sigConstF?` (the WS-LP CplxE lift keeps baked pairs literal)
+  let cf := fun (s : Tropical.EmitArrow.Sig) => (Tropical.EmitArrow.sigConstF? s).getD 0.0
+  let mu : CplxB := ⟨-(cf p.muSigma), cf p.muOmega⟩
+  let nu : CplxB := ⟨-(cf p.nuSigma), cf p.nuOmega⟩
   let aC := (nu.sub mu).scale (1.0 / p.gRate)
   let plan := classifyBloomPair mu nu p.bloomB p.gRate
-  let (cfK, _) := bloomCF aC p.kappa
+  let kappaB : CplxB := ⟨cf p.kappa.1, cf p.kappa.2⟩
+  let (cfK, _) := bloomCF aC kappaB
   let cfB := (Array.range (plan.kDepth + 1)).map (fun j => (⟨(2 * j + 1).toFloat - aC.re, -aC.im⟩ : CplxB))
   let cfN := (Array.range plan.kDepth).map (fun j =>
     let jf := (j + 1).toFloat
     (⟨jf, 0⟩ : CplxB).mul ((⟨jf, 0⟩ : CplxB).sub aC))
   let invA := (Array.range plan.nDepth).map (fun k => CplxB.div ⟨1, 0⟩ (aC.add ⟨(k + 1).toFloat, 0⟩))
-  return { p with k1Cf := (cfK.scale (1.0 / p.gRate)).neg, cfB, cfN, invA }
+  return { p with k1Cf := cplxLitE ((cfK.scale (1.0 / p.gRate)).neg),
+                  cfB := cfB.map cplxLitE, cfN := cfN.map cplxLitE,
+                  invA := invA.map cplxLitE }
 
 /-- THE LANE-CLEAN GATE (WS-CL). The region-indexed `coincidentSubtle` emit (the
     whole CF lane DROPPED) is BYTE-IDENTICAL to the pre-refactor emit (which always

--- a/lean/Tropical/Tropicaltest/Slide.lean
+++ b/lean/Tropical/Tropicaltest/Slide.lean
@@ -152,6 +152,52 @@ def runBootstrapLog (arena : Arena)
     | .error e => failGate "bootstrap-log" s!"render: {firstLine e}"
   | .error e => failGate "bootstrap-log" s!"build: {firstLine e}"
 
+open Tropical.EmitArrow in
+/-- THE SETTLE gate. `settle e` returns the s0 value `e` converges to (the glide's
+    saturating ramp → its ceiling), or `none` when a clock read survives (a genuine
+    modulation). Asserts, on a synthetic glide `2 → 10` built in `glideExpr`'s exact
+    shape: (1) the glide READS the clock (s1) and renders as a ramp (first ≈ 2, last
+    ≈ 10); (2) `settle glide = some g'` with `readsSampleIndex g' = false` — s0 BY
+    CONSTRUCTION, the enforceable contract — and `g'` renders as the CONSTANT target
+    10 (`= v1`, the value behind the ramp); (3) `settle (oscillator)` = `none` (a
+    surviving clock read → decline); (4) `settle (const) = some const`. This is what
+    lets the gauge norm be Metal-safe by construction, not by precondition. -/
+def runSettle (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  -- a synthetic glide v0=2 → v1=10, glideExpr's shape (smoothstep of a clamped ramp)
+  let dur := mul (lit 2 2) .sampleRate
+  let s := clampE (div (sub (toFloatE .sampleIndex) (lit 0)) dur) (lit 0) (lit 1)
+  let ss := mul (mul s s) (sub (lit 3) (mul (lit 2) s))
+  let glide := add (lit 2) (mul (sub (lit 10) (lit 2)) ss)
+  let osc := sinSig (toFloatE .sampleIndex)           -- a surviving clock read
+  let konst := lit 7
+  let sinkGain : Float := Tropical.Plan.defaultSinkGain.toFloat
+  let renderConst := fun (name : String) (e : Sig) => do
+    match buildAndFinish (.ok (buildExprCarrier name e arena)) with
+    | .ok p => match ← renderPlanSamples p 8192 with
+      | .ok v => pure (some v)
+      | .error e => IO.println s!"        settle render: {firstLine e}"; pure none
+    | .error e => IO.println s!"        settle build: {firstLine e}"; pure none
+  let glideS1 := readsSampleIndex glide
+  let some g' := settle glide | return (← failGate "settle" "settle glide = none")
+  let g'S0 := !readsSampleIndex g'
+  let oscNone := (settle osc).isNone
+  let konstSome := match settle konst with | some k => !readsSampleIndex k | none => false
+  let some rGlide ← renderConst "settle_ramp" glide | return (← failGate "settle" "ramp render")
+  let some rSettled ← renderConst "settle_dst" g' | return (← failGate "settle" "settled render")
+  -- the glide rises 2 → 10 over 20 ms (≈882 samples at 44.1k), so 8192 samples reach v1
+  let rampLo := rGlide[10]! / sinkGain
+  let rampHi := rGlide[8000]! / sinkGain
+  let dstFlat := (rSettled[10]! - rSettled[8000]!).abs / sinkGain      -- constant?
+  let dstVal := rSettled[4000]! / sinkGain
+  let rampsUp := rampLo < 3.0 && rampHi > 9.5                          -- ramp 2 → 10
+  let settledTo10 := (dstVal - 10.0).abs < 1e-3 && dstFlat < 1e-3      -- flat at v1=10
+  IO.println s!"        settle: glide reads clock={glideS1} (ramp {rampLo}→{rampHi}); settled reads clock={!g'S0} val={dstVal} (flat Δ={dstFlat}); osc→none={oscNone}; const→some={konstSome}"
+  if glideS1 && g'S0 && rampsUp && settledTo10 && oscNone && konstSome then
+    passGate "settle" "settle: glide (s1 ramp 2→10) ↦ its s0 ceiling 10 (=v1), clock read GONE by construction; a surviving clock read (osc) declines; a const passes through"
+  else
+    failGate "settle" s!"glideS1={glideS1} g'S0={g'S0} rampsUp={rampsUp} settledTo10={settledTo10} oscNone={oscNone} konstSome={konstSome}"
+
 /-- THE FIXED-SINE ACCURACY gate. `fixedSinCycSig` (the Q2.30 integer-datapath
     sine) over the integer phasor, rendered by the engine, vs the TRUE sine at
     the exactly-known phase: the phasor model `P(i) = (21426140·i) mod 2³²` is

--- a/lean/Tropical/Tropicaltest/Slide.lean
+++ b/lean/Tropical/Tropicaltest/Slide.lean
@@ -152,6 +152,34 @@ def runBootstrapLog (arena : Arena)
     | .error e => failGate "bootstrap-log" s!"render: {firstLine e}"
   | .error e => failGate "bootstrap-log" s!"build: {firstLine e}"
 
+/-- THE BOOTSTRAP-ATAN2 gate. `atan2E` (the one new op WS-LP's live Γ★ bridge needs
+    past `logSig` — for complex `log`/`lgamma`) traces a circle: `atan2E(sin θ, cos θ)`
+    over `θ ∈ [−3.1, 3.096]` must recover `θ` across all four quadrants. Independent
+    oracle (the known angle), so a bad octant fold or quadrant `select` shows as error
+    ≫ 1e-5. Absolute error on the angle scale. `logSig`'s `bootstrap-exp`, for atan2. -/
+def runBootstrapAtan2 (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  match buildAndFinish (.ok (Tropical.EmitArrow.buildAtan2Probe "atan2_probe" arena)) with
+  | .ok p =>
+    match ← renderPlanSamples p 2048 with
+    | .ok s =>
+      let n := min s.size 2048
+      let sinkGain : Float := Tropical.Plan.defaultSinkGain.toFloat
+      let mut maxAbs : Float := 0.0
+      let mut worstT : Float := 0.0
+      for i in [0:n] do
+        let theta := -3.1 + i.toFloat * 0.00302734375
+        let err := (s[i]! / sinkGain - theta).abs
+        if err > maxAbs then maxAbs := err; worstT := theta
+      IO.println s!"        atan2E(sin θ, cos θ) vs θ, θ∈[−3.1,3.096] across 2048 samples (all quadrants):"
+      IO.println s!"        result   max absolute error = {maxAbs}  (at θ={worstT})"
+      if maxAbs < 1e-5 then
+        passGate "bootstrap-atan2" s!"emitted octant-reduced atan2 ≡ the true angle to {maxAbs} (incl. sin/cos error) — quadrants + fold correct"
+      else
+        failGate "bootstrap-atan2" s!"max abs err {maxAbs} (want <1e-5) at θ={worstT}"
+    | .error e => failGate "bootstrap-atan2" s!"render: {firstLine e}"
+  | .error e => failGate "bootstrap-atan2" s!"build: {firstLine e}"
+
 open Tropical.EmitArrow in
 /-- THE SETTLE gate. `settle e` returns the s0 value `e` converges to (the glide's
     saturating ramp → its ceiling), or `none` when a clock read survives (a genuine

--- a/lean/Tropical/Tropicaltest/Slide.lean
+++ b/lean/Tropical/Tropicaltest/Slide.lean
@@ -118,6 +118,40 @@ def runBootstrapExp (arena : Arena)
     | .error e => failGate "bootstrap-exp" s!"render: {firstLine e}"
   | .error e => failGate "bootstrap-exp" s!"build: {firstLine e}"
 
+/-- THE BOOTSTRAP-LOG gate. `logSig` (the excitation-gauge norm's inverse-of-`exp`)
+    evaluated by the engine over a positive ramp `x∈[0.02,200]` must match libm
+    `log` to its minimax tolerance. An independent oracle (true log, not a second
+    copy of the atanh series), so a transcribed-coefficient typo or a mis-branched
+    range reduction shows up as error ≫ 1e-6. Absolute error on the log scale (the
+    accuracy that maps to relative error in `norm^{−g} = exp(−g·log)`), so the
+    x→1 (log→0) region is not a false relative-error blowup. `logSig`'s
+    `bootstrap-exp`. -/
+def runBootstrapLog (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  match buildAndFinish (.ok (Tropical.EmitArrow.buildLogProbe "log_probe" arena)) with
+  | .ok p =>
+    match ← renderPlanSamples p 2048 with
+    | .ok s =>
+      let n := min s.size 2048
+      let sinkGain : Float := Tropical.Plan.defaultSinkGain.toFloat
+      let mut maxAbs : Float := 0.0
+      let mut worstX : Float := 0.0
+      for i in [0:n] do
+        let x := 0.02 + i.toFloat * 0.09765625
+        let ref := sinkGain * Float.log x
+        let err := (s[i]! - ref).abs / sinkGain
+        if err > maxAbs then
+          maxAbs := err
+          worstX := x
+      IO.println s!"        logSig(x) vs libm log, x∈[0.02,200] across 2048 samples:"
+      IO.println s!"        result   max absolute error = {maxAbs}  (at x={worstX})"
+      if maxAbs < 1e-6 then
+        passGate "bootstrap-log" s!"emitted atanh-series log ≡ true log to {maxAbs} abs (minimax) — transcription + range reduction correct"
+      else
+        failGate "bootstrap-log" s!"max abs err {maxAbs} (want <1e-6) at x={worstX}"
+    | .error e => failGate "bootstrap-log" s!"render: {firstLine e}"
+  | .error e => failGate "bootstrap-log" s!"build: {firstLine e}"
+
 /-- THE FIXED-SINE ACCURACY gate. `fixedSinCycSig` (the Q2.30 integer-datapath
     sine) over the integer phasor, rendered by the engine, vs the TRUE sine at
     the exactly-known phase: the phasor model `P(i) = (21426140·i) mod 2³²` is

--- a/lean/Tropical/Tropicaltest/Synthetic.lean
+++ b/lean/Tropical/Tropicaltest/Synthetic.lean
@@ -244,8 +244,12 @@ private def peakAbsLE (b : ByteArray) : Float × Bool := Id.run do
     sample finite, where `C` is the device-boundary bound
     (`kDeviceOutputBound`, engine/dac/TropicalDAC.hpp).
 
-    It is trivially green today (the corpus peaks at 1.807 against C = 4), and
+    It is trivially green today (the corpus peaks at 1.807 against C = 256), and
     that is the point: it exists to catch the NEXT rail before a speaker does.
+    Note what the headroom number does NOT mean: C is set by the modal
+    vocabulary's legitimate reach (≈ Q·master_gain ≈ 163 at the top of the
+    resonance knob), not by this corpus, so a large ratio here is a statement
+    about the corpus being quiet, not about the margin being safe.
     It matters MORE than it would have under the rejected design. The clamp
     deliberately does not live in the emitted kernel — the kernel's output is
     the value of `f(τ)`, read as a number by `render-bytes`, the goldens, the
@@ -261,7 +265,7 @@ private def peakAbsLE (b : ByteArray) : Float × Bool := Id.run do
     a general readout and legitimately exceed C. Bounding *them* is what the
     rejected design got wrong. -/
 def runDeviceBound : IO Bool := do
-  let bound : Float := 4.0   -- must equal kDeviceOutputBound (TropicalDAC.hpp)
+  let bound : Float := 256.0   -- must equal kDeviceOutputBound (TropicalDAC.hpp)
   let corpus := [
     "patches/reverse_reverb.json", "patches/scrub_reverb.json",
     "web/patches/pure-sine-440.json", "web/patches/ring-mod.json",

--- a/lean/Tropical/Tropicaltest/Synthetic.lean
+++ b/lean/Tropical/Tropicaltest/Synthetic.lean
@@ -220,6 +220,70 @@ def runGolden (writeMode : Bool) (name patchPath goldenPath : String) : IO Bool 
       if got == expected then passGate s!"{name}" s!"{got.take 16}"
       else failGate s!"{name}" s!"expected {expected.take 16} got {got.take 16}"
 
+-- ── The device-boundary early-warning gate (the safety class) ────────────────
+
+/-- Peak |sample| of a little-endian f64 render, and whether every sample is
+    finite. Folds the bytes in place — no intermediate `Array Float`. -/
+private def peakAbsLE (b : ByteArray) : Float × Bool := Id.run do
+  let n := b.size / 8
+  let mut peak : Float := 0.0
+  let mut finite := true
+  for i in [0:n] do
+    let mut u : UInt64 := 0
+    for j in [0:8] do
+      u := u * 256 + (b.get! (i * 8 + (7 - j))).toUInt64
+    let x := (Float.ofBits u).abs
+    if !x.isFinite then finite := false
+    else if x > peak then peak := x
+  pure (peak, finite)
+
+/-- THE STANDING BOUNDED-OUTPUT ASSERTION — the early-warning half of the
+    safety-class gate landed 2026-07-20.
+
+    Every audio patch in the corpus renders with `max |out| ≤ C` and every
+    sample finite, where `C` is the device-boundary bound
+    (`kDeviceOutputBound`, engine/dac/TropicalDAC.hpp).
+
+    It is trivially green today (the corpus peaks at 1.807 against C = 4), and
+    that is the point: it exists to catch the NEXT rail before a speaker does.
+    It matters MORE than it would have under the rejected design. The clamp
+    deliberately does not live in the emitted kernel — the kernel's output is
+    the value of `f(τ)`, read as a number by `render-bytes`, the goldens, the
+    wasm≡JIT differential and the numeric coverage gates, and bounding it there
+    would make the compiler lie (`bootstrap-exp` legitimately renders exp(10) ≈
+    22026 through the sink). So nothing upstream of the DAC is bounded by
+    construction, and THIS gate is what notices. Had it existed before the i64
+    modal-datapath rail incident (peaks of 63.3,
+    `design/modal-datapath-rail.local.md`) it would have caught it in CI.
+
+    Deliberately scoped to AUDIO patches — the synthetic numeric fixtures
+    (`op-coverage`, `reduce-coverage`, `bootstrap-exp`) use the output buffer as
+    a general readout and legitimately exceed C. Bounding *them* is what the
+    rejected design got wrong. -/
+def runDeviceBound : IO Bool := do
+  let bound : Float := 4.0   -- must equal kDeviceOutputBound (TropicalDAC.hpp)
+  let corpus := [
+    "patches/reverse_reverb.json", "patches/scrub_reverb.json",
+    "web/patches/pure-sine-440.json", "web/patches/ring-mod.json",
+    "web/patches/tz-flanger.json"]
+  let mut worst : Float := 0.0
+  let mut worstName := ""
+  let mut bad : Array String := #[]
+  for path in corpus do
+    if ← System.FilePath.pathExists path then
+      match ← compilePatchStaged path with
+      | .error e => bad := bad.push s!"{path}: compile {firstLine e}"
+      | .ok (plan, blocks) =>
+        let (peak, finite) := peakAbsLE (← renderTypedBytes plan blocks)
+        if !finite then bad := bad.push s!"{path}: NON-FINITE sample"
+        else if peak > bound then bad := bad.push s!"{path}: peak {peak} > C={bound}"
+        if peak > worst then worst := peak; worstName := path
+  IO.println s!"        device bound C = {bound}; worst corpus peak {worst} ({worstName})"
+  if bad.isEmpty then
+    passGate "device-bound" s!"every audio patch renders bounded and finite (worst {worst} ≤ C = {bound}, {(bound / worst)}× headroom) — the early warning for the next rail"
+  else
+    failGate "device-bound" s!"unbounded render(s): {String.intercalate "; " bad.toList}"
+
 /-- Compile a patch and emit its Metal kernel source (the EmitMsl path). -/
 private def emitMslOf (patchPath : String) : IO (Except String String) := do
   match ← compilePatch patchPath .fused with

--- a/lean/Tropical/Tropicaltest/Vocabulary.lean
+++ b/lean/Tropical/Tropicaltest/Vocabulary.lean
@@ -109,17 +109,35 @@ def runVocabDriven (arena : Arena)
     through `outletOf`, the lowering decides modal-ness through `nodeIsModal` on
     the constructed node. Nothing proves they agree, so a new modal kind missing
     an `outletOf` case would be silently signal-colored (the checker rejecting
-    wiring the lowering accepts, or the reverse). This asserts, for every
-    vocabulary kind, that `nodeIsModal(default node) ⟺ outletOf(kind) == some
-    .modal` — one meaning for "modal", pinned by a test. -/
+    wiring the lowering accepts, or the reverse). Driven off `buildNodeKinds` (every
+    kind `buildNode` constructs, not just the served table), so a served-but-unlisted
+    kind is SEEN. Asserts two properties: (1) no SERVED kind drifts —
+    `nodeIsModal(default node) ⟺ outletOf(kind) == some .modal` — one meaning for
+    "modal"; a WITHHELD kind may drift (that drift is precisely why it is withheld,
+    and `checkServedKinds` rejects it pre-lowering, so it cannot mis-type an edge);
+    (2) the three kind lists are mutually consistent — every served (non-`out`) and
+    withheld kind is BUILT, and every built kind is served-or-withheld — so
+    `buildNode` cannot grow a kind the vocabulary/withholding machinery misses. -/
 def runModalClassAgreement : IO Bool := do
-  let drift := Tropical.Playground.modalClassificationDrift
-  IO.println s!"        {Tropical.Playground.vocabularyKinds.size} kinds: nodeIsModal(node) ⟺ outletOf == modal"
-  IO.println s!"        result   {if drift.isEmpty then "every kind's outlet color agrees with its constructed node" else s!"DRIFT {drift}"}"
-  if drift.isEmpty then
-    passGate "modal-class-agreement" "outletOf (the edge checker's color) and nodeIsModal (the lowering's) agree on modal-ness for every kind — the typing rule has one meaning, not two coincidentally-equal ones"
+  let vocab    := Tropical.Playground.vocabularyKinds
+  let built    := Tropical.Playground.buildNodeKinds
+  let withheld := Tropical.Playground.withheldKinds
+  let drift    := Tropical.Playground.modalClassificationDrift          -- over `built`
+  let servedDrift   := drift.filter (fun k => !withheld.contains k)
+  let withheldDrift := drift.filter (fun k => withheld.contains k)
+  -- list-consistency: served/withheld ⊆ built, built ⊆ served ∪ withheld
+  let servedNotBuilt   := (vocab.filter (· != "out")).filter (fun k => !built.contains k)
+  let withheldNotBuilt := withheld.filter (fun k => !built.contains k)
+  let builtUnaccounted := built.filter (fun k => !vocab.contains k && !withheld.contains k)
+  let setIssues := servedNotBuilt.map (s!"served-not-built {·}")
+    ++ withheldNotBuilt.map (s!"withheld-not-built {·}")
+    ++ builtUnaccounted.map (s!"built-unaccounted {·}")
+  IO.println s!"        {built.size} built kinds: nodeIsModal(node) ⟺ outletOf == modal (served drift asserted empty)"
+  IO.println s!"        served drift {servedDrift} · withheld drift (contained, rejected pre-lowering) {withheldDrift} · list-consistency {if setIssues.isEmpty then "ok" else toString setIssues}"
+  if servedDrift.isEmpty && setIssues.isEmpty then
+    passGate "modal-class-agreement" s!"outletOf and nodeIsModal agree for every SERVED kind, and buildNodeKinds ⊆ served∪withheld (the {withheldDrift.size} withheld kind(s) may drift — rejected pre-lowering, so the drift cannot mis-type an edge)"
   else
-    failGate "modal-class-agreement" s!"kinds where outletOf and nodeIsModal disagree: {drift}"
+    failGate "modal-class-agreement" s!"servedDrift {servedDrift} · setIssues {setIssues}"
 
 /-- THE MALFORMED-DOCUMENT REJECTION gate (Findings 1 & 3). A malformed patch is a
     BROKEN document — distinct from a legal-incomplete one (an unwired inlet →
@@ -159,6 +177,23 @@ def runMalformedRejection (arena : Arena)
   let danglingOut := "{\"nodes\":[" ++
     "{\"id\":\"osc\",\"kind\":\"source\",\"params\":{\"freq\":220}}," ++
     "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"osc\"]}}],\"out\":\"typo\"}"
+  -- a WITHHELD kind (built by buildNode, not surface-served): its `bloomgong`→out
+  -- edge is color-legal by luck (modal→signal realizes), so `checkServedKinds`
+  -- must reject it FIRST, honestly — not let it reach the unguarded factor site.
+  let withheldKind := "{\"nodes\":[" ++
+    "{\"id\":\"bg\",\"kind\":\"bloomgong\",\"params\":{\"freq\":110}}," ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"bg\"]}}],\"out\":\"out\"}"
+  -- an UNKNOWN kind (a typo): otherwise silent silence under buildNode's fallthrough.
+  let unknownKind := "{\"nodes\":[" ++
+    "{\"id\":\"x\",\"kind\":\"reverbb\",\"params\":{\"rt60\":2}}," ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"x\"]}}],\"out\":\"out\"}"
+  -- a non-empty WIRE INTO A KNOB (`rt60` is a set value, not an inlet): slips past
+  -- the color loop (empty accepts) yet suppresses the slot — a silently dead knob.
+  let knobWire := "{\"nodes\":[" ++
+    "{\"id\":\"res\",\"kind\":\"resonator\",\"params\":{\"freq\":220,\"decay\":4}}," ++
+    "{\"id\":\"k\",\"kind\":\"knob\",\"params\":{\"value\":3}}," ++
+    "{\"id\":\"rev\",\"kind\":\"reverb\",\"in\":{\"in\":[\"res\"],\"rt60\":[\"k\"]}}," ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"rev\"]}}],\"out\":\"out\"}"
   -- the crisp boundary: a valid modal patch still compiles.
   let valid := "{\"nodes\":[" ++
     "{\"id\":\"res\",\"kind\":\"resonator\",\"params\":{\"freq\":220,\"decay\":4}}," ++
@@ -168,6 +203,9 @@ def runMalformedRejection (arena : Arena)
   let mMix := compileErr cycleMix
   let mWire := compileErr danglingWire
   let mOut := compileErr danglingOut
+  let mWithheld := compileErr withheldKind
+  let mUnknown := compileErr unknownKind
+  let mKnob := compileErr knobWire
   let mValid := match Lean.Json.parse valid with
     | .ok j => (Tropical.Playground.compilePlanPure arena resolved j).toOption.isSome
     | .error _ => false
@@ -175,16 +213,22 @@ def runMalformedRejection (arena : Arena)
   let mixOk := hasSub mMix "connection cycle"
   let wireOk := hasSub mWire "not a node in the patch"
   let outOk := hasSub mOut "output target error"
+  let withheldOk := hasSub mWithheld "unserved kind"
+  let unknownOk := hasSub mUnknown "unknown kind"
+  let knobOk := hasSub mKnob "is a knob"
   IO.println s!"        malformed patches rejected (no crash); legal-incomplete unaffected:"
   IO.println s!"        cycle(reverb self)   {mRev}"
   IO.println s!"        cycle(mix self)      {mMix}"
   IO.println s!"        dangling wire        {mWire}"
   IO.println s!"        dangling out         {mOut}"
+  IO.println s!"        withheld kind        {mWithheld}"
+  IO.println s!"        unknown kind         {mUnknown}"
+  IO.println s!"        wire into a knob     {mKnob}"
   IO.println s!"        valid modal patch compiles={mValid}"
-  if revOk && mixOk && wireOk && outOk && mValid then
-    passGate "malformed-rejection" "a color-legal cycle, a dangling wire, and a dangling out each return a clear error (no stack-overflow); a valid patch still compiles"
+  if revOk && mixOk && wireOk && outOk && withheldOk && unknownOk && knobOk && mValid then
+    passGate "malformed-rejection" "a color-legal cycle, a dangling wire/out, a WITHHELD kind (bloomgong), an UNKNOWN kind, and a wire-into-a-knob each return a clear error (no stack-overflow); a valid patch still compiles"
   else
-    failGate "malformed-rejection" s!"revOk={revOk} mixOk={mixOk} wireOk={wireOk} outOk={outOk} valid={mValid}"
+    failGate "malformed-rejection" s!"revOk={revOk} mixOk={mixOk} wireOk={wireOk} outOk={outOk} withheldOk={withheldOk} unknownOk={unknownOk} knobOk={knobOk} valid={mValid}"
 
 open Tropical.Playground in
 /-- THE REALIZED-STATE REPORT gate. The `load_patch_graph` reply must state

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -430,6 +430,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← runModalFilter arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runModalRail arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalAddr arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -389,6 +389,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runSeamLaneClean arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runFoldChain arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalPatch arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -383,6 +383,12 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runGongReverb arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runSeamCoverage arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runSeamLaneClean arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalPatch arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -373,6 +373,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← runGaugeAdapter arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runKInvariance arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalBessel arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -289,6 +289,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← runBootstrapLog arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runBootstrapAtan2 arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runSettle arena resolved) then
       failed := failed + 1
     IO.println "fixed-point datapath sine (scope A — the sample values in i64):"
@@ -374,6 +377,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runKInvariance arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runLgammaEmit arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runModalBessel arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -285,6 +285,9 @@ def main (args : List String) : IO UInt32 := do
     total := total + 1
     if !(← runBootstrapExp arena resolved) then
       failed := failed + 1
+    total := total + 1
+    if !(← runBootstrapLog arena resolved) then
+      failed := failed + 1
     IO.println "fixed-point datapath sine (scope A — the sample values in i64):"
     total := total + 1
     if !(← runFixedSinAccuracy arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -406,6 +406,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runGongReverb arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runBloomLivePole arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runSeamCoverage arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -424,6 +424,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← runBanksStaging arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runGaugeStage arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runMslColumnGuard arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -433,6 +433,12 @@ def main (args : List String) : IO UInt32 := do
     if !(← runModalRail arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runModalRailDir arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runModalRailIdentity arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalAddr arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -288,6 +288,9 @@ def main (args : List String) : IO UInt32 := do
     total := total + 1
     if !(← runBootstrapLog arena resolved) then
       failed := failed + 1
+    total := total + 1
+    if !(← runSettle arena resolved) then
+      failed := failed + 1
     IO.println "fixed-point datapath sine (scope A — the sample values in i64):"
     total := total + 1
     if !(← runFixedSinAccuracy arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -367,6 +367,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← runModalPair arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← runGaugeAdapter arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← runModalBessel arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -108,6 +108,11 @@ def main (args : List String) : IO UInt32 := do
       total := total + 1
       if !(← runGolden writeMode name patchPath s!"tests/golden/cf/{name}.hash") then failed := failed + 1
 
+  -- ── (e′) The device-boundary bound: every audio patch renders bounded ──────
+  IO.println "device boundary (the safety class):"
+  total := total + 1
+  if !(← runDeviceBound) then failed := failed + 1
+
   -- ── (f′) MSL emitter goldens: the Metal backend's codegen, text-frozen ─────
   IO.println "msl emitter (EmitMsl text-frozen + the f64 fold):"
   for (name, patchPath) in [

--- a/web/runtime/kernel.ts
+++ b/web/runtime/kernel.ts
@@ -17,7 +17,7 @@ const FADE_SAMPLES = 2048
  *  feed) and never in `render` (the equivalence surface). Must equal
  *  `kDeviceOutputBound` in engine/dac/TropicalDAC.hpp, which carries the
  *  rationale and the measurement. */
-const DEVICE_OUTPUT_BOUND = 4.0
+const DEVICE_OUTPUT_BOUND = 256.0
 
 // @llvm.round = round half away from zero — the one math op with no wasm
 // instruction (f64.nearest is ties-to-even), so the kernel imports it. Must

--- a/web/runtime/kernel.ts
+++ b/web/runtime/kernel.ts
@@ -13,6 +13,12 @@ import { computeLayout, type KernelLayout } from './layout.js'
 const WASM_PAGE = 65536
 const FADE_SAMPLES = 2048
 
+/** `C` — the device-boundary output bound, applied in `process` (the worklet
+ *  feed) and never in `render` (the equivalence surface). Must equal
+ *  `kDeviceOutputBound` in engine/dac/TropicalDAC.hpp, which carries the
+ *  rationale and the measurement. */
+const DEVICE_OUTPUT_BOUND = 4.0
+
 // @llvm.round = round half away from zero — the one math op with no wasm
 // instruction (f64.nearest is ties-to-even), so the kernel imports it. Must
 // match the native kernel's rounding bit-for-bit.
@@ -115,7 +121,19 @@ export class WasmKernel {
     return new Float64Array(this.memory.buffer, L.output, n)
   }
 
-  /** Render `n` samples into `out` (f32 audio) with the anti-click fade. */
+  /** Render `n` samples into `out` (f32 audio) with the anti-click fade and the
+   *  device-boundary clamp.
+   *
+   *  The clamp lives HERE and not in `render` on purpose: `render` returns the
+   *  kernel's own f64 output — the value of `f(τ)` — and that is the surface the
+   *  WASM≡JIT equivalence gate compares against `diffcli render-bytes`. Bounding
+   *  it there would make the artifact lie about the function it encodes. This
+   *  method is the worklet feed: the point where a value becomes sound, and so
+   *  the point where a sound-safety bound belongs. Exact mirror of the native
+   *  side, where `FlatRuntime.outputBuffer` is honest and `TropicalDAC`'s
+   *  callback clamps — see `kDeviceOutputBound` in engine/dac/TropicalDAC.hpp
+   *  for `C`, its measurement, and the NaN/±0 argument for spelling it as
+   *  ordered-compare + select rather than Math.min/Math.max. */
   process(out: Float32Array, n: number): void {
     const f64 = this.render(n)
     for (let i = 0; i < n; i++) {
@@ -127,7 +145,8 @@ export class WasmKernel {
         const t = this.fadeOutRem / FADE_SAMPLES
         v *= t * t * (3 - 2 * t); this.fadeOutRem--
       }
-      out[i] = v
+      const lo = v > -DEVICE_OUTPUT_BOUND ? v : -DEVICE_OUTPUT_BOUND
+      out[i] = lo < DEVICE_OUTPUT_BOUND ? lo : DEVICE_OUTPUT_BOUND
     }
   }
 }


### PR DESCRIPTION
Four completed workstreams on the modal seam, sequenced so each hardens the ground the next stands on. `make validate` fully green throughout (tropicaltest 104/104, ctest, bun suites, wasm≡jit).

## 1. The rail fix — option E (`2f2895a` + witnesses)

Modal weights land Q4.28 against exact Q2.30 rotators in i64, so a landed magnitude past 2⁵ = 32 wraps — reachable from the shipped vocabulary (a resonant lowpass at the top ~8% of the resonance knob). The fix: land at `2^(28−k)` and shift back by `28−k`, with `k` derived per bank from the coefficient-time bound `maxAbs = maxₘ sup_d |env₂ₘ·Aₘ|` (envelope-lifted for deg>0 modes, `99db926`). The rendered value is k-invariant — witnessed by a mutation-verified gate (`82777e8`) — and `k=0` emits byte-identical ops. Alongside it: the device-boundary clamp at C = 256 (`4e4425a`, `73a9306`), documented honestly as a hazard bound, not a level control.

## 2. Region classifier + surface seal (`cfcdab5`, `432c0c0`)

The bloom crossing's config space is now a TOTAL `SeamRegion` partition (`classifyBloomPair`) — dispatch is an exhaustive match, the depth-cap drop is a counted region, and the emit is region-indexed (dead lanes no longer baked; the lane-clean gate proves the drop moved zero samples). The `bloomgong` surface is sealed as an explicitly WITHHELD kind (`checkServedKinds`) until the factor site carries the per-pair exponent, and the Γ★-bridge record is corrected: the bridge is exact (74-digit witness in `demos/bridge_verify.py`); the old "lane disagreement" was the float64 Horner's own cancellation, misread.

## 3. §5 excitation gauge (`ab7b1c7` … `e027fbd`)

`normalizePeak`: residues re-leveled by the self-measured `‖H‖^{−g}` (g=0 strike/unity-DC identity, g=1 unity-peak), computed at coefficient time from the bank's own poles. Needed `logSig` (expSig's mirror) and resolved the s0/glide tension with `settle` (`9033fae`): s0/s1 is binding time, not a control rate — the norm reads the settled parameter, never τ. Surfaced as the composable `gauge` node; the gauge-stage gate enforces the stage split structurally (zero FloatExponent added to the audio kernel).

## 4. WS-LP phases 0–1 — live poles across the bloom (`efd6c57`, `e6c664b`)

Previously any live pole dropped a bloomed crossing to the bare bloom. Phase 0 landed the emitted transcendental foundation (`atan2E`, `clogE`/`cexpE`/`lgammaE`/`bloomGammaStarE`, gated at 0.000000 rel vs build time). Phase 1 makes a live-rt60 reverb CROSS: `BloomPair` is fully `CplxE`/`Sig`-valued (the baked path wraps literals — byte-identical, pinned by the goldens and the bit-exact gates), and `bloomCompose` lifts serOnly pairs whose live σ is s0 and range-declared (`ModalMode.sigmaRange`, threaded from the rt60 knob span). Classification runs over the whole declared interval with the live σ clamped to it in-kernel, so the region choice is sound by construction; κ = μ·B is rt60-independent, so no live trip count is needed. The `bloom-live-pole` gate: 6/6 pairs lift with unfoldable s0 constants, live ≡ baked crossing at 2.1e-8, ≡ quadrature oracle at 2e-6, and a room mode parked on a voice partial drops per-pair.

Phase 2 (the `crossing` region, using the already-landed `bloomGammaStarE`) continues on a follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)