### PR TITLE
feat(modal): WS-LP crossing + EC/DD erasure — the modal seam goes total over live and coincident configs

### DIFF
--- a/demos/ecdd_partition.py
+++ b/demos/ecdd_partition.py
@@ -8,9 +8,11 @@ divided-difference paired form (coincidence-stable, bounded c = a·r). This
 cockpit produces the partition predicate's constants AS DATA, the config
 census that sizes the cost, and the second-order-DD go/no-go for v2.
 
-The predicate under measurement (design decision D1 — dual, cost-only):
+The predicate under measurement (design decision D1 — dual, cost-only), gated
+by the paired range cap `|a·r|·min(2/|Δ|, 1/(e·σ_min)) < 8` (a lens-fired
+coupling the cap rejects is REFUSED — stays collected, a stated exclusion):
 
-    route (λ, ν) to DD  ⇔  |Δ| < θ_acc  ∨  |a·r| / |Δ| > W_rail
+    route (λ, ν) to DD  ⇔  (|Δ| < θ_acc  ∨  |a·r| / |Δ| > W_rail)  ∧  cap
 
 θ_acc is where the collected form's cancellation error (~eps/|Δ| relative)
 crosses the seam gate floor; W_rail is the Q4.28 landing ceiling on the
@@ -88,6 +90,7 @@ rng = np.random.default_rng(0x7501)
 # fold chain gate currently 6.7e-4 (the 1/Δ artifact this sprint tightens).
 GATE_FLOOR = 2e-6
 Q428_CEIL = 8.0          # plain-bank Q4.28 magnitude ceiling (modal_divdiff D_dd2)
+PAIR_CAP = 8.0           # the paired atom's build-time range cap (ecddPairCap)
 DD_PREMIUM = 2.2         # per-mode render cost of the paired atom vs a plain mode
 
 # ---------------------------------------------------------------- evaluators
@@ -479,18 +482,44 @@ print(f"\nDD coeff |c| = |a·r| max over sweep: {dd_c_max:.2f}  "
       f"(ceiling {Q428_CEIL}; bounded, no 1/Δ)")
 assert dd_c_max < Q428_CEIL
 
-# the dual predicate, as the compiler will state it
-def route_to_dd(delta_abs, c_abs,
-                theta_acc=THETA_ACC, rail=Q428_CEIL, rail_margin=2.0):
-    """D1: accuracy lens OR range lens (amp-dependent), both compile-time."""
-    return (delta_abs < theta_acc) or (c_abs / delta_abs > rail / rail_margin)
+# the routing verdict, as the compiler states it (classifyCoupling, Modal.lean):
+# lens (accuracy | range) then the paired range cap — the SAME function the
+# shipped predicate computes, so every witness below runs on shipped semantics.
+def classify_coupling(delta_abs, c_abs, sigma_min,
+                      theta_acc=THETA_ACC, rail=Q428_CEIL, rail_margin=2.0,
+                      cap=PAIR_CAP):
+    """'cold' | 'paired' | 'refused' — D1's dual lens gated by the paired
+    range cap |c|·min(2/|Δ|, 1/(e·σ_min)) < cap (min < cap ⟺ either bound
+    clears)."""
+    lens = (delta_abs < theta_acc) or (
+        delta_abs > 0.0 and c_abs / delta_abs > rail / rail_margin)
+    if not lens:
+        return "cold"
+    cap_ok = (delta_abs > 0.0 and c_abs * (2.0 / delta_abs) < cap) or \
+             (sigma_min > 0.0 and c_abs * (1.0 / (np.e * sigma_min)) < cap)
+    return "paired" if cap_ok else "refused"
 
-# the rail lens catches couplings the |Δ| lens alone would pass
-example = (1.0, 8.0)    # |Δ| well above θ_acc, but |c/Δ| = 8 > rail/margin
-assert example[0] > THETA_ACC and route_to_dd(*example), \
-    "the range lens must route what the accuracy lens alone misses"
-print(f"dual-lens witness: |Δ|={example[0]}, |c|={example[1]} -> DD "
-      f"(rail), though |Δ| > θ_acc — |Δ| alone is NOT the criterion")
+def route_to_dd(delta_abs, c_abs, sigma_min):
+    return classify_coupling(delta_abs, c_abs, sigma_min) == "paired"
+
+# THE CAP INTERPLAY (the review finding, stated as data): |c|·2/|Δ| < cap is
+# EXACTLY the complement of the rail lens (|c|/|Δ| > rail/margin = cap/4·2 ⇔
+# cap = 8, margin 2), so a rail-fired coupling routes ONLY through the damping
+# arm: |Δ| < 2e·σ_min and |c| < 8e·σ_min. Witnesses on both sides:
+# (a) the rail lens's SERVICE region — well-damped, heavy, Δ > θ_acc: routes.
+assert 0.6 > THETA_ACC and classify_coupling(0.6, 4.0, 1.5) == "paired", \
+    "the rail lens must route a well-damped heavy coupling the θ lens misses"
+# (b) the same coupling lightly damped — the damping arm can't clear: REFUSED
+#     (stays collected, a stated exclusion, never a certified one).
+assert classify_coupling(0.6, 4.0, 0.05) == "refused", \
+    "a lightly-damped rail-fired coupling must be refused by the cap"
+# (c) the complement identity: with sup = 2/|Δ| binding (σ_min large enough to
+#     matter removed), rail-fired ⇒ cap-rejected — the two conditions negate.
+assert classify_coupling(1.0, 8.0, 0.0) == "refused", \
+    "rail-fired with only the 2/|Δ| arm available must always be refused"
+print(f"rail service region: |Δ|=0.6, |c|=4, σ_min=1.5 -> paired (damping arm "
+      f"clears); σ_min=0.05 -> refused; the 2/|Δ| cap arm alone NEGATES the "
+      f"rail lens exactly (|c|·2/|Δ| < 8 ⟺ |c|/|Δ| < 4)")
 
 # ------------------------------------------------- D_p3: the census
 print()
@@ -511,35 +540,46 @@ def voice_poles(f0, n):
 
 def census(voice, room, amps):
     """Per-coupling routing over the full m·n grid; returns (n_couplings,
-    n_hot, poles that carry >1 hot coupling)."""
+    n_hot, n_refused, poles that carry >1 hot coupling). Cap-refused couplings
+    render collected (the stated exclusion) — counted so the refusal region's
+    real-world bite is on record, not assumed empty."""
     hot_pairs = []
+    n_refused = 0
     for i, lam in enumerate(voice):
         for q, nu in enumerate(room):
-            if route_to_dd(abs(lam - nu), abs(amps[i, q])):
+            verdict = classify_coupling(abs(lam - nu), abs(amps[i, q]),
+                                        min(-lam.real, -nu.real))
+            if verdict == "paired":
                 hot_pairs.append((i, q))
+            elif verdict == "refused":
+                n_refused += 1
     from collections import Counter
     v_deg = Counter(i for i, _ in hot_pairs)
     r_deg = Counter(q for _, q in hot_pairs)
     shared = [p for p, d in list(v_deg.items()) + list(r_deg.items()) if d > 1]
-    return len(voice) * len(room), len(hot_pairs), shared
+    return len(voice) * len(room), len(hot_pairs), n_refused, shared
 
 N_TRIALS = 400
-tot_hot, tot_coup, multi_hot_cfgs, any_hot_cfgs = 0, 0, 0, 0
+tot_hot, tot_coup, tot_refused = 0, 0, 0
+multi_hot_cfgs, any_hot_cfgs = 0, 0
 for _ in range(N_TRIALS):
     room = room_poles(24)
     f0 = rng.uniform(60.0, 1200.0)
     voice = voice_poles(f0, 12)
     amps = (rng.uniform(0.05, 1.0, (len(voice), len(room)))
             * np.exp(1j * rng.uniform(0, 2 * np.pi, (len(voice), len(room)))))
-    nc, nh, shared = census(voice, room, amps)
+    nc, nh, nr, shared = census(voice, room, amps)
     tot_coup += nc
     tot_hot += nh
+    tot_refused += nr
     any_hot_cfgs += (nh > 0)
     multi_hot_cfgs += (len(shared) > 0)
 
 print(f"random voice x log-spaced room, {N_TRIALS} trials:")
 print(f"  hot couplings: {tot_hot}/{tot_coup} "
       f"({100.0 * tot_hot / tot_coup:.3f}% of couplings)")
+print(f"  cap-REFUSED couplings (lens fired, collected floor): "
+      f"{tot_refused}/{tot_coup}")
 print(f"  configs with any hot coupling: {any_hot_cfgs}/{N_TRIALS}")
 print(f"  configs with a SHARED-pole multi-hot (triple coincidence, the "
       f"sort-hot-last gap): {multi_hot_cfgs}/{N_TRIALS}")
@@ -549,15 +589,16 @@ room = room_poles(24)
 voice = voice_poles(100.0, 12)
 voice[3] = room[10] + 1j * 1e-5            # tuned unison, the served case
 amps = np.full((12, 24), 0.5 + 0j)
-nc, nh, shared = census(voice, room, amps)
+nc, nh, nr, shared = census(voice, room, amps)
 cost = (nc - nh + DD_PREMIUM * nh) / nc
 print(f"\ntuned-unison config (a partial parked on a room mode): "
-      f"{nh}/{nc} hot, shared-pole poles: {len(shared)}, "
+      f"{nh}/{nc} hot ({nr} refused), shared-pole poles: {len(shared)}, "
       f"render cost x{cost:.3f} of all-collected")
+assert nh >= 1 and nr == 0, "the tuned unison must route, not be cap-refused"
 
 # a deliberate unison STACK: many rooms on one pole (the columnize watch-item)
 stack = np.repeat(room[10], 6) + 1j * rng.uniform(-1e-4, 1e-4, 6)
-nc, nh, shared = census(voice, stack, np.full((12, 6), 0.5 + 0j))
+nc, nh, nr, shared = census(voice, stack, np.full((12, 6), 0.5 + 0j))
 print(f"unison stack (6 rooms on one mode): {nh}/{nc} hot — the paired "
       f"family wants WS2 columnizing before it wants v2 if this is common")
 
@@ -567,7 +608,8 @@ for _ in range(N_TRIALS):
     r1, r2 = room_poles(16), room_poles(16)
     for nu1 in r1:
         for nu2 in r2:
-            if route_to_dd(abs(nu1 - nu2), 0.25):
+            if route_to_dd(abs(nu1 - nu2), 0.25,
+                           min(-nu1.real, -nu2.real)):
                 chain_hot += 1
 print(f"chain fold (room x room, {N_TRIALS} trials): "
       f"{chain_hot}/{N_TRIALS * 256} couplings hot "
@@ -664,7 +706,10 @@ print(f"  THETA_ACC  = {THETA_ACC:.3e} rad/s  (datapath ADVANTAGE crossing "
 print(f"  RAIL lens  = |c|/|Δ| > {Q428_CEIL}/2 (margin 2x) — amp-dependent; "
       f"comparable in scale to θ_acc (binding for |c| > ~{THETA_ACC * Q428_CEIL / 2:.1f}), "
       f"so BOTH lenses earn their keep: accuracy for moderate amps, range "
-      f"for heavy couplings. |Δ| alone is not the criterion (D1 confirmed).")
+      f"for heavy couplings. |Δ| alone is not the criterion (D1 confirmed). "
+      f"SERVICE region: the 2/|Δ| cap arm exactly negates this lens, so it "
+      f"routes only through the damping arm (|c| < 8e·σ_min) — well-damped "
+      f"heavy couplings; the rest are REFUSED (stated, collected floor).")
 print(f"  DD plateau = {dd_plateau:.3e} everywhere (θ is a COST boundary)")
 print(f"  census     = hot couplings are rare in log-spaced configs, "
       f"~all singletons; sort-hot-last covers everything short of "

--- a/demos/ecdd_partition.py
+++ b/demos/ecdd_partition.py
@@ -447,8 +447,13 @@ print(f"advantage crossing: collected worse than 10x DD for |Δ| <= "
 print(f"DD TOTAL ceiling across the sweep: {dd_dp_floor:.3e} "
       f"(the shared grid noise; its sub-grid floor is 2.4e-6)")
 
-assert theta_dp > 100 * max(theta_pair, theta_chain), \
+# DIRECTION invariant only — the magnitude is a finding, not a gate: asserting
+# a specific dominance ratio would fail the cockpit on a different datapath
+# while the compiler is fine. The measured ratio goes on record instead.
+assert theta_dp > max(theta_pair, theta_chain), \
     "the datapath advantage region must dominate the float64 algebra bound"
+print(f"datapath dominance ratio: {theta_dp / max(theta_pair, theta_chain):.1e}x "
+      f"(the frequency grid, not float64 cancellation — a finding, not a gate)")
 assert dd_dp_floor < 2e-4, \
     "the DD body must hold the registered seam snr across the whole sweep"
 # the representation-failure witness: sub-grid collected renders ~silence

--- a/demos/ecdd_partition.py
+++ b/demos/ecdd_partition.py
@@ -1,0 +1,675 @@
+"""ecdd_partition — the EC/DD erasure Phase-0 cockpit (fork 3').
+
+Scope: design/ecdd-erasure-scope.local.md. The sprint erases the
+residueComposeEC / residueComposeDD choice from every surface: the compiler
+partitions PER COUPLING (voice pole λ against room pole ν, Δ = λ−ν) and routes
+each coupling to the collected form (cheap, `m+n` modes, carries a 1/Δ) or the
+divided-difference paired form (coincidence-stable, bounded c = a·r). This
+cockpit produces the partition predicate's constants AS DATA, the config
+census that sizes the cost, and the second-order-DD go/no-go for v2.
+
+The predicate under measurement (design decision D1 — dual, cost-only):
+
+    route (λ, ν) to DD  ⇔  |Δ| < θ_acc  ∨  |a·r| / |Δ| > W_rail
+
+θ_acc is where the collected form's cancellation error (~eps/|Δ| relative)
+crosses the seam gate floor; W_rail is the Q4.28 landing ceiling on the
+collected ringing weight (range lens, amp-dependent — |Δ| alone is not the
+criterion). Because DD ≡ collected to ~2e-6 away from coincidence, θ is a COST
+boundary, not a correctness boundary — the freeze errs generous, toward DD.
+
+Differentials (house style: independent oracle, a PLATEAU or a RATE):
+
+  D_p1  θ_acc as data. Collected-vs-oracle relative L2 error SCALES ~eps/|Δ|
+        across amp × Q sweeps (amp-INVARIANT — relative error divides the amp
+        out, which is exactly why the rail lens is a separate, amp-dependent
+        predicate); the DD form PLATEAUS at machine precision over the same
+        sweep. θ_acc = (largest |Δ| where any swept config's collected error
+        exceeds the 2e-6 gate floor) × 10 generosity margin.
+  D_p1b the CHAIN site (deliverable 2's preview). voice ⋙ room ⋙ room with
+        the two room poles near-coincident, lowered exactly as Patch.lean does
+        (nested residueComposeEC): the collected chain's error vs the oracle
+        scales ~eps/|Δ| with a larger constant than the pair site (this is
+        the standing 6.7e-4 folded-fold datum's mechanism); the PARTITIONED
+        chain — identical EC algebra except the one hot coupling routed to a
+        paired atom at the final fold (sort-hot-last) — plateaus at the
+        single-crossing floor. The split is EXACT algebra, not approximation:
+        EC's residues decompose coupling-wise, and the hot coupling's two
+        ±c/Δ residues sum exactly to the bounded paired atom. θ_acc freezes
+        off the WORSE of the two sites.
+  D_p1c the DATAPATH — the lens that actually decides θ_acc, measured
+        through the faithful Q-datapath transcription (divdiff_qdatapath's
+        primitives, the WS-B2 cockpit) with option E's per-bank landing
+        exponent. The float64 sweeps above bound the compile-time algebra;
+        what the sweep FOUND is that neither float64 cancellation nor the
+        Q4.28 landing decides — the FREQUENCY GRID does. Each mode's
+        rotator increment quantizes ω to a 2π·SR/2³² ≈ 6.5e-5 rad/s grid,
+        so the collected form renders a grid-quantized Δ: below one quantum
+        the two increments coincide and the ±c/Δ residues cancel to exact
+        SILENCE (rel err 1.0 — a representation failure), and up to ~0.05
+        rad/s the mis-rendered beat keeps it decades over the floor. The
+        paired body's series branch (|z| < 0.1) carries RAW Δ and holds
+        ~2.4e-6 throughout. Above ~0.1 rad/s both representations sit on
+        the same shared grid noise and there is nothing to win. θ_acc
+        freezes off the ADVANTAGE region (collected worse than 10× DD);
+        the landing-conditioning error (the old 300× story) is real but
+        subordinate (~5e-5 at worst under option E's exponent).
+  D_p2  the rail curve. The collected ringing weight |a·r/Δ| crosses the ±8
+        Q4.28 magnitude ceiling at |Δ| = |a·r|/8 — measured, and confirmed
+        amp-dependent (so a pure-|Δ| predicate provably under-routes). The DD
+        coeff |c| = |a·r| stays bounded across the entire sweep (no 1/Δ).
+  D_p3  the census. Realistic configs (log-spaced rooms × harmonic voices,
+        room chains, deliberate unison stacks): how many couplings are hot
+        under the D_p1/D_p2 predicate, how often >1 coupling shares a pole
+        (triple coincidence — the sort-hot-last fallback's only gap), and the
+        per-config cost delta at the DD premium (~2.2×/mode).
+  D_p4  the v2 probe. The second-order divided difference of e^{·d} over
+        three poles, evaluated by the STABLE two-regime candidate (bivariate
+        ψ₂ series when all nodes coincide within radius; recursive first-order
+        cexpm1 legs with a safe outer division otherwise), PLATEAUS vs the
+        40-digit mpmath oracle through a triple-coincidence sweep, while the
+        naive Newton recursion scales ~eps/|Δ|². This is the Newton fold's
+        kernel: if it plateaus, v2 is numerically fundable and the ladder has
+        a top (sprint invariant 3).
+
+Run:  uv run --with numpy --with mpmath python demos/ecdd_partition.py
+"""
+import numpy as np
+
+try:
+    import mpmath as mp
+    HAVE_MP = True
+except ImportError:
+    HAVE_MP = False
+
+rng = np.random.default_rng(0x7501)
+
+# gate floors on record (seam-sweep data): single crossing 2e-6; the folded-
+# fold chain gate currently 6.7e-4 (the 1/Δ artifact this sprint tightens).
+GATE_FLOOR = 2e-6
+Q428_CEIL = 8.0          # plain-bank Q4.28 magnitude ceiling (modal_divdiff D_dd2)
+DD_PREMIUM = 2.2         # per-mode render cost of the paired atom vs a plain mode
+
+# ---------------------------------------------------------------- evaluators
+def cexpm1(z):
+    """(e^z − 1)/z, stable: Horner series (N=6, matches cexpm1SeriesE) for
+    |z| < 1e-3, direct otherwise. Limit 1 at z = 0."""
+    z = np.asarray(z, dtype=complex)
+    small = np.abs(z) < 1e-3
+    out = np.empty_like(z)
+    zs = z[small]
+    acc = np.full_like(zs, 1.0 / 5040.0)
+    for ck in (1.0 / 720, 1.0 / 120, 1.0 / 24, 1.0 / 6, 1.0 / 2, 1.0):
+        acc = ck + zs * acc
+    out[small] = acc
+    zb = z[~small]
+    out[~small] = np.expm1(zb) / zb
+    return out
+
+
+def pair_collected(lam, nu, c, d):
+    """The hot coupling rendered as the COLLECTED bank computes it: two modes
+    with residues ±c/Δ, summed in float64. The 1/Δ cancellation site."""
+    w = c / (lam - nu)
+    return w * np.exp(lam * d) - w * np.exp(nu * d)
+
+
+def pair_dd(lam, nu, c, d):
+    """The same coupling as the fused paired atom: c·e^{νd}·d·cexpm1(Δd).
+    No 1/Δ is ever formed; the τ·e resonance is the smooth series limit."""
+    return c * np.exp(nu * d) * d * cexpm1((lam - nu) * d)
+
+
+def pair_oracle(lam, nu, c, d, dps=40):
+    """40-digit ground truth for c·(e^{λd} − e^{νd})/Δ (→ c·d·e^{νd} at
+    coincidence), evaluated pointwise in mpmath."""
+    with mp.workdps(dps):
+        L, N, C = mp.mpc(lam), mp.mpc(nu), mp.mpc(c)
+        out = np.empty(len(d), dtype=complex)
+        for i, dv in enumerate(d):
+            D = mp.mpf(float(dv))
+            if L == N:
+                v = C * D * mp.exp(N * D)
+            else:
+                v = C * (mp.exp(L * D) - mp.exp(N * D)) / (L - N)
+            out[i] = complex(v)
+    return out
+
+
+def rel_l2(y, ref):
+    n = np.linalg.norm(ref)
+    return np.linalg.norm(y - ref) / n if n > 0 else np.linalg.norm(y)
+
+# ------------------------------------------------- D_p1: θ_acc as data
+print("=" * 72)
+print("D_p1  θ_acc — collected error rate vs DD plateau, amp × Q sweep")
+print("=" * 72)
+
+D_GRID = np.linspace(1e-4, 1.0, 160)          # render window: 1 s
+DELTAS = np.logspace(-8, 2, 21)               # |Δ| in rad/s (detune along iω)
+AMPS = [0.01, 0.5, 4.0]                       # |a·r| — should NOT move rel err
+SIGMAS = [0.5, 4.0, 30.0]                     # decay rates s⁻¹ (the Q sweep)
+W0 = 2 * np.pi * 440.0
+
+if not HAVE_MP:
+    raise SystemExit("mpmath required for the Phase-0 oracle "
+                     "(uv run --with numpy --with mpmath ...)")
+
+# worst collected error per |Δ| across the amp × Q sweep, and the DD ceiling
+coll_worst = np.zeros(len(DELTAS))
+dd_worst = np.zeros(len(DELTAS))
+for j, dlt in enumerate(DELTAS):
+    for amp in AMPS:
+        for sg in SIGMAS:
+            nu = -sg + 1j * W0
+            lam = nu + 1j * dlt              # detune along ω: |Δ| exactly dlt
+            c = amp + 0.0j
+            ref = pair_oracle(lam, nu, c, D_GRID)
+            e_coll = rel_l2(pair_collected(lam, nu, c, D_GRID).real, ref.real)
+            e_dd = rel_l2(pair_dd(lam, nu, c, D_GRID).real, ref.real)
+            coll_worst[j] = max(coll_worst[j], e_coll)
+            dd_worst[j] = max(dd_worst[j], e_dd)
+
+print(f"{'|Δ| rad/s':>12} {'collected rel L2':>18} {'DD rel L2':>12}")
+for j, dlt in enumerate(DELTAS):
+    mark = "  <-- over gate floor" if coll_worst[j] > GATE_FLOOR else ""
+    print(f"{dlt:12.3e} {coll_worst[j]:18.3e} {dd_worst[j]:12.3e}{mark}")
+
+# amp-invariance of the relative error (rail is the separate amp lens)
+j_probe = np.argmin(np.abs(DELTAS - 1e-4))
+errs_by_amp = []
+for amp in AMPS:
+    nu = -4.0 + 1j * W0
+    lam = nu + 1j * DELTAS[j_probe]
+    ref = pair_oracle(lam, nu, amp + 0j, D_GRID)
+    errs_by_amp.append(rel_l2(pair_collected(lam, nu, amp + 0j, D_GRID).real,
+                              ref.real))
+amp_spread = max(errs_by_amp) / min(errs_by_amp)
+print(f"\namp-invariance at |Δ|={DELTAS[j_probe]:.1e}: rel-err spread across "
+      f"|c| in {AMPS} = {amp_spread:.2f}x")
+
+# pair-site crossing: largest |Δ| whose worst swept error exceeds the floor
+hot = [DELTAS[j] for j in range(len(DELTAS)) if coll_worst[j] > GATE_FLOOR]
+theta_pair = max(hot) if hot else 0.0
+dd_plateau = dd_worst.max()
+print(f"\npair-site crossing: collected > {GATE_FLOOR:.0e} for |Δ| <= "
+      f"{theta_pair:.3e} rad/s")
+print(f"DD plateau across the ENTIRE sweep: {dd_plateau:.3e}")
+
+assert dd_plateau < GATE_FLOOR, "DD must sit under the gate floor everywhere"
+# the rate signature: error at the smallest Δ dwarfs the error at the largest
+assert coll_worst[0] > 1e3 * coll_worst[-1], "collected error must SCALE"
+assert amp_spread < 3.0, "relative collected error must be ~amp-invariant"
+
+# ------------------------------------- D_p1b: the chain-fold site
+print()
+print("=" * 72)
+print("D_p1b chain site — voice >> room >> room through room coincidence")
+print("=" * 72)
+
+def ec(bank, room):
+    """residueComposeEC as Patch.lean writes it: forced a·H(λ) per bank pole
+    + one ringing mode per room pole with the coupling sum. float64."""
+    forced = [(p, a * sum(r / (p - q) for q, r in room)) for p, a in bank]
+    ringing = [(q, -r * sum(a / (p - q) for p, a in bank)) for q, r in room]
+    return forced + ringing
+
+def ec_partitioned(bank, room, hot):
+    """EC with the couplings in `hot` (bank-idx, room-idx) routed OUT of the
+    collected amps and into paired atoms (pole_bank, pole_room, c = a·r) —
+    the exact coupling-wise split of EC's residue algebra. NOTE the forced
+    amp is a·h with h the PARTIAL Cauchy sum (hot terms excluded), so the
+    hot voice pole's forced mode loses its 1/Δ term too — both halves of
+    the coupling migrate together."""
+    plain, paired = [], []
+    for i, (p, a) in enumerate(bank):
+        h = sum(r / (p - q) for qi, (q, r) in enumerate(room)
+                if (i, qi) not in hot)
+        plain.append((p, a * h))
+    for qi, (q, r) in enumerate(room):
+        coup = sum(a / (p - q) for i, (p, a) in enumerate(bank)
+                   if (i, qi) not in hot)
+        plain.append((q, -r * coup))
+    for (i, qi) in hot:
+        p, a = bank[i]
+        q, r = room[qi]
+        paired.append((p, q, a * r))
+    return plain, paired
+
+def render_plain(modes, d):
+    return sum(a * np.exp(p * d) for p, a in modes)
+
+def render_paired(pairs, d):
+    return sum(c * np.exp(q * d) * d * cexpm1((p - q) * d)
+               for p, q, c in pairs)
+
+def chain_oracle(lam, a, nu1, r1, nu2, r2, d, dps=40):
+    """Partial fractions of a·r1·r2/((s−λ)(s−ν1)(s−ν2)) at 40 digits."""
+    with mp.workdps(dps):
+        L, N1, N2 = mp.mpc(lam), mp.mpc(nu1), mp.mpc(nu2)
+        C = mp.mpc(a) * mp.mpc(r1) * mp.mpc(r2)
+        AL = C / ((L - N1) * (L - N2))
+        A1 = C / ((N1 - L) * (N1 - N2))
+        A2 = C / ((N2 - L) * (N2 - N1))
+        out = np.empty(len(d), dtype=complex)
+        for i, dv in enumerate(d):
+            D = mp.mpf(float(dv))
+            out[i] = complex(AL * mp.exp(L * D) + A1 * mp.exp(N1 * D)
+                             + A2 * mp.exp(N2 * D))
+    return out
+
+lam, a = -5.0 + 2j * np.pi * 220.0, 1.0 + 0j
+NU1 = -2.5 + 2j * np.pi * 700.0
+r1, r2 = 0.5 + 0j, 0.4 + 0.1j
+
+chain_coll = np.zeros(len(DELTAS))
+chain_part = np.zeros(len(DELTAS))
+print(f"{'|Δ| rad/s':>12} {'collected chain':>16} {'partitioned':>12}")
+for j, dlt in enumerate(DELTAS):
+    nu2 = NU1 + 1j * dlt
+    ref = chain_oracle(lam, a, NU1, r1, nu2, r2, D_GRID).real
+    # collected all the way: EC(EC(voice, room1), room2) in float64 — the hot
+    # (ν1, ν2) coupling forms at the second compose as ±c/Δ residues.
+    full = ec(ec([(lam, a)], [(NU1, r1)]), [(nu2, r2)])
+    y_coll = render_plain(full, D_GRID).real
+    # partitioned: same fold order, the one hot coupling (bank idx 1 = the ν1
+    # ringing mode of the first compose) routed to a paired atom at the final
+    # fold — sort-hot-last's mechanics, exact split.
+    bank1 = ec([(lam, a)], [(NU1, r1)])
+    plain, paired = ec_partitioned(bank1, [(nu2, r2)], {(1, 0)})
+    y_part = (render_plain(plain, D_GRID) + render_paired(paired, D_GRID)).real
+    chain_coll[j] = rel_l2(y_coll, ref)
+    chain_part[j] = rel_l2(y_part, ref)
+    mark = "  <-- over gate floor" if chain_coll[j] > GATE_FLOOR else ""
+    print(f"{dlt:12.3e} {chain_coll[j]:16.3e} {chain_part[j]:12.3e}{mark}")
+
+hot_chain = [DELTAS[j] for j in range(len(DELTAS))
+             if chain_coll[j] > GATE_FLOOR]
+theta_chain = max(hot_chain) if hot_chain else 0.0
+part_plateau = chain_part.max()
+print(f"\nchain-site crossing: collected > {GATE_FLOOR:.0e} for |Δ| <= "
+      f"{theta_chain:.3e} rad/s (pair site: {theta_pair:.3e})")
+print(f"partitioned-chain plateau: {part_plateau:.3e}")
+
+assert part_plateau < GATE_FLOOR, \
+    "the partitioned chain must sit at the single-crossing floor"
+assert chain_coll[0] > 1e3 * chain_coll[-1], "collected chain error must SCALE"
+
+print(f"\nfloat64 crossings (pure-algebra bound): pair {theta_pair:.1e}, "
+      f"chain {theta_chain:.1e} rad/s — the datapath (D_p1c) decides θ_acc")
+
+# ------------------------------------- D_p1c: the datapath floor
+print()
+print("=" * 72)
+print("D_p1c datapath floor — Q4.28/Q2.30/i64, collected vs DD paired body")
+print("=" * 72)
+
+import divdiff_qdatapath as qd
+
+# a 2 s window on the engine's clock, as the WS-B2 calibration does
+_idx = np.unique(np.round(np.linspace(1e-4, 2.0, 500) * qd.SR).astype(np.int64))
+_idx = _idx[_idx > 0]
+CLK = (_idx << 32).astype(np.int64)
+DSEC = CLK / qd.TWO32 / qd.SR
+
+def land_k(max_abs):
+    """bankLandExp/landK (option E): k = clamp(0, 28, ⌊log₂ maxAbs⌋ − 4) —
+    the per-bank Q exponent that removed the i64 wrap for all |A|."""
+    if max_abs <= 0.0:
+        return 0
+    e = int(np.floor(np.log2(max_abs))) - 4       # floatExpZ = ⌊log₂⌋
+    return min(28, max(0, e))
+
+def q_collected(lam, nu, c):
+    """The hot coupling through modalBankSigTable's exact op sequence
+    (option E): two modes with residues ±c/Δ, per-bank landing exponent k,
+    Wc = env·amp landed at 2^(28−k), exact Q2.30 oscillator, per-mode
+    >>(28−k), i64 sum."""
+    w = c / (lam - nu)
+    k = land_k(2.0 * (abs(w.real) + abs(w.imag)))  # both modes, |cre|+|cim|
+    sc, sh = float(2 ** (28 - k)), 28 - k
+    acc = np.zeros(len(CLK), np.int64)
+    for pole, amp in ((lam, w), (nu, -w)):
+        sig, om = -pole.real, pole.imag
+        phQ = qd.mode_phase_q(om, CLK)
+        env = np.exp(-sig * DSEC)
+        wre = qd.to_int(env * amp.real * sc)
+        wim = qd.to_int(env * amp.imag * sc)
+        acc = acc + ((wre * qd.fixed_cos_cyc(phQ)
+                      - wim * qd.fixed_sin_cyc(phQ)) >> sh)
+    return acc.astype(np.float64) / qd.Q30
+
+def q_paired(lam, nu, c):
+    """The same coupling through the paired DD body (qA, the shipped
+    modalBankSigTableDD skeleton): ν rotator + difference rotator, cexpm1
+    select, Wc = c·e^{νd}·d·cexpm1 landed Q4.28, i64 combine."""
+    sl, wl = -lam.real, lam.imag
+    sn, wn = -nu.real, nu.imag
+    ds, wd = sl - sn, wl - wn
+    phQnu = qd.mode_phase_q(wn, CLK)
+    phQdf = qd.mode_phase_q(wd, CLK)
+    cos_df = qd.fixed_cos_cyc(phQdf) / qd.Q30
+    sin_df = qd.fixed_sin_cyc(phQdf) / qd.Q30
+    env_nu = np.exp(-sn * DSEC)
+    env_df = np.exp(-ds * DSEC)
+    ez = env_df * (cos_df + 1j * sin_df)
+    z = (-ds * DSEC) + 1j * (wd * DSEC)
+    zsq = z.real * z.real + z.imag * z.imag
+    direct = (ez - 1.0) / np.where(zsq >= qd.THR2, z, 1.0)
+    series = qd.cexpm1_series(z, qd.NSERIES)
+    ce = np.where(zsq >= qd.THR2, direct, series)
+    Wc = c * (env_nu * DSEC) * ce
+    wre = qd.to_int(Wc.real * qd.Q28)
+    wim = qd.to_int(Wc.imag * qd.Q28)
+    acc = (wre * qd.fixed_cos_cyc(phQnu) - wim * qd.fixed_sin_cyc(phQnu)) >> 28
+    return acc.astype(np.float64) / qd.Q30
+
+def ref_collected(lam, nu, c):
+    """The collected body's own integer-phase float64 mirror (quantized
+    increments, exact arithmetic) — isolates the fixed-point landing error."""
+    out = np.zeros(len(CLK))
+    for pole, amp in ((lam, c / (lam - nu)), (nu, -c / (lam - nu))):
+        sig, om = -pole.real, pole.imag
+        ph = qd.mode_phase_float(om, CLK)
+        env = np.exp(-sig * DSEC)
+        out += env * (amp.real * np.cos(ph) - amp.imag * np.sin(ph))
+    return out
+
+def ref_paired(lam, nu, c):
+    """The paired body's own float mirror (quantized rotator phases, raw z,
+    exact float arithmetic, no landing)."""
+    sl, wl = -lam.real, lam.imag
+    sn, wn = -nu.real, nu.imag
+    ds, wd = sl - sn, wl - wn
+    ph_nu = qd.mode_phase_float(wn, CLK)
+    ph_df = qd.mode_phase_float(wd, CLK)
+    ez = np.exp(-ds * DSEC) * (np.cos(ph_df) + 1j * np.sin(ph_df))
+    z = (-ds * DSEC) + 1j * (wd * DSEC)
+    zsq = z.real * z.real + z.imag * z.imag
+    direct = (ez - 1.0) / np.where(zsq >= qd.THR2, z, 1.0)
+    series = qd.cexpm1_series(z, qd.NSERIES)
+    ce = np.where(zsq >= qd.THR2, direct, series)
+    Wc = c * (np.exp(-sn * DSEC) * DSEC) * ce
+    return Wc.real * np.cos(ph_nu) - Wc.imag * np.sin(ph_nu)
+
+def ref_exact(lam, nu, c):
+    """RAW-pole float64 truth (no frequency grid): what the listener is owed.
+    Computed via the stable DD form (float64 cancellation would re-enter at
+    |Δ| below ~1e-7 — negligible over this sweep's range)."""
+    return (c * np.exp(nu * DSEC) * DSEC * cexpm1((lam - nu) * DSEC)).real
+
+NU_DP = -3.0 + 2j * np.pi * 700.0
+DELTAS_DP = np.logspace(-5, 1, 19)
+dp_coll_tot, dp_dd_tot = {}, {}
+for c_abs in (0.5, 4.0):
+    dp_coll_tot[c_abs] = np.zeros(len(DELTAS_DP))
+    dp_dd_tot[c_abs] = np.zeros(len(DELTAS_DP))
+    print(f"  |c| = {c_abs}:")
+    print(f"{'|Δ| rad/s':>12} {'|c/Δ|':>10} {'coll arith':>11} "
+          f"{'coll TOTAL':>11} {'dd arith':>10} {'dd TOTAL':>10}")
+    for j, dlt in enumerate(DELTAS_DP):
+        lam = NU_DP + 1j * dlt
+        c = c_abs + 0j
+        exact = ref_exact(lam, NU_DP, c)
+        ca = rel_l2(q_collected(lam, NU_DP, c), ref_collected(lam, NU_DP, c))
+        ct = rel_l2(q_collected(lam, NU_DP, c), exact)
+        da = rel_l2(q_paired(lam, NU_DP, c), ref_paired(lam, NU_DP, c))
+        dt = rel_l2(q_paired(lam, NU_DP, c), exact)
+        dp_coll_tot[c_abs][j] = ct
+        dp_dd_tot[c_abs][j] = dt
+        over = "  <-- over gate floor" if ct > GATE_FLOOR else ""
+        print(f"{dlt:12.3e} {c_abs/dlt:10.1e} {ca:11.3e} {ct:11.3e} "
+              f"{da:10.3e} {dt:10.3e}{over}")
+
+# The datapath verdict is an ADVANTAGE region, not an absolute floor: above
+# ~0.1 rad/s BOTH representations sit on the shared frequency-grid noise
+# (identical totals — nothing for DD to win); below it the collected form
+# degrades (grid-quantized Δ renders the wrong beat; at sub-grid Δ the two
+# increments COINCIDE and the ±c/Δ residues cancel to silence — rel err 1.0,
+# a representation failure, not a precision one) while DD's series branch
+# carries RAW Δ and holds the single-crossing floor. θ_acc = the widest |Δ|
+# where collected is materially worse than DD, × 10.
+GRID_Q = 2 * np.pi * qd.SR / qd.TWO32
+theta_dp = 0.0
+for c_abs in dp_coll_tot:
+    for j, dlt in enumerate(DELTAS_DP):
+        if dp_coll_tot[c_abs][j] > max(10.0 * dp_dd_tot[c_abs][j], GATE_FLOOR):
+            theta_dp = max(theta_dp, dlt)
+dd_dp_floor = max(v.max() for v in dp_dd_tot.values())
+print(f"\nfrequency-grid quantum: {GRID_Q:.3e} rad/s — collected detunes "
+      f"below it are UNREPRESENTABLE (exact cancellation to silence)")
+print(f"advantage crossing: collected worse than 10x DD for |Δ| <= "
+      f"{theta_dp:.3e} rad/s  (float64 algebra said "
+      f"{max(theta_pair, theta_chain):.0e})")
+print(f"DD TOTAL ceiling across the sweep: {dd_dp_floor:.3e} "
+      f"(the shared grid noise; its sub-grid floor is 2.4e-6)")
+
+assert theta_dp > 100 * max(theta_pair, theta_chain), \
+    "the datapath advantage region must dominate the float64 algebra bound"
+assert dd_dp_floor < 2e-4, \
+    "the DD body must hold the registered seam snr across the whole sweep"
+# the representation-failure witness: sub-grid collected renders ~silence
+assert dp_coll_tot[0.5][0] > 0.5 and dp_dd_tot[0.5][0] < 1e-5, \
+    "sub-grid detune: collected must fail, DD must serve"
+
+# θ_acc freezes off the datapath site, × 10 generosity
+THETA_ACC = theta_dp * 10.0
+print(f"\nTHETA_ACC (frozen, datapath-site x10 generous-toward-DD): "
+      f"{THETA_ACC:.3e} rad/s")
+
+# ------------------------------------------------- D_p2: the rail curve
+print()
+print("=" * 72)
+print("D_p2  the Q4.28 rail — collected weight |a·r/Δ| vs the ±8 ceiling")
+print("=" * 72)
+
+print(f"{'|c|':>8} {'rail crossing |Δ| = |c|/8':>28}")
+rail_at = {}
+for amp in AMPS:
+    rail_at[amp] = amp / Q428_CEIL
+    print(f"{amp:8.2f} {rail_at[amp]:28.3e}")
+
+# measured: the weight actually crosses the ceiling there, and DD's c never does
+dd_c_max = max(AMPS)
+for amp in AMPS:
+    dlt = rail_at[amp]
+    assert abs(amp / dlt) >= Q428_CEIL - 1e-9
+    assert abs(amp / (dlt * 1.5)) < Q428_CEIL
+print(f"\nDD coeff |c| = |a·r| max over sweep: {dd_c_max:.2f}  "
+      f"(ceiling {Q428_CEIL}; bounded, no 1/Δ)")
+assert dd_c_max < Q428_CEIL
+
+# the dual predicate, as the compiler will state it
+def route_to_dd(delta_abs, c_abs,
+                theta_acc=THETA_ACC, rail=Q428_CEIL, rail_margin=2.0):
+    """D1: accuracy lens OR range lens (amp-dependent), both compile-time."""
+    return (delta_abs < theta_acc) or (c_abs / delta_abs > rail / rail_margin)
+
+# the rail lens catches couplings the |Δ| lens alone would pass
+example = (1.0, 8.0)    # |Δ| well above θ_acc, but |c/Δ| = 8 > rail/margin
+assert example[0] > THETA_ACC and route_to_dd(*example), \
+    "the range lens must route what the accuracy lens alone misses"
+print(f"dual-lens witness: |Δ|={example[0]}, |c|={example[1]} -> DD "
+      f"(rail), though |Δ| > θ_acc — |Δ| alone is NOT the criterion")
+
+# ------------------------------------------------- D_p3: the census
+print()
+print("=" * 72)
+print("D_p3  census — hot couplings in realistic configs")
+print("=" * 72)
+
+def room_poles(n, f_lo=100.0, f_hi=8000.0, jitter=0.03, sigma=(1.0, 6.0)):
+    """A reverbRoom-shaped bank: log-spaced modes with jitter."""
+    f = np.geomspace(f_lo, f_hi, n) * (1 + jitter * rng.standard_normal(n))
+    sg = rng.uniform(*sigma, n)
+    return -sg + 2j * np.pi * f
+
+def voice_poles(f0, n):
+    """Harmonic partials, mild inharmonicity."""
+    k = np.arange(1, n + 1)
+    return -rng.uniform(1.0, 8.0, n) + 2j * np.pi * f0 * k * (1 + 1e-4 * k * k)
+
+def census(voice, room, amps):
+    """Per-coupling routing over the full m·n grid; returns (n_couplings,
+    n_hot, poles that carry >1 hot coupling)."""
+    hot_pairs = []
+    for i, lam in enumerate(voice):
+        for q, nu in enumerate(room):
+            if route_to_dd(abs(lam - nu), abs(amps[i, q])):
+                hot_pairs.append((i, q))
+    from collections import Counter
+    v_deg = Counter(i for i, _ in hot_pairs)
+    r_deg = Counter(q for _, q in hot_pairs)
+    shared = [p for p, d in list(v_deg.items()) + list(r_deg.items()) if d > 1]
+    return len(voice) * len(room), len(hot_pairs), shared
+
+N_TRIALS = 400
+tot_hot, tot_coup, multi_hot_cfgs, any_hot_cfgs = 0, 0, 0, 0
+for _ in range(N_TRIALS):
+    room = room_poles(24)
+    f0 = rng.uniform(60.0, 1200.0)
+    voice = voice_poles(f0, 12)
+    amps = (rng.uniform(0.05, 1.0, (len(voice), len(room)))
+            * np.exp(1j * rng.uniform(0, 2 * np.pi, (len(voice), len(room)))))
+    nc, nh, shared = census(voice, room, amps)
+    tot_coup += nc
+    tot_hot += nh
+    any_hot_cfgs += (nh > 0)
+    multi_hot_cfgs += (len(shared) > 0)
+
+print(f"random voice x log-spaced room, {N_TRIALS} trials:")
+print(f"  hot couplings: {tot_hot}/{tot_coup} "
+      f"({100.0 * tot_hot / tot_coup:.3f}% of couplings)")
+print(f"  configs with any hot coupling: {any_hot_cfgs}/{N_TRIALS}")
+print(f"  configs with a SHARED-pole multi-hot (triple coincidence, the "
+      f"sort-hot-last gap): {multi_hot_cfgs}/{N_TRIALS}")
+
+# a deliberately tuned config: one partial parked on a room mode
+room = room_poles(24)
+voice = voice_poles(100.0, 12)
+voice[3] = room[10] + 1j * 1e-5            # tuned unison, the served case
+amps = np.full((12, 24), 0.5 + 0j)
+nc, nh, shared = census(voice, room, amps)
+cost = (nc - nh + DD_PREMIUM * nh) / nc
+print(f"\ntuned-unison config (a partial parked on a room mode): "
+      f"{nh}/{nc} hot, shared-pole poles: {len(shared)}, "
+      f"render cost x{cost:.3f} of all-collected")
+
+# a deliberate unison STACK: many rooms on one pole (the columnize watch-item)
+stack = np.repeat(room[10], 6) + 1j * rng.uniform(-1e-4, 1e-4, 6)
+nc, nh, shared = census(voice, stack, np.full((12, 6), 0.5 + 0j))
+print(f"unison stack (6 rooms on one mode): {nh}/{nc} hot — the paired "
+      f"family wants WS2 columnizing before it wants v2 if this is common")
+
+# chain-fold site: two rooms, room-vs-room couplings under the same predicate
+chain_hot = 0
+for _ in range(N_TRIALS):
+    r1, r2 = room_poles(16), room_poles(16)
+    for nu1 in r1:
+        for nu2 in r2:
+            if route_to_dd(abs(nu1 - nu2), 0.25):
+                chain_hot += 1
+print(f"chain fold (room x room, {N_TRIALS} trials): "
+      f"{chain_hot}/{N_TRIALS * 256} couplings hot "
+      f"({100.0 * chain_hot / (N_TRIALS * 256):.3f}%)")
+
+# ------------------------------------------------- D_p4: the v2 probe
+print()
+print("=" * 72)
+print("D_p4  second-order DD probe — the Newton fold's kernel (v2 go/no-go)")
+print("=" * 72)
+
+def psi2(z0, z1, terms=24):
+    """ψ₂(z0,z1) = Σ_{m,n≥0} z0^m z1^n / (m+n+2)!  (Hermite–Genocchi: the
+    2-simplex integral of e over the node offsets). Entire, symmetric;
+    ψ₂(0,0) = 1/2. The bivariate generalization of cexpm1's series."""
+    import math
+    tot = 0.0 + 0.0j
+    for m in range(terms):
+        for n in range(terms - m):
+            tot += (z0 ** m) * (z1 ** n) / math.factorial(m + n + 2)
+    return tot
+
+
+def dd2_stable(x0, x1, x2, d):
+    """f[x0,x1,x2] of e^{·d}: all-close -> d²·e^{x2 d}·ψ₂((x0−x2)d,(x1−x2)d);
+    otherwise recursive Newton with STABLE first-order legs (d·e^{·d}·cexpm1)
+    and the outer division taken over the WIDEST node gap (safe by regime)."""
+    xs = sorted([x0, x1, x2], key=lambda x: x.imag)
+    gaps = [abs(xs[0] - xs[1]), abs(xs[1] - xs[2]), abs(xs[0] - xs[2])]
+    if max(g * d for g in gaps) < 0.5:                      # all-close regime
+        z0, z1 = (xs[0] - xs[2]) * d, (xs[1] - xs[2]) * d
+        return d * d * np.exp(xs[2] * d) * psi2(z0, z1)
+    a, b, c_ = xs                                           # widest gap = a..c_
+    dd_ab = d * np.exp(b * d) * complex(cexpm1((a - b) * d))
+    dd_bc = d * np.exp(c_ * d) * complex(cexpm1((b - c_) * d))
+    return (dd_ab - dd_bc) / (a - c_)
+
+
+def dd2_naive(x0, x1, x2, d):
+    """The Newton recursion as float64 writes it — both cancellation sites live."""
+    f = [np.exp(x0 * d), np.exp(x1 * d), np.exp(x2 * d)]
+    d01 = (f[0] - f[1]) / (x0 - x1)
+    d12 = (f[1] - f[2]) / (x1 - x2)
+    return (d01 - d12) / (x0 - x2)
+
+
+def dd2_oracle(x0, x1, x2, d, dps=40):
+    with mp.workdps(dps):
+        X = [mp.mpc(x0), mp.mpc(x1), mp.mpc(x2)]
+        D = mp.mpf(d)
+        f = [mp.exp(x * D) for x in X]
+        d01 = (f[0] - f[1]) / (X[0] - X[1])
+        d12 = (f[1] - f[2]) / (X[1] - X[2])
+        return complex((d01 - d12) / (X[0] - X[2]))
+
+NU2 = -3.0 + 2j * np.pi * 440.0
+D_PROBE = [0.05, 0.3, 1.0]
+print(f"{'|Δ| rad/s':>12} {'naive rel err':>14} {'stable rel err':>15}")
+naive_errs, stable_errs = [], []
+for dlt in np.logspace(-6, 1, 15):
+    nu1 = NU2 + 1j * dlt                 # triple coincidence: all within Δ
+    lam = NU2 + 1j * dlt * 0.5
+    en = es = 0.0
+    for d in D_PROBE:
+        ref = dd2_oracle(lam, nu1, NU2, d)
+        en = max(en, abs(dd2_naive(lam, nu1, NU2, d) - ref) / abs(ref))
+        es = max(es, abs(dd2_stable(lam, nu1, NU2, d) - ref) / abs(ref))
+    naive_errs.append(en)
+    stable_errs.append(es)
+    print(f"{dlt:12.3e} {en:14.3e} {es:15.3e}")
+
+# mixed regime: two coincident, one far (the recursive branch)
+lam_far = -5.0 + 2j * np.pi * 2000.0
+mixed = max(abs(dd2_stable(lam_far, NU2 + 1j * 1e-7, NU2, d)
+                - dd2_oracle(lam_far, NU2 + 1j * 1e-7, NU2, d))
+            / abs(dd2_oracle(lam_far, NU2 + 1j * 1e-7, NU2, d))
+            for d in D_PROBE)
+print(f"mixed regime (two close, one 1.5 kHz away): stable rel err "
+      f"{mixed:.3e}")
+
+v2_plateau = max(stable_errs)
+assert v2_plateau < 1e-9, "the stable 2nd-order DD must plateau"
+assert max(naive_errs[:5]) > 1e2 * v2_plateau, "naive must scale (~eps/Δ²)"
+assert mixed < 1e-9, "the mixed-regime recursive branch must hold"
+
+print()
+print("=" * 72)
+print("Phase-0 verdict")
+print("=" * 72)
+print(f"  THETA_ACC  = {THETA_ACC:.3e} rad/s  (datapath ADVANTAGE crossing "
+      f"{theta_dp:.0e} x 10; the frequency grid, not float64 cancellation, "
+      f"owns the accuracy lens — float64 algebra said {theta_pair:.0e}. "
+      f"Sub-grid detunes are unrepresentable collected: exact silence.)")
+print(f"  RAIL lens  = |c|/|Δ| > {Q428_CEIL}/2 (margin 2x) — amp-dependent; "
+      f"comparable in scale to θ_acc (binding for |c| > ~{THETA_ACC * Q428_CEIL / 2:.1f}), "
+      f"so BOTH lenses earn their keep: accuracy for moderate amps, range "
+      f"for heavy couplings. |Δ| alone is not the criterion (D1 confirmed).")
+print(f"  DD plateau = {dd_plateau:.3e} everywhere (θ is a COST boundary)")
+print(f"  census     = hot couplings are rare in log-spaced configs, "
+      f"~all singletons; sort-hot-last covers everything short of "
+      f"deliberate unison stacks")
+print(f"  v2 probe   = stable 2nd-order DD plateaus at {v2_plateau:.3e} "
+      f"(bivariate ψ₂ + recursive regime); the Newton fold is numerically "
+      f"fundable — go, pending the census saying anyone needs it")
+print("\nall differentials PASS")

--- a/demos/wslp_union_probe.py
+++ b/demos/wslp_union_probe.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""WS-LP phase 3a probe: can the CROSSING representation serve the region UNION?
+
+A region-CHANGING pair (|a+1| straddles |kappa| as rt60 sweeps) is dropped
+today. The candidate fix is NO union machinery at all: emit the crossing lanes
+for the whole interval — at serOnly configs dSwitch = ln(|kappa|/|a+1|)/g goes
+negative, the per-sample select sits on the series lane permanently, and the
+series-lane constant k1Ser = GammaStar - CF(kappa)/g equals serOnly's
+M(1,a+1,kappa)/(nu-mu) EXACTLY (the bridge identity, demos/bridge_verify.py).
+The open question is float64 ACCURACY of the crossing representation on the
+serOnly side of the boundary, where it has never been exercised.
+
+This probe sweeps sigma_nu over the full clamped rt60 interval for straddling
+pairs and compares BOTH f64 representations (replicating the emitted
+algorithms: the fixed-depth Kummer Horner, the fixed-depth bottom-up CF, the
+Lanczos+reflection lgamma of lgammaB/lgammaE) against a 60-digit mpmath
+reference. Encouraging prior bounds, checked here too:
+  - a straddling pair has |Im a| < |kappa| <= ~183, far from the
+    e^{-pi |Im a|/2} Gamma underflow cliff (~465);
+  - non-coincidence (|Im a| >= 1/2) keeps the reflection's log sin(pi a)
+    bounded away from the poles (|sin| >= sinh(pi/2) ~ 2.3).
+"""
+
+import cmath
+import math
+
+import mpmath as mp
+
+mp.mp.dps = 60
+
+G = 1.8
+B = 0.05 / 1.8
+SIG_LO = 6.91 / 12.0
+SIG_HI = 6.91 / 0.2
+TP = 2.0 * math.pi
+
+LANCZOS = [0.99999999999980993, 676.5203681218851, -1259.1392167224028,
+           771.32342877765313, -176.61502916214059, 12.507343278686905,
+           -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7]
+
+
+def lgamma_f64(z):
+    """The shipped Lanczos(g=7,n=9) + dominant-half reflection (lgammaB/lgammaE)."""
+    def core(z):
+        zz = z - 1.0
+        x = LANCZOS[0]
+        for i in range(8):
+            x += LANCZOS[i + 1] / (zz + (i + 1))
+        t = zz + 7.5
+        return (zz + 0.5) * cmath.log(t) - t + cmath.log(x) \
+            + 0.5 * math.log(2.0 * math.pi)
+    if z.real >= 0.5:
+        return core(z)
+    if z.imag < 0:
+        s = complex(-math.pi * z.imag, math.pi * z.real)
+        log2i = complex(math.log(2.0), math.pi / 2.0)
+    else:
+        s = complex(math.pi * z.imag, -math.pi * z.real)
+        log2i = complex(math.log(2.0), -math.pi / 2.0)
+    logsin = s + cmath.log(1.0 - cmath.exp(-2.0 * s)) - log2i
+    return math.log(math.pi) - logsin - core(1.0 - z)
+
+
+def m1_forward_depth(a, z, tol=1e-17, cap=4000):
+    """bloomM1: forward recurrence, returns (value, depth) — the depth sizer."""
+    s = 1.0 + 0j
+    t = 1.0 + 0j
+    for n in range(1, cap):
+        t = t * z / (a + n)
+        s += t
+        if abs(t) <= tol * max(abs(s), 1.0):
+            return s, n
+    return s, cap
+
+
+def m1_horner(a, z, n_depth):
+    """The EMITTED fixed-depth Kummer Horner (bloomM1E)."""
+    h = 1.0 + 0j
+    for k in range(n_depth - 1, -1, -1):
+        h = 1.0 + z / (a + k + 1) * h
+    return h
+
+
+def cf_bottomup(a, z, k_depth):
+    """The EMITTED fixed-depth bottom-up CF (bloomCFE): CF = Gamma(a,z) e^z z^-a."""
+    h = z + (2 * k_depth + 1) - a
+    for j in range(k_depth - 1, -1, -1):
+        h = (z + (2 * j + 1) - a) - (j + 1) * ((j + 1) - a) / h
+    return 1.0 / h
+
+
+def cf_depth(a, z):
+    """Smallest depth where the bottom-up CF is converged to 1e-15 (sizer proxy)."""
+    prev = cf_bottomup(a, z, 8)
+    k = 16
+    while k < 2048:
+        cur = cf_bottomup(a, z, k)
+        if abs(cur - prev) <= 1e-15 * max(abs(cur), 1e-300):
+            return k
+        prev = cur
+        k += 16
+    return 2048
+
+
+def k1_ref(a, nu_mu, kappa):
+    """60-digit reference: M(1, a+1, kappa)/(nu - mu)."""
+    am = mp.mpc(a.real, a.imag)
+    km = mp.mpc(kappa.real, kappa.imag)
+    m = mp.hyp1f1(1, am + 1, km)
+    r = m / mp.mpc(nu_mu.real, nu_mu.imag)
+    return r
+
+
+def rel(x, ref):
+    d = abs(mp.mpc(x.real, x.imag) - ref)
+    return float(d / max(abs(ref), mp.mpf("1e-300")))
+
+
+def sweep(f_v, sig_v, df, n_pts=60):
+    mu = complex(-sig_v, TP * f_v)
+    kappa = mu * B
+    om_nu = TP * (f_v + df)
+    im_a = (om_nu - mu.imag) / G
+
+    # classifier-style depth sizing at the interval samples (endpoints + -1 approach)
+    re_lo = (-SIG_HI - mu.real) / G
+    re_hi = (-SIG_LO - mu.real) / G
+    t_star = max(re_lo, min(re_hi, -1.0))
+    n_ship = 0
+    k_ship = 0
+    for re_a in (re_lo, re_hi, t_star):
+        a = complex(re_a, im_a)
+        z_bnd = kappa * (abs(a + 1) / abs(kappa))
+        z_ser = kappa  # union depth must cover the serOnly side too
+        n_ship = max(n_ship, m1_forward_depth(a, z_ser)[1])
+        k_ship = max(k_ship, cf_depth(a, z_bnd), cf_depth(a, kappa))
+    n_ship += 8
+    k_ship += 8
+
+    worst_ser = worst_cross = 0.0
+    worst_ser_at = worst_cross_at = None
+    n_ser_side = 0
+    for i in range(n_pts):
+        sig_nu = SIG_LO * (SIG_HI / SIG_LO) ** (i / (n_pts - 1))
+        nu = complex(-sig_nu, om_nu)
+        a = (nu - mu) / G
+        ap1 = a + 1
+        ser_side = abs(ap1) >= abs(kappa)
+        n_ser_side += ser_side
+
+        ref = k1_ref(a, nu - mu, kappa)
+        # serOnly representation: emitted Horner / (nu - mu)
+        r_ser = m1_horner(a, kappa, n_ship) / (nu - mu)
+        # crossing representation: GammaStar - CF(kappa)/g
+        gstar = cmath.exp(lgamma_f64(a) - a * cmath.log(kappa) + kappa) / G
+        r_cross = gstar - cf_bottomup(a, kappa, k_ship) / G
+
+        e_ser = rel(r_ser, ref)
+        e_cross = rel(r_cross, ref)
+        if e_ser > worst_ser:
+            worst_ser, worst_ser_at = e_ser, (sig_nu, ser_side)
+        if e_cross > worst_cross:
+            worst_cross, worst_cross_at = e_cross, (sig_nu, ser_side)
+
+    print(f"  voice f={f_v} sigma={sig_v}  df={df:+.2f} Hz  |kappa|={abs(kappa):.1f}  "
+          f"|Im a|={abs(im_a):.1f}  depths ser/cf={n_ship}/{k_ship}  "
+          f"serOnly-side {n_ser_side}/{n_pts}")
+    print(f"    serOnly rep  worst rel {worst_ser:.3e} at sigma_nu={worst_ser_at[0]:.3f} "
+          f"({'ser' if worst_ser_at[1] else 'cross'} side)")
+    print(f"    crossing rep worst rel {worst_cross:.3e} at sigma_nu={worst_cross_at[0]:.3f} "
+          f"({'ser' if worst_cross_at[1] else 'cross'} side)")
+    return worst_cross
+
+
+def main():
+    print("WS-LP phase 3a: crossing-representation accuracy over the WHOLE interval")
+    print(f"sigma_nu in [{SIG_LO:.3f}, {SIG_HI:.2f}]  g={G}  B={B:.5f}\n")
+    worst = 0.0
+    # straddling pairs (|a+1| crosses |kappa| inside the interval)
+    worst = max(worst, sweep(220.0, 1.0, 9.8))
+    worst = max(worst, sweep(220.0, 1.0, 10.4))
+    worst = max(worst, sweep(220.0, 1.0, 10.9))
+    worst = max(worst, sweep(1023.0, 1.13, 51.0))
+    # control: a comfortably-crossing pair (phase 2 territory) and a deep-serOnly one
+    print("\ncontrols:")
+    worst = max(worst, sweep(1023.0, 1.13, 43.0))
+    sweep(220.0, 1.0, 60.0)
+    print(f"\nVERDICT: worst crossing-rep rel err over straddling pairs = {worst:.3e}")
+    print("union-collapse viable" if worst < 1e-9 else "union-collapse NEEDS THOUGHT")
+
+
+if __name__ == "__main__":
+    main()

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -676,27 +676,55 @@ def ecddRailCeil : Float := 4.0
     DD site's i64 rail of 32. -/
 def ecddPairCap : Float := 8.0
 
+/-- The σ INTERVAL a mode's damping ranges over: a const σ is its own point
+    interval; a LIVE σ with a declared `sigmaRange` classifies over the knob
+    span (WS-LP's build-time-over-the-declared-interval discipline); a live σ
+    without a range is unclassifiable (`none` ⇒ the coupling stays collected). -/
+def sigmaInterval? (m : ModalMode) : Option (Float × Float) :=
+  match sigConstF? m.sigma with
+  | some s => some (s, s)
+  | none => m.sigmaRange
+
+/-- A mode's pole with a LIVE σ CLAMPED to its declared interval (coefficient-
+    time, the WS-LP kernel-clamp precedent) — what makes the paired route's
+    build-time range cap sound by construction even if the host drives the knob
+    out of its declared span. A const σ passes through untouched. -/
+def clampedPoleE (m : ModalMode) : CplxE :=
+  match sigConstF? m.sigma, m.sigmaRange with
+  | none, some (lo, hi) => (neg (clampE m.sigma (litF lo) (litF hi)), m.omega)
+  | _, _ => m.poleE
+
 /-- The per-coupling routing predicate — compile-time only. `true` ⇒ the (v, r)
-    coupling leaves the collected sums and becomes one `PairedMode`. Requires
-    BOTH poles and BOTH amps to const-fold (a live anything stays collected in
-    v1) and both modes deg-0, then fires on either lens (accuracy | range),
-    gated by the paired range cap. -/
+    coupling leaves the collected sums and becomes one `PairedMode`. σ may be
+    LIVE with a declared range (Phase 2): the lenses evaluate at min |Δ| over
+    the interval — a coupling whose interval DIPS under θ takes DD throughout
+    the knob span, so no runtime select ever exists (D2; the WS-LP phase-3a
+    pattern). ω and amps must const-fold, both modes deg-0; anything else stays
+    collected. Fires on either lens (accuracy | range), gated by the paired
+    range cap at the interval's worst point. -/
 def couplingHot (v r : ModalMode) : Bool :=
   v.deg == 0 && r.deg == 0 &&
   (Id.run do
-    let some sv := sigConstF? v.sigma | return false
+    let some (svLo, svHi) := sigmaInterval? v | return false
+    let some (srLo, srHi) := sigmaInterval? r | return false
     let some wv := sigConstF? v.omega | return false
-    let some sr := sigConstF? r.sigma | return false
     let some wr := sigConstF? r.omega | return false
     let some ar := sigConstF? v.cre | return false
     let some ai := sigConstF? v.cim | return false
     let some rr := sigConstF? r.cre | return false
     let some ri := sigConstF? r.cim | return false
-    let dAbs := Float.sqrt ((sv - sr) * (sv - sr) + (wv - wr) * (wv - wr))
+    -- min |Δ| over the σ interval(s): the span distance (0 when they overlap —
+    -- the dipper), ω exact. Const σ degenerates to the point distance.
+    let sepLo := if svLo < srLo then srLo else svLo
+    let sepHi := if svHi < srHi then svHi else srHi
+    let dSig := if sepLo > sepHi then sepLo - sepHi else 0.0
+    let dAbs := Float.sqrt (dSig * dSig + (wv - wr) * (wv - wr))
     let cAbs := Float.sqrt (ar * ar + ai * ai) * Float.sqrt (rr * rr + ri * ri)
     let hot := dAbs < ecddThetaAcc || (dAbs > 0.0 && cAbs / dAbs > ecddRailCeil)
-    -- the paired range cap: sup of the divided-difference kernel, both bounds
-    let smin := if sv < sr then sv else sr
+    -- the paired range cap: sup of the divided-difference kernel over the
+    -- WHOLE interval — σ_min at the spans' low edge, |Δ| at its minimum
+    -- (sound: the paired pole clamps to the interval, `clampedPoleE`)
+    let smin := if svLo < srLo then svLo else srLo
     let sup1 := if dAbs > 0.0 then 2.0 / dAbs else 1e308
     let sup2 := if smin > 0.0 then 1.0 / (2.718281828459045 * smin) else 1e308
     let sup := if sup1 < sup2 then sup1 else sup2
@@ -730,7 +758,10 @@ def residueComposePartitioned (voice reverb : Array ModalMode) :
   for (v, i) in voice.zipIdx do
     for (r, q) in reverb.zipIdx do
       if isHot i q then
-        paired := paired.push { lam := v.poleE, nu := r.poleE, c := cmulE v.ampE r.ampE }
+        -- live-σ poles enter the paired atom CLAMPED to their declared
+        -- interval, keeping the routing's range cap sound (Phase 2)
+        paired := paired.push
+          { lam := clampedPoleE v, nu := clampedPoleE r, c := cmulE v.ampE r.ampE }
   return (forced ++ ringing, paired)
 
 /-- Multiply a `CplxE` by a real `Sig`. -/

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -664,16 +664,27 @@ def ecddThetaAcc : Float := 0.4642
 
 /-- The range lens: route when the collected ringing weight `|a·r|/|Δ|` exceeds
     the Q4.28 magnitude ceiling 8 with a 2× margin. Amp-dependent — `|Δ|` alone
-    is not the criterion (cockpit D_p2: binding for `|a·r| ≳ 1.9`). -/
+    is not the criterion (cockpit D_p2: binding for `|a·r| ≳ 1.9`).
+
+    SERVICE REGION (the cap interplay, stated — it is NOT the whole lens): the
+    paired range cap admits only `|c|·min(2/|Δ|, 1/(e·σ_min)) < 8`, and the
+    `2/|Δ|` arm of that min is EXACTLY the complement of this lens
+    (`|c|·2/|Δ| < 8 ⟺ |c|/|Δ| < 4`). So a rail-fired coupling can only route
+    through the DAMPING arm: `|Δ| < 2e·σ_min` (the damping bound is the binding
+    sup) and `|c| < 8e·σ_min` (it clears). Well-damped heavy couplings route;
+    a lightly-damped heavy coupling is `CouplingRoute.refused` — a STATED
+    exclusion, never a silent fallback. -/
 def ecddRailCeil : Float := 4.0
 
 /-- The paired atom's own build-time range cap: per pair, `|Wc| ≤ |c|·sup_d
     |e^{νd}·d·cexpm1(Δd)| ≤ |c|·min(2/|Δ|, 1/(e·σ_min))` (the sup the
     remainder-handoff deferred until the DD wiring landed — this is that
-    landing). A coupling whose bound exceeds the cap is NOT routed (stays
-    collected — reject, the status-quo floor; the scale arm can come later if a
-    real patch ever trips this). Cap 8 = the plain Q4.28 ceiling, 4× under the
-    DD site's i64 rail of 32. -/
+    landing). A coupling whose bound exceeds the cap is NOT routed — it stays
+    collected at the status-quo floor (wrong near coincidence), and the refusal
+    is FIRST-CLASS (`CouplingRoute.refused`): the merged seam atom's admission
+    excludes it rather than certifying the collected floor there. The scale arm
+    is the recorded route out if a real patch ever lands in the refusal region.
+    Cap 8 = the plain Q4.28 ceiling, 4× under the DD site's i64 rail of 32. -/
 def ecddPairCap : Float := 8.0
 
 /-- The σ INTERVAL a mode's damping ranges over: a const σ is its own point
@@ -694,41 +705,70 @@ def clampedPoleE (m : ModalMode) : CplxE :=
   | none, some (lo, hi) => (neg (clampE m.sigma (litF lo) (litF hi)), m.omega)
   | _, _ => m.poleE
 
-/-- The per-coupling routing predicate — compile-time only. `true` ⇒ the (v, r)
-    coupling leaves the collected sums and becomes one `PairedMode`. σ may be
-    LIVE with a declared range (Phase 2): the lenses evaluate at min |Δ| over
-    the interval — a coupling whose interval DIPS under θ takes DD throughout
-    the knob span, so no runtime select ever exists (D2; the WS-LP phase-3a
-    pattern). ω and amps must const-fold, both modes deg-0; anything else stays
-    collected. Fires on either lens (accuracy | range), gated by the paired
-    range cap at the interval's worst point. -/
-def couplingHot (v r : ModalMode) : Bool :=
-  v.deg == 0 && r.deg == 0 &&
-  (Id.run do
-    let some (svLo, svHi) := sigmaInterval? v | return false
-    let some (srLo, srHi) := sigmaInterval? r | return false
-    let some wv := sigConstF? v.omega | return false
-    let some wr := sigConstF? r.omega | return false
-    let some ar := sigConstF? v.cre | return false
-    let some ai := sigConstF? v.cim | return false
-    let some rr := sigConstF? r.cre | return false
-    let some ri := sigConstF? r.cim | return false
+/-- Where a (v, r) coupling lands — the routing verdict with the paired range
+    cap made a FIRST-CLASS outcome rather than a silent fallback, so the seam
+    apparatus can state the refusal region as admission instead of certifying
+    the collected floor over it. -/
+inductive CouplingRoute where
+  /-- Neither lens fires (or the coupling is unmeasurable at build time): the
+      collected `±c/Δ` representation is accurate — stays in the Cauchy sums. -/
+  | cold
+  /-- A lens fires and the paired range cap clears: one fused `PairedMode`. -/
+  | paired
+  /-- A lens fires but the pair's landed sup exceeds `ecddPairCap`: stays
+      collected at the status-quo floor (wrong near coincidence) — a STATED
+      exclusion, out of the merged atom's certified region. Reachable only at
+      extreme Q (`σ_min < |c|/(8e)` with a fired lens — rt60 of minutes at
+      unit amps); the scale arm is the recorded route out. -/
+  | refused
+deriving DecidableEq
+
+/-- The per-coupling routing verdict — compile-time only. σ may be LIVE with a
+    declared range (Phase 2): the lenses evaluate at min |Δ| over the interval —
+    a coupling whose interval DIPS under θ takes DD throughout the knob span, so
+    no runtime select ever exists (D2; the WS-LP phase-3a pattern). ω and amps
+    must const-fold, both modes deg-0; anything else is `cold`. A lens fires
+    (accuracy | range) ⇒ `paired` if the paired range cap clears at the
+    interval's worst point, else `refused`. -/
+def classifyCoupling (v r : ModalMode) : CouplingRoute :=
+  if !(v.deg == 0 && r.deg == 0) then .cold else
+  Id.run do
+    let some (svLo, svHi) := sigmaInterval? v | return .cold
+    let some (srLo, srHi) := sigmaInterval? r | return .cold
+    let some wv := sigConstF? v.omega | return .cold
+    let some wr := sigConstF? r.omega | return .cold
+    let some ar := sigConstF? v.cre | return .cold
+    let some ai := sigConstF? v.cim | return .cold
+    let some rr := sigConstF? r.cre | return .cold
+    let some ri := sigConstF? r.cim | return .cold
     -- min |Δ| over the σ interval(s): the span distance (0 when they overlap —
     -- the dipper), ω exact. Const σ degenerates to the point distance.
     let sepLo := if svLo < srLo then srLo else svLo
-    let sepHi := if svHi < srHi then svHi else srHi
+    let sepHi := if svHi < srHi then srHi else svHi
     let dSig := if sepLo > sepHi then sepLo - sepHi else 0.0
     let dAbs := Float.sqrt (dSig * dSig + (wv - wr) * (wv - wr))
     let cAbs := Float.sqrt (ar * ar + ai * ai) * Float.sqrt (rr * rr + ri * ri)
-    let hot := dAbs < ecddThetaAcc || (dAbs > 0.0 && cAbs / dAbs > ecddRailCeil)
+    if !(dAbs < ecddThetaAcc || (dAbs > 0.0 && cAbs / dAbs > ecddRailCeil)) then
+      return .cold
     -- the paired range cap: sup of the divided-difference kernel over the
     -- WHOLE interval — σ_min at the spans' low edge, |Δ| at its minimum
-    -- (sound: the paired pole clamps to the interval, `clampedPoleE`)
+    -- (sound: the paired pole clamps to the interval, `clampedPoleE`).
+    -- `min(sup₁, sup₂) < cap ⟺ either bound clears` — no infinity sentinels.
     let smin := if svLo < srLo then svLo else srLo
-    let sup1 := if dAbs > 0.0 then 2.0 / dAbs else 1e308
-    let sup2 := if smin > 0.0 then 1.0 / (2.718281828459045 * smin) else 1e308
-    let sup := if sup1 < sup2 then sup1 else sup2
-    return hot && cAbs * sup < ecddPairCap)
+    let capOk := (dAbs > 0.0 && cAbs * (2.0 / dAbs) < ecddPairCap)
+              || (smin > 0.0 && cAbs * (1.0 / (Float.exp 1.0 * smin)) < ecddPairCap)
+    return if capOk then .paired else .refused
+
+/-- `true` ⇒ the (v, r) coupling leaves the collected sums and becomes one
+    `PairedMode` (`classifyCoupling = .paired`). -/
+def couplingHot (v r : ModalMode) : Bool :=
+  classifyCoupling v r == .paired
+
+/-- `true` ⇒ a lens fired but the paired range cap refused the coupling: it
+    renders collected at the status-quo floor. The merged seam atom's admission
+    predicate is the negation of this — the refusal is stated, not certified. -/
+def couplingRefused (v r : ModalMode) : Bool :=
+  classifyCoupling v r == .refused
 
 /-- The PARTITIONED compose — the one `residueCompose` seam. Cold couplings take
     `residueComposeEC`'s collected shapes; hot couplings (per `couplingHot`)

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -699,11 +699,34 @@ def sigmaInterval? (m : ModalMode) : Option (Float × Float) :=
 /-- A mode's pole with a LIVE σ CLAMPED to its declared interval (coefficient-
     time, the WS-LP kernel-clamp precedent) — what makes the paired route's
     build-time range cap sound by construction even if the host drives the knob
-    out of its declared span. A const σ passes through untouched. -/
+    out of its declared span. A const σ passes through untouched. Production
+    unit modes arrive PRE-clamped (`clampSigmas` at graph ingestion), making
+    this a value-identical second wrap there; it stays as defense in depth for
+    direct callers (fixtures, the seam sweep) that own their own discipline. -/
 def clampedPoleE (m : ModalMode) : CplxE :=
   match sigConstF? m.sigma, m.sigmaRange with
   | none, some (lo, hi) => (neg (clampE m.sigma (litF lo) (litF hi)), m.omega)
   | _, _ => m.poleE
+
+/-- Clamp every LIVE σ with a declared interval to that interval, in-kernel —
+    the UNIFORM-BANK extension of `clampedPoleE`, applied to unit modes at
+    graph ingestion (`lowerModal`'s source/reverb arms). Two things it buys:
+    (1) CONSISTENCY under knob overdrive — the collected modes and the paired
+    atoms of one bank saturate TOGETHER when the host drives a knob out of its
+    declared span, instead of the paired lanes clamping while the collected
+    lanes follow the raw knob (an internally inconsistent bank); (2) COLD
+    soundness — `couplingHot` decides cold at min |Δ| over the DECLARED
+    interval, so an unclamped out-of-span drive could dip a cold coupling's
+    |Δ| under θ_acc while it stays collected; the clamp makes the declared
+    interval the enforced one. `sigmaRange` is kept on the mode (the
+    classifiers still read it); the wrap is value-identity for any in-span
+    drive, so in-range behavior is bit-identical. Const σ passes untouched
+    (the cold byte-identity discipline). -/
+def clampSigmas (ms : Array ModalMode) : Array ModalMode :=
+  ms.map fun m =>
+    match sigConstF? m.sigma, m.sigmaRange with
+    | none, some (lo, hi) => { m with sigma := clampE m.sigma (litF lo) (litF hi) }
+    | _, _ => m
 
 /-- Where a (v, r) coupling lands — the routing verdict with the paired range
     cap made a FIRST-CLASS outcome rather than a silent fallback, so the seam

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -659,7 +659,15 @@ def residueComposeDD (voice reverb : Array ModalMode) : Array PairedMode :=
     mis-rendered beat keeps it decades over the gate floor up to ~0.05 rad/s.
     The paired body's series branch carries RAW Δ and holds ~2.4e-6 throughout.
     Frozen at the advantage crossing 4.6e-2 × 10 (generous toward DD — DD is
-    accurate everywhere, so θ is a COST boundary, not a correctness boundary). -/
+    accurate everywhere, so θ is a COST boundary, not a correctness boundary).
+
+    RATE PROVENANCE (the constant is a function of the datapath, not physics):
+    frozen AT SR = 44100 with the 2³² rotator — the grid quantum `2π·SR/2³²`
+    is LINEAR in SR and the advantage crossing tracks it, so the 44.1k–96k
+    family moves the crossing by ≤ ~2.2×, well inside the ×10 margin. If the
+    rotator width or the served rate family ever changes, re-freeze off the
+    cockpit's D_p1c sweep (`demos/ecdd_partition.py`) rather than trusting
+    the margin. -/
 def ecddThetaAcc : Float := 0.4642
 
 /-- The range lens: route when the collected ringing weight `|a·r|/|Δ|` exceeds
@@ -1417,6 +1425,15 @@ def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
   | .excludedDepth => false
   | _ => true
 
+/-- The two regions the LIVE classifier can emit — a two-constructor sum, so
+    `bloomCompose`'s match is exhaustive BY TYPE rather than by an
+    "unreachable" comment (the coincident regions and the depth exclusion are
+    not representable here: they return `none` and stay baked-only). The
+    baked classifier keeps the full five-region `SeamRegion`. -/
+inductive LiveRegion where
+  | serOnly
+  | crossing
+
 /-- WS-LP: classify a live-σ pair over its whole σ interval — `some (region,
     nDepth, kDepth)` iff the pair sits in ONE non-coincident region at EVERY
     σ ∈ `[sigLo, sigHi]` (`serOnly` throughout, phase 1, or `crossing`
@@ -1431,7 +1448,7 @@ def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
     `zBnd` per region (κ itself for serOnly; the branch-boundary `|z| = |a+1|`
     for crossing), same `+8` guard and `≤ 300` cap. -/
 def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
-    (B g : Float) : Option (SeamRegion × Nat × Nat) := Id.run do
+    (B g : Float) : Option (LiveRegion × Nat × Nat) := Id.run do
   let kappa := mu.scale B
   let imA := (nuOmega - mu.im) / g
   -- Re a = (−σ_ν − Re μ)/g, decreasing in σ_ν
@@ -1565,7 +1582,6 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
               k1Ser := csubE (bloomGammaStarE aE kE (litF g)) cfOverG
               k1Cf := cnegE cfOverG, fSer := cnegE invNuMuE
               dSwitch, invA, cfB, cfN }
-          | _ => continue   -- unreachable: the live classifier only emits serOnly/crossing
       | some rSig =>
         let nu : CplxB := ⟨-rSig, rOm⟩
         -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -1264,18 +1264,28 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
     let nRaw := samples.foldl (fun m re => max m (bloomM1 ⟨re, imA⟩ kappa).2) 0
     if nRaw + 8 > 300 then return none
     return some (.serOnly, nRaw + 8, 0)
-  if max (absAt reLo 1.0) (absAt reHi 1.0) < kappa.abs then
-    -- crossing throughout: |a+1| never reaches |κ| (max at an endpoint)
-    let mut nRaw := 0
-    let mut kRaw := 0
-    for re in samples do
-      let aC : CplxB := ⟨re, imA⟩
-      let zBnd := kappa.scale ((aC.add ⟨1, 0⟩).abs / kappa.abs)
-      nRaw := max nRaw (bloomM1 aC zBnd).2
-      kRaw := max kRaw (bloomCF aC zBnd).2
-    if nRaw + 8 > 300 || kRaw + 8 > 300 then return none
-    return some (.crossing, nRaw + 8, kRaw + 8)
-  return none
+  -- |a+1| dips below |κ| somewhere: crossing-throughout OR straddling (phase 3a
+  -- — the union COLLAPSES onto the crossing lanes: on a serOnly-side config
+  -- `dSwitch < 0`, the per-sample select sits on the series lane from d = 0,
+  -- and the bridge identity makes its `Γ★ − CF(κ)/g` constant EQUAL serOnly's
+  -- `mK/(ν−μ)`; f64-accurate over the whole interval because a straddling pair
+  -- has `|Im a| < |κ|` by construction, which keeps the CF at z = κ inside its
+  -- convergence territory — probed at ≤ 7.5e-13 vs mpmath incl. the |Im a| ≈
+  -- |κ| edge (`demos/wslp_union_probe.py`; the DEEP-serOnly regime |Im a| ≫
+  -- |κ| fails at rel ~50 there, which is why serOnly-throughout keeps its own
+  -- arm). Only the depth sizing differs: a straddling pair's series lane runs
+  -- from d = 0 on its serOnly side (|z| up to |κ|), so size at z = κ;
+  -- crossing-throughout keeps the branch-boundary `zBnd` (phase 2, unchanged).
+  let straddles := max (absAt reLo 1.0) (absAt reHi 1.0) ≥ kappa.abs
+  let mut nRaw := 0
+  let mut kRaw := 0
+  for re in samples do
+    let aC : CplxB := ⟨re, imA⟩
+    let zBnd := kappa.scale ((aC.add ⟨1, 0⟩).abs / kappa.abs)
+    nRaw := max nRaw (bloomM1 aC (if straddles then kappa else zBnd)).2
+    kRaw := max kRaw (bloomCF aC zBnd).2
+  if nRaw + 8 > 300 || kRaw + 8 > 300 then return none
+  return some (.crossing, nRaw + 8, kRaw + 8)
 
 /-- `bloomedVoice ⋙ reverb` as Γ-bridge pairs — the residue composition ACROSS a
     pitch-bloom warp (`B = β·scale/g` seconds of total clock advance, `g` the

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -644,6 +644,95 @@ def residueComposeDD (voice reverb : Array ModalMode) : Array PairedMode :=
   voice.flatMap fun v => reverb.map fun r =>
     { lam := v.poleE, nu := r.poleE, c := cmulE v.ampE r.ampE }
 
+-- ── The EC/DD PARTITIONED compose (fork 3′ erasure, Phase 1) ──────────────────
+-- The compiler owns the EC-vs-DD choice PER COUPLING: a (λ, ν) pair routes to
+-- the fused paired atom when the collected `±c/Δ` representation would degrade,
+-- and stays collected otherwise. Everything decides at compile time on
+-- const-folded poles/amps; anything unmeasurable (live pole, live amp) stays
+-- collected in v1 — Phase 2 classifies live poles over their declared interval.
+
+/-- θ_acc — the accuracy lens (rad/s), frozen from `demos/ecdd_partition.py`
+    (2026-07-23). The measured mechanism is the FREQUENCY GRID, not float64
+    cancellation: rotator increments quantize ω at `2π·SR/2³² ≈ 6.5e-5 rad/s`,
+    so the collected form renders a grid-quantized Δ — below one quantum the two
+    increments coincide and the `±c/Δ` residues cancel to exact silence, and the
+    mis-rendered beat keeps it decades over the gate floor up to ~0.05 rad/s.
+    The paired body's series branch carries RAW Δ and holds ~2.4e-6 throughout.
+    Frozen at the advantage crossing 4.6e-2 × 10 (generous toward DD — DD is
+    accurate everywhere, so θ is a COST boundary, not a correctness boundary). -/
+def ecddThetaAcc : Float := 0.4642
+
+/-- The range lens: route when the collected ringing weight `|a·r|/|Δ|` exceeds
+    the Q4.28 magnitude ceiling 8 with a 2× margin. Amp-dependent — `|Δ|` alone
+    is not the criterion (cockpit D_p2: binding for `|a·r| ≳ 1.9`). -/
+def ecddRailCeil : Float := 4.0
+
+/-- The paired atom's own build-time range cap: per pair, `|Wc| ≤ |c|·sup_d
+    |e^{νd}·d·cexpm1(Δd)| ≤ |c|·min(2/|Δ|, 1/(e·σ_min))` (the sup the
+    remainder-handoff deferred until the DD wiring landed — this is that
+    landing). A coupling whose bound exceeds the cap is NOT routed (stays
+    collected — reject, the status-quo floor; the scale arm can come later if a
+    real patch ever trips this). Cap 8 = the plain Q4.28 ceiling, 4× under the
+    DD site's i64 rail of 32. -/
+def ecddPairCap : Float := 8.0
+
+/-- The per-coupling routing predicate — compile-time only. `true` ⇒ the (v, r)
+    coupling leaves the collected sums and becomes one `PairedMode`. Requires
+    BOTH poles and BOTH amps to const-fold (a live anything stays collected in
+    v1) and both modes deg-0, then fires on either lens (accuracy | range),
+    gated by the paired range cap. -/
+def couplingHot (v r : ModalMode) : Bool :=
+  v.deg == 0 && r.deg == 0 &&
+  (Id.run do
+    let some sv := sigConstF? v.sigma | return false
+    let some wv := sigConstF? v.omega | return false
+    let some sr := sigConstF? r.sigma | return false
+    let some wr := sigConstF? r.omega | return false
+    let some ar := sigConstF? v.cre | return false
+    let some ai := sigConstF? v.cim | return false
+    let some rr := sigConstF? r.cre | return false
+    let some ri := sigConstF? r.cim | return false
+    let dAbs := Float.sqrt ((sv - sr) * (sv - sr) + (wv - wr) * (wv - wr))
+    let cAbs := Float.sqrt (ar * ar + ai * ai) * Float.sqrt (rr * rr + ri * ri)
+    let hot := dAbs < ecddThetaAcc || (dAbs > 0.0 && cAbs / dAbs > ecddRailCeil)
+    -- the paired range cap: sup of the divided-difference kernel, both bounds
+    let smin := if sv < sr then sv else sr
+    let sup1 := if dAbs > 0.0 then 2.0 / dAbs else 1e308
+    let sup2 := if smin > 0.0 then 1.0 / (2.718281828459045 * smin) else 1e308
+    let sup := if sup1 < sup2 then sup1 else sup2
+    return hot && cAbs * sup < ecddPairCap)
+
+/-- The PARTITIONED compose — the one `residueCompose` seam. Cold couplings take
+    `residueComposeEC`'s collected shapes; hot couplings (per `couplingHot`)
+    leave the Cauchy sums (BOTH halves — the forced amp's `r/(λ−ν)` term and the
+    ringing amp's `a/(λ−ν)` term migrate together; the split is EXACT residue
+    algebra, not an approximation) and land as fused `PairedMode` atoms.
+    When NOTHING is hot the result is `residueComposeEC` VERBATIM (the same
+    call), so the cold path is byte-identical to the pre-partition compiler —
+    the erasure gate's discipline. -/
+def residueComposePartitioned (voice reverb : Array ModalMode) :
+    Array ModalMode × Array PairedMode := Id.run do
+  if voice.isEmpty then return (#[], #[])
+  let hotM := voice.map fun v => reverb.map fun r => couplingHot v r
+  if hotM.all (·.all (!·)) then return (residueComposeEC voice reverb, #[])
+  let isHot := fun (i q : Nat) => (hotM[i]!)[q]!
+  let forced := voice.mapIdx fun i v =>
+    let Hlam := reverb.zipIdx.foldl (init := ((lit 0, lit 0) : CplxE)) fun s (r, q) =>
+      if isHot i q then s
+      else caddE s (cdivE r.ampE (csubE v.poleE r.poleE))
+    modeOfE v.poleE (cmulE v.ampE Hlam)
+  let ringing := reverb.mapIdx fun q r =>
+    let coupling := voice.zipIdx.foldl (init := ((lit 0, lit 0) : CplxE)) fun s (v, i) =>
+      if isHot i q then s
+      else caddE s (cdivE v.ampE (csubE v.poleE r.poleE))
+    modeOfE r.poleE (cnegE (cmulE r.ampE coupling))
+  let mut paired : Array PairedMode := #[]
+  for (v, i) in voice.zipIdx do
+    for (r, q) in reverb.zipIdx do
+      if isHot i q then
+        paired := paired.push { lam := v.poleE, nu := r.poleE, c := cmulE v.ampE r.ampE }
+  return (forced ++ ringing, paired)
+
 /-- Multiply a `CplxE` by a real `Sig`. -/
 def scaleRealE (s : Sig) (z : CplxE) : CplxE := (mul s z.1, mul s z.2)
 
@@ -714,12 +803,13 @@ def bankFoldPaired (cols : PairedBankCols) (body : PairedModeSym → Sig) : Sig 
     `|Wc|·2²⁸·2³⁰ < 2⁶³` ⇒ **per mode `|Wc| < 32`**. This is a FACTOR site: `Wc`
     carries the per-sample `d·cexpm1(Δd)` secular, which is UNBOUNDED by a
     coefficient-time `max|A|` (it needs the bake-time sup `min(2/|Δ|, 1/(e·σ_min))`),
-    so the plain `bankLandExp` does NOT reach it. **Reachable max**: not bounded by
-    admission (a pole-DISTANCE test). **DEFERRED, not fixed** (remainder-handoff §1):
-    this is a fixture-only site — no Playground surface routes through
-    `modalBankSigTableDD` (the DD dispatch is never wired into `lowerModal`), so it
-    lands nothing in production. Option E covers it when the DD wiring lands, with
-    its own measured sup and witness, per the role-split rule. `envDf`
+    so the plain `bankLandExp` does NOT reach it. **Reachable max**: bounded at the
+    ROUTING site, not here — the EC/DD partition (`couplingHot`) admits a coupling
+    to this body only when the build-time sup `|c|·min(2/|Δ|, 1/(e·σ_min)) <
+    ecddPairCap = 8` clears (4× under this rail; a coupling over the cap stays
+    collected — reject, per the remainder-handoff's deferred item, now landed).
+    Direct callers outside the partition (fixtures, the seam sweep) own their own
+    amp discipline. `envDf`
     and `e^z` stay float (never landed); `z`'s imaginary part uses raw `ω_d·dSec`
     (the divisor needs only relative precision; the rotator phase is integer-reduced,
     consistent because `e^z` is periodic). -/
@@ -1834,6 +1924,25 @@ def modalBankTerm (modes : Array ModalMode) (anchor : Sig) (c : Clock)
     then fun ms clk a => modalBankSigTable ms clk a count?
     else fun ms clk a => modalBankSig ms clk a
   ArrowTerm.arrUn (fun clkSig => lower modes clkSig anchor) (ArrowTerm.clk c)
+
+/-- The PARTITIONED bank: the collected component through `modalBankTerm`'s
+    exact lowering plus the paired component (`modalBankSigTableDD`) summed at
+    the SAME clock leaf — one `arrUn`, so warps/scrub reach both bodies through
+    the shared clock identically. `paired = #[]` falls through to
+    `modalBankTerm` VERBATIM (the byte-identity discipline: a cold partition
+    emits today's term). The two bank regions are sequential siblings, so the
+    `idxId 0` reuse is safe (the `modalBankSigPairTable` precedent). -/
+def modalBankTermPartitioned (plain : Array ModalMode) (paired : Array PairedMode)
+    (anchor : Sig) (c : Clock) (count? : Option Sig := none) : ArrowTerm :=
+  if paired.isEmpty then modalBankTerm plain anchor c count? else
+  let banked := bankIsUniform plain && (count?.isSome || banksTableEnabled)
+  let lowerP := if banked
+    then fun ms clk a => modalBankSigTable ms clk a count?
+    else fun ms clk a => modalBankSig ms clk a
+  ArrowTerm.arrUn
+    (fun clkSig => add (lowerP plain clkSig anchor)
+                       (modalBankSigTableDD paired clkSig anchor))
+    (ArrowTerm.clk c)
 
 -- ── The DIRECTION operator: forward↔reverse crossfade ─────────────────────────
 -- A bank's reading DIRECTION crossfades between the CAUSAL tail (energy at d>0, a

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -817,6 +817,21 @@ def cOneE : CplxE := (lit 1, lit 0)
 def bloomM1E (invA : Array CplxE) (z : CplxE) : CplxE :=
   invA.foldr (fun ik h => caddE cOneE (cmulE (cmulE z ik) h)) cOneE
 
+/-- The fixed-depth bottom-up continued fraction `CF(z) = Γ(a,z)eᶻz^{−a}` over
+    the emitted constants `cfB` (b-terms, `z` added per level) and `cfN`
+    (numerators) — THE CF lane's expression, shared verbatim by the per-sample
+    lane in `bloomComposedSig` (z live) and the live-pole lift's `CF(κ)`
+    constant in `bloomCompose` (z = κ, s0), so the constant is computed by the
+    SAME arithmetic the lane renders with (WS-LP phase 2, `bloomM1E`'s twin).
+    Requires `cfB.size = cfN.size + 1`. -/
+def bloomCFE (cfB cfN : Array CplxE) (z : CplxE) : CplxE := Id.run do
+  let kk := cfN.size
+  let mut h : CplxE := caddE z cfB[kk]!
+  for jr in [0:kk] do
+    let j := kk - 1 - jr
+    h := csubE (caddE z cfB[j]!) (cdivE cfN[j]! h)
+  return cdivE cOneE h
+
 /-- Is this `Sig` a pure s0 value — a function of knob slots and constants only
     (no `τ`/tick, no input, no bank machinery)? The live-pole lift's admission
     check: the lifted pair constants are correct (and Stage0-hoistable) only if
@@ -1218,34 +1233,49 @@ def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
   | .excludedDepth => false
   | _ => true
 
-/-- WS-LP Phase 1: classify a live-σ pair over its whole σ interval — `some
-    nDepth` iff the pair is `serOnly` at EVERY σ ∈ `[sigLo, sigHi]`, else `none`
-    (the pair drops gracefully; region-crossing pairs are Phase 3's union emit).
-    Only `Re a = (σ_μ − σ_ν)/g` moves with σ_ν (`Im a` and `κ = μ·B` are
-    σ_ν-independent), so the two region conditions reduce to interval minima of
-    `|a + c|` along a horizontal segment — attained at `Re a = −c` clamped to the
-    segment. The depth is sized at the interval's worst case: `bloomM1`'s
-    convergence slows as `|a+1|` falls toward `|κ|`, so sample both endpoints
-    and the closest approach to `−1`; same `+8` guard and `≤ 300` cap as the
-    baked classifier. -/
-def classifyBloomPairLiveSer (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
-    (B g : Float) : Option Nat := Id.run do
+/-- WS-LP: classify a live-σ pair over its whole σ interval — `some (region,
+    nDepth, kDepth)` iff the pair sits in ONE non-coincident region at EVERY
+    σ ∈ `[sigLo, sigHi]` (`serOnly` throughout, phase 1, or `crossing`
+    throughout, phase 2), else `none` (the pair drops gracefully; a pair that
+    CHANGES region across the interval is phase 3's union emit, and the
+    coincident regions are with it). Only `Re a = (σ_μ − σ_ν)/g` moves with σ_ν
+    (`Im a` and `κ = μ·B` are σ_ν-independent), so the region conditions reduce
+    to interval extrema of `|a + c|` along a horizontal segment — the min at
+    `Re a = −c` clamped to the segment, the max at an endpoint (convexity).
+    Depths are sized at the interval's worst case (both endpoints + the closest
+    approach to `−1`, where `|a+1|` bottoms out), with the baked classifier's
+    `zBnd` per region (κ itself for serOnly; the branch-boundary `|z| = |a+1|`
+    for crossing), same `+8` guard and `≤ 300` cap. -/
+def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
+    (B g : Float) : Option (SeamRegion × Nat × Nat) := Id.run do
   let kappa := mu.scale B
   let imA := (nuOmega - mu.im) / g
   -- Re a = (−σ_ν − Re μ)/g, decreasing in σ_ν
   let reLo := (-sigHi - mu.re) / g
   let reHi := (-sigLo - mu.re) / g
+  let absAt := fun (re c : Float) => Float.sqrt ((re + c) * (re + c) + imA * imA)
   let minAbsAt := fun (c : Float) =>
-    let t := max reLo (min reHi (-c))
-    Float.sqrt ((t + c) * (t + c) + imA * imA)
-  -- ¬coincident throughout (min |a| ≥ ½) ∧ serOnly throughout (min |a+1| ≥ |κ|)
+    absAt (max reLo (min reHi (-c))) c
+  -- ¬coincident throughout: min |a| ≥ ½ (the τ·e coincidence stays baked-only)
   if minAbsAt 0.0 < 0.5 then return none
-  if minAbsAt 1.0 < kappa.abs then return none
-  let depthAt := fun (re : Float) => (bloomM1 ⟨re, imA⟩ kappa).2
-  let tStar := max reLo (min reHi (-1.0))
-  let nRaw := max (depthAt reLo) (max (depthAt reHi) (depthAt tStar))
-  if nRaw + 8 > 300 then return none
-  return some (nRaw + 8)
+  let samples := #[reLo, reHi, max reLo (min reHi (-1.0))]
+  if minAbsAt 1.0 ≥ kappa.abs then
+    -- serOnly throughout: |a+1| never falls below |κ|
+    let nRaw := samples.foldl (fun m re => max m (bloomM1 ⟨re, imA⟩ kappa).2) 0
+    if nRaw + 8 > 300 then return none
+    return some (.serOnly, nRaw + 8, 0)
+  if max (absAt reLo 1.0) (absAt reHi 1.0) < kappa.abs then
+    -- crossing throughout: |a+1| never reaches |κ| (max at an endpoint)
+    let mut nRaw := 0
+    let mut kRaw := 0
+    for re in samples do
+      let aC : CplxB := ⟨re, imA⟩
+      let zBnd := kappa.scale ((aC.add ⟨1, 0⟩).abs / kappa.abs)
+      nRaw := max nRaw (bloomM1 aC zBnd).2
+      kRaw := max kRaw (bloomCF aC zBnd).2
+    if nRaw + 8 > 300 || kRaw + 8 > 300 then return none
+    return some (.crossing, nRaw + 8, kRaw + 8)
+  return none
 
 /-- `bloomedVoice ⋙ reverb` as Γ-bridge pairs — the residue composition ACROSS a
     pitch-bloom warp (`B = β·scale/g` seconds of total clock advance, `g` the
@@ -1292,9 +1322,9 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
         -- pre-WS-LP baked-pole fallback (`none` ⇒ the caller's bare bloom).
         let some (sLo, sHi) := r.sigmaRange | return none
         if !(sigIsS0 r.sigma) then return none
-        match classifyBloomPairLiveSer mu rOm sLo sHi B g with
-        | none => continue   -- not serOnly over the whole interval: graceful per-pair drop (Phase 3 widens)
-        | some nDepth =>
+        match classifyBloomPairLive mu rOm sLo sHi B g with
+        | none => continue   -- coincident / region-changing over the interval: graceful per-pair drop (Phase 3 widens)
+        | some (region, nDepth, kDepth) =>
           -- the lift: every baked constant re-expressed as an s0 `CplxE` of the
           -- live pole. The clamp ENFORCES the classified interval in-kernel, so
           -- an out-of-range slot write saturates the crossing's σ instead of
@@ -1306,14 +1336,42 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
           let invNuMuE := cdivE cOneE dNuMu
           let invA := (Array.range nDepth).map (fun k =>
             cdivE cOneE (caddE aE (litF (k + 1).toFloat, lit 0)))
-          let kE := cplxLitE (mu.scale B)
-          out := out.push {
-            muSigma := litF vSig, muOmega := litF vOm
-            nuSigma := sigC, nuOmega := litF rOm
-            bloomB := B, gRate := g, c, kappa := kE
-            k1Ser := cmulE (bloomM1E invA kE) invNuMuE
-            k1Cf := (lit 0, lit 0), fSer := cnegE invNuMuE
-            dSwitch := lit 0, invA, cfB := #[], cfN := #[] }
+          let kappaB := mu.scale B
+          let kE := cplxLitE kappaB
+          match region with
+          | .serOnly =>
+            out := out.push {
+              muSigma := litF vSig, muOmega := litF vOm
+              nuSigma := sigC, nuOmega := litF rOm
+              bloomB := B, gRate := g, c, kappa := kE
+              k1Ser := cmulE (bloomM1E invA kE) invNuMuE
+              k1Cf := (lit 0, lit 0), fSer := cnegE invNuMuE
+              dSwitch := lit 0, invA, cfB := #[], cfN := #[] }
+          | .crossing =>
+            -- WS-LP phase 2: the CF lane's constants as s0 `CplxE` of the live
+            -- pole — `cfB`/`cfN` linear in `a`, `CF(κ)` by the SAME emitted
+            -- fraction the lane renders with (`bloomCFE` at z = κ), the bridge
+            -- constant by the emitted `Γ★` (`bloomGammaStarE`, phase 0), and
+            -- `dSwitch = (ln|κ| − ½·ln|a+1|²)/g` via `logSig` (the `clogE`
+            -- modulus form — no sqrt in the vocabulary needed).
+            let cfB := (Array.range (kDepth + 1)).map (fun j =>
+              ((sub (litF (2 * j + 1).toFloat) aE.1, neg aE.2) : CplxE))
+            let cfN := (Array.range kDepth).map (fun j =>
+              let jf := cplxLitE ⟨(j + 1).toFloat, 0⟩
+              cmulE jf (csubE jf aE))
+            let cfK := bloomCFE cfB cfN kE
+            let cfOverG : CplxE := (div cfK.1 (litF g), div cfK.2 (litF g))
+            let aP1 := caddE aE cOneE
+            let dSwitch := div (sub (litF (Float.log kappaB.abs))
+              (mul (lit 5 1) (logSig (add (mul aP1.1 aP1.1) (mul aP1.2 aP1.2))))) (litF g)
+            out := out.push {
+              muSigma := litF vSig, muOmega := litF vOm
+              nuSigma := sigC, nuOmega := litF rOm
+              bloomB := B, gRate := g, c, kappa := kE
+              k1Ser := csubE (bloomGammaStarE aE kE (litF g)) cfOverG
+              k1Cf := cnegE cfOverG, fSer := cnegE invNuMuE
+              dSwitch, invA, cfB, cfN }
+          | _ => continue   -- unreachable: the live classifier only emits serOnly/crossing
       | some rSig =>
         let nu : CplxB := ⟨-rSig, rOm⟩
         -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope
@@ -1466,15 +1524,10 @@ def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Si
   let land := fun (env : Sig) (w : CplxE) (ph : Sig) =>
     rshift (sub (mul (toIntE (mul (mul env w.1) (lit 268435456))) (fixedCosCycSig ph))
                 (mul (toIntE (mul (mul env w.2) (lit 268435456))) (fixedSinCycSig ph))) (lit 28)
-  -- the per-sample continued fraction `CF(z) = Γ(a,z)eᶻz^{−a}` (bottom-up, fixed
-  -- depth), shared by the crossing and coincident branches (both large-z sides).
-  let cfEnv := fun (p : BloomPair) (z : CplxE) => Id.run do
-    let kk := p.cfN.size
-    let mut h : CplxE := caddE z p.cfB[kk]!
-    for jr in [0:kk] do
-      let j := kk - 1 - jr
-      h := csubE (caddE z p.cfB[j]!) (cdivE p.cfN[j]! h)
-    return cdivE one h
+  -- the per-sample continued fraction `CF(z) = Γ(a,z)eᶻz^{−a}` (`bloomCFE`,
+  -- shared with the live-pole lift's CF(κ) constant), used by the crossing and
+  -- coincident branches (both large-z sides).
+  let cfEnv := fun (p : BloomPair) (z : CplxE) => bloomCFE p.cfB p.cfN z
   let bankQ := pairs.foldl (fun acc p =>
     let eg := expSig (neg (mul (litF p.gRate) dPos))
     let z : CplxE := (mul p.kappa.1 eg, mul p.kappa.2 eg)

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -257,7 +257,18 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     -- gauge is a COLLECTED surface in v1: it needs the composed bank to
     -- self-measure, so it forces the fold here (today's exact expressions) —
     -- and its output amps carry the norm's expSig, so downstream couplings
-    -- are unmeasurable and stay collected (status quo, documented).
+    -- are unmeasurable and stay collected (status quo, documented). The fold
+    -- is SAFE against hot chains even though the collected amps carry the
+    -- huge cancelling ±c/Δ pair: the norm reads the transfer function H,
+    -- which has NO 1/Δ pole (the partial fractions recombine into the
+    -- bounded product form), so the f64 cancellation is benign — measured,
+    -- not assumed (the ecdd-gauge gate mirrors the norm independently and
+    -- pins gauged ≡ scale × collected). The residual under a gauge is the
+    -- hot pair rendering at the collected floor — which at sub-grid detune
+    -- means the pair is silent AND its ±c/Δ amps size the bank's landing
+    -- exponent, quantizing the cold modes coarsely (the LANDING POISON, the
+    -- gate's own finding) — the stated status quo of every collected
+    -- surface, one more reason the routed path is the served one.
     | .plain v rooms =>
       .ok (.plain (normalizePeak gExpr (foldRoomsEC v rooms)) #[], a, clk, addr, dirIn, count)
     | .bloomed voice acc B gr =>

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -152,19 +152,60 @@ def nodeIsModal (g : PatchGraph) (id : String) : Bool :=
     | .modalGauge .. => true
     | _ => false
 
-/-- The lowered modal value: a PLAIN composed bank (realized directly at the
-    boundary) or a BLOOMED source kept modal — its voice modes and the FOLDED
-    room chain held SEPARATE, so the pitch bloom is crossed ONCE (`bloomCompose`)
-    at realization, AFTER the rooms fold. The rooms fold by `residueComposeEC`
-    reinterpreted as filter∘filter (the two-hats reading: a bank is both a struck
-    source `Σaᵢe^{λᵢd}` and a transfer function `Σaᵢ/(s−λᵢ)`, same data), so
-    gong⋙reverb⋙reverb crosses each nonlinearity exactly once. This is the
-    reassociated lowering order: right-fold the modal tail, cross the bloom
-    last — attaching the crossing per-inlet would force the bloom at the first
-    room and hand the second a bare `Sig`. -/
+/-- The lowered modal value: a PLAIN source with its room chain DEFERRED
+    (accumulated, folded at realization — the EC/DD partition site) or a
+    BLOOMED source kept modal — its voice modes and the FOLDED room chain held
+    SEPARATE, so the pitch bloom is crossed ONCE (`bloomCompose`) at
+    realization, AFTER the rooms fold. Rooms fold by the residue calculus
+    reinterpreted as filter∘filter (the two-hats reading: a bank is both a
+    struck source `Σaᵢe^{λᵢd}` and a transfer function `Σaᵢ/(s−λᵢ)`, same
+    data), so gong⋙reverb⋙reverb crosses each nonlinearity exactly once.
+
+    Why the plain arm defers (fork 3′): rooms COMMUTE (filter∘filter, the
+    bit-exact registered EC-commute law), so the fold order is free — and the
+    partition wants hot rooms (couplings near coincidence, `couplingHot`) to
+    fold LAST, where their couplings become `PairedMode` atoms that never need
+    to re-compose. A cold chain folds in arrival order through
+    `residueComposeEC` — byte-identical to the eager fold this replaced. -/
 inductive ModalBank where
-  | plain (modes : Array ModalMode)
+  | plain (voice : Array ModalMode) (rooms : Array (Array ModalMode))
   | bloomed (voice room : Array ModalMode) (bloomB gRate : Float)
+
+/-- The COLLECTED chain fold, arrival order — today's exact expressions (the
+    byte-identity comparator, and the fallback for the surfaces that need a
+    plain `Array ModalMode`: gauge, mix, direction). -/
+def foldRoomsEC (voice : Array ModalMode) (rooms : Array (Array ModalMode)) :
+    Array ModalMode :=
+  rooms.foldl residueComposeEC voice
+
+/-- The PARTITIONED chain fold: cold rooms fold first in arrival order
+    (collected, verbatim), rooms carrying a hot coupling fold LAST, and only
+    the final fold partitions — so `PairedMode`s form once and never
+    re-compose. The hot-room test is a sort HEURISTIC on source-unit
+    poles/amps (the partition itself re-decides per coupling, on the composed
+    amps, inside `residueComposePartitioned`); a multi-hot residual (a hot
+    coupling forming before the final fold — a deliberate triple/multi-unison)
+    stays collected at the status-quo floor, served gracefully, not silently
+    wrong. When no room is hot this is `foldRoomsEC` VERBATIM. -/
+def foldRoomsPartitioned (voice : Array ModalMode)
+    (rooms : Array (Array ModalMode)) :
+    Array ModalMode × Array PairedMode :=
+  if rooms.isEmpty then (voice, #[]) else
+  let units := #[voice] ++ rooms
+  let roomHot := fun (j : Nat) (room : Array ModalMode) =>
+    room.any fun q => units.zipIdx.any fun (u, i) =>
+      i != j + 1 && u.any fun p => couplingHot p q || couplingHot q p
+  if (rooms.zipIdx.all fun (r, j) => !roomHot j r) then
+    (foldRoomsEC voice rooms, #[])
+  else
+    let cold := rooms.zipIdx.filterMap fun (r, j) =>
+      if roomHot j r then none else some r
+    let hot := rooms.zipIdx.filterMap fun (r, j) =>
+      if roomHot j r then some r else none
+    let ordered := cold ++ hot
+    let front := ordered.pop
+    let last := ordered.back!
+    residueComposePartitioned (foldRoomsEC voice front) last
 
 /-- Lower a modal-island subgraph to its `ModalBank` + strike anchor + the master
     clock it realizes against. Pure pole algebra at BUILD time: a reverb is the
@@ -178,13 +219,13 @@ partial def lowerModal (g : PatchGraph) (id : String) :
   -- source is a legal, incomplete patch — it compiles to an EMPTY bank (silence),
   -- not an error. (The graceful-silence contract, same as `mix []`.)
   if id == "__silence__" then
-    return (.plain #[], lit 0, clockLit, none, none, none)
+    return (.plain #[] #[], lit 0, clockLit, none, none, none)
   let some pn := g.nodes.find? (·.id == id)
     | .error s!"lowerModal: node '{id}' not found"
   match pn.node with
   | .modalSource ms a clk addr count bloom? =>
     match bloom? with
-    | none => .ok (.plain ms, a, clk, addr, none, count)
+    | none => .ok (.plain ms #[], a, clk, addr, none, count)
     -- a bloomed source starts modal with an EMPTY room; reverbs fold in downstream
     | some (B, gr) => .ok (.bloomed ms #[] B gr, a, clk, addr, none, count)
   | .modalReverb inId room dir => do
@@ -193,11 +234,12 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     -- longer a prefix of the source's) — realize at full capacity (graceful-
     -- silent through a reverb; v1, no warning, legal state).
     match bank with
-    | .plain v =>
-      -- source ⋙ filter: the COLLECTED residue calculus (`m + n` modes) — the
-      -- voice colored by the room (`a·H_room(λ)`) plus the room colored by the
-      -- voice. Amps stay symbolic, so live source knobs survive the room.
-      .ok (.plain (residueComposeEC v room), a, clk, addr, dir.orElse (fun _ => dirIn), none)
+    | .plain v rooms =>
+      -- source ⋙ filter: ACCUMULATE the room; the fold (and the EC/DD
+      -- partition) happens once, at realization — where the whole chain is
+      -- visible and hot rooms can sort last. Amps stay symbolic, so live
+      -- source knobs survive the room.
+      .ok (.plain v (rooms.push room), a, clk, addr, dir.orElse (fun _ => dirIn), none)
     | .bloomed voice acc B gr =>
       -- filter ∘ filter: FOLD this room into the accumulated room chain (voice
       -- stays separate, bloom uncrossed). An empty accumulator is the fold
@@ -212,7 +254,12 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     -- `normalizePeak`. A bloomed source gauges its VOICE modes; the folded room and
     -- the uncrossed bloom are untouched.
     match bank with
-    | .plain v => .ok (.plain (normalizePeak gExpr v), a, clk, addr, dirIn, count)
+    -- gauge is a COLLECTED surface in v1: it needs the composed bank to
+    -- self-measure, so it forces the fold here (today's exact expressions) —
+    -- and its output amps carry the norm's expSig, so downstream couplings
+    -- are unmeasurable and stay collected (status quo, documented).
+    | .plain v rooms =>
+      .ok (.plain (normalizePeak gExpr (foldRoomsEC v rooms)) #[], a, clk, addr, dirIn, count)
     | .bloomed voice acc B gr =>
       .ok (.bloomed (normalizePeak gExpr voice) acc B gr, a, clk, addr, dirIn, count)
   | .modalMix inputs => do
@@ -223,12 +270,16 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     | (bank0, a0, clk0, addr0, dir0, _count0) :: rest =>
       -- pole union is defined on PLAIN banks; a bloomed source carries a warp
       -- the union can't merge (v1) — reverb it before mixing.
+      -- mix is a COLLECTED surface in v1: pole union needs plain mode arrays,
+      -- so a deferred chain folds here (today's exact expressions). A hot
+      -- coupling BELOW a mix stays collected (status quo, documented); one
+      -- formed by a reverb ABOVE the mix partitions normally.
       let modesOf : ModalBank → Except String (Array ModalMode) := fun b => match b with
-        | .plain ms => .ok ms
+        | .plain ms rooms => .ok (foldRoomsEC ms rooms)
         | .bloomed .. => .error s!"modalMix '{id}': a bloomed source has a pitch-bloom warp pole-union can't merge (v1) — cross it through a reverb before mixing"
       let ms0 ← modesOf bank0
       let union ← rest.foldlM (fun acc p => do let m ← modesOf p.1; pure (acc ++ m)) ms0
-      .ok (.plain union, a0, clk0, addr0, dir0, none)
+      .ok (.plain union #[], a0, clk0, addr0, dir0, none)
   | _ => .error s!"a modal inlet (reverb/modal-mix) needs a modal SOURCE — resonator or modal-mix — but '{id}' is a signal node; a Sig has no poles to compose"
 
 mutual
@@ -273,13 +324,20 @@ partial def lowerInput (g : PatchGraph) (id : String) : Except String ArrowTerm 
     let (bank, a, clk, addr?, dir?, count?) ← lowerModal g id
     -- realize the lowered bank at THIS edge (the one-directional Modal→Sig seam).
     let term ← match bank with
-      | .plain ms =>
+      | .plain ms rooms =>
         -- a DIRECTION rotates the poles and reads them through the per-mode
         -- `sign(σ·d)` gate (`modalBankTermDir`), else the plain forward causal
         -- bank. `count?` (trip-count-as-data) is the bank's live mode count.
+        -- The deferred room chain folds HERE, partitioned (`couplingHot` routes
+        -- near-coincident couplings to the paired DD body; a cold chain emits
+        -- today's collected term verbatim). Direction is a collected surface
+        -- in v1 (its pole-rotation machinery has no paired form) — a hot
+        -- coupling under a direction stays collected, status quo.
         .ok (match dir? with
-          | none => modalBankTerm ms a clk count?
-          | some d => modalBankTermDir ms a clk d.dir d.damp count?)
+          | none =>
+            let (plain, paired) := foldRoomsPartitioned ms rooms
+            modalBankTermPartitioned plain paired a clk count?
+          | some d => modalBankTermDir (foldRoomsEC ms rooms) a clk d.dir d.damp count?)
       | .bloomed voice room B gr =>
         -- the bare bloomed source: the bloom-warped bank (identical to a gong
         -- register's `warpFx`-around-`modalSource`). Also the graceful fallback

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -224,6 +224,11 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     | .error s!"lowerModal: node '{id}' not found"
   match pn.node with
   | .modalSource ms a clk addr count bloom? =>
+    -- unit modes enter the island CLAMPED to their declared σ intervals
+    -- (`clampSigmas` — the uniform-bank clamp; every downstream fold,
+    -- partition, gauge, and mix inherits it, so the whole bank saturates
+    -- together under knob overdrive). In-span drives are value-identical.
+    let ms := clampSigmas ms
     match bloom? with
     | none => .ok (.plain ms #[], a, clk, addr, none, count)
     -- a bloomed source starts modal with an EMPTY room; reverbs fold in downstream
@@ -233,6 +238,9 @@ partial def lowerModal (g : PatchGraph) (id : String) :
     -- The live count does NOT survive composition (the composed modes are no
     -- longer a prefix of the source's) — realize at full capacity (graceful-
     -- silent through a reverb; v1, no warning, legal state).
+    -- Room unit modes enter clamped (the uniform-bank σ clamp — see
+    -- `.modalSource`); in-span drives are value-identical.
+    let room := clampSigmas room
     match bank with
     | .plain v rooms =>
       -- source ⋙ filter: ACCUMULATE the room; the fold (and the EC/DD

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -181,12 +181,26 @@ def foldRoomsEC (voice : Array ModalMode) (rooms : Array (Array ModalMode)) :
 /-- The PARTITIONED chain fold: cold rooms fold first in arrival order
     (collected, verbatim), rooms carrying a hot coupling fold LAST, and only
     the final fold partitions — so `PairedMode`s form once and never
-    re-compose. The hot-room test is a sort HEURISTIC on source-unit
-    poles/amps (the partition itself re-decides per coupling, on the composed
-    amps, inside `residueComposePartitioned`); a multi-hot residual (a hot
-    coupling forming before the final fold — a deliberate triple/multi-unison)
-    stays collected at the status-quo floor, served gracefully, not silently
-    wrong. When no room is hot this is `foldRoomsEC` VERBATIM. -/
+    re-compose. When no room is hot this is `foldRoomsEC` VERBATIM.
+
+    THE DETECTION INVARIANT (stated precisely, not hedged): heat is decided
+    twice — the sort HEURISTIC here reads source-UNIT poles/amps; the
+    partition re-decides per coupling on the COMPOSED amps, but only at the
+    final fold. The two predicates cohere exactly this far:
+    · θ_acc (accuracy-lens) heat is a pole-distance test — amp-independent —
+      and composition never moves poles, so the sort CANNOT miss it; every
+      near-coincident coupling reaches the final fold and partitions.
+    · Rail-lens heat is amp-dependent, and composed ringing amps carry `1/Δ`
+      factors from earlier folds — so a coupling can be rail-cold on unit
+      amps yet rail-hot on composed amps. If it forms BEFORE the final fold
+      it folds collected, silently, at the status-quo floor. That is: **amp-
+      dependent heat is only detected at the final fold.** The exposure is
+      narrow today — the rail lens's routed service region is itself cap-
+      bounded to well-damped couplings (`ecddRailCeil` doc) — but it WIDENS
+      if the cap or lens is ever retuned; re-examine this invariant then.
+    A multi-hot residual (a hot coupling forming before the final fold — a
+    deliberate triple/multi-unison) likewise stays collected at the
+    status-quo floor, served gracefully, not silently wrong. -/
 def foldRoomsPartitioned (voice : Array ModalMode)
     (rooms : Array (Array ModalMode)) :
     Array ModalMode × Array PairedMode :=

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -1382,27 +1382,41 @@ def runEcddLive (arena : Arena)
   let oracleChainAt := fun (rv : Float) => oracleSeam voice
     (foldRoomsFloat room1 #[{ sigma := 6.91 / rv, omega := tp * 220, are := 0.7 }])
     idWarp admAll 8 nWin
+  -- (4) OVERDRIVE — the uniform-bank clamp (`clampSigmas` at graph ingestion):
+  -- a σ expression driven OUT of the declared span (rt60 = 0.1 through a
+  -- wide value clamp, so the raw σ evaluates to 69.1; the DECLARED span is
+  -- still [0.576, 34.55]) saturates in-kernel to the declared edge. The whole
+  -- bank — collected modes and the paired atom alike — must behave as
+  -- rt60 = 0.2: out-of-span drives can neither desync the two lane families
+  -- nor walk a cold-classified coupling's |Δ| under θ_acc.
+  let oobRoom : Array ModalMode :=
+    #[{ sigma := div (lit 691 2) (clampE (litF 0.1) (litF 0.05) (litF 30.0)),
+        omega := litF (tp * 220), cre := litF 0.7, cim := lit 0,
+        sigmaRange := span }]
   match ← renderGraphN arena "ecddlive_a" (graphOf #[tunedAt 2.0]) nWin,
         ← renderGraphN arena "ecddlive_b" (graphOf #[tunedAt 4.0]) nWin,
-        ← renderGraphN arena "ecddlive_chain" (graphOf #[r1M, tunedAt 2.0]) nWin with
-  | .ok dutA, .ok dutB, .ok dutC =>
+        ← renderGraphN arena "ecddlive_chain" (graphOf #[r1M, tunedAt 2.0]) nWin,
+        ← renderGraphN arena "ecddlive_oob" (graphOf #[oobRoom]) nWin with
+  | .ok dutA, .ok dutB, .ok dutC, .ok dutO =>
     let eA := relL2Win dutA (oracleAt 2.0) lo nWin
     let eB := relL2Win dutB (oracleAt 4.0) lo nWin
     let eC := relL2Win dutC (oracleChainAt 2.0) lo nWin
+    let eO := relL2Win dutO (oracleAt 0.2) lo nWin
     IO.println s!"ecdd live-pole (interval classification over the declared rt60 span):"
     IO.println s!"        structure ok={structOk} (tuned routes, untuned/rangeless stay collected, chain routes at the final fold)"
     IO.println s!"        law: rt60=2.0 rel {eA} · rt60=4.0 rel {eB} (one DD lane across the knob) · live+chain rel {eC}"
+    IO.println s!"        overdrive: rt60 driven to 0.1 (out of span) ≡ oracle at the declared edge 0.2 rel {eO} (the whole bank saturates together)"
     -- frozen 2026-07-23 off first-landing measurements (eA/eB ≈ 5e-7, the
     -- single-crossing floor; eC ≈ 1.7e-5): the live lane owes the same floors
     -- as the baked lane — the lift changes WHERE constants are computed, not
     -- their accuracy.
-    let pass := structOk && allFinite dutA
-             && eA < 5e-5 && eB < 5e-5 && eC < 1e-4
+    let pass := structOk && allFinite dutA && allFinite dutO
+             && eA < 5e-5 && eB < 5e-5 && eC < 1e-4 && eO < 5e-5
     if pass then
-      passGate "ecdd-live" s!"a live-rt60 room tuned onto a partial classifies over its declared interval and takes the DD lane throughout ({eA} / {eB} at two knob values, no runtime select to click); live+chain served on the plain arm ({eC}); untuned/rangeless live rooms stay collected"
+      passGate "ecdd-live" s!"a live-rt60 room tuned onto a partial classifies over its declared interval and takes the DD lane throughout ({eA} / {eB} at two knob values, no runtime select to click); live+chain served on the plain arm ({eC}); untuned/rangeless live rooms stay collected; an out-of-span drive saturates the WHOLE bank to the declared edge ({eO})"
     else
-      failGate "ecdd-live" s!"structOk={structOk} eA={eA} eB={eB} eC={eC}"
-  | _, _, _ => failGate "ecdd-live" "build/render failed for a live-pole erasure config"
+      failGate "ecdd-live" s!"structOk={structOk} eA={eA} eB={eB} eC={eC} eO={eO}"
+  | _, _, _, _ => failGate "ecdd-live" "build/render failed for a live-pole erasure config"
 
 /-- THE GAUGE-OVER-HOT-CHAIN GATE (the gauge × partition interaction, measured
     rather than assumed). Gauge is a COLLECTED surface in v1: it forces the

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -1286,4 +1286,85 @@ def runEcddPartition (arena : Arena)
       failGate "ecdd-partition" s!"bitCold={bitCold} structOk={structOk} e1DD={e1DD} e1Coll={e1Coll} eCDD={eCDD} eCColl={eCColl} coinFinite={coinFinite} coinPre={coinPre} coinE={coinE}"
   | _, _, _, _, _, _, _ => failGate "ecdd-partition" "build/render failed for an erasure-gate config"
 
+/-- THE EC/DD LIVE-POLE GATE (fork 3′ Phase 2). Interval classification: a
+    live-rt60 room mode tuned ONTO a baked partial routes to the paired DD
+    body at BUILD time when min |Δ| over the declared σ span dips under θ_acc
+    — the dipper takes DD THROUGHOUT the knob range, so no runtime select
+    exists and "no click at θ" is a compile-time triviality (D2). Asserts:
+    (1) STRUCTURE — the tuned live coupling routes (paired size 1: ω matched,
+        σ span ∋ the partial's σ), an UNTUNED live room routes nothing
+        (ordinary reverbs stay byte-identical), and a live σ with NO declared
+        range stays collected (unclassifiable — graceful);
+    (2) THE LAW ACROSS THE KNOB — the live render matches `oracleSeam` at TWO
+        rt60 values (same classification, same DD lane, constants computed by
+        kernel arithmetic off the live slot instead of at build time) — the
+        "confirm, don't assume" check that the paired columns (`ds`, `sigmaNu`
+        as s0 expressions of the knob; the per-sample series/direct `cexpm1`
+        select) genuinely lift;
+    (3) LIVE + CHAIN (the coverage-matrix cell, decided HERE, not by
+        accident): the PLAIN arm serves it — a baked room folds first, the
+        live tuned room folds last and partitions against the composed
+        (const-foldable) amps. The WS-LP bloomed live arm's refusal of
+        composed rooms is untouched (`runBloomLivePole` pins it). -/
+def runEcddLive (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let lo := anchorNat + 1
+  let nWin : Nat := 32768
+  let admAll := fun (_ _ : SeamMode) => true
+  -- the partial sits at σ = 3.455 = 6.91/2.0 — INSIDE the σ span of an
+  -- rt60 ∈ [0.2, 12] room ([0.576, 34.55]) ⇒ with ω matched, min|Δ| = 0
+  let voice : Array SeamMode := #[mkMode 220 3.455 1.0, mkMode 610 1.3 0.6]
+  let vM := voice.map (·.toModal)
+  let room1 : Array SeamMode := #[mkMode 200 1.2 1.0, mkMode 380 1.6 0.8]
+  let r1M := room1.map (·.toModal)
+  let (rtLo, rtHi) : Float × Float := (0.2, 12.0)
+  let liveSigma := fun (rv : Float) =>
+    div (lit 691 2) (clampE (litF rv) (litF rtLo) (litF rtHi))
+  let liveRoomAt := fun (rv : Float) (fHz amp : Float) (range? : Option (Float × Float)) =>
+    #[({ sigma := liveSigma rv, omega := litF (tp * fHz),
+         cre := litF amp, cim := lit 0,
+         sigmaRange := range? } : ModalMode)]
+  let span := some (6.91 / rtHi, 6.91 / rtLo)
+  let graphOf := fun (rooms : Array (Array ModalMode)) =>
+    let mkRev := fun (i : Nat) (rm : Array ModalMode) =>
+      ({ id := s!"rev{i}", node := .modalReverb (if i == 0 then "src" else s!"rev{i-1}") rm none })
+    ({ nodes := #[⟨"src", .modalSource vM anchorSig clockLit none none none⟩]
+              ++ rooms.zipIdx.map (fun (rm, i) => mkRev i rm)
+       output := s!"rev{rooms.size - 1}" } : PatchGraph)
+  -- (1) structure: tuned+ranged routes; untuned stays cold; rangeless stays cold
+  let tunedAt := fun rv => liveRoomAt rv 220.0 0.7 span
+  let (_, pTuned) := residueComposePartitioned vM (tunedAt 2.0)
+  let (_, pUntuned) := residueComposePartitioned vM (liveRoomAt 2.0 500.0 0.7 span)
+  let (_, pNoRange) := residueComposePartitioned vM (liveRoomAt 2.0 220.0 0.7 none)
+  let (_, pChain) := foldRoomsPartitioned vM #[r1M, tunedAt 2.0]
+  let structOk := pTuned.size == 1 && pUntuned.isEmpty && pNoRange.isEmpty
+               && pChain.size == 1
+  -- (2) the law at two knob values (single compose), (3) through a chain
+  let oracleAt := fun (rv : Float) => oracleSeam voice
+    #[{ sigma := 6.91 / rv, omega := tp * 220, are := 0.7 }] idWarp admAll 8 nWin
+  let oracleChainAt := fun (rv : Float) => oracleSeam voice
+    (foldRoomsFloat room1 #[{ sigma := 6.91 / rv, omega := tp * 220, are := 0.7 }])
+    idWarp admAll 8 nWin
+  match ← renderGraphN arena "ecddlive_a" (graphOf #[tunedAt 2.0]) nWin,
+        ← renderGraphN arena "ecddlive_b" (graphOf #[tunedAt 4.0]) nWin,
+        ← renderGraphN arena "ecddlive_chain" (graphOf #[r1M, tunedAt 2.0]) nWin with
+  | .ok dutA, .ok dutB, .ok dutC =>
+    let eA := relL2Win dutA (oracleAt 2.0) lo nWin
+    let eB := relL2Win dutB (oracleAt 4.0) lo nWin
+    let eC := relL2Win dutC (oracleChainAt 2.0) lo nWin
+    IO.println s!"ecdd live-pole (interval classification over the declared rt60 span):"
+    IO.println s!"        structure ok={structOk} (tuned routes, untuned/rangeless stay collected, chain routes at the final fold)"
+    IO.println s!"        law: rt60=2.0 rel {eA} · rt60=4.0 rel {eB} (one DD lane across the knob) · live+chain rel {eC}"
+    -- frozen 2026-07-23 off first-landing measurements (eA/eB ≈ 5e-7, the
+    -- single-crossing floor; eC ≈ 1.7e-5): the live lane owes the same floors
+    -- as the baked lane — the lift changes WHERE constants are computed, not
+    -- their accuracy.
+    let pass := structOk && allFinite dutA
+             && eA < 5e-5 && eB < 5e-5 && eC < 1e-4
+    if pass then
+      passGate "ecdd-live" s!"a live-rt60 room tuned onto a partial classifies over its declared interval and takes the DD lane throughout ({eA} / {eB} at two knob values, no runtime select to click); live+chain served on the plain arm ({eC}); untuned/rangeless live rooms stay collected"
+    else
+      failGate "ecdd-live" s!"structOk={structOk} eA={eA} eB={eB} eC={eC}"
+  | _, _, _ => failGate "ecdd-live" "build/render failed for a live-pole erasure config"
+
 end Tropical.Tropicaltest.SeamSweep

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -191,67 +191,68 @@ private def SeamAtom.oracleAdmits (atom : SeamAtom) : SeamMode → SeamMode → 
 
 private def idWarp : Float → Float := fun s => s
 
-/-- `residueComposeEC` — the collected residue bank (`voice ⋙ reverb`, m+n
-    modes), realized through the default banked lowering. Total composition; the
-    admission predicate marks where EC's `1/Δ` residue stays ACCURATE — below it
-    is `residueComposeDD`'s region, not EC's promise (passive exclusion).
+/-- `residueCompose` — THE one compose seam (fork 3′ erasure). The EC and DD
+    atoms MERGED: the realization is the PARTITIONED compose
+    (`residueComposePartitioned` — cold couplings collected, hot couplings
+    routed to the paired DD body by `couplingHot`, decided at build time), and
+    the admission region is the UNION of the two half-regions the predecessors
+    certified — i.e. TOTAL. The epistemic win this sprint exists for: the
+    apparatus stops certifying two half-regions with a folklore boundary and
+    certifies one whole; the old EC exclusion interior (`|a·r/Δ| ≥ 8`) is now
+    ordinary served territory with hard probes inside it.
 
-    RE-DERIVED (option E, the modal-datapath rail fix). This predicate ONCE
-    conflated two boundaries under one `|a·r/Δ| < 8` threshold: the i64 Q4.28
-    WRAP (a collected weight past 32 — `modalBankSigTable`'s landing) and the
-    near-coincidence ACCURACY floor (EC's `1/Δ` forms two huge opposite-sign
-    residues whose landed cancellation loses precision). Option E's per-bank
-    exponent (`bankLandExp`) removed the wrap for ALL |A|, so this predicate no
-    longer guards it — that boundary is now covered on the PRODUCTION path by the
-    `modal-rail`/`modal-rail-dir` witnesses (the real gesture, stronger than a
-    sweep probe). What remains is the accuracy boundary, and that is genuinely
-    PER-PAIR-LOCAL — accuracy degrades when ONE voice pole nears ONE room pole
-    (`λ_j → ν` ⇒ residue `a_j·r/(λ_j−ν) → ∞`, its cancellation error growing with
-    the landed magnitude even at zero wrap), unlike the wrap which was collective.
-    So the rail doc's collected-sum unsoundness applied to the WRAP (now fixed);
-    the per-pair form is SOUND for the accuracy purpose it now serves alone. The
-    `8` stays as the empirical EC-accurate edge (where DD takes over), no longer
-    a Q4.28-headroom number. -/
-private def ecAtom : SeamAtom :=
-  { name := "residueEC"
+    History (kept because the boundary's meaning has flipped twice): the old EC
+    atom's `|a·r/Δ| < 8` admission once guarded the i64 Q4.28 wrap, then —
+    after option E's per-bank exponent removed the wrap — the near-coincidence
+    accuracy floor. It is now the compiler's own ROUTING boundary
+    (`ecddRailCeil`, with margin), so the sweep no longer states it as
+    admission at all: both sides are served, each by its correct
+    representation, and the probes assert accuracy on both. -/
+private def composeAtom : SeamAtom :=
+  { name := "residueCompose"
     phi := idWarp
-    realize := fun v r => modalBankSigTable (residueComposeEC (v.map (·.toModal)) (r.map (·.toModal))) clockLit anchorSig
-    admitsPair := fun v r =>
-      -- EC's accuracy edge: the per-pair 1/Δ residue below DD's coincidence region
-      -- (`|a·r/Δ| < 8`). NOT a wrap bound — option E removed that (see the header).
-      let dpole := (v.pole.sub r.pole).abs
-      let amp := (v.amp.mul r.amp).abs
-      dpole * 8.0 > amp
-    activeExclusion := false
-    snr := 2e-4
-    interior := (Array.range 4).map (fun c =>
-      (#[haltonMode (c*10+1) 220 900, haltonMode (c*10+2) 220 900],
-       #[haltonMode (c*10+3) 1500 3300, haltonMode (c*10+4) 1500 3300]))
-    boundary :=
-      -- two poles near the coincidence floor: same freq, σ apart by ~0.6 (|Δ| ≈
-      -- 0.6, |a·r| ≈ 0.5 ⇒ admitted, |a·r/Δ| ≈ 0.8 < 8) — the accuracy edge.
-      #[ (mkMode 800 0.4 0.8, { sigma := 1.0, omega := tp * 800, are := 0.6 })
-       , (mkMode 500 0.5 0.7, { sigma := 1.1, omega := tp * 500, are := 0.7 }) ] }
-
-/-- `residueComposeDD` — the fused divided-difference paired bank (`m·n` paired
-    modes; the `cexpm1` limit is the τ·e resonance, no branch). TOTAL admission
-    (it exists precisely to be accurate through coincidence). -/
-private def ddAtom : SeamAtom :=
-  { name := "residueDD"
-    phi := idWarp
-    realize := fun v r => modalBankSigTableDD (residueComposeDD (v.map (·.toModal)) (r.map (·.toModal))) clockLit anchorSig
+    realize := fun v r =>
+      let (plain, paired) :=
+        residueComposePartitioned (v.map (·.toModal)) (r.map (·.toModal))
+      let base := modalBankSigTable plain clockLit anchorSig
+      if paired.isEmpty then base
+      else add base (modalBankSigTableDD paired clockLit anchorSig)
+    -- the UNION admission — TOTAL. The old EC atom admitted `|a·r/Δ| < 8` and
+    -- passively excluded the rest; the old DD atom was total; the merged seam
+    -- serves everything, routing per coupling (`couplingHot`).
     admitsPair := fun _ _ => true
     activeExclusion := false
+    -- one snr: both routes' floors sit under 2e-4 at this window (the trap
+    -- note about region-dependent error models is satisfied by construction —
+    -- if a route's floor ever rises past the shared snr, the probes on that
+    -- side fail loudly rather than silently averaging).
     snr := 2e-4
-    interior := (Array.range 4).map (fun c =>
-      let vo := #[haltonMode (c*10+1) 400 1200, haltonMode (c*10+2) 400 1200]
-      -- reverb poles NEAR the voice poles (the DD regime): a shrinking offset
-      let off := 0.6 * haltonF 2 (c+1)
-      (vo, vo.map (fun m => { m with omega := m.omega + tp * off, sigma := m.sigma + 0.1 })))
+    interior :=
+      -- the old EC interiors (separated pairs — all route collected) …
+      (Array.range 4).map (fun c =>
+        (#[haltonMode (c*10+1) 220 900, haltonMode (c*10+2) 220 900],
+         #[haltonMode (c*10+3) 1500 3300, haltonMode (c*10+4) 1500 3300]))
+      -- … plus the old DD interiors (near-coincident offsets — these straddle
+      -- θ_acc, so the sweep exercises BOTH sides of the routing boundary).
+      ++ (Array.range 4).map (fun c =>
+        let vo := #[haltonMode (c*10+1) 400 1200, haltonMode (c*10+2) 400 1200]
+        let off := 0.6 * haltonF 2 (c+1)
+        (vo, vo.map (fun m => { m with omega := m.omega + tp * off, sigma := m.sigma + 0.1 })))
     boundary :=
-      -- exact coincidence (λ = ν): the τ·e resonance, must stay finite/accurate
-      #[ (mkMode 700 0.8 0.6, mkMode 700 0.8 0.5)
-       , (mkMode 1100 0.5 0.7, { sigma := 0.5, omega := tp * 1100 + 0.02, are := 0.4 }) ] }
+      -- the old EC accuracy edge (|Δ| ≈ 0.6 > θ_acc, |a·r/Δ| < 4 — still cold,
+      -- the collected route's regression probes) …
+      #[ (mkMode 800 0.4 0.8, { sigma := 1.0, omega := tp * 800, are := 0.6 })
+       , (mkMode 500 0.5 0.7, { sigma := 1.1, omega := tp * 500, are := 0.7 })
+      -- … the old DD coincidence probes (λ = ν exactly; the τ·e resonance) …
+       , (mkMode 700 0.8 0.6, mkMode 700 0.8 0.5)
+       , (mkMode 1100 0.5 0.7, { sigma := 0.5, omega := tp * 1100 + 0.02, are := 0.4 })
+      -- … and the WIDENING (gate iii): hard probes INSIDE the old EC exclusion
+      -- — configurations the apparatus previously certified for nobody.
+      -- The rail-lens interior (|a·r/Δ| ≈ 14 ≫ 8, θ_acc < Δ? no — Δ = 0.05):
+       , (mkMode 800 0.6 0.9, { sigma := 0.6, omega := tp * 800 + 0.05, are := 0.8 })
+      -- the sub-grid detune (Δ = 1e-6 rad/s < the 6.5e-5 rotator quantum —
+      -- UNREPRESENTABLE collected; the served-full upgrade's sharpest point):
+       , (mkMode 500 0.8 0.7, { sigma := 0.8, omega := tp * 500 + 1e-6, are := 0.7 }) ] }
 
 /-- The pitch bloom warp (shipped gong: β=0.05, g=1.8, scale 1 ⇒ B = β/g). -/
 private def bloomBg : Float × Float := (0.05 / 1.8, 1.8)
@@ -304,7 +305,7 @@ private def bloomAtom : SeamAtom :=
        , (mkMode 700 0.5 0.8, { sigma := 0.5, omega := tp * 700 + 0.5, are := 0.4 })      -- |a|≈0.278 (imag spiral)
        , (mkMode 2600 0.9 0.5, mkMode 300 0.8 0.4) ] }
 
-private def allAtoms : Array SeamAtom := #[ecAtom, ddAtom, bloomAtom]
+private def allAtoms : Array SeamAtom := #[composeAtom, bloomAtom]
 
 -- ── The gate ──────────────────────────────────────────────────────────────────
 
@@ -1164,5 +1165,125 @@ def runFoldChain (arena : Arena)
     else
       passGate "ddfold" s!"the room-chain fold holds its law in both arms (A near-coincident DD {eD} ≤ collected {eC}; B separated DD {eS} on the direct cexpm1 lane); the a-DD machinery transferred to the fold site (WS-DDF datum). Finding: the bloom's K factor keeps the collected fold from breaking at reachable Δ — the wound is narrower than assumed"
   | _, _, _ => failGate "ddfold" "build/render failed for the WS-DDF fold witness"
+
+-- ── The EC/DD erasure gate (fork 3′ Phase 1) ──────────────────────────────────
+
+/-- Render an arrow TERM through the production emit seam (`normalize` →
+    `emitTerm`) — the comparator side of the byte-identity checks and the
+    collected counter-renders. -/
+private def renderTerm (arena : Arena) (name : String) (t : ArrowTerm)
+    (nLen : Nat := nProbe) : IO (Except String (Array Float)) := do
+  let (out, _) := emitTerm (normalize t) {}
+  renderConfig arena name out nLen
+
+private def renderGraphN (arena : Arena) (name : String) (gr : PatchGraph)
+    (nLen : Nat) : IO (Except String (Array Float)) := do
+  match lowerGraph gr with
+  | .error e => pure (.error e)
+  | .ok term => renderTerm arena name term nLen
+
+/-- THE EC/DD ERASURE GATE (fork 3′ Phase 1). The compiler owns the EC-vs-DD
+    choice per coupling; this gate pins the three behaviors that make that an
+    ERASURE rather than a new mode:
+    (1) COLD BYTE-IDENTITY — a separated chain from the patch surface
+        (src⋙rev⋙rev, nothing hot) renders BIT-IDENTICAL to the direct
+        collected chain `EC(EC(v,r₁),r₂)`: the deferred fold + partition
+        emits yesterday's compiler verbatim when θ is false.
+    (2) THE MIGRATION WITNESS — a room mode tuned ONTO a voice partial
+        (sub-grid detune, the old documented hazard) routes to the paired
+        atom: the partitioned render holds the law vs `oracleSeam` while the
+        collected counter-render (yesterday's output) is off it by decades —
+        served-full where it was served-wrong. Checked at the single compose
+        AND through a chain (the coupling forms against the COMPOSED amps at
+        the final fold, `sort-hot-last`'s mechanics).
+    (3) ROUTING STRUCTURE — the partition routes exactly the expected
+        couplings (one paired atom per tuned pair; room-room coincidence in
+        a chain routes at the final fold), and a room-room-coincident chain
+        renders finite and causal. (Its QUANTITATIVE oracle needs a deg-1
+        capable reference — the folded room's τ·e limit — which `oracleSeam`
+        can't express; recorded as the v2/deg-1 oracle gap, not silently
+        skipped.) -/
+def runEcddPartition (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let lo := anchorNat + 1
+  let nWin : Nat := 32768        -- ~0.74 s: the τ·e resonance (peak ≈ 1/σ s) is in-window
+  let admAll := fun (_ _ : SeamMode) => true
+  let voice : Array SeamMode := #[mkMode 220 1.0 1.0, mkMode 610 1.3 0.6]
+  let room1 : Array SeamMode := #[mkMode 200 1.2 1.0, mkMode 380 1.6 0.8]
+  let vM := voice.map (·.toModal)
+  let r1M := room1.map (·.toModal)
+  -- (1) cold byte-identity through the production seam
+  let roomCold : Array SeamMode := #[mkMode 260 1.4 0.9, mkMode 460 1.8 0.7]
+  let rCM := roomCold.map (·.toModal)
+  let gCold : PatchGraph :=
+    { nodes := #[ { id := "src", node := .modalSource vM anchorSig clockLit none none none }
+                , { id := "rev1", node := .modalReverb "src" r1M none }
+                , { id := "rev2", node := .modalReverb "rev1" rCM none } ]
+      output := "rev2" }
+  let directCold := modalBankTerm (residueComposeEC (residueComposeEC vM r1M) rCM) anchorSig clockLit
+  -- (2) the tuned-unison mutation: ω on the partial, σ matched ⇒ |Δ| = 1e-6
+  -- rad/s (below the 6.5e-5 rotator quantum — the unrepresentable-collected
+  -- point), amps const ⇒ `couplingHot` fires on the θ_acc lens.
+  let roomHot : Array SeamMode := #[{ sigma := 1.0, omega := tp * 220 + 1e-6, are := 0.7 }]
+  let rHM := roomHot.map (·.toModal)
+  let gHot1 : PatchGraph :=
+    { nodes := #[ { id := "src", node := .modalSource vM anchorSig clockLit none none none }
+                , { id := "rev", node := .modalReverb "src" rHM none } ]
+      output := "rev" }
+  let gHotC : PatchGraph :=
+    { nodes := #[ { id := "src", node := .modalSource vM anchorSig clockLit none none none }
+                , { id := "rev1", node := .modalReverb "src" r1M none }
+                , { id := "rev2", node := .modalReverb "rev1" rHM none } ]
+      output := "rev2" }
+  -- (3) structural routing: the partition's shape, checked directly
+  let (plainS, pairedS) := residueComposePartitioned vM rHM
+  let (_plainC, pairedC) := foldRoomsPartitioned vM #[r1M, rHM]
+  let r2Coin : Array SeamMode := #[{ sigma := 1.2, omega := tp * 200 + 1e-6, are := 0.7 }]
+  let r2CM := r2Coin.map (·.toModal)
+  let (_plainR, pairedR) := foldRoomsPartitioned vM #[r1M, r2CM]
+  let structOk := pairedS.size == 1 && plainS.size == vM.size + rHM.size
+              && pairedC.size == 1 && pairedR.size == 1
+  let gCoinC : PatchGraph :=
+    { nodes := #[ { id := "src", node := .modalSource vM anchorSig clockLit none none none }
+                , { id := "rev1", node := .modalReverb "src" r1M none }
+                , { id := "rev2", node := .modalReverb "rev1" r2CM none } ]
+      output := "rev2" }
+  match ← renderGraph arena "ecdd_cold" gCold,
+        ← renderTerm arena "ecdd_cold_direct" directCold,
+        ← renderGraphN arena "ecdd_hot1" gHot1 nWin,
+        ← renderTerm arena "ecdd_hot1_coll" (modalBankTerm (residueComposeEC vM rHM) anchorSig clockLit) nWin,
+        ← renderGraphN arena "ecdd_hotC" gHotC nWin,
+        ← renderTerm arena "ecdd_hotC_coll" (modalBankTerm (residueComposeEC (residueComposeEC vM r1M) rHM) anchorSig clockLit) nWin,
+        ← renderGraphN arena "ecdd_coinC" gCoinC nWin with
+  | .ok cold, .ok coldD, .ok hot1, .ok hot1C, .ok hotC, .ok hotCC, .ok coinC =>
+    let bitCold := bitDiffCount cold coldD
+    let ref1 := oracleSeam voice roomHot idWarp admAll 8 nWin
+    let e1DD := relL2Win hot1 ref1 lo nWin
+    let e1Coll := relL2Win hot1C ref1 lo nWin
+    let refC := oracleSeam voice (foldRoomsFloat room1 roomHot) idWarp admAll 8 nWin
+    let eCDD := relL2Win hotC refC lo nWin
+    let eCColl := relL2Win hotCC refC lo nWin
+    let coinFinite := allFinite coinC
+    let coinPre := energyWin coinC 0 lo
+    let coinE := energyWin coinC lo nWin
+    IO.println s!"ecdd erasure (per-coupling partition, θ_acc={Tropical.EmitArrow.ecddThetaAcc} rad/s):"
+    IO.println s!"        cold chain bitDiff {bitCold} (deferred fold ≡ yesterday's collected chain)"
+    IO.println s!"        tuned unison (|Δ|=1e-6, sub-grid): partitioned {e1DD} vs collected {e1Coll} (oracle law)"
+    IO.println s!"        tuned unison through a chain:      partitioned {eCDD} vs collected {eCColl}"
+    IO.println s!"        routing structure ok={structOk} · room-room coincident chain finite={coinFinite} preE={coinPre} E={coinE}"
+    -- frozen 2026-07-23 off first-landing measurements (e1DD ≈ 5e-7, eCDD ≈
+    -- 6e-6, both collected counter-renders ≈ 1.0): the plain-path chain floor
+    -- is 1e-4 — deliverable 2's re-freeze, an order tighter than the bloomed
+    -- chain gate's 2e-3 (whose 6.7e-4 is floor-relative, not 1/Δ — diagnosed,
+    -- out of v1). The collected/partitioned ratio floor is 1e4×.
+    let pass := bitCold == 0 && structOk
+             && e1DD < 5e-5 && e1Coll > 1000.0 * e1DD
+             && eCDD < 1e-4 && eCColl > 1000.0 * eCDD
+             && coinFinite && coinPre < 1e-18 && coinE > 1e-9
+    if pass then
+      passGate "ecdd-partition" s!"the EC/DD choice is the compiler's: cold chain byte-identical (bitDiff 0), tuned unison served through the paired route ({e1DD} vs collected {e1Coll}; chain {eCDD} vs {eCColl}), routing structural, coincident room chain graceful"
+    else
+      failGate "ecdd-partition" s!"bitCold={bitCold} structOk={structOk} e1DD={e1DD} e1Coll={e1Coll} eCDD={eCDD} eCColl={eCColl} coinFinite={coinFinite} coinPre={coinPre} coinE={coinE}"
+  | _, _, _, _, _, _, _ => failGate "ecdd-partition" "build/render failed for an erasure-gate config"
 
 end Tropical.Tropicaltest.SeamSweep

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -1404,4 +1404,89 @@ def runEcddLive (arena : Arena)
       failGate "ecdd-live" s!"structOk={structOk} eA={eA} eB={eB} eC={eC}"
   | _, _, _ => failGate "ecdd-live" "build/render failed for a live-pole erasure config"
 
+/-- THE GAUGE-OVER-HOT-CHAIN GATE (the gauge × partition interaction, measured
+    rather than assumed). Gauge is a COLLECTED surface in v1: it forces the
+    room fold at the gauge node, so a tuned (sub-grid) coupling under a gauge
+    renders collected — the status-quo floor for that pair (grid silence),
+    stated in `lowerModal`. The open question was the NORM: `gaugeScale`
+    self-measures on the collected amps, which for a tuned unison are the huge
+    cancelling `±c/Δ` pair (~7e5 here) — does the measure survive, or does it
+    mis-scale the WHOLE bank? It survives, and not by luck: the norm reads the
+    bank's transfer function `H(iω)`, and `H` has NO `1/Δ` pole — the `±c/Δ`
+    partial fractions recombine into the bounded product form
+    `c/((iω−λ)(iω−ν))`, so the f64 build-time cancellation is benign (rel err
+    ~eps·|c/Δ|/|H| ≈ 1e-10 at this detune; an f32 coefficient path would owe
+    its own witness — recorded, not covered here). Asserts:
+    (1) THE SCALE LAW — the gauged render is `scale · (ungauged collected
+        render)` with `scale` recomputed from an INDEPENDENT f64 mirror of
+        `gaugeScale` on the float-EC amps (the render is linear in residues:
+        one shared s0 scale, so any norm damage would show here). Asserted at
+        a REPRESENTABLE detune (Δ = 1e-3 > the grid quantum; amps ±700) where
+        the datapath resolves the signal;
+    (2) NORM SANITY at the sub-grid worst case (|c/Δ| ≈ 7e5) — the mirrored
+        scale sits in a sane band: the "scaled to oblivion" failure mode is
+        excluded by measurement;
+    (3) THE LANDING POISON, recorded as data (this gate's own finding): at
+        sub-grid detune the scale-law comparison is dominated by QUANTIZATION,
+        not the norm — the cancelling `±c/Δ` amps size the per-bank landing
+        exponent (`bankLandExp` k off maxAbs ≈ 7e5 ⇒ LSB ≈ 2⁻¹³), which
+        quantizes the surviving cold modes (amps ~1e-4) to ~1 LSB. The
+        collected floor under a forced-collected surface is therefore not just
+        "the hot pair is silent": the pair's amps degrade the WHOLE bank's
+        landing resolution. Where the partition routes, this cannot happen
+        (paired amps are bounded, `ecddPairCap`) — one more reason the routed
+        path is the served one. Pinned loosely (finite + the poisoned
+        comparison stays O(1), i.e. the bank still renders the cold modes at
+        the right ORDER, no blowup). -/
+def runEcddGauge (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let lo := anchorNat + 1
+  let nWin : Nat := 32768
+  let voice : Array SeamMode := #[mkMode 220 1.0 1.0, mkMode 610 1.3 0.6]
+  let vM := voice.map (·.toModal)
+  -- the f64 norm mirror: float-EC amps → H at each pole ω → S = Σ|H|⁸ →
+  -- scale = S^{−g/8} (g = 1) — `gaugeScale`'s formula on a separate code
+  -- path (CplxB floats, not symbolic CplxE).
+  let scaleOf := fun (room : Array SeamMode) =>
+    let ecF := foldRoomsFloat voice room
+    let hAt := fun (wk : Float) => ecF.foldl (fun (acc : CplxB) m =>
+        acc.add ((⟨m.are, m.aim⟩ : CplxB).div (⟨m.sigma, wk - m.omega⟩ : CplxB))) ⟨0, 0⟩
+    let sNorm := ecF.foldl (fun s m =>
+        let h := hAt m.omega
+        let h2 := h.re * h.re + h.im * h.im
+        s + (h2 * h2) * (h2 * h2)) 0.0
+    Float.exp (-(1.0 / 8.0) * Float.log sNorm)
+  let gaugedGraph := fun (rm : Array ModalMode) =>
+    ({ nodes := #[ { id := "src", node := .modalSource vM anchorSig clockLit none none none }
+                 , { id := "rev", node := .modalReverb "src" rm none }
+                 , { id := "gg",  node := .modalGauge "rev" (litF 1.0) } ]
+       output := "gg" } : PatchGraph)
+  -- config A: the sub-grid worst case (norm sanity + the landing poison)
+  let roomSub : Array SeamMode := #[{ sigma := 1.0, omega := tp * 220 + 1e-6, are := 0.7 }]
+  -- config B: representable detune (the clean scale-law witness — amps ±700,
+  -- landing exponent k = 6, quantization decades under the signal)
+  let roomRep : Array SeamMode := #[{ sigma := 1.0, omega := tp * 220 + 1e-3, are := 0.7 }]
+  let rSubM := roomSub.map (·.toModal)
+  let rRepM := roomRep.map (·.toModal)
+  match ← renderGraphN arena "ecddg_gauged_sub" (gaugedGraph rSubM) nWin,
+        ← renderTerm arena "ecddg_bare_sub" (modalBankTerm (residueComposeEC vM rSubM) anchorSig clockLit) nWin,
+        ← renderGraphN arena "ecddg_gauged_rep" (gaugedGraph rRepM) nWin,
+        ← renderTerm arena "ecddg_bare_rep" (modalBankTerm (residueComposeEC vM rRepM) anchorSig clockLit) nWin with
+  | .ok dutGS, .ok dutBS, .ok dutGR, .ok dutBR =>
+    let scaleSub := scaleOf roomSub
+    let scaleRep := scaleOf roomRep
+    let eLawRep := relL2Win dutGR (dutBR.map (· * scaleRep)) lo nWin
+    let ePoison := relL2Win dutGS (dutBS.map (· * scaleSub)) lo nWin
+    let eGS := energyWin dutGS lo nWin
+    let saneSub := 0.1 < scaleSub && scaleSub < 10.0
+    IO.println s!"ecdd gauge-over-hot (the norm on cancelling ±c/Δ amps):"
+    IO.println s!"        scale law (Δ=1e-3, resolvable): gauged ≡ {scaleRep} × collected rel {eLawRep}"
+    IO.println s!"        sub-grid (|c/Δ|≈7e5): norm sane {saneSub} (scale {scaleSub}) · landing-poison comparison {ePoison} (quantization-dominated, recorded) · E {eGS}"
+    if allFinite dutGS && allFinite dutGR && eLawRep < 1e-4
+        && saneSub && ePoison < 2.0 && eGS > 1e-9 then
+      passGate "ecdd-gauge" s!"gauge over a tuned-unison chain: the H-norm survives the ±c/Δ amps (sub-grid scale {scaleSub}, mirrored independently — no oblivion; scale law holds where the datapath resolves, {eLawRep}); the recorded residual is the collected floor PLUS the landing poison (huge amps size the bank's k, LSB over the cold modes)"
+    else
+      failGate "ecdd-gauge" s!"eLawRep={eLawRep} scaleSub={scaleSub} scaleRep={scaleRep} ePoison={ePoison} finite={allFinite dutGS}/{allFinite dutGR} E={eGS}"
+  | _, _, _, _ => failGate "ecdd-gauge" "build/render failed for a gauge-over-hot config"
+
 end Tropical.Tropicaltest.SeamSweep

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -648,13 +648,33 @@ def runBloomLivePole (arena : Arena)
     p.invA.foldl (fun a ik => a ++ #[ik.1, ik.2]) #[]) #[]
   let genuinelyLive := pairsLive.all (fun p => (sigConstF? p.nuSigma).isNone)
   let allS0 := liveConsts.all sigIsS0
-  -- (4) graceful per-pair drop: a room mode ON the 220 Hz partial is not
-  -- serOnly anywhere on the interval (|a+1| dips below |κ| at Re a = −1)
-  let nearRoom := liveRoom #[mkMode 220.5 sigLive 0.5]
+  -- (4) graceful per-pair drop: a room mode 10.5 Hz off the 220 Hz partial
+  -- CHANGES region across the rt60 interval (|a+1| straddles |κ| = 38.4:
+  -- max ≈ 40.7 at the σ-high endpoint ⇒ serOnly there, min ≈ 36.7 at
+  -- Re a = −1 ⇒ crossing there) — the phase 3 union-emit case, dropped per
+  -- pair today. (The 220.5 Hz ON-partial pair phase 1 used here is now
+  -- crossing-throughout and LIFTS — the drop set shrank with phase 2.)
+  let nearRoom := liveRoom #[mkMode 230.5 sigLive 0.5]
   let dropCount := match bloomCompose vM nearRoom B g with
     | some ps => ps.size
     | none => 1000
-  -- (2)+(3) render the live crossing, the baked crossing, and the oracle
+  -- (5) WS-LP phase 2 — the CROSSING region, live: a room mode close enough to
+  -- the 1023 Hz voice partial that `|a+1| < |κ|` over the WHOLE rt60 range
+  -- (crossing-throughout: both lanes emitted, `dSwitch` live). The window is
+  -- 2·nProbe so the live `dSwitch` (≈ 0.096 s at rt60 = 2 ⇒ sample ≈ 4443)
+  -- falls INSIDE it — the render exercises the CF lane, the seam, AND the
+  -- Γ★-bridged series lane.
+  let nX := 2 * nProbe
+  let voiceX : Array SeamMode := #[mkMode 1023 1.13 1.0]
+  let roomX  : Array SeamMode := #[mkMode 1066 sigLive 0.6]
+  let vMX := voiceX.map (·.toModal)
+  let some pairsX := bloomCompose vMX (liveRoom roomX) B g
+    | failGate "bloom-live-pole" "bloomCompose returned none for the live crossing-region room"
+  let crossingLifted := pairsX.size == 1 && pairsX.all (fun p => !p.cfN.isEmpty)
+  let bakedX := match bloomCompose vMX (roomX.map (·.toModal)) B g with
+    | some ps => bloomComposedSig ps clockLit anchorSig
+    | none => litI 0
+  -- (2)+(3) render live vs baked vs oracle (phase 1 graph route + phase 2 direct)
   let clk : Clock := clockLit
   let mkGraph := fun (rm : Array ModalMode) =>
     ({ nodes := #[ { id := "src", node := .modalSource vM anchorSig clk none none (some (B, g)) }
@@ -662,8 +682,10 @@ def runBloomLivePole (arena : Arena)
        output := "rev" } : PatchGraph)
   let rLive ← renderGraph arena "wslp_live" (mkGraph rMLive)
   let rBaked ← renderGraph arena "wslp_baked" (mkGraph rMBaked)
-  match rLive, rBaked with
-  | .ok pL, .ok pB =>
+  let rLiveX ← renderConfig arena "wslp_xlive" (bloomComposedSig pairsX clockLit anchorSig) nX
+  let rBakedX ← renderConfig arena "wslp_xbaked" bakedX nX
+  match rLive, rBaked, rLiveX, rBakedX with
+  | .ok pL, .ok pB, .ok pLX, .ok pBX =>
     let lo := anchorNat + 1
     let hi := nProbe
     let adm := fun (v r : SeamMode) => bloomAdmitsPair v.pole r.pole B g
@@ -671,19 +693,24 @@ def runBloomLivePole (arena : Arena)
     let eOracle := relL2Win pL (oracleSeam voice room bloomWarp adm 8) lo hi
     let preE := energyWin pL 0 lo
     let e := energyWin pL lo hi
-    IO.println s!"bloom live-pole crossing (WS-LP Phase 1: serOnly, live rt60):"
+    let eBakedX := relL2Win pLX pBX lo nX
+    let eOracleX := relL2Win pLX (oracleSeam voiceX roomX bloomWarp adm 8 nX) lo nX
+    IO.println s!"bloom live-pole crossing (WS-LP: serOnly + crossing regions, live rt60):"
     IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · near-partial pair drops to {dropCount}/3"
-    IO.println s!"        render   live ≡ baked crossing {eBaked * 1e9}e-9 · live ≡ oracle {eOracle} · pre-E {preE} · E {e}"
+    IO.println s!"        serOnly  live ≡ baked crossing {eBaked * 1e9}e-9 · live ≡ oracle {eOracle} · pre-E {preE} · E {e}"
+    IO.println s!"        crossing lifted (1 pair, CF lane) {crossingLifted} · live ≡ baked {eBakedX * 1e9}e-9 · live ≡ oracle {eOracleX} (window {nX}, seam inside)"
     -- live ≡ baked is a CONSISTENCY check, not the law (the oracle is): the
-    -- baked `mK` comes from build-time forward summation (`bloomM1`), the lifted
-    -- one from the emitted Horner (`bloomM1E`) — a real reassociation of a
-    -- ~200-term series, so the honest bar is ~1e-6, not bit-identity.
+    -- baked constants come from build-time forward summation (`bloomM1`) and
+    -- `lgammaB`, the lifted ones from the emitted Horner/fraction/`lgammaE` —
+    -- real reassociations, so the honest bar is ~1e-6, not bit-identity.
     if pairsLive.size == 6 && genuinelyLive && allS0 && dropCount == 2
-        && eBaked < 1e-6 && eOracle < 3e-4 && preE < 1e-18 && e > 1e-9 && allFinite pL then
-      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom (no bare-bloom drop): 6/6 pairs lifted s0, live ≡ baked {eBaked * 1e9}e-9, ≡ oracle {eOracle}, non-serOnly pair drops per-pair"
+        && eBaked < 1e-6 && eOracle < 3e-4 && preE < 1e-18 && e > 1e-9 && allFinite pL
+        && crossingLifted && eBakedX < 1e-6 && eOracleX < 3e-4 && allFinite pLX then
+      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom in BOTH lifted regions: serOnly 6/6 (≡ baked {eBaked * 1e9}e-9, ≡ oracle {eOracle}); crossing incl. live dSwitch seam (≡ baked {eBakedX * 1e9}e-9, ≡ oracle {eOracleX}); non-liftable pair drops per-pair"
     else
-      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL}"
-  | .error e, _ | _, .error e => failGate "bloom-live-pole" s!"build/render: {e}"
+      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL} xLift={crossingLifted} eBakedX={eBakedX * 1e9}e-9 eOracleX={eOracleX} finiteX={allFinite pLX}"
+  | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
+    failGate "bloom-live-pole" s!"build/render: {e}"
 
 -- ── The Γ-bridge coefficient comparator (per-identity, series-shaped) ──────────
 -- Truncated power-series (Taylor-in-d) arithmetic over `CplxB`, depth N. The

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -629,10 +629,10 @@ def runBloomLivePole (arena : Arena)
   -- the live room: σ = 6.91/rt60 with rt60 NOT a foldable literal (clamp is
   -- outside `sigConstF?`'s vocabulary, exactly like a `paramRef` slot read),
   -- range declared as the knob span mapped through σ = 6.91/rt60
-  let rt60E : Sig := clampE (litF rt60Val) (litF rtLo) (litF rtHi)
-  let liveRoom := fun (rm : Array SeamMode) => rm.map (fun m =>
-    { m.toModal with sigma := div (lit 691 2) rt60E
+  let liveRoomAt := fun (rv : Float) (rm : Array SeamMode) => rm.map (fun m =>
+    { m.toModal with sigma := div (lit 691 2) (clampE (litF rv) (litF rtLo) (litF rtHi))
                      sigmaRange := some (6.91 / rtHi, 6.91 / rtLo) })
+  let liveRoom := liveRoomAt rt60Val
   let rMLive  := liveRoom room
   let rMBaked := room.map (·.toModal)
   -- (1) the lift engages: all 6 pairs, live and s0
@@ -648,16 +648,50 @@ def runBloomLivePole (arena : Arena)
     p.invA.foldl (fun a ik => a ++ #[ik.1, ik.2]) #[]) #[]
   let genuinelyLive := pairsLive.all (fun p => (sigConstF? p.nuSigma).isNone)
   let allS0 := liveConsts.all sigIsS0
-  -- (4) graceful per-pair drop: a room mode 10.5 Hz off the 220 Hz partial
-  -- CHANGES region across the rt60 interval (|a+1| straddles |κ| = 38.4:
-  -- max ≈ 40.7 at the σ-high endpoint ⇒ serOnly there, min ≈ 36.7 at
-  -- Re a = −1 ⇒ crossing there) — the phase 3 union-emit case, dropped per
-  -- pair today. (The 220.5 Hz ON-partial pair phase 1 used here is now
-  -- crossing-throughout and LIFTS — the drop set shrank with phase 2.)
-  let nearRoom := liveRoom #[mkMode 230.5 sigLive 0.5]
+  -- (4) graceful per-pair drop: a room mode 0.05 Hz off the 220 Hz partial is
+  -- COINCIDENT-dipping (|Im a| ≈ 0.17 < ½, and the rt60 range walks Re a
+  -- through the disc) — the one remaining per-pair drop after phase 3a (the
+  -- τ·e lanes stay baked-only). The drop set shrank twice: phase 1's
+  -- on-partial probe (220.5 Hz) lifted with phase 2's crossing arm, and
+  -- phase 2's region-CHANGING probe (230.5 Hz) lifted with phase 3a's
+  -- union collapse — it is now witness (6) below.
+  let nearRoom := liveRoom #[mkMode 220.05 sigLive 0.5]
   let dropCount := match bloomCompose vM nearRoom B g with
     | some ps => ps.size
     | none => 1000
+  -- (6) phase 3a — the STRADDLING pair (region-changing over the interval):
+  -- room 230.5 Hz vs voice 220 (|a+1| straddles |κ| = 38.4: serOnly at low
+  -- rt60, crossing at high). Served by the crossing lanes alone (the union
+  -- collapse, probed in demos/wslp_union_probe.py). Witnessed on BOTH sides:
+  -- at rt60 = 2 the live dSwitch ≈ 0.026 s (seam in-window, both lanes); at
+  -- rt60 = 0.25 the pair sits on its serOnly side (dSwitch < 0, series from
+  -- d = 0) and the BAKED pair takes the serOnly ARM — so live ≡ baked there
+  -- is the bridge identity `Γ★ − CF(κ)/g = mK/(ν−μ)` IN THE EMITTED KERNEL.
+  let renderPairs := fun (name : String) (ps : Array BloomPair) =>
+    renderConfig arena name (bloomComposedSig ps clockLit anchorSig)
+  let straddleCheck : Float → String → IO (Option (Float × Float)) := fun rv tag => do
+    let sv := 6.91 / rv
+    let vS : Array SeamMode := #[mkMode 220 1.0 1.0]
+    let rS : Array SeamMode := #[mkMode 230.5 sv 0.5]
+    let some psL := bloomCompose (vS.map (·.toModal)) (liveRoomAt rv rS) B g | return none
+    let some psB := bloomCompose (vS.map (·.toModal)) (rS.map (·.toModal)) B g | return none
+    if psL.size != 1 || psL.any (fun p => p.cfN.isEmpty) then return none
+    match ← renderPairs s!"wslp_str_{tag}_l" psL, ← renderPairs s!"wslp_str_{tag}_b" psB with
+    | .ok l, .ok b =>
+      let admS := fun (v r : SeamMode) => bloomAdmitsPair v.pole r.pole B g
+      let eB := relL2Win l b (anchorNat + 1) nProbe
+      let eO := relL2Win l (oracleSeam vS rS bloomWarp admS 8) (anchorNat + 1) nProbe
+      if !(allFinite l) then return none
+      return some (eB, eO)
+    | _, _ => return none
+  let some (eBS2, eOS2) ← straddleCheck 2.0 "r2"
+    | failGate "bloom-live-pole" "straddle witness (rt60=2, crossing side) failed to lift/render"
+  let some (eBS0, eOS0) ← straddleCheck 0.25 "r025"
+    | failGate "bloom-live-pole" "straddle witness (rt60=0.25, serOnly side) failed to lift/render"
+  -- the full bank with the straddling room mode now lifts ALL THREE pairs
+  let straddleBankFull := match bloomCompose vM (liveRoom #[mkMode 230.5 sigLive 0.5]) B g with
+    | some ps => ps.size == 3
+    | none => false
   -- (5) WS-LP phase 2 — the CROSSING region, live: a room mode close enough to
   -- the 1023 Hz voice partial that `|a+1| < |κ|` over the WHOLE rt60 range
   -- (crossing-throughout: both lanes emitted, `dSwitch` live). The window is
@@ -695,20 +729,22 @@ def runBloomLivePole (arena : Arena)
     let e := energyWin pL lo hi
     let eBakedX := relL2Win pLX pBX lo nX
     let eOracleX := relL2Win pLX (oracleSeam voiceX roomX bloomWarp adm 8 nX) lo nX
-    IO.println s!"bloom live-pole crossing (WS-LP: serOnly + crossing regions, live rt60):"
-    IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · near-partial pair drops to {dropCount}/3"
+    IO.println s!"bloom live-pole crossing (WS-LP: serOnly + crossing + straddling, live rt60):"
+    IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · coincident-dip pair drops to {dropCount}/3"
     IO.println s!"        serOnly  live ≡ baked crossing {eBaked * 1e9}e-9 · live ≡ oracle {eOracle} · pre-E {preE} · E {e}"
     IO.println s!"        crossing lifted (1 pair, CF lane) {crossingLifted} · live ≡ baked {eBakedX * 1e9}e-9 · live ≡ oracle {eOracleX} (window {nX}, seam inside)"
+    IO.println s!"        straddle rt60=2 (seam in-window) ≡ baked {eBS2 * 1e9}e-9, ≡ oracle {eOS2} · rt60=0.25 (serOnly side) ≡ baked-SER-ARM {eBS0 * 1e9}e-9 (the bridge identity in-kernel), ≡ oracle {eOS0} · full bank 3/3 {straddleBankFull}"
     -- live ≡ baked is a CONSISTENCY check, not the law (the oracle is): the
     -- baked constants come from build-time forward summation (`bloomM1`) and
     -- `lgammaB`, the lifted ones from the emitted Horner/fraction/`lgammaE` —
     -- real reassociations, so the honest bar is ~1e-6, not bit-identity.
     if pairsLive.size == 6 && genuinelyLive && allS0 && dropCount == 2
         && eBaked < 1e-6 && eOracle < 3e-4 && preE < 1e-18 && e > 1e-9 && allFinite pL
-        && crossingLifted && eBakedX < 1e-6 && eOracleX < 3e-4 && allFinite pLX then
-      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom in BOTH lifted regions: serOnly 6/6 (≡ baked {eBaked * 1e9}e-9, ≡ oracle {eOracle}); crossing incl. live dSwitch seam (≡ baked {eBakedX * 1e9}e-9, ≡ oracle {eOracleX}); non-liftable pair drops per-pair"
+        && crossingLifted && eBakedX < 1e-6 && eOracleX < 3e-4 && allFinite pLX
+        && eBS2 < 1e-6 && eOS2 < 3e-4 && eBS0 < 1e-6 && eOS0 < 3e-4 && straddleBankFull then
+      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom in every non-coincident region: serOnly 6/6 (≡ oracle {eOracle}); crossing incl. live dSwitch seam (≡ oracle {eOracleX}); STRADDLING pair served by the union collapse on both sides (crossing side ≡ oracle {eOS2}; serOnly side ≡ baked ser arm {eBS0 * 1e9}e-9 — the bridge identity in-kernel); only the coincident dip drops per-pair"
     else
-      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL} xLift={crossingLifted} eBakedX={eBakedX * 1e9}e-9 eOracleX={eOracleX} finiteX={allFinite pLX}"
+      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL} xLift={crossingLifted} eBakedX={eBakedX * 1e9}e-9 eOracleX={eOracleX} finiteX={allFinite pLX} eBS2={eBS2 * 1e9}e-9 eOS2={eOS2} eBS0={eBS0 * 1e9}e-9 eOS0={eOS0} bank3={straddleBankFull}"
   | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
     failGate "bloom-live-pole" s!"build/render: {e}"
 

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -196,10 +196,13 @@ private def idWarp : Float → Float := fun s => s
     (`residueComposePartitioned` — cold couplings collected, hot couplings
     routed to the paired DD body by `couplingHot`, decided at build time), and
     the admission region is the UNION of the two half-regions the predecessors
-    certified — i.e. TOTAL. The epistemic win this sprint exists for: the
-    apparatus stops certifying two half-regions with a folklore boundary and
-    certifies one whole; the old EC exclusion interior (`|a·r/Δ| ≥ 8`) is now
-    ordinary served territory with hard probes inside it.
+    certified MINUS the stated cap refusal (`couplingRefused`: a lens fired but
+    the paired range cap rejected the coupling back to the collected floor —
+    reachable only at extreme Q, and excluded here rather than certified). The
+    epistemic win this sprint exists for: the apparatus stops certifying two
+    half-regions with a folklore boundary and certifies one whole, with its one
+    true edge stated as admission; the old EC exclusion interior (`|a·r/Δ| ≥ 8`)
+    is now ordinary served territory with hard probes inside it.
 
     History (kept because the boundary's meaning has flipped twice): the old EC
     atom's `|a·r/Δ| < 8` admission once guarded the i64 Q4.28 wrap, then —
@@ -217,10 +220,15 @@ private def composeAtom : SeamAtom :=
       let base := modalBankSigTable plain clockLit anchorSig
       if paired.isEmpty then base
       else add base (modalBankSigTableDD paired clockLit anchorSig)
-    -- the UNION admission — TOTAL. The old EC atom admitted `|a·r/Δ| < 8` and
-    -- passively excluded the rest; the old DD atom was total; the merged seam
-    -- serves everything, routing per coupling (`couplingHot`).
-    admitsPair := fun _ _ => true
+    -- the UNION admission minus the STATED cap refusal. The old EC atom
+    -- admitted `|a·r/Δ| < 8` and passively excluded the rest; the old DD atom
+    -- was total; the merged seam serves everything it routes (per coupling,
+    -- `couplingHot`) and REFUSES a lens-fired coupling the paired range cap
+    -- rejects (`couplingRefused` — it renders collected at the status-quo
+    -- floor, wrong near coincidence, so certifying it would be false). Passive
+    -- exclusion: the refused pair still renders; it is out of contract here
+    -- and pinned structurally by the ecdd-partition gate.
+    admitsPair := fun v r => !couplingRefused v.toModal r.toModal
     activeExclusion := false
     -- one snr: both routes' floors sit under 2e-4 at this window (the trap
     -- note about region-dependent error models is satisfied by construction —
@@ -248,11 +256,22 @@ private def composeAtom : SeamAtom :=
        , (mkMode 1100 0.5 0.7, { sigma := 0.5, omega := tp * 1100 + 0.02, are := 0.4 })
       -- … and the WIDENING (gate iii): hard probes INSIDE the old EC exclusion
       -- — configurations the apparatus previously certified for nobody.
-      -- The rail-lens interior (|a·r/Δ| ≈ 14 ≫ 8, θ_acc < Δ? no — Δ = 0.05):
+      -- Deep inside the old exclusion (|a·r/Δ| ≈ 14 ≫ 8; Δ = 0.05 < θ_acc, so
+      -- the ACCURACY lens routes it — the rail lens's own witness is below):
        , (mkMode 800 0.6 0.9, { sigma := 0.6, omega := tp * 800 + 0.05, are := 0.8 })
       -- the sub-grid detune (Δ = 1e-6 rad/s < the 6.5e-5 rotator quantum —
       -- UNREPRESENTABLE collected; the served-full upgrade's sharpest point):
-       , (mkMode 500 0.8 0.7, { sigma := 0.8, omega := tp * 500 + 1e-6, are := 0.7 }) ] }
+       , (mkMode 500 0.8 0.7, { sigma := 0.8, omega := tp * 500 + 1e-6, are := 0.7 })
+      -- the RAIL lens's own service region (its only discriminating law probe:
+      -- Δ = 0.6 > θ_acc so the accuracy lens is OFF; |a·r|/Δ = 4/0.6 ≈ 6.7 > 4
+      -- fires the rail lens; σ = 1.5 makes the damping arm the binding sup and
+      -- clears the cap, |c|/(e·σ_min) ≈ 0.98 < 8 — routed, law asserted):
+       , (mkMode 800 1.5 2.0, { sigma := 1.5, omega := tp * 800 + 0.6, are := 2.0 })
+      -- the STATED refusal (sub-grid Δ fires the accuracy lens; σ = 0.02 is
+      -- extreme Q, |c|/(e·σ_min) ≈ 18 ≥ 8 — the cap refuses, `admitsPair` is
+      -- false, the harness skips it as out-of-contract; the ecdd-partition
+      -- gate pins the refusal structurally):
+       , (mkMode 400 0.02 1.0, { sigma := 0.02, omega := tp * 400 + 1e-6, are := 1.0 }) ] }
 
 /-- The pitch bloom warp (shipped gong: β=0.05, g=1.8, scale 1 ⇒ B = β/g). -/
 private def bloomBg : Float × Float := (0.05 / 1.8, 1.8)
@@ -1241,6 +1260,24 @@ def runEcddPartition (arena : Arena)
   let r2Coin : Array SeamMode := #[{ sigma := 1.2, omega := tp * 200 + 1e-6, are := 0.7 }]
   let r2CM := r2Coin.map (·.toModal)
   let (_plainR, pairedR) := foldRoomsPartitioned vM #[r1M, r2CM]
+  -- (3b) the routing boundary, lens-discriminated. The RAIL lens's service
+  -- region (Δ = 0.6 > θ_acc — the accuracy lens is OFF — with |a·r|/Δ ≈ 6.7 >
+  -- 4 and σ = 1.5 so the damping arm clears the cap) must route; the SAME Δ at
+  -- small amps (|a·r|/Δ ≈ 1.7 < 4) must stay cold — together they prove the
+  -- rail lens itself decided, not θ_acc. And the STATED refusal: a lens-fired
+  -- coupling at extreme Q (σ = 0.02: |c|/(e·σ_min) ≈ 18 ≥ cap 8) classifies
+  -- `refused` and the partition leaves it collected — the admission edge the
+  -- merged seam atom now states instead of certifying.
+  let railVm := (mkMode 800 1.5 2.0).toModal
+  let railRm := ({ sigma := 1.5, omega := tp * 800 + 0.6, are := 2.0 } : SeamMode).toModal
+  let railRmCold := ({ sigma := 1.5, omega := tp * 800 + 0.6, are := 0.5 } : SeamMode).toModal
+  let refVm := (mkMode 400 0.02 1.0).toModal
+  let refRm := ({ sigma := 0.02, omega := tp * 400 + 1e-6, are := 1.0 } : SeamMode).toModal
+  let railRouted := (residueComposePartitioned #[railVm] #[railRm]).2.size == 1
+  let railDiscr := (residueComposePartitioned #[railVm] #[railRmCold]).2.isEmpty
+  let refusedStated := couplingRefused refVm refRm
+                    && (residueComposePartitioned #[refVm] #[refRm]).2.isEmpty
+  let lensOk := railRouted && railDiscr && refusedStated
   let structOk := pairedS.size == 1 && plainS.size == vM.size + rHM.size
               && pairedC.size == 1 && pairedR.size == 1
   let gCoinC : PatchGraph :=
@@ -1270,20 +1307,20 @@ def runEcddPartition (arena : Arena)
     IO.println s!"        cold chain bitDiff {bitCold} (deferred fold ≡ yesterday's collected chain)"
     IO.println s!"        tuned unison (|Δ|=1e-6, sub-grid): partitioned {e1DD} vs collected {e1Coll} (oracle law)"
     IO.println s!"        tuned unison through a chain:      partitioned {eCDD} vs collected {eCColl}"
-    IO.println s!"        routing structure ok={structOk} · room-room coincident chain finite={coinFinite} preE={coinPre} E={coinE}"
+    IO.println s!"        routing structure ok={structOk} · lens-discriminated: rail routes {railRouted} / small-amp cold {railDiscr} / extreme-Q refusal stated {refusedStated} · room-room coincident chain finite={coinFinite} preE={coinPre} E={coinE}"
     -- frozen 2026-07-23 off first-landing measurements (e1DD ≈ 5e-7, eCDD ≈
     -- 6e-6, both collected counter-renders ≈ 1.0): the plain-path chain floor
     -- is 1e-4 — deliverable 2's re-freeze, an order tighter than the bloomed
     -- chain gate's 2e-3 (whose 6.7e-4 is floor-relative, not 1/Δ — diagnosed,
     -- out of v1). The collected/partitioned ratio floor is 1e4×.
-    let pass := bitCold == 0 && structOk
+    let pass := bitCold == 0 && structOk && lensOk
              && e1DD < 5e-5 && e1Coll > 1000.0 * e1DD
              && eCDD < 1e-4 && eCColl > 1000.0 * eCDD
              && coinFinite && coinPre < 1e-18 && coinE > 1e-9
     if pass then
-      passGate "ecdd-partition" s!"the EC/DD choice is the compiler's: cold chain byte-identical (bitDiff 0), tuned unison served through the paired route ({e1DD} vs collected {e1Coll}; chain {eCDD} vs {eCColl}), routing structural, coincident room chain graceful"
+      passGate "ecdd-partition" s!"the EC/DD choice is the compiler's: cold chain byte-identical (bitDiff 0), tuned unison served through the paired route ({e1DD} vs collected {e1Coll}; chain {eCDD} vs {eCColl}), routing structural + lens-discriminated (rail routes, small-amp cold, extreme-Q refusal stated), coincident room chain graceful"
     else
-      failGate "ecdd-partition" s!"bitCold={bitCold} structOk={structOk} e1DD={e1DD} e1Coll={e1Coll} eCDD={eCDD} eCColl={eCColl} coinFinite={coinFinite} coinPre={coinPre} coinE={coinE}"
+      failGate "ecdd-partition" s!"bitCold={bitCold} structOk={structOk} railRouted={railRouted} railDiscr={railDiscr} refusedStated={refusedStated} e1DD={e1DD} e1Coll={e1Coll} eCDD={eCDD} eCColl={eCColl} coinFinite={coinFinite} coinPre={coinPre} coinE={coinE}"
   | _, _, _, _, _, _, _ => failGate "ecdd-partition" "build/render failed for an erasure-gate config"
 
 /-- THE EC/DD LIVE-POLE GATE (fork 3′ Phase 2). Interval classification: a

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -406,6 +406,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runGongReverb arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runEcddPartition arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runBloomLivePole arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -409,6 +409,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runEcddPartition arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runEcddLive arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runBloomLivePole arena resolved) then
       failed := failed + 1
     total := total + 1

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -412,6 +412,9 @@ def main (args : List String) : IO UInt32 := do
     if !(← Tropical.Tropicaltest.SeamSweep.runEcddLive arena resolved) then
       failed := failed + 1
     total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runEcddGauge arena resolved) then
+      failed := failed + 1
+    total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runBloomLivePole arena resolved) then
       failed := failed + 1
     total := total + 1


### PR DESCRIPTION
Two sequential sprints on the modal seam, each validate-green at landing (now 106/106 tropicaltest + full validate).

## WS-LP: the live-pole crossing (phases 1–3a + seam hardening)

A bloomed source crosses a reverb whose rt60 is a **live knob**: `bloomCompose` classifies each pair over the knob's declared interval (`sigmaRange`) at build time and lifts the crossing constants as s0 expressions of the live slot (live CF + emitted Γ★, `atan2E` + complex `lgamma`). Phase 3a's finding: the anticipated region-union/select machinery was **deleted** — the region union collapses onto the crossing lanes, one representation valid across the whole interval. Seam hardening alongside: modal-datapath rail fix, surface seal, live poles.

## EC/DD erasure (fork 3′): the compiler owns the choice per coupling

`residueComposeEC` vs `residueComposeDD` leaves every surface. The compiler partitions **per coupling** at build time (`couplingHot`: accuracy lens θ_acc = 0.4642 rad/s ∨ range lens |a·r|/|Δ| > 4, gated by the paired range cap) and routes hot couplings to the fused divided-difference paired atom.

**The Phase-0 finding that reframed the sprint** (`demos/ecdd_partition.py`): the accuracy mechanism is the **frequency grid**, not float64 cancellation — rotator increments quantize ω at 2π·SR/2³² ≈ 6.5e-5 rad/s, so sub-grid detunes are *unrepresentable* in the collected form (the ±c/Δ residues cancel to exact silence) while the DD series branch carries raw Δ at the single-crossing floor.

- The plain arm **defers its room chain** (`ModalBank.plain` accumulates rooms); cold rooms fold in arrival order (collected, verbatim), hot rooms sort last, only the final fold partitions — `PairedMode`s never re-compose.
- **Cold byte-identity**: a θ-false partition emits yesterday's compiler exactly (bitDiff 0 through the patch surface; whole suite unchanged).
- **The migration witness**: a room mode tuned onto a voice partial (sub-grid) renders at 5e-7 vs the oracle where the collected counter-render is 1.000 — served-full where it was served-wrong.
- **One SeamAtom**: ecAtom + ddAtom merge into `residueCompose` with the union (total) admission; the old |a·r/Δ| ≥ 8 exclusion interior now carries hard probes.
- **Live poles** (phase 2): interval classification over `sigmaRange` — dippers take DD throughout the span, no runtime select; paired atoms clamp live σ to the declared interval (range cap sound by construction); the DD columns' lift confirmed at two knob values through one lane.
- **Chain floor re-frozen** at 1e-4 (plain path); the standing 6.7e-4 bloomed-chain datum diagnosed as floor-relative (not 1/Δ conditioning — nothing routes there).

## Coverage matrix (modal-seam service map, gates attached)

| cell | status |
|---|---|
| compose | closed (EC) — theorem |
| + coincident | closed (per-coupling routing; gate: ecdd-partition) |
| + chain | closed tighter (plain floor 1e-4) |
| + chain + coincident | v1 closed (sort-hot-last; Newton fold = recorded terminus, unfunded) |
| + bloom / + bloom + coincident (baked) | closed (bloomCompose, DD lanes) |
| + live | closed (WS-LP 1–3a) |
| + live + coincident (plain) | closed (interval classification; gate: ecdd-live) |
| + live + chain | plain arm served (gate: ecdd-live); bloomed arm still refused (WS-LP lift) — its own future item |

Recorded v1 conservatisms (routes out, no regressions): gauge/mix/direction force the collected fold; multi-hot beyond the final fold stays collected; room-room coincidence has structural+graceful gates (quantitative oracle = the deg-1 gap); Phase 3 (Newton fold) unfunded by census, cockpit go-verdict attached as fork 3″.

🤖 Generated with [Claude Code](https://claude.com/claude-code)