### PR TITLE
feat(ir): turn bank order, clock algebra, and i64 folding into theorems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,15 @@ ResolvedProgram (lowered)
   scalar-only · monomorphic · acyclic · non-nested (inline path) ·
   DECISION-FREE: no combinator exists except `bankSum`, the bounded
   reduction that is itself the normal form for uniform indexed families
-  (modal banks, reverbs, partial banks). How to REALIZE it — loop vs
-  unroll — is a backend's decision, made below this seam; the trunk
-  refuses it. Order preservation makes every realization bit-identical,
-  floats included (no associativity precondition). The waist of the
+  (modal banks, reverbs, partial banks). Whether a bank is REALIZED as a
+  `bankSum` region or unrolled is chosen at AUTHORING time, by the arrow
+  modal builder reading the one shared flag (`Ir/BanksFlag.lean`,
+  `TROPICAL_BANKS_UNROLL` — a debugging bisection, banked is the
+  default); backends realize whatever arrives. Order preservation makes
+  every realization bit-identical, floats included (no associativity
+  precondition) — a theorem since slice 3c (`EmitArrow/BankOrder.lean` +
+  `Ir/EmitBankLaws.lean`; trusted base = one named assumption,
+  `REDUCE_REGION_EXECUTES_IN_ARRAY_ORDER`). The waist of the
   hourglass: the smallest sub-IR sufficient for any per-sample
   evaluator — and, because `Sig` is this same constructor set, the
   authoring layer and the trunk are ONE vocabulary with the `assemble`

--- a/lean/Tropical.lean
+++ b/lean/Tropical.lean
@@ -5,3 +5,4 @@ import Tropical.Ir.Nodes
 import Tropical.Ir.Codec
 import Tropical.Plan
 import Tropical.Ir.Strata
+import Tropical.Ir.EmitBankLaws

--- a/lean/Tropical.lean
+++ b/lean/Tropical.lean
@@ -6,3 +6,4 @@ import Tropical.Ir.Codec
 import Tropical.Plan
 import Tropical.Ir.Strata
 import Tropical.Ir.EmitBankLaws
+import Tropical.Ir.ConstFoldLaws

--- a/lean/Tropical/EmitArrow.lean
+++ b/lean/Tropical/EmitArrow.lean
@@ -3,6 +3,7 @@ import Tropical.EmitArrow.Term
 import Tropical.EmitArrow.Numerics
 import Tropical.EmitArrow.Modal
 import Tropical.EmitArrow.BankOrder
+import Tropical.EmitArrow.ClockAlgebra
 import Tropical.EmitArrow.Patch
 import Tropical.EmitArrow.Gong
 

--- a/lean/Tropical/EmitArrow.lean
+++ b/lean/Tropical/EmitArrow.lean
@@ -2,6 +2,7 @@ import Tropical.EmitArrow.Sig
 import Tropical.EmitArrow.Term
 import Tropical.EmitArrow.Numerics
 import Tropical.EmitArrow.Modal
+import Tropical.EmitArrow.BankOrder
 import Tropical.EmitArrow.Patch
 import Tropical.EmitArrow.Gong
 

--- a/lean/Tropical/EmitArrow/BankOrder.lean
+++ b/lean/Tropical/EmitArrow/BankOrder.lean
@@ -1,0 +1,808 @@
+import Tropical.EmitArrow.Modal
+
+/-!
+# Bank order-preservation as a theorem (slice 3c)
+
+The claim that was prose (`Ir/Emit.lean`'s region docstring, CLAUDE.md's
+"order preservation makes every realization bit-identical") becomes a
+theorem here — carrier-parametric, exactly as scoped in
+`design/bank-order-proof-handoff.local.md`:
+
+* **`instLoop`** is the β-rule of the `bankSum` binder: instantiate
+  `loopIdx id` at a concrete index `k`, reducing the column redex
+  `index (arr xs) (loopIdx id)` to `xs[k]` in place. Capture-aware: a
+  nested `bankSum` that rebinds the same id shields its body.
+* **`unrollBanks`** is the REFERENCE REALIZATION of banks-as-data at the
+  `Sig` level: homomorphic on every constructor, and a *static* `bankSum`
+  becomes the left-nested `add` fold over `0 … count−1` in array order —
+  the same tree the unrolled builder writes by hand. A *dynamic* bank
+  (`dynCount? = some _`) has no static unrolling; its law is the emit-half
+  clamp statement (WS-B), not a `Sig` equation.
+* **WS-A** (`unrollBanks_modalBankSigTable`) states the builder's two
+  branches agree SYNTACTICALLY: `unrollBanks (modalBankSigTable …) =
+  modalBankSig …`. Syntactic `Sig` equality is stronger than any
+  denotational statement — every denotation into every carrier maps equal
+  trees to equal values, so no float model and no associativity ever enter.
+* **`refFold`** and `denote_unrollBanks_bankSum` restate the fold in the
+  handoff's carrier-parametric vocabulary: for ANY `d : Sig → α` that is a
+  homomorphism on `add` alone, the reference realization of a bank IS
+  `refFold op (d (litI 0)) (fun k => d (body@k)) count`. Which operands
+  meet in which order — nothing else.
+
+Freshness side conditions (`LoopFree`, `BankFree`) are hypotheses on the
+caller-supplied leaves (clock, anchor, mode scalars), not on anything the
+builders construct: they say the caller's Sigs do not capture the bank's
+binder id and do not smuggle a bank of their own into the leaves. On a
+concrete patch both discharge by unfolding (every real leaf is a literal,
+a param ref, or a clock expression, all of which satisfy them trivially).
+-/
+
+namespace Tropical.EmitArrow
+
+open Tropical.Ir
+
+-- ─────────────────────────────────────────────────────────────
+-- Freshness predicates
+-- ─────────────────────────────────────────────────────────────
+
+/-- `s` has no FREE occurrence of `loopIdx id` — binder-aware: a nested
+    `bankSum` whose `idxId` rebinds `id` shields its body (its tables and
+    dynamic count are outside the binder's scope and stay checked). -/
+def LoopFree (id : Nat) : Sig → Prop
+  | .num _ => True
+  | .binary _ a b => LoopFree id a ∧ LoopFree id b
+  | .unary _ a => LoopFree id a
+  | .clamp a b c => LoopFree id a ∧ LoopFree id b ∧ LoopFree id c
+  | .select a b c => LoopFree id a ∧ LoopFree id b ∧ LoopFree id c
+  | .inputRef _ => True
+  | .paramRef _ => True
+  | .nestedOut _ _ => True
+  | .sampleRate => True
+  | .sampleIndex => True
+  | .arr items => ∀ x ∈ items, LoopFree id x
+  | .index a b => LoopFree id a ∧ LoopFree id b
+  | .loopIdx j => j ≠ id
+  | .bankSum _ ts b dc ii =>
+    (∀ x ∈ ts, LoopFree id x) ∧ (ii = id ∨ LoopFree id b) ∧
+      (∀ d ∈ dc, LoopFree id d)
+
+/-- `s` contains no `bankSum` node at all (so the reference realization
+    `unrollBanks` is the identity on it). -/
+def BankFree : Sig → Prop
+  | .num _ => True
+  | .binary _ a b => BankFree a ∧ BankFree b
+  | .unary _ a => BankFree a
+  | .clamp a b c => BankFree a ∧ BankFree b ∧ BankFree c
+  | .select a b c => BankFree a ∧ BankFree b ∧ BankFree c
+  | .inputRef _ => True
+  | .paramRef _ => True
+  | .nestedOut _ _ => True
+  | .sampleRate => True
+  | .sampleIndex => True
+  | .arr items => ∀ x ∈ items, BankFree x
+  | .index a b => BankFree a ∧ BankFree b
+  | .loopIdx _ => True
+  | .bankSum _ _ _ _ _ => False
+
+-- ─────────────────────────────────────────────────────────────
+-- instLoop — the binder's β-rule
+-- ─────────────────────────────────────────────────────────────
+
+/-- Collapse an array read at a CONCRETE index: a literal array indexed at
+    `k` is its `k`-th element. Any other shape (never builder-produced —
+    columns are always `Sig.arr`) keeps the explicit indexed form. -/
+def readAt (k : Nat) : Sig → Sig
+  | .arr xs => if h : k < xs.size then xs[k] else .index (.arr xs) (litI k)
+  | a => .index a (litI k)
+
+/-- Instantiate the loop binder `id` at concrete index `k`: `loopIdx id`
+    becomes the integer literal `k`, and the column-read redex
+    `index (arr xs) (loopIdx id)` reduces to the instantiated array's
+    `k`-th element (`readAt` — the element is itself instantiated first;
+    columns may read an OUTER binder). A nested `bankSum` that rebinds `id`
+    shields its body — capture-avoidance, though the unique-binder-id
+    discipline (WS5) means the shield is never exercised on a
+    builder-produced tree. -/
+def instLoop (id k : Nat) : Sig → Sig
+  | .num n => .num n
+  | .binary t a b => .binary t (instLoop id k a) (instLoop id k b)
+  | .unary t a => .unary t (instLoop id k a)
+  | .clamp a b c => .clamp (instLoop id k a) (instLoop id k b) (instLoop id k c)
+  | .select a b c => .select (instLoop id k a) (instLoop id k b) (instLoop id k c)
+  | .inputRef i => .inputRef i
+  | .paramRef i => .paramRef i
+  | .nestedOut i o => .nestedOut i o
+  | .sampleRate => .sampleRate
+  | .sampleIndex => .sampleIndex
+  | .arr items => .arr (items.attach.map fun ⟨x, _⟩ => instLoop id k x)
+  | .index a b =>
+    match b with
+    | .loopIdx j =>
+      if j = id then readAt k (instLoop id k a)
+      else .index (instLoop id k a) (.loopIdx j)
+    | b => .index (instLoop id k a) (instLoop id k b)
+  | .loopIdx j => if j = id then litI k else .loopIdx j
+  | .bankSum c ts b dc ii =>
+    .bankSum c (ts.attach.map fun ⟨x, _⟩ => instLoop id k x)
+      (if ii = id then b else instLoop id k b)
+      (match dc with | none => none | some d => some (instLoop id k d)) ii
+
+-- ─────────────────────────────────────────────────────────────
+-- unrollBanks — the reference realization
+-- ─────────────────────────────────────────────────────────────
+
+/-- The reference realization of banks-as-data: every STATIC `bankSum`
+    becomes the left-nested `add` fold over its body instantiated at
+    `0 … count−1`, in array order — `add (… (add (add 0 b₀) b₁) …) b₍ₙ₋₁₎`,
+    the exact tree the unrolled builder (`modalBankSig`'s `foldl`) writes.
+    Inner banks unroll first (the recursion is on the body), then the outer
+    index instantiates through the result — WS-C's commutation lemma shows
+    the order doesn't matter. Tables vanish: every read of them was a redex
+    `instLoop` reduced away. A DYNAMIC bank (`dynCount? = some _`) is kept
+    as a node (its trip count is runtime data; its law is the emit-half
+    clamp, WS-B), with its pieces unrolled recursively. -/
+def unrollBanks : Sig → Sig
+  | .num n => .num n
+  | .binary t a b => .binary t (unrollBanks a) (unrollBanks b)
+  | .unary t a => .unary t (unrollBanks a)
+  | .clamp a b c => .clamp (unrollBanks a) (unrollBanks b) (unrollBanks c)
+  | .select a b c => .select (unrollBanks a) (unrollBanks b) (unrollBanks c)
+  | .inputRef i => .inputRef i
+  | .paramRef i => .paramRef i
+  | .nestedOut i o => .nestedOut i o
+  | .sampleRate => .sampleRate
+  | .sampleIndex => .sampleIndex
+  | .arr items => .arr (items.attach.map fun ⟨x, _⟩ => unrollBanks x)
+  | .index a b => .index (unrollBanks a) (unrollBanks b)
+  | .loopIdx j => .loopIdx j
+  | .bankSum c _ts b none ii =>
+    (List.range c).foldl
+      (fun acc k => .binary .add acc (instLoop ii k (unrollBanks b)))
+      (litI 0)
+  | .bankSum c ts b (some d) ii =>
+    .bankSum c (ts.attach.map fun ⟨x, _⟩ => unrollBanks x)
+      (unrollBanks b) (some (unrollBanks d)) ii
+
+-- ─────────────────────────────────────────────────────────────
+-- refFold — the handoff's carrier-parametric vocabulary
+-- ─────────────────────────────────────────────────────────────
+
+/-- Reference semantics of an indexed reduction over an ARBITRARY carrier:
+    the fold in array order. `refFold op z f (n+1) = op (refFold op z f n)
+    (f n)` — element `n` meets the accumulator last. No associativity, no
+    commutativity, no float model: the statement is about which operands
+    meet in which order, nothing else. -/
+def refFold {α : Sort _} (op : α → α → α) (z : α) (f : Nat → α) : Nat → α
+  | 0 => z
+  | n + 1 => op (refFold op z f n) (f n)
+
+-- ─────────────────────────────────────────────────────────────
+-- Equation lemmas for the overlapping `index` match
+-- ─────────────────────────────────────────────────────────────
+
+/-- The column-read β-redex: indexing a literal array at the binder being
+    instantiated reduces to the (instantiated) element. -/
+theorem instLoop_redex {id k : Nat} {xs : Array Sig} (h : k < xs.size) :
+    instLoop id k (.index (.arr xs) (.loopIdx id)) = instLoop id k (xs[k]'h) := by
+  simp [instLoop, readAt, h]
+
+-- ─────────────────────────────────────────────────────────────
+-- Identity lemmas: fresh trees are fixed points
+-- ─────────────────────────────────────────────────────────────
+
+private theorem attach_map_eq_of_id {f : Sig → Sig} (xs : Array Sig)
+    (hf : ∀ x ∈ xs, f x = x) :
+    (xs.attach.map fun ⟨x, _⟩ => f x) = xs := by
+  apply Array.ext
+  · simp
+  · intro i h1 h2
+    simp only [Array.getElem_map, Array.getElem_attach]
+    exact hf xs[i] (Array.getElem_mem h2)
+
+/-- Instantiation is the identity on a tree with no free occurrence of the
+    binder: `instLoop` can only rewrite at `loopIdx id` (directly or through
+    the column redex), and `LoopFree` says there is none. -/
+theorem instLoop_of_loopFree {id k : Nat} :
+    ∀ {s : Sig}, LoopFree id s → instLoop id k s = s := by
+  intro s
+  induction s using instLoop.induct id with
+  | case1 n => intro _; simp [instLoop]
+  | case2 t a b iha ihb =>
+    intro h; simp only [LoopFree] at h
+    simp [instLoop, iha h.1, ihb h.2]
+  | case3 t a ih =>
+    intro h; simp only [LoopFree] at h
+    simp [instLoop, ih h]
+  | case4 a b c iha ihb ihc =>
+    intro h; simp only [LoopFree] at h
+    simp [instLoop, iha h.1, ihb h.2.1, ihc h.2.2]
+  | case5 a b c iha ihb ihc =>
+    intro h; simp only [LoopFree] at h
+    simp [instLoop, iha h.1, ihb h.2.1, ihc h.2.2]
+  | case6 i => intro _; simp [instLoop]
+  | case7 i => intro _; simp [instLoop]
+  | case8 i o => intro _; simp [instLoop]
+  | case9 => intro _; simp [instLoop]
+  | case10 => intro _; simp [instLoop]
+  | case11 items ih =>
+    intro h; simp only [LoopFree] at h
+    simp only [instLoop]
+    rw [attach_map_eq_of_id items (fun x hx => ih x hx (h x hx))]
+  | case12 a iha =>
+    -- reading at the binder itself: contradicts LoopFree (`loopIdx id`)
+    intro hf; simp only [LoopFree] at hf
+    exact absurd rfl hf.2
+  | case13 a j hne iha =>
+    intro h; simp only [LoopFree] at h
+    simp [instLoop, hne, iha h.1]
+  | case14 a b hg iha ihb =>
+    intro h; simp only [LoopFree] at h
+    simp only [instLoop]
+    rw [iha h.1, ihb h.2]
+  | case15 => intro hf; simp only [LoopFree] at hf; exact absurd rfl hf
+  | case16 j hne => intro _; simp [instLoop, hne]
+  | case17 c ts b dc ii ihts ihb ihdc =>
+    intro h; simp only [LoopFree] at h
+    have hbody : (if ii = id then b else instLoop id k b) = b := by
+      split
+      · rfl
+      · rename_i hii
+        exact ihb (h.2.1.resolve_left hii)
+    cases dc with
+    | none =>
+      simp only [instLoop]
+      rw [attach_map_eq_of_id ts (fun x hx => ihts x hx (h.1 x hx)), hbody]
+    | some d =>
+      simp only [instLoop]
+      rw [attach_map_eq_of_id ts (fun x hx => ihts x hx (h.1 x hx)), hbody,
+        ihdc (h.2.2 d rfl)]
+
+/-- The reference realization is the identity on a bank-free tree. -/
+theorem unrollBanks_of_bankFree :
+    ∀ {s : Sig}, BankFree s → unrollBanks s = s := by
+  intro s
+  induction s using unrollBanks.induct with
+  | case1 n => intro _; simp [unrollBanks]
+  | case2 t a b iha ihb =>
+    intro h; simp only [BankFree] at h
+    simp [unrollBanks, iha h.1, ihb h.2]
+  | case3 t a ih =>
+    intro h; simp only [BankFree] at h
+    simp [unrollBanks, ih h]
+  | case4 a b c iha ihb ihc =>
+    intro h; simp only [BankFree] at h
+    simp [unrollBanks, iha h.1, ihb h.2.1, ihc h.2.2]
+  | case5 a b c iha ihb ihc =>
+    intro h; simp only [BankFree] at h
+    simp [unrollBanks, iha h.1, ihb h.2.1, ihc h.2.2]
+  | case6 i => intro _; simp [unrollBanks]
+  | case7 i => intro _; simp [unrollBanks]
+  | case8 i o => intro _; simp [unrollBanks]
+  | case9 => intro _; simp [unrollBanks]
+  | case10 => intro _; simp [unrollBanks]
+  | case11 items ih =>
+    intro h; simp only [BankFree] at h
+    simp only [unrollBanks]
+    rw [attach_map_eq_of_id items (fun x hx => ih x hx (h x hx))]
+  | case12 a b iha ihb =>
+    intro h; simp only [BankFree] at h
+    simp [unrollBanks, iha h.1, ihb h.2]
+  | case13 j => intro _; simp [unrollBanks]
+  | case14 c ts b ii ihb =>
+    intro hf; simp only [BankFree] at hf
+  | case15 c ts b d ii ihts ihb ihd =>
+    intro hf; simp only [BankFree] at hf
+-- ─────────────────────────────────────────────────────────────
+-- Freshness composes through folds and the landing-exponent builder
+-- ─────────────────────────────────────────────────────────────
+
+private theorem pred_foldl {β} {P : Sig → Prop} (xs : Array β) (g : Sig → β → Sig)
+    (z : Sig) (hz : P z) (hstep : ∀ acc x, x ∈ xs → P acc → P (g acc x)) :
+    P (xs.foldl g z) :=
+  Array.foldl_induction (motive := fun _ acc => P acc) hz
+    (fun i b hb => hstep b xs[i] (Array.getElem_mem i.isLt) hb)
+
+/-- The dynamic branch of `bankLandExp` is `⌊log₂⌋` of the per-mode
+    weight-bound max fold — the SHAPE fact the freshness lemmas read (the
+    static branch is literals and needs nothing beyond its constructor). -/
+theorem bankLandExp_dynamic_shape {modes : Array ModalMode} {ks : Sig}
+    (h : bankLandExp modes = .dynamic ks) :
+    ks = clampE (sub (.unary .floatExponent (modes.foldl (fun acc m =>
+        selectE (gt acc (modeWeightBoundSig m)) acc (modeWeightBoundSig m))
+      (lit 0))) (lit 4)) (lit 0) (lit 28) := by
+  unfold bankLandExp at h
+  simp only [Id.run, bind, pure] at h
+  split at h
+  split at h
+  · exact LandExp.noConfusion h
+  · cases h; rfl
+
+private theorem loopFree_litF {id : Nat} (x : Float) : LoopFree id (litF x) := by
+  simp only [litF, lit]
+  split <;> split <;> simp [LoopFree]
+
+private theorem bankFree_litF (x : Float) : BankFree (litF x) := by
+  simp only [litF, lit]
+  split <;> split <;> simp [BankFree]
+
+private theorem loopFree_powE {id : Nat} {b : Sig} (hb : LoopFree id b) :
+    ∀ n, LoopFree id (powE b n)
+  | 0 => by simp [powE, lit, LoopFree]
+  | 1 => hb
+  | n + 2 => by
+    simpa [powE, mul, LoopFree] using ⟨loopFree_powE hb (n + 1), hb⟩
+
+private theorem bankFree_powE {b : Sig} (hb : BankFree b) :
+    ∀ n, BankFree (powE b n)
+  | 0 => by simp [powE, lit, BankFree]
+  | 1 => hb
+  | n + 2 => by
+    simpa [powE, mul, BankFree] using ⟨bankFree_powE hb (n + 1), hb⟩
+
+private theorem loopFree_modeWeightBoundSig {id : Nat} {m : ModalMode}
+    (hs : LoopFree id m.sigma) (hcre : LoopFree id m.cre)
+    (hcim : LoopFree id m.cim) : LoopFree id (modeWeightBoundSig m) := by
+  unfold modeWeightBoundSig
+  split
+  · simp [add, LoopFree, hcre, hcim]
+  · have hbase : LoopFree id (div (litF m.deg.toFloat)
+        (mul m.sigma (litF 2.718281828459045))) := by
+      simp [div, mul, LoopFree, loopFree_litF, hs]
+    have hp := loopFree_powE hbase m.deg
+    simp only [mul, add, LoopFree]
+    exact ⟨hp, hcre, hcim⟩
+
+private theorem bankFree_modeWeightBoundSig {m : ModalMode}
+    (hs : BankFree m.sigma) (hcre : BankFree m.cre)
+    (hcim : BankFree m.cim) : BankFree (modeWeightBoundSig m) := by
+  unfold modeWeightBoundSig
+  split
+  · simp [add, BankFree, hcre, hcim]
+  · have hbase : BankFree (div (litF m.deg.toFloat)
+        (mul m.sigma (litF 2.718281828459045))) := by
+      simp [div, mul, BankFree, bankFree_litF, hs]
+    have hp := bankFree_powE hbase m.deg
+    simp only [mul, add, BankFree]
+    exact ⟨hp, hcre, hcim⟩
+
+/-- The landing scale/shift are as fresh as the bank's mode scalars: the
+    static branch is literals; the dynamic branch folds
+    `modeWeightBoundSig` over the modes and freshness rides the fold. -/
+theorem loopFree_landExp {id : Nat} {modes : Array ModalMode}
+    (hm : ∀ m ∈ modes, LoopFree id m.sigma ∧ LoopFree id m.cre ∧ LoopFree id m.cim) :
+    LoopFree id (bankLandExp modes).scale ∧ LoopFree id (bankLandExp modes).shift := by
+  cases hle : bankLandExp modes with
+  | static k => exact ⟨by simp [LandExp.scale, lit, LoopFree],
+      by simp [LandExp.shift, lit, LoopFree]⟩
+  | dynamic ks =>
+    have hks := bankLandExp_dynamic_shape hle
+    subst hks
+    have hfold : LoopFree id (modes.foldl (fun acc m =>
+        selectE (gt acc (modeWeightBoundSig m)) acc (modeWeightBoundSig m)) (lit 0)) := by
+      refine pred_foldl _ _ _ (by simp [lit, LoopFree]) ?_
+      intro acc x hx hacc
+      have h := hm x hx
+      simp [selectE, gt, LoopFree, hacc,
+        loopFree_modeWeightBoundSig h.1 h.2.1 h.2.2]
+    simp only [lit] at hfold
+    exact ⟨by simp [LandExp.scale, ldexpE, sub, clampE, lit, LoopFree, hfold],
+      by simp [LandExp.shift, sub, clampE, lit, LoopFree, hfold]⟩
+
+theorem bankFree_landExp {modes : Array ModalMode}
+    (hm : ∀ m ∈ modes, BankFree m.sigma ∧ BankFree m.cre ∧ BankFree m.cim) :
+    BankFree (bankLandExp modes).scale ∧ BankFree (bankLandExp modes).shift := by
+  cases hle : bankLandExp modes with
+  | static k => exact ⟨by simp [LandExp.scale, lit, BankFree],
+      by simp [LandExp.shift, lit, BankFree]⟩
+  | dynamic ks =>
+    have hks := bankLandExp_dynamic_shape hle
+    subst hks
+    have hfold : BankFree (modes.foldl (fun acc m =>
+        selectE (gt acc (modeWeightBoundSig m)) acc (modeWeightBoundSig m)) (lit 0)) := by
+      refine pred_foldl _ _ _ (by simp [lit, BankFree]) ?_
+      intro acc x hx hacc
+      have h := hm x hx
+      simp [selectE, gt, BankFree, hacc,
+        bankFree_modeWeightBoundSig h.1 h.2.1 h.2.2]
+    simp only [lit] at hfold
+    exact ⟨by simp [LandExp.scale, ldexpE, sub, clampE, lit, BankFree, hfold],
+      by simp [LandExp.shift, sub, clampE, lit, BankFree, hfold]⟩
+
+-- ─────────────────────────────────────────────────────────────
+-- The fold bridge: `List.range` index fold ≡ array element fold
+-- ─────────────────────────────────────────────────────────────
+
+private theorem range_foldl_eq_list_foldl {β} (l : List β) (f : Nat → Sig)
+    (osc : β → Sig) (z : Sig)
+    (h : ∀ (k : Nat) (hk : k < l.length), f k = osc l[k]) :
+    (List.range l.length).foldl (fun acc k => add acc (f k)) z
+      = l.foldl (fun acc m => add acc (osc m)) z := by
+  induction l generalizing f z with
+  | nil => simp
+  | cons m l' ih =>
+    have h0 : f 0 = osc m := h 0 (by simp)
+    simp only [List.length_cons, List.range_succ_eq_map, List.foldl_cons,
+      List.foldl_map, h0]
+    exact ih (fun k => f (k + 1)) (add z (osc m))
+      (fun k hk => by simpa using h (k + 1) (by simpa))
+
+/-- The reference realization's index fold over `0 … n−1` IS the builder's
+    element fold: same operands, same order, same left-nested `add` tree. -/
+private theorem range_foldl_eq_array_foldl {β} (xs : Array β) (f : Nat → Sig)
+    (osc : β → Sig) (z : Sig)
+    (h : ∀ (k : Nat) (hk : k < xs.size), f k = osc xs[k]) :
+    (List.range xs.size).foldl (fun acc k => add acc (f k)) z
+      = xs.foldl (fun acc m => add acc (osc m)) z := by
+  rw [← Array.foldl_toList, ← Array.length_toList]
+  exact range_foldl_eq_list_foldl xs.toList f osc z (fun k hk => by
+    simpa [Array.getElem_toList] using h k (by simpa using hk))
+
+-- ─────────────────────────────────────────────────────────────
+-- Distribution lemmas: instLoop / unrollBanks through the op algebra
+-- ─────────────────────────────────────────────────────────────
+-- Both walkers are homomorphic on every scalar smart constructor; stating
+-- the fact per constructor (rather than unfolding constructors globally)
+-- keeps every proof at the combinator level the builders are written in.
+
+section Distribution
+
+variable {id k : Nat} {a b c : Sig}
+
+@[local simp] theorem instLoop_binary {t} :
+    instLoop id k (.binary t a b) = .binary t (instLoop id k a) (instLoop id k b) := by
+  simp [instLoop]
+@[local simp] theorem instLoop_unary {t} :
+    instLoop id k (.unary t a) = .unary t (instLoop id k a) := by simp [instLoop]
+@[local simp] theorem instLoop_mul : instLoop id k (mul a b) = mul (instLoop id k a) (instLoop id k b) := by simp [mul]
+@[local simp] theorem instLoop_add : instLoop id k (add a b) = add (instLoop id k a) (instLoop id k b) := by simp [add]
+@[local simp] theorem instLoop_sub : instLoop id k (sub a b) = sub (instLoop id k a) (instLoop id k b) := by simp [sub]
+@[local simp] theorem instLoop_div : instLoop id k (div a b) = div (instLoop id k a) (instLoop id k b) := by simp [div]
+@[local simp] theorem instLoop_neg : instLoop id k (neg a) = neg (instLoop id k a) := by simp [neg]
+@[local simp] theorem instLoop_toIntE : instLoop id k (toIntE a) = toIntE (instLoop id k a) := by simp [toIntE]
+@[local simp] theorem instLoop_toFloatE : instLoop id k (toFloatE a) = toFloatE (instLoop id k a) := by simp [toFloatE]
+@[local simp] theorem instLoop_rshift : instLoop id k (rshift a b) = rshift (instLoop id k a) (instLoop id k b) := by simp [rshift]
+@[local simp] theorem instLoop_lshift : instLoop id k (lshift a b) = lshift (instLoop id k a) (instLoop id k b) := by simp [lshift]
+@[local simp] theorem instLoop_bitAnd : instLoop id k (bitAnd a b) = bitAnd (instLoop id k a) (instLoop id k b) := by simp [bitAnd]
+@[local simp] theorem instLoop_gt : instLoop id k (gt a b) = gt (instLoop id k a) (instLoop id k b) := by simp [gt]
+@[local simp] theorem instLoop_roundE : instLoop id k (roundE a) = roundE (instLoop id k a) := by simp [roundE]
+@[local simp] theorem instLoop_ldexpE : instLoop id k (ldexpE a b) = ldexpE (instLoop id k a) (instLoop id k b) := by simp [ldexpE]
+@[local simp] theorem instLoop_clampE :
+    instLoop id k (clampE a b c) = clampE (instLoop id k a) (instLoop id k b) (instLoop id k c) := by
+  simp [clampE, instLoop]
+@[local simp] theorem instLoop_selectE :
+    instLoop id k (selectE a b c) = selectE (instLoop id k a) (instLoop id k b) (instLoop id k c) := by
+  simp [selectE, instLoop]
+@[local simp] theorem instLoop_lit {m : Int} {e : Nat} : instLoop id k (lit m e) = lit m e := by
+  simp [lit, instLoop]
+@[local simp] theorem instLoop_litI {m : Int} : instLoop id k (litI m) = litI m := by
+  simp [litI, instLoop]
+@[local simp] theorem instLoop_sampleRate : instLoop id k .sampleRate = .sampleRate := by
+  simp [instLoop]
+@[local simp] theorem instLoop_twoPiE : instLoop id k twoPiE = twoPiE := by
+  simp [twoPiE]
+
+@[local simp] theorem unrollBanks_binary {t} :
+    unrollBanks (.binary t a b) = .binary t (unrollBanks a) (unrollBanks b) := by
+  simp [unrollBanks]
+@[local simp] theorem unrollBanks_unary {t} :
+    unrollBanks (.unary t a) = .unary t (unrollBanks a) := by simp [unrollBanks]
+@[local simp] theorem unrollBanks_mul : unrollBanks (mul a b) = mul (unrollBanks a) (unrollBanks b) := by simp [mul]
+@[local simp] theorem unrollBanks_add : unrollBanks (add a b) = add (unrollBanks a) (unrollBanks b) := by simp [add]
+@[local simp] theorem unrollBanks_sub : unrollBanks (sub a b) = sub (unrollBanks a) (unrollBanks b) := by simp [sub]
+@[local simp] theorem unrollBanks_div : unrollBanks (div a b) = div (unrollBanks a) (unrollBanks b) := by simp [div]
+@[local simp] theorem unrollBanks_neg : unrollBanks (neg a) = neg (unrollBanks a) := by simp [neg]
+@[local simp] theorem unrollBanks_toIntE : unrollBanks (toIntE a) = toIntE (unrollBanks a) := by simp [toIntE]
+@[local simp] theorem unrollBanks_toFloatE : unrollBanks (toFloatE a) = toFloatE (unrollBanks a) := by simp [toFloatE]
+@[local simp] theorem unrollBanks_rshift : unrollBanks (rshift a b) = rshift (unrollBanks a) (unrollBanks b) := by simp [rshift]
+@[local simp] theorem unrollBanks_lshift : unrollBanks (lshift a b) = lshift (unrollBanks a) (unrollBanks b) := by simp [lshift]
+@[local simp] theorem unrollBanks_bitAnd : unrollBanks (bitAnd a b) = bitAnd (unrollBanks a) (unrollBanks b) := by simp [bitAnd]
+@[local simp] theorem unrollBanks_gt : unrollBanks (gt a b) = gt (unrollBanks a) (unrollBanks b) := by simp [gt]
+@[local simp] theorem unrollBanks_roundE : unrollBanks (roundE a) = roundE (unrollBanks a) := by simp [roundE]
+@[local simp] theorem unrollBanks_ldexpE : unrollBanks (ldexpE a b) = ldexpE (unrollBanks a) (unrollBanks b) := by simp [ldexpE]
+@[local simp] theorem unrollBanks_clampE :
+    unrollBanks (clampE a b c) = clampE (unrollBanks a) (unrollBanks b) (unrollBanks c) := by
+  simp [clampE, unrollBanks]
+@[local simp] theorem unrollBanks_selectE :
+    unrollBanks (selectE a b c) = selectE (unrollBanks a) (unrollBanks b) (unrollBanks c) := by
+  simp [selectE, unrollBanks]
+@[local simp] theorem unrollBanks_lit {m : Int} {e : Nat} : unrollBanks (lit m e) = lit m e := by
+  simp [lit, unrollBanks]
+@[local simp] theorem unrollBanks_litI {m : Int} : unrollBanks (litI m) = litI m := by
+  simp [litI, unrollBanks]
+@[local simp] theorem unrollBanks_sampleRate : unrollBanks .sampleRate = .sampleRate := by
+  simp [unrollBanks]
+@[local simp] theorem unrollBanks_twoPiE : unrollBanks twoPiE = twoPiE := by
+  simp [twoPiE]
+@[local simp] theorem unrollBanks_index :
+    unrollBanks (.index a b) = .index (unrollBanks a) (unrollBanks b) := by
+  simp [unrollBanks]
+@[local simp] theorem unrollBanks_loopIdx {j : Nat} :
+    unrollBanks (.loopIdx j) = .loopIdx j := by simp [unrollBanks]
+
+/-- The reference realization of a STATIC bank: the left-nested `add` fold
+    over the instantiated body, in array order. -/
+theorem unrollBanks_bankSum {n : Nat} {ts : Array Sig} {b : Sig} {ii : Nat} :
+    unrollBanks (.bankSum n ts b none ii)
+      = (List.range n).foldl
+          (fun acc j => add acc (instLoop ii j (unrollBanks b))) (litI 0) := by
+  simp [unrollBanks, add]
+
+-- Commutation through the numeric kernels: each is a fixed finite tree of
+-- smart constructors, so the walkers pass through by the lemmas above.
+
+@[local simp] theorem instLoop_relClockQ {x y : Sig} :
+    instLoop id k (relClockQ x y) = relClockQ (instLoop id k x) (instLoop id k y) := by
+  simp [relClockQ]
+@[local simp] theorem unrollBanks_relClockQ {x y : Sig} :
+    unrollBanks (relClockQ x y) = relClockQ (unrollBanks x) (unrollBanks y) := by
+  simp [relClockQ]
+@[local simp] theorem instLoop_modePhaseQFromIncr {x y : Sig} :
+    instLoop id k (modePhaseQFromIncr x y)
+      = modePhaseQFromIncr (instLoop id k x) (instLoop id k y) := by
+  simp [modePhaseQFromIncr]
+@[local simp] theorem unrollBanks_modePhaseQFromIncr {x y : Sig} :
+    unrollBanks (modePhaseQFromIncr x y)
+      = modePhaseQFromIncr (unrollBanks x) (unrollBanks y) := by
+  simp [modePhaseQFromIncr]
+@[local simp] theorem instLoop_expSig {x : Sig} :
+    instLoop id k (expSig x) = expSig (instLoop id k x) := by
+  simp [expSig]
+@[local simp] theorem unrollBanks_expSig {x : Sig} :
+    unrollBanks (expSig x) = expSig (unrollBanks x) := by
+  simp [expSig]
+@[local simp] theorem instLoop_fixedSinCycSig {x : Sig} :
+    instLoop id k (fixedSinCycSig x) = fixedSinCycSig (instLoop id k x) := by
+  simp [fixedSinCycSig]
+@[local simp] theorem unrollBanks_fixedSinCycSig {x : Sig} :
+    unrollBanks (fixedSinCycSig x) = fixedSinCycSig (unrollBanks x) := by
+  simp [fixedSinCycSig]
+@[local simp] theorem instLoop_fixedCosCycSig {x : Sig} :
+    instLoop id k (fixedCosCycSig x) = fixedCosCycSig (instLoop id k x) := by
+  simp [fixedCosCycSig]
+@[local simp] theorem unrollBanks_fixedCosCycSig {x : Sig} :
+    unrollBanks (fixedCosCycSig x) = fixedCosCycSig (unrollBanks x) := by
+  simp [fixedCosCycSig]
+@[local simp] theorem instLoop_fixedOutQ {n : Nat} {x : Sig} :
+    instLoop id k (fixedOutQ n x) = fixedOutQ n (instLoop id k x) := by
+  simp [fixedOutQ]
+@[local simp] theorem unrollBanks_fixedOutQ {n : Nat} {x : Sig} :
+    unrollBanks (fixedOutQ n x) = fixedOutQ n (unrollBanks x) := by
+  simp [fixedOutQ]
+
+/-- Baking the increment into a column and re-`toInt`ing it in the body IS
+    the unrolled phase computation — definitionally. -/
+theorem modePhaseQ_fromIncr {omega clkRel : Sig} :
+    modePhaseQFromIncr
+        (toIntE (div (mul (div omega twoPiE) (lit 4294967296)) .sampleRate)) clkRel
+      = modePhaseQ omega clkRel := rfl
+
+/-- Instantiating a column read: `index (arr (xs.map f)) (loopIdx id)` at
+    concrete `k` is `f xs[k]` — provided the column's entries do not
+    themselves read the binder. THE β-step of banks-as-data. -/
+theorem instLoop_read_map {id k : Nat} {β} (xs : Array β) (f : β → Sig)
+    (hf : ∀ x ∈ xs, LoopFree id (f x)) (hk : k < xs.size) :
+    instLoop id k (.index (.arr (xs.map f)) (.loopIdx id)) = f xs[k] := by
+  have hcol : ((xs.map f).attach.map fun ⟨x, _⟩ => instLoop id k x) = xs.map f :=
+    attach_map_eq_of_id _ (fun x hx => by
+      obtain ⟨m, hm', rfl⟩ := Array.mem_map.mp hx
+      exact instLoop_of_loopFree (hf m hm'))
+  simp [instLoop, readAt, hcol, Array.size_map, hk, Array.getElem_map]
+
+end Distribution
+
+-- ─────────────────────────────────────────────────────────────
+-- WS-A: the builder's two branches agree
+-- ─────────────────────────────────────────────────────────────
+
+/-- Caller-supplied leaves must be FRESH for the bank's binder: no free
+    read of the binder id, and no bank of their own smuggled into a leaf.
+    Trivially true of every real call site (literals, param refs, clock
+    expressions) — the hypotheses exist because `Sig` cannot say "closed
+    term" by type. -/
+def Fresh (id : Nat) (s : Sig) : Prop := LoopFree id s ∧ BankFree s
+
+/-- **WS-A.** The banked lowering `modalBankSigTable` and the unrolled
+    lowering `modalBankSig` are the SAME tree once the bank region is read
+    through its reference realization: `unrollBanks` turns the `bankSum`
+    into the left-nested add fold in array order, and the result is
+    syntactically `modalBankSig`'s output. Carrier-free: syntactic equality
+    is preserved by every denotation, so any interpretation of the ops —
+    floats included — renders the two identically. Hypotheses: the bank is
+    uniform (`deg = 0`, the table lowering's admission gate) and the
+    caller-supplied leaves are fresh. -/
+theorem unrollBanks_modalBankSigTable
+    (modes : Array ModalMode) (clkInt anchor : Sig)
+    (hu : bankIsUniform modes = true)
+    (hclk : Fresh 0 clkInt) (hanc : Fresh 0 anchor)
+    (hm : ∀ m ∈ modes,
+      Fresh 0 m.omega ∧ Fresh 0 m.sigma ∧ Fresh 0 m.cre ∧ Fresh 0 m.cim) :
+    unrollBanks (modalBankSigTable modes clkInt anchor none)
+      = modalBankSig modes clkInt anchor := by
+  -- repackaged freshness
+  have hmL : ∀ m ∈ modes, LoopFree 0 m.sigma ∧ LoopFree 0 m.cre ∧ LoopFree 0 m.cim :=
+    fun m h => ⟨(hm m h).2.1.1, (hm m h).2.2.1.1, (hm m h).2.2.2.1⟩
+  have hmB : ∀ m ∈ modes, BankFree m.sigma ∧ BankFree m.cre ∧ BankFree m.cim :=
+    fun m h => ⟨(hm m h).2.1.2, (hm m h).2.2.1.2, (hm m h).2.2.2.2⟩
+  have hleL := loopFree_landExp (id := 0) hmL
+  have hleB := bankFree_landExp hmB
+  have hdeg : ∀ (i : Nat) (hi : i < modes.size), modes[i].deg = 0 := by
+    unfold bankIsUniform at hu
+    simpa [Array.all_eq_true] using hu
+  -- identity facts for the walkers on the opaque leaves
+  have huClk : unrollBanks clkInt = clkInt := unrollBanks_of_bankFree hclk.2
+  have huAnc : unrollBanks anchor = anchor := unrollBanks_of_bankFree hanc.2
+  have huScale : unrollBanks (bankLandExp modes).scale = (bankLandExp modes).scale :=
+    unrollBanks_of_bankFree hleB.1
+  have huShift : unrollBanks (bankLandExp modes).shift = (bankLandExp modes).shift :=
+    unrollBanks_of_bankFree hleB.2
+  -- the four coefficient columns are bank-free arrays: unrollBanks fixes them
+  have hcolU : ∀ (f : ModalMode → Sig), (∀ m ∈ modes, BankFree (f m)) →
+      unrollBanks (Sig.arr (modes.map f)) = Sig.arr (modes.map f) := by
+    intro f hf
+    refine unrollBanks_of_bankFree ?_
+    simp only [BankFree]
+    intro x hx
+    obtain ⟨m, hm', rfl⟩ := Array.mem_map.mp hx
+    exact hf m hm'
+  have hcIncr := hcolU (fun m => div (mul (div m.omega twoPiE) (lit 4294967296)) .sampleRate)
+    (fun m h => by simp [div, mul, lit, twoPiE, BankFree, (hm m h).1.2])
+  have hcSigma := hcolU (fun m => m.sigma) (fun m h => (hm m h).2.1.2)
+  have hcCre := hcolU (fun m => m.cre) (fun m h => (hm m h).2.2.1.2)
+  have hcCim := hcolU (fun m => m.cim) (fun m h => (hm m h).2.2.2.2)
+  -- Phase A: expose both builders, push `unrollBanks` to the leaves, erase it
+  simp only [modalBankSigTable, modalBankSig, bankFold, bankCols,
+    unrollBanks_selectE, unrollBanks_gt, unrollBanks_fixedOutQ, unrollBanks_lit,
+    unrollBanks_relClockQ, unrollBanks_bankSum, huClk, huAnc]
+  -- Phase A': the bank body under the fold — push the walker through it
+  simp only [unrollBanks_rshift, unrollBanks_sub, unrollBanks_mul,
+    unrollBanks_toIntE, unrollBanks_expSig, unrollBanks_neg, unrollBanks_div,
+    unrollBanks_toFloatE, unrollBanks_modePhaseQFromIncr,
+    unrollBanks_fixedSinCycSig, unrollBanks_fixedCosCycSig, unrollBanks_index,
+    unrollBanks_loopIdx, unrollBanks_sampleRate, unrollBanks_lit,
+    hcIncr, hcSigma, hcCre, hcCim, huScale, huShift, huClk, huAnc,
+    unrollBanks_relClockQ]
+  -- the two folds: index fold over `range modes.size` = element fold
+  congr 1
+  congr 1
+  refine range_foldl_eq_array_foldl modes _ _ _ ?_
+  intro j hj
+  -- Phase B: instantiate the body at index j and compare with mode j's unroll
+  have hiClk : instLoop 0 j clkInt = clkInt := instLoop_of_loopFree hclk.1
+  have hiAnc : instLoop 0 j anchor = anchor := instLoop_of_loopFree hanc.1
+  have hiScale : instLoop 0 j (bankLandExp modes).scale = (bankLandExp modes).scale :=
+    instLoop_of_loopFree hleL.1
+  have hiShift : instLoop 0 j (bankLandExp modes).shift = (bankLandExp modes).shift :=
+    instLoop_of_loopFree hleL.2
+  have hrIncr := instLoop_read_map (id := 0) (k := j) modes
+    (fun m => div (mul (div m.omega twoPiE) (lit 4294967296)) .sampleRate)
+    (fun m h => by simp [div, mul, lit, twoPiE, LoopFree, (hm m h).1.1]) hj
+  have hrSigma := instLoop_read_map (id := 0) (k := j) modes (fun m => m.sigma)
+    (fun m h => (hm m h).2.1.1) hj
+  have hrCre := instLoop_read_map (id := 0) (k := j) modes (fun m => m.cre)
+    (fun m h => (hm m h).2.2.1.1) hj
+  have hrCim := instLoop_read_map (id := 0) (k := j) modes (fun m => m.cim)
+    (fun m h => (hm m h).2.2.2.1) hj
+  simp only [instLoop_rshift, instLoop_sub, instLoop_mul, instLoop_toIntE,
+    instLoop_expSig, instLoop_neg, instLoop_div, instLoop_toFloatE,
+    instLoop_modePhaseQFromIncr, instLoop_fixedSinCycSig,
+    instLoop_fixedCosCycSig, instLoop_sampleRate, instLoop_lit,
+    instLoop_relClockQ,
+    hrIncr, hrSigma, hrCre, hrCim, hiScale, hiShift, hiClk, hiAnc,
+    modePhaseQ_fromIncr, hdeg j hj]
+  simp
+
+-- ─────────────────────────────────────────────────────────────
+-- The carrier-parametric corollaries (the handoff's vocabulary)
+-- ─────────────────────────────────────────────────────────────
+
+private theorem denote_range_foldl {α} (d : Sig → α) (op : α → α → α)
+    (hadd : ∀ a b, d (add a b) = op (d a) (d b)) (f : Nat → Sig) (z0 : Sig) :
+    ∀ n, d ((List.range n).foldl (fun acc j => add acc (f j)) z0)
+      = refFold op (d z0) (fun j => d (f j)) n
+  | 0 => by simp [refFold]
+  | n + 1 => by
+    rw [List.range_succ, List.foldl_append]
+    simp only [List.foldl_cons, List.foldl_nil]
+    rw [hadd, denote_range_foldl d op hadd f z0 n]
+    rfl
+
+/-- The reference realization of a STATIC bank, read through ANY map
+    `d : Sig → α` that is a homomorphism on `add` alone (no other structure,
+    no properties of `op` — not associativity, not commutativity, nothing):
+    it is `refFold` — the fold over `0 … n−1` in array order. This is the
+    handoff's `⟦bank⟧ op = refFold op z body n`, with the carrier fully
+    abstract; instantiating `α := Float` with IEEE addition is just one
+    reading, and needs no float model because the statement never looks
+    inside `op`. -/
+theorem denote_unrollBanks_bankSum {α} (d : Sig → α) (op : α → α → α) (z : α)
+    (hadd : ∀ a b, d (add a b) = op (d a) (d b)) (hz : d (litI 0) = z)
+    {n : Nat} {ts : Array Sig} {b : Sig} {ii : Nat} :
+    d (unrollBanks (.bankSum n ts b none ii))
+      = refFold op z (fun j => d (instLoop ii j (unrollBanks b))) n := by
+  rw [unrollBanks_bankSum, denote_range_foldl d op hadd _ _ n, hz]
+
+/-- **WS-A, denotationally.** Any denotation whatsoever agrees on the two
+    builder branches once the banked one is read through its reference
+    realization — immediate from the syntactic theorem, and the reason the
+    syntactic theorem is the strong form: `d` never has to be specified. -/
+theorem denote_modalBankSigTable_eq_modalBankSig {α} (d : Sig → α)
+    (modes : Array ModalMode) (clkInt anchor : Sig)
+    (hu : bankIsUniform modes = true)
+    (hclk : Fresh 0 clkInt) (hanc : Fresh 0 anchor)
+    (hm : ∀ m ∈ modes,
+      Fresh 0 m.omega ∧ Fresh 0 m.sigma ∧ Fresh 0 m.cre ∧ Fresh 0 m.cim) :
+    d (unrollBanks (modalBankSigTable modes clkInt anchor none))
+      = d (modalBankSig modes clkInt anchor) :=
+  congrArg d (unrollBanks_modalBankSigTable modes clkInt anchor hu hclk hanc hm)
+
+-- ─────────────────────────────────────────────────────────────
+-- WS-C: nested banks compose (fold-of-folds, WS5's unique binder ids)
+-- ─────────────────────────────────────────────────────────────
+
+/-- Instantiating a binder DISTRIBUTES through an unrolled fold: the fold
+    structure (count, order, the left-nested `add` spine, the zero) is
+    untouched; only the per-iteration body is instantiated. This is the
+    load-bearing half of WS-C: an outer bank's index reaches an inner
+    bank's unrolled body without disturbing the inner fold's shape. -/
+theorem instLoop_range_foldl {id k : Nat} (f : Nat → Sig) (n : Nat) :
+    instLoop id k ((List.range n).foldl (fun acc j => add acc (f j)) (litI 0))
+      = (List.range n).foldl (fun acc j => add acc (instLoop id k (f j))) (litI 0) := by
+  suffices h : ∀ (z : Sig),
+      instLoop id k ((List.range n).foldl (fun acc j => add acc (f j)) z)
+        = (List.range n).foldl (fun acc j => add acc (instLoop id k (f j)))
+            (instLoop id k z) by
+    simpa [instLoop_litI] using h (litI 0)
+  induction n with
+  | zero => intro z; simp
+  | succ n ih =>
+    intro z
+    rw [List.range_succ, List.foldl_append, List.foldl_append]
+    simp only [List.foldl_cons, List.foldl_nil]
+    rw [instLoop_add, ih]
+
+/-- **WS-C.** A nested bank (fold-of-folds, WS5) unrolls to the ROW-MAJOR
+    double fold: for each outer index `j` in array order, the ENTIRE inner
+    fold in array order — the inner region's fold order is manifestly
+    independent of the outer's index, because the outer instantiation
+    distributes through the inner fold's spine and touches only the body.
+
+    The unique-binder-id discipline is exactly what makes the statement
+    meaningful: the inner bank unrolls FIRST (consuming every free
+    `loopIdx i₂` in its own body — including reads baked into its column
+    entries by the outer builder), and the outer index `i₁` is instantiated
+    through the result. Were `i₁ = i₂`, the inner instantiation would
+    capture the outer's reads — the failure WS5 removed by correcting
+    de Bruijn away to chain-unique ids. -/
+theorem unrollBanks_bankSum_nested {c c' : Nat} {ts ts' : Array Sig}
+    {b : Sig} {i₁ i₂ : Nat} :
+    unrollBanks (.bankSum c ts (.bankSum c' ts' b none i₂) none i₁)
+      = (List.range c).foldl (fun acc j => add acc
+          ((List.range c').foldl (fun acc' i => add acc'
+            (instLoop i₁ j (instLoop i₂ i (unrollBanks b)))) (litI 0)))
+        (litI 0) := by
+  rw [unrollBanks_bankSum]
+  have hstep : (fun (acc : Sig) (j : Nat) =>
+        add acc (instLoop i₁ j (unrollBanks (Sig.bankSum c' ts' b none i₂))))
+      = (fun acc j => add acc ((List.range c').foldl (fun acc' i => add acc'
+          (instLoop i₁ j (instLoop i₂ i (unrollBanks b)))) (litI 0))) := by
+    funext acc j
+    rw [unrollBanks_bankSum, instLoop_range_foldl]
+  rw [hstep]
+
+/-- **WS-C, denotationally.** Read through any `add`-homomorphism, a nested
+    bank IS the double `refFold`, row-major — the composable form: the
+    inner fold is a closed sub-computation re-run per outer index, operands
+    meeting in the same order at both depths. -/
+theorem denote_unrollBanks_bankSum_nested {α} (d : Sig → α) (op : α → α → α)
+    (z : α) (hadd : ∀ a b, d (add a b) = op (d a) (d b)) (hz : d (litI 0) = z)
+    {c c' : Nat} {ts ts' : Array Sig} {b : Sig} {i₁ i₂ : Nat} :
+    d (unrollBanks (.bankSum c ts (.bankSum c' ts' b none i₂) none i₁))
+      = refFold op z (fun j => refFold op z
+          (fun i => d (instLoop i₁ j (instLoop i₂ i (unrollBanks b)))) c') c := by
+  rw [unrollBanks_bankSum_nested,
+    denote_range_foldl d op hadd _ _ c, hz]
+  congr 1
+  funext j
+  rw [denote_range_foldl d op hadd _ _ c', hz]
+
+end Tropical.EmitArrow

--- a/lean/Tropical/EmitArrow/ClockAlgebra.lean
+++ b/lean/Tropical/EmitArrow/ClockAlgebra.lean
@@ -1,0 +1,270 @@
+import Tropical.EmitArrow.Modal
+import Tropical.EmitArrow.Numerics
+
+/-!
+# The clock algebra as theorems (slice 3b) — warp laws over Int, not renders
+
+`Tropicaltest/ArrowLaws.lean` defends the warp arrow laws by rendering both
+sides and comparing SHA256 — a sample of a universally quantified statement.
+This module states the statement: the integer fragment of `Sig` (the Q32.32
+fixed-point clock rail) gets a typing judgment (`OnClockRail`), a total
+`Int` denotation dependent on the derivation (`denoteClock` — no `Option`,
+no `Float` anywhere), and the warp laws become theorems quantified over ALL
+rail expressions, not the four that get rendered.
+
+## The carving (WS-1's finding)
+
+The handoff sketched the fragment as `{num, binary add/sub/mul, select,
+sampleIndex, clock leaf, toIntE, ldexpE}`. The rail as actually carved by
+the code is different, and the difference is the finding:
+
+* `select` and `ldexpE` are NOT clock-rail ops — they live on the value
+  datapath (bounded-type defaults, option E's exponent bump). No clock
+  expression in the tree uses either.
+* The rail NEEDS `lshift`/`rshift`/`bitAnd` — the root clock is
+  `sampleIndex <<< 32`, and the phase reductions (`modePhaseQ`,
+  `modePhaseQFromIncr`) are split-multiplies over shifts and masks.
+* Every crossing FROM float land enters through exactly one door: `toInt`.
+  A `toIntE e` node is an OPAQUE integer leaf (the `boundary` constructor)
+  — its value is a free variable of the environment, keyed by the source
+  subterm. The dual door `toFloatE` is where the rail ENDS (the phasor's
+  phase output, the envelope coordinate `dSec` — value-land, not claimed).
+
+So the rail is: integer literals, `sampleIndex`, `toInt` boundaries, and
+`{add, sub, mul, neg, <<<k, >>>k, &&&(2^k−1)}` over rail operands — shift
+amounts and masks literal, masks a low-bits pattern (the only masks the
+datapath spells). The judgment is syntax-directed: each tree shape admits
+one derivation, so the denotation is a function of the tree.
+
+`OnClockRail` is `Type`-valued, not `Prop`-valued: `denoteClock` recurses
+on the derivation (Prop can't eliminate into `Int` — the handoff's
+`Sig → Prop` sketch and its witness-dependent `denoteClock` were in
+tension, and the derivation-as-data form is the one that typechecks).
+
+## The trusted base (one named hypothesis)
+
+**CLOCK_RAIL_IS_EXACT**: *per sample, the runtime computes each rail node
+as the two's-complement i64 image of its `denoteClock` value, equal
+subterms yielding equal values.*
+
+Discharge notes, per op class (inspection, not proof — the execution is
+LLVM/MSL):
+* `tick` / `boundary`: the kernel is pure `f(τ, params)` and the emitter
+  CSEs by subterm — one i64 value per subterm per sample. The env's
+  `boundary : Sig → Int` being a FUNCTION is exactly this assumption.
+* `add`/`sub`/`neg`/`mul`/`<<<k`: the quotient `ℤ → ℤ/2⁶⁴` is a ring
+  homomorphism and `<<<k` is `·2ᵏ`, so any `denoteClock` equality pushes
+  forward to bit-identical i64 — WITHOUT a no-overflow side condition.
+  (This is why the laws survive wrap: they are ring identities.)
+* `>>>k` (ashr) / `&&&(2ᵏ−1)`: floor-shift and low-bits agree with the
+  i64 ops on values whose live bits fit 64 — the Q32.32 headroom
+  discipline the datapath already documents (`modePhaseQ`'s docstring).
+
+Everything downstream of the clock — that equal i64 clocks render equal
+audio — is the kernel's purity, already the whole system's premise.
+
+## What this does NOT replace
+
+The audio-golden law gates in `Tropicaltest/ArrowLaws.lean` gate the
+BACKENDS (LLVM/wasm agree with the frozen render); these theorems gate the
+FRONT (the algebra is right for every clock expression). Both survive; the
+theorems make the per-law-instance golden multiplication unnecessary
+(one-per-backend-path suffices), they do not license deleting the backend
+check.
+
+Out-of-fragment laws, documented as scoped:
+* **Law 3 (cartesian diagonal)** — a program-graph/CSE property (shared
+  vs duplicated dry oscillator), not a clock-expression identity; nothing
+  here quantifies over program graphs.
+* **Law 6 (reverse commutes with the symmetric flanger)** — a VALUE-
+  datapath law: the ±δ tap sum reassociates in float
+  (`ArrowLaws.lean`'s slice-5 finding). The proof boundary lands exactly
+  on the empirical boundary found by ear; a proof that reached law 6
+  through this fragment would be a bug in the fragment.
+-/
+
+namespace Tropical.EmitArrow
+
+open Tropical.Ir
+
+/-- The environment a clock expression denotes against: the ambient tick
+    (what `sampleIndex` reads this sample) and the value of each `toInt`
+    boundary crossing, keyed by the SOURCE subterm. The leaf is a free
+    variable, not a model — nothing here claims what the runtime feeds it
+    (scope decision 4); `boundary` being a function is the determinism
+    half of CLOCK_RAIL_IS_EXACT (equal subterms, equal values). -/
+structure ClockEnv where
+  tick : Int
+  boundary : Sig → Int
+
+/-- The integer (Q32.32) rail as a typing judgment: the derivation that a
+    `Sig` stays on the fixed datapath. Syntax-directed — one derivation
+    per admissible tree — and `Type`-valued so the denotation can recurse
+    on it. Shift amounts and masks are LITERAL (`hm` pins the mantissa),
+    masks are the low-bits pattern `2^k − 1` — the only masks the
+    datapath spells (`& (2³²−1)`, `& 1`). -/
+inductive OnClockRail : Sig → Type where
+  | intLit (m : Int) : OnClockRail (.num ⟨m, 0⟩)
+  | tick : OnClockRail .sampleIndex
+  | boundary (e : Sig) : OnClockRail (.unary .toInt e)
+  | neg {a : Sig} : OnClockRail a → OnClockRail (.unary .neg a)
+  | add {a b : Sig} : OnClockRail a → OnClockRail b → OnClockRail (.binary .add a b)
+  | sub {a b : Sig} : OnClockRail a → OnClockRail b → OnClockRail (.binary .sub a b)
+  | mul {a b : Sig} : OnClockRail a → OnClockRail b → OnClockRail (.binary .mul a b)
+  | lshift {a : Sig} (m : Int) (k : Nat) (hm : m = (k : Int)) :
+      OnClockRail a → OnClockRail (.binary .lshift a (.num ⟨m, 0⟩))
+  | rshift {a : Sig} (m : Int) (k : Nat) (hm : m = (k : Int)) :
+      OnClockRail a → OnClockRail (.binary .rshift a (.num ⟨m, 0⟩))
+  | mask {a : Sig} (m : Int) (k : Nat) (hm : m = 2 ^ k - 1) :
+      OnClockRail a → OnClockRail (.binary .bitAnd a (.num ⟨m, 0⟩))
+
+/-- The `Int` denotation of a rail expression — TOTAL on the fragment
+    (recursion on the derivation; no `Option`, no `Float`). `>>>` is
+    `Int.shiftRight` (arithmetic/floor — i64 `ashr`), the mask is `emod`
+    (low `k` bits as a nonnegative value — i64 `and` with a low mask). -/
+def denoteClock : {s : Sig} → OnClockRail s → ClockEnv → Int
+  | _, .intLit m, _ => m
+  | _, .tick, env => env.tick
+  | _, .boundary e, env => env.boundary e
+  | _, .neg h, env => -(denoteClock h env)
+  | _, .add ha hb, env => denoteClock ha env + denoteClock hb env
+  | _, .sub ha hb, env => denoteClock ha env - denoteClock hb env
+  | _, .mul ha hb, env => denoteClock ha env * denoteClock hb env
+  | _, .lshift _ k _ ha, env => denoteClock ha env <<< k
+  | _, .rshift _ k _ ha, env => denoteClock ha env >>> k
+  | _, .mask _ k _ ha, env => denoteClock ha env % 2 ^ k
+
+-- ─────────────────────────────────────────────────────────────
+-- The warp laws — for ALL rail expressions, not four renders
+-- ─────────────────────────────────────────────────────────────
+
+/-- **Law 1, universally (warp inverse / cancellation).** `(c+δ)−δ = c`
+    for EVERY rail clock `c` and EVERY rail offset `δ` — the τ-scrub moat
+    as an equation: a forward warp followed by its inverse feeds the
+    oscillator the identical integer clock. "Reverse is exact, no
+    rounding" stops being a measurement. -/
+theorem warp_inv {c δ : Sig} (hc : OnClockRail c) (hδ : OnClockRail δ)
+    (env : ClockEnv) :
+    denoteClock (.sub (.add hc hδ) hδ) env = denoteClock hc env := by
+  simp [denoteClock]
+
+/-- Law 1 with the warps the other way around: `(c−δ)+δ = c`. -/
+theorem warp_inv' {c δ : Sig} (hc : OnClockRail c) (hδ : OnClockRail δ)
+    (env : ClockEnv) :
+    denoteClock (.add (.sub hc hδ) hδ) env = denoteClock hc env := by
+  simp [denoteClock]
+
+/-- **Law 2, universally (additive delay / functoriality).**
+    `(c−δ₁)−δ₂ = c−(δ₁+δ₂)`: composing delays is delaying by the sum. -/
+theorem warp_assoc {c δ₁ δ₂ : Sig} (hc : OnClockRail c)
+    (h₁ : OnClockRail δ₁) (h₂ : OnClockRail δ₂) (env : ClockEnv) :
+    denoteClock (.sub (.sub hc h₁) h₂) env
+      = denoteClock (.sub hc (.add h₁ h₂)) env := by
+  simp [denoteClock]; omega
+
+/-- **Law 4, universally (reverse is an involution).** `−(−c) = c`:
+    reversing twice is the identity, for every rail clock. -/
+theorem rev_involution {c : Sig} (hc : OnClockRail c) (env : ClockEnv) :
+    denoteClock (.neg (.neg hc)) env = denoteClock hc env := by
+  simp [denoteClock]
+
+/-- **Law 5, universally (reverse conjugates delay).**
+    `−(c−δ) = (−c)+δ`: pulling reverse past a delay flips it to an
+    advance — the time-mirror algebra the reverse-cue path leans on. -/
+theorem rev_swap {c δ : Sig} (hc : OnClockRail c) (hδ : OnClockRail δ)
+    (env : ClockEnv) :
+    denoteClock (.neg (.sub hc hδ)) env
+      = denoteClock (.add (.neg hc) hδ) env := by
+  simp [denoteClock]; omega
+
+-- ─────────────────────────────────────────────────────────────
+-- Modal's clock construction typechecks against the predicate
+-- ─────────────────────────────────────────────────────────────
+-- The done-when criterion: the production clock constructions are ON the
+-- rail, witnessed with no escape hatch. Each definition below is the
+-- derivation for one constructor in `EmitArrow/Modal.lean` /
+-- `EmitArrow/Numerics.lean`; that they typecheck IS the check. Every
+-- float ingredient (anchor seconds, ω/2π scaling, the rounded period
+-- increment) enters through a `boundary` — the rail is carved exactly at
+-- `toInt`.
+
+/-- `relClockQ clk anchor = clk − toInt(anchor·2³²)` — rail, for ANY
+    anchor expression (the anchor's float math is behind the boundary). -/
+def relClockQ_rail {c : Sig} (hc : OnClockRail c) (anchor : Sig) :
+    OnClockRail (relClockQ c anchor) :=
+  .sub hc (.boundary _)
+
+/-- The split-multiply phase reduction over a supplied increment
+    (`modePhaseQFromIncr`): `(incr·(clk>>>32) + (incr·(clk&&&(2³²−1)))>>>32)
+    &&& (2³²−1)` — rail whenever the increment and clock are. -/
+def modePhaseQFromIncr_rail {incr clkRel : Sig}
+    (hi : OnClockRail incr) (hc : OnClockRail clkRel) :
+    OnClockRail (modePhaseQFromIncr incr clkRel) :=
+  .mask _ 32 (by decide)
+    (.add (.mul hi (.rshift _ 32 rfl hc))
+          (.rshift _ 32 rfl (.mul hi (.mask _ 32 (by decide) hc))))
+
+/-- `modePhaseQ ω clkRel` — the increment `⌊(ω/2π)·2³²/SR⌋` is a
+    boundary (ω may be float, live, anything); the reduction is rail. -/
+def modePhaseQ_rail (omega : Sig) {clkRel : Sig} (hc : OnClockRail clkRel) :
+    OnClockRail (modePhaseQ omega clkRel) :=
+  modePhaseQFromIncr_rail (.boundary _) hc
+
+/-- The PERIODIC relative clock's INTERIOR phase — the split-multiply
+    reduction over the rounded period increment and the one-tick-shifted
+    relative clock — is rail whenever the ambient clock is: exactly
+    `modePhaseQFromIncr` applied to two boundary-guarded rail operands. -/
+def relClockQuotPhase_rail {c : Sig} (hc : OnClockRail c)
+    (anchor : Sig) (pSec : Float) :
+    OnClockRail (modePhaseQFromIncr
+      (toIntE (roundE (div (lit 4294967296) (mul (litF pSec) .sampleRate))))
+      (sub (relClockQ c anchor) (litI 1))) :=
+  modePhaseQFromIncr_rail (.boundary _) (.sub (relClockQ_rail hc anchor) (.boundary _))
+
+/-- The PERIODIC relative clock `relClockQuot` as a whole is **rail-in,
+    boundary-out** — a carving finding, not a defect: the quotient
+    re-expands its masked phase to ticks THROUGH FLOAT
+    (`toInt(toFloat(phase)·P·SR)`), so the outermost expression is
+    `add boundary boundary` and needs NO hypothesis on the ambient clock.
+    The exactness story lives in the interior (`relClockQuotPhase_rail`)
+    plus one documented float crossing (the ~2e-14 s sub-quantization lag
+    in `relClockQuot`'s own docstring). The rail predicate finds the seam
+    exactly where the code documented it. -/
+def relClockQuot_rail (c anchor : Sig) (pSec : Float) :
+    OnClockRail (relClockQuot c anchor pSec) :=
+  .add (.boundary _) (.boundary _)
+
+/-- The root clock `clockLit = sampleIndex <<< 32` (the session `clk`
+    default, every closed-form carrier's clock) — rail off the tick. -/
+def rootClock_rail : OnClockRail clockLit :=
+  .lshift _ 32 rfl .tick
+
+/-- The phasor accumulator `inc·(clk>>>32) + (inc·(clk&&&(2³²−1)))>>>32 + off`
+    (`phasorPhaseSig`'s integer core) — rail; the phasor's OUTPUT then
+    crosses `toFloatE` and leaves the rail (the dual door, where the value
+    datapath begins). Witness for the accumulator shape. -/
+def phasorAcc_rail {clk : Sig} (hc : OnClockRail clk) (freqE offsetE : Sig) :
+    OnClockRail (.binary .add
+      (.binary .add
+        (.binary .mul (toIntE (div (mul freqE (lit 4294967296)) .sampleRate))
+          (.binary .rshift clk (.num ⟨32, 0⟩)))
+        (.binary .rshift
+          (.binary .mul (toIntE (div (mul freqE (lit 4294967296)) .sampleRate))
+            (.binary .bitAnd clk (.num ⟨4294967295, 0⟩)))
+          (.num ⟨32, 0⟩)))
+      (toIntE (mul offsetE (lit 4294967296)))) :=
+  .add (.add (.mul (.boundary _) (.rshift _ 32 rfl hc))
+             (.rshift _ 32 rfl (.mul (.boundary _) (.mask _ 32 (by decide) hc))))
+       (.boundary _)
+
+/-- The split identity the phase reduction's exactness rests on
+    (`modePhaseQ`'s docstring: "`clkRel = (clkRel>>32)·2³² +
+    (clkRel & (2³²−1))` holds exactly on NEGATIVE relative clocks") —
+    true of the DENOTATION for every `Int`, negative included: floor-shift
+    and low-bits recompose exactly. The docstring's claim, as arithmetic. -/
+theorem rail_split_identity (x : Int) :
+    (x >>> (32 : Nat)) * 2 ^ 32 + x % 2 ^ 32 = x := by
+  rw [Int.shiftRight_eq_div_pow]
+  omega
+
+end Tropical.EmitArrow

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -198,7 +198,7 @@ private def envPeakD (deg : Nat) (sigma : DyadicI) : Option DyadicI :=
 /-- The `Sig` mirror of `envPeakF` for the DYNAMIC max fold: `(p/(σe))^p·(|cre|+
     |cim|)`. Reduces to exactly `|cre|+|cim|` at `deg=0`, so a deg-0 bank's `maxSig`
     is unchanged (byte-identical dynamic path). -/
-private def modeWeightBoundSig (m : ModalMode) : Sig :=
+def modeWeightBoundSig (m : ModalMode) : Sig :=
   let amp := add (.unary .abs m.cre) (.unary .abs m.cim)
   if m.deg == 0 then amp
   else mul (powE (div (litF m.deg.toFloat) (mul m.sigma (litF 2.718281828459045))) m.deg) amp

--- a/lean/Tropical/Ir/BanksFlag.lean
+++ b/lean/Tropical/Ir/BanksFlag.lean
@@ -3,12 +3,16 @@
 
 Banks-as-data is the default: uniform (deg-0) modal banks lower through an
 indexed reduction (a `bankSum` region) instead of unrolling.
-`TROPICAL_BANKS_UNROLL` is the escape hatch back to the unrolled form — the
-bisection ladder, where the naive realization stays reachable. Read once here,
-at load; the consumer that branches on it is the arrow modal builder
-(`EmitArrow.Modal`), which chooses the banked or unrolled lowering at
-authoring time. (Hand-authored `Sig.bankSum` always stays a region — the
-flag governs the builder's choice, not the emit.)
+`TROPICAL_BANKS_UNROLL` is a DEBUGGING convenience — a bisection flag that
+keeps the naive realization reachable — not a correctness ladder: since
+slice 3c, banked ≡ unrolled is a theorem
+(`EmitArrow/BankOrder.lean` + `Ir/EmitBankLaws.lean`, trusted base = the one
+named assumption `REDUCE_REGION_EXECUTES_IN_ARRAY_ORDER`), so flipping the
+flag can only ever isolate an emitter/runtime bug, never rescue the
+semantics. Read once here, at load; the consumer that branches on it is the
+arrow modal builder (`EmitArrow.Modal`), which chooses the banked or
+unrolled lowering at authoring time. (Hand-authored `Sig.bankSum` always
+stays a region — the flag governs the builder's choice, not the emit.)
 -/
 
 namespace Tropical.Ir

--- a/lean/Tropical/Ir/ConstFoldLaws.lean
+++ b/lean/Tropical/Ir/ConstFoldLaws.lean
@@ -1,0 +1,346 @@
+import Tropical.Ir.ConstFold
+import Init.Data.Int.Bitwise.Lemmas
+import Init.Data.Int.DivMod.Lemmas
+
+/-!
+# ConstFoldLaws — the integer constant folder as an i64 algebra
+
+`ConstFold.lean` says its integer path reproduces i64 two's-complement
+execution. This module makes the integer half of that sentence checked:
+
+* `wrap64` is the canonical representative in `[-2^63, 2^63)`, fixes every
+  value already in range, is idempotent, and preserves the residue modulo
+  `2^64`;
+* wrapping commutes with add, sub, mul, and neg, so the arbitrary-precision
+  `Int` implementation realizes the quotient ring `ℤ/2^64ℤ`;
+* `toU64` is exactly the nonnegative residue and `bit64` always returns an
+  i64-range value;
+* every integer-only `foldOp` route is pinned to its intended equation:
+  arithmetic (including zero guards), comparisons, truthiness, bitwise ops,
+  shifts (including the `[0,63]` refusal), casts, clamp, and select.
+
+No Float claim is made here. In particular, `toFloat`, Float comparisons,
+transcendentals, and `truncToInt?` remain outside this proof boundary.
+-/
+
+namespace Tropical.Ir
+
+open Tropical.Plan (PlanOp)
+
+/-- `2^63`, the positive exclusive bound of a signed i64. -/
+def i64Half : Int := 9223372036854775808
+
+/-- `2^64`, the modulus of two's-complement i64 arithmetic. -/
+def i64Modulus : Int := 18446744073709551616
+
+/-- The mathematical signed-i64 range. -/
+def IsI64 (x : Int) : Prop := -i64Half ≤ x ∧ x < i64Half
+
+private theorem scalar_int_beq_int :
+    ((Tropical.Parse.ScalarKind.int == Tropical.Parse.ScalarKind.int) = true) := by
+  decide
+
+private theorem scalar_int_beq_bool :
+    ((Tropical.Parse.ScalarKind.int == Tropical.Parse.ScalarKind.bool) = false) := by
+  decide
+
+-- ─────────────────────────────────────────────────────────────
+-- wrap64 — canonical quotient representative
+-- ─────────────────────────────────────────────────────────────
+
+/-- Every wrapped integer is in the signed-i64 range. -/
+theorem wrap64_isI64 (x : Int) : IsI64 (wrap64 x) := by
+  constructor
+  · unfold i64Half wrap64
+    have h := Int.emod_nonneg
+      (x + 9223372036854775808)
+      (by omega : (18446744073709551616 : Int) ≠ 0)
+    omega
+  · unfold i64Half wrap64
+    have h := Int.emod_lt_of_pos
+      (x + 9223372036854775808)
+      (by omega : (0 : Int) < 18446744073709551616)
+    omega
+
+/-- Wrapping is the identity on values already representable as i64. -/
+theorem wrap64_eq_self {x : Int} (hx : IsI64 x) : wrap64 x = x := by
+  unfold IsI64 i64Half at hx
+  unfold wrap64
+  rw [Int.emod_eq_of_lt] <;> omega
+
+/-- Wrapping preserves exactly the residue modulo `2^64`. -/
+theorem wrap64_emod (x : Int) :
+    wrap64 x % i64Modulus = x % i64Modulus := by
+  unfold i64Modulus wrap64
+  rw [Int.emod_sub_emod]
+  simp
+
+/-- Equal residues have equal canonical signed representatives. -/
+theorem wrap64_eq_of_emod_eq {x y : Int}
+    (h : x % i64Modulus = y % i64Modulus) :
+    wrap64 x = wrap64 y := by
+  unfold i64Modulus at h
+  unfold wrap64
+  rw [← Int.emod_add_emod x 18446744073709551616 9223372036854775808,
+      ← Int.emod_add_emod y 18446744073709551616 9223372036854775808, h]
+
+/-- `wrap64` is a canonicalization: applying it twice changes nothing. -/
+theorem wrap64_idem (x : Int) : wrap64 (wrap64 x) = wrap64 x := by
+  exact wrap64_eq_self (wrap64_isI64 x)
+
+/-- Addition in the canonical representatives is addition modulo `2^64`. -/
+theorem wrap64_add (a b : Int) :
+    wrap64 (wrap64 a + wrap64 b) = wrap64 (a + b) := by
+  apply wrap64_eq_of_emod_eq
+  calc
+    (wrap64 a + wrap64 b) % i64Modulus =
+        (wrap64 a % i64Modulus +
+          wrap64 b % i64Modulus) % i64Modulus :=
+      Int.add_emod _ _ _
+    _ = (a % i64Modulus +
+          b % i64Modulus) % i64Modulus := by
+      rw [wrap64_emod, wrap64_emod]
+    _ = (a + b) % i64Modulus := (Int.add_emod _ _ _).symm
+
+/-- Subtraction in the canonical representatives is subtraction modulo `2^64`. -/
+theorem wrap64_sub (a b : Int) :
+    wrap64 (wrap64 a - wrap64 b) = wrap64 (a - b) := by
+  apply wrap64_eq_of_emod_eq
+  calc
+    (wrap64 a - wrap64 b) % i64Modulus =
+        (wrap64 a % i64Modulus -
+          wrap64 b % i64Modulus) % i64Modulus :=
+      Int.sub_emod _ _ _
+    _ = (a % i64Modulus -
+          b % i64Modulus) % i64Modulus := by
+      rw [wrap64_emod, wrap64_emod]
+    _ = (a - b) % i64Modulus := (Int.sub_emod _ _ _).symm
+
+/-- Multiplication in the canonical representatives is multiplication modulo `2^64`. -/
+theorem wrap64_mul (a b : Int) :
+    wrap64 (wrap64 a * wrap64 b) = wrap64 (a * b) := by
+  apply wrap64_eq_of_emod_eq
+  calc
+    (wrap64 a * wrap64 b) % i64Modulus =
+        (wrap64 a % i64Modulus *
+          (wrap64 b % i64Modulus)) % i64Modulus :=
+      Int.mul_emod _ _ _
+    _ = (a % i64Modulus *
+          (b % i64Modulus)) % i64Modulus := by
+      rw [wrap64_emod, wrap64_emod]
+    _ = (a * b) % i64Modulus := (Int.mul_emod _ _ _).symm
+
+/-- Negation in the canonical representatives is negation modulo `2^64`. -/
+theorem wrap64_neg (a : Int) :
+    wrap64 (-wrap64 a) = wrap64 (-a) := by
+  apply wrap64_eq_of_emod_eq
+  rw [Int.neg_emod_eq_sub_emod, Int.neg_emod_eq_sub_emod]
+  exact (Int.emod_sub_cancel_left i64Modulus).2 (wrap64_emod a)
+
+-- ─────────────────────────────────────────────────────────────
+-- Unsigned image and bitwise result range
+-- ─────────────────────────────────────────────────────────────
+
+/-- `toU64` is exactly the least nonnegative residue modulo `2^64`. -/
+theorem ofNat_toU64 (x : Int) :
+    Int.ofNat (toU64 x) = x % i64Modulus := by
+  unfold i64Modulus toU64
+  have hx0 : 0 ≤ x % (18446744073709551616 : Int) :=
+    Int.emod_nonneg _ (by omega)
+  rw [Int.add_emod]
+  simp only [Int.emod_emod, Int.emod_self, Int.add_zero]
+  exact Int.toNat_of_nonneg hx0
+
+/-- The unsigned image fits in exactly 64 bits. -/
+theorem toU64_lt (x : Int) : toU64 x < 18446744073709551616 := by
+  have hxlt : x % i64Modulus < i64Modulus := by
+    unfold i64Modulus
+    exact Int.emod_lt_of_pos _ (by omega)
+  rw [← ofNat_toU64] at hxlt
+  exact Int.ofNat_lt.mp hxlt
+
+/-- Any natural bit-operation, reinterpreted through `bit64`, lands in i64. -/
+theorem bit64_isI64 (f : Nat → Nat → Nat) (a b : Int) :
+    IsI64 (bit64 f a b) := by
+  exact wrap64_isI64 _
+
+-- ─────────────────────────────────────────────────────────────
+-- foldOp — arithmetic and zero guards
+-- ─────────────────────────────────────────────────────────────
+
+theorem foldOp_add_int (a b : Int) :
+    foldOp PlanOp.add.name .int #[.i a, .i b] =
+      some (.i (wrap64 (a + b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_sub_int (a b : Int) :
+    foldOp PlanOp.sub.name .int #[.i a, .i b] =
+      some (.i (wrap64 (a - b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_mul_int (a b : Int) :
+    foldOp PlanOp.mul.name .int #[.i a, .i b] =
+      some (.i (wrap64 (a * b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_div_int (a b : Int) :
+    foldOp PlanOp.div.name .int #[.i a, .i b] =
+      some (.i (if b == 0 then 0 else wrap64 (Int.tdiv a b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_mod_int (a b : Int) :
+    foldOp PlanOp.mod.name .int #[.i a, .i b] =
+      some (.i (if b == 0 then 0 else wrap64 (Int.tmod a b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_floorDiv_int (a b : Int) :
+    foldOp PlanOp.floorDiv.name .int #[.i a, .i b] =
+      some (.i (if b == 0 then 0 else wrap64 (Int.tdiv a b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_neg_int (a : Int) :
+    foldOp PlanOp.neg.name .int #[.i a] =
+      some (.i (wrap64 (-a))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_abs_int (a : Int) :
+    foldOp PlanOp.abs.name .int #[.i a] =
+      some (.i (if a < 0 then wrap64 (-a) else a)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+-- ─────────────────────────────────────────────────────────────
+-- foldOp — integer comparisons and truthiness
+-- ─────────────────────────────────────────────────────────────
+
+theorem foldOp_less_int (a b : Int) :
+    foldOp PlanOp.less.name .bool #[.i a, .i b] =
+      some (.b (decide (a < b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_lessEq_int (a b : Int) :
+    foldOp PlanOp.lessEq.name .bool #[.i a, .i b] =
+      some (.b (decide (a ≤ b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_greater_int (a b : Int) :
+    foldOp PlanOp.greater.name .bool #[.i a, .i b] =
+      some (.b (decide (a > b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_greaterEq_int (a b : Int) :
+    foldOp PlanOp.greaterEq.name .bool #[.i a, .i b] =
+      some (.b (decide (a ≥ b))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_equal_int (a b : Int) :
+    foldOp PlanOp.equal.name .bool #[.i a, .i b] =
+      some (.b (a == b)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_notEqual_int (a b : Int) :
+    foldOp PlanOp.notEqual.name .bool #[.i a, .i b] =
+      some (.b (a != b)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_and_int (a b : Int) :
+    foldOp PlanOp.and.name .bool #[.i a, .i b] =
+      some (.b ((a != 0) && (b != 0))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_bool]
+
+theorem foldOp_or_int (a b : Int) :
+    foldOp PlanOp.or.name .bool #[.i a, .i b] =
+      some (.b ((a != 0) || (b != 0))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_bool]
+
+theorem foldOp_not_int (a : Int) :
+    foldOp PlanOp.not.name .bool #[.i a] =
+      some (.b (a == 0)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?]
+
+theorem foldOp_toInt_int (a : Int) :
+    foldOp PlanOp.toInt.name .int #[.i a] = some (.i a) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_toBool_int (a : Int) :
+    foldOp PlanOp.toBool.name .bool #[.i a] = some (.b (a != 0)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_bool]
+
+-- ─────────────────────────────────────────────────────────────
+-- foldOp — bitwise ops and shifts
+-- ─────────────────────────────────────────────────────────────
+
+theorem foldOp_bitAnd_int (a b : Int) :
+    foldOp PlanOp.bitAnd.name .int #[.i a, .i b] =
+      some (.i (bit64 (· &&& ·) a b)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty]
+
+theorem foldOp_bitOr_int (a b : Int) :
+    foldOp PlanOp.bitOr.name .int #[.i a, .i b] =
+      some (.i (bit64 (· ||| ·) a b)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty]
+
+theorem foldOp_bitXor_int (a b : Int) :
+    foldOp PlanOp.bitXor.name .int #[.i a, .i b] =
+      some (.i (bit64 (· ^^^ ·) a b)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty]
+
+theorem foldOp_bitNot_int (a : Int) :
+    foldOp PlanOp.bitNot.name .int #[.i a] =
+      some (.i (bit64 (· ^^^ ·) a (-1))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty]
+
+theorem foldOp_lshift_int {a sh : Int} (h0 : 0 ≤ sh) (h63 : sh ≤ 63) :
+    foldOp PlanOp.lshift.name .int #[.i a, .i sh] =
+      some (.i (wrap64 (a <<< sh.toNat))) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty, h0, h63]
+
+theorem foldOp_lshift_int_refuses {a sh : Int} (h : sh < 0 ∨ 63 < sh) :
+    foldOp PlanOp.lshift.name .int #[.i a, .i sh] = none := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty, h]
+
+theorem foldOp_rshift_int {a sh : Int} (h0 : 0 ≤ sh) (h63 : sh ≤ 63) :
+    foldOp PlanOp.rshift.name .int #[.i a, .i sh] =
+      some (.i (a >>> sh.toNat)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty, h0, h63]
+
+theorem foldOp_rshift_int_refuses {a sh : Int} (h : sh < 0 ∨ 63 < sh) :
+    foldOp PlanOp.rshift.name .int #[.i a, .i sh] = none := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty, h]
+
+-- ─────────────────────────────────────────────────────────────
+-- foldOp — integer clamp and select
+-- ─────────────────────────────────────────────────────────────
+
+theorem foldOp_clamp_int (v lo hi : Int) :
+    foldOp PlanOp.clamp.name .int #[.i v, .i lo, .i hi] =
+      some (.i (let lc := if v > lo then v else lo
+        if lc < hi then lc else hi)) := by
+  simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+    scalar_int_beq_int]
+
+theorem foldOp_select_int (c t f : Int) :
+    foldOp PlanOp.select.name .int #[.i c, .i t, .i f] =
+      some (.i (if c != 0 then t else f)) := by
+  by_cases hc : c = 0 <;>
+    simp [foldOp, PlanOp.name, PlanOp.ofString?, CVal.coerce?, CVal.ty,
+      scalar_int_beq_int, hc]
+
+end Tropical.Ir

--- a/lean/Tropical/Ir/Emit.lean
+++ b/lean/Tropical/Ir/Emit.lean
@@ -181,14 +181,14 @@ private def operandKind : NOperand → String
   | .source .. => "source" | .slot .. => "slot"
   | .loopIdx _ => "loop_idx"
 
-private def allocReg : EmitM Nat :=
+def allocReg : EmitM Nat :=
   modifyGet fun s => (s.nextReg, { s with nextReg := s.nextReg + 1 })
 
 private def allocArraySlot (size : Nat) : EmitM Nat :=
   modifyGet fun s => (s.nextArraySlot,
     { s with nextArraySlot := s.nextArraySlot + 1, arraySizes := s.arraySizes.push size })
 
-private def emit (i : NInstr) : EmitM Unit :=
+def emit (i : NInstr) : EmitM Unit :=
   modify fun s => { s with instrs := s.instrs.push i,
                            instrStages := s.instrStages.push s.curStage }
 
@@ -486,9 +486,17 @@ decreasing_by all_goals (apply Prod.Lex.left; omega)
 /-- Emit an indexed reduction (`ENode.bankSum`) as a `ReduceBegin`/body/`ReduceEnd`
     region — the banks-as-data lowering (slice 3b). The loop visits elements in
     array order — the same order the unrolled fold nests its adds — so the region
-    renders bit-identical to the unroll for ANY scalar element type (order
-    preservation needs no associativity; the earlier i64-only restriction was the
-    scaffolding's, not the fold's).
+    renders bit-identical to the unroll for ANY scalar element type. Since
+    slice 3c this is a THEOREM, not prose: `compileBankSum_stream`
+    (`Ir/EmitBankLaws.lean`) proves this function emits exactly
+    `tables ++ [ReduceBegin] ++ body ++ [Add, ReduceEnd]`, the frontend half
+    (`EmitArrow/BankOrder.lean`, `unrollBanks_modalBankSigTable`) proves the
+    banked and unrolled builders are the same tree under the reference
+    realization, and the whole trusted base is the ONE named assumption
+    `REDUCE_REGION_EXECUTES_IN_ARRAY_ORDER` (`regionDenotation`'s docstring,
+    `Ir/EmitBankLaws.lean`) — checkable against the emitted LLVM/MSL by eye.
+    Order preservation needs no associativity; the earlier i64-only
+    restriction was the scaffolding's, not the fold's.
 
     - The coefficient columns (`tables`) are materialized ONCE *before* the
       region: compiling them here (not lazily inside the body) keeps their `Pack`
@@ -511,7 +519,7 @@ decreasing_by all_goals (apply Prod.Lex.left; omega)
       is the region's binder id: it rides `ReduceBegin` as `loop_id`, and the
       body's `loopIdx idxId` operands resolve against the emitters' stack of
       open regions. -/
-private def compileBankSum (arena : ExprArena) (hw : arena.wf = true) (bound : Nat)
+def compileBankSum (arena : ExprArena) (hw : arena.wf = true) (bound : Nat)
     (count : Nat) (tables : Array ExprId) (body : ExprId)
     (dynCount? : Option ExprId) (idxId : Nat)
     (_hts : ∀ t ∈ tables, t.idx < bound) (_hb : body.idx < bound)

--- a/lean/Tropical/Ir/EmitBankLaws.lean
+++ b/lean/Tropical/Ir/EmitBankLaws.lean
@@ -1,0 +1,323 @@
+import Tropical.Ir.Emit
+import Tropical.EmitArrow.BankOrder
+
+/-!
+# WS-D: the emit half of the bank order-preservation theorem (slice 3c)
+
+`compileBankSum` (`Ir/Emit.lean`) lowers `ENode.bankSum` to a
+`ReduceBegin`/body/`ReduceEnd` region. The frontend half
+(`EmitArrow/BankOrder.lean`) proves the banked and unrolled builders are
+the same tree under the reference realization; this file proves the emit
+half: **the instruction stream `compileBankSum` produces has exactly the
+region shape** — everything the sub-compiles emitted for the tables and
+the optional runtime count (loop-invariant, BEFORE the region), then
+`ReduceBegin` spliced IMMEDIATELY before the body's instructions, then the
+body, then the `Add`-accumulate and `ReduceEnd`, and nothing else. In
+particular the splice-at-recorded-size logic (the part nested banks lean
+on — "the outer's insertion point never moves") is verified:
+`ReduceBegin` lands at the exact boundary between loop-invariant and
+per-iteration instructions (`insertIdx!_at_prefix`).
+
+The single hypothesis `AppendsOnly (compileNode …)` states the
+sub-compiler only appends instructions — the emitter-wide discipline
+(`emit` pushes; the one non-append in the whole emitter is
+`compileBankSum`'s own splice, which inserts at an index ≥ its entry
+stream length and so preserves every enclosing region's prefix — exactly
+what this theorem shows, one nesting level at a time).
+
+What remains between this theorem and "banked audio ≡ unrolled audio" is
+ONE sentence about the backends — `REDUCE_REGION_EXECUTES_IN_ARRAY_ORDER`
+(`Ir/Emit.lean`), discharged by inspection per backend.
+-/
+
+namespace Tropical.Ir.Emit
+
+open Tropical.Plan
+
+/-- The emitter contract the region-shape theorem consumes: a compile
+    action only APPENDS to the instruction stream (it never edits or
+    reorders what was already emitted). -/
+def AppendsOnly {α : Type} (act : EmitM α) : Prop :=
+  ∀ (s : EmitSt) (r : α) (s' : EmitSt),
+    act.run s = .ok (r, s') → ∃ d, s'.instrs = s.instrs ++ d
+
+theorem AppendsOnly.pure {α} (a : α) : AppendsOnly (pure a : EmitM α) := by
+  intro s r s' h
+  rw [StateT.run_pure] at h
+  cases h
+  exact ⟨#[], by simp⟩
+
+theorem AppendsOnly.bind {α β} {x : EmitM α} {f : α → EmitM β}
+    (hx : AppendsOnly x) (hf : ∀ a, AppendsOnly (f a)) :
+    AppendsOnly (x >>= f) := by
+  intro s r s' h
+  rw [StateT.run_bind] at h
+  match hx1 : x.run s with
+  | .error e => rw [hx1] at h; cases h
+  | .ok (a, s₁) =>
+    rw [hx1] at h
+    obtain ⟨d₁, hd₁⟩ := hx s a s₁ hx1
+    obtain ⟨d₂, hd₂⟩ := hf a s₁ r s' (by simpa [bind, Except.bind] using h)
+    exact ⟨d₁ ++ d₂, by rw [hd₂, hd₁, Array.append_assoc]⟩
+
+theorem AppendsOnly.discard {α} {x : EmitM α} (hx : AppendsOnly x) :
+    AppendsOnly (Functor.discard x) := by
+  intro s r s' h
+  have hrun : (Functor.discard x).run s
+      = (x.run s).map (fun (p : α × EmitSt) => (PUnit.unit, p.2)) := by
+    simp [Functor.discard, Functor.mapConst, Functor.map, StateT.map, StateT.run]
+  rw [hrun] at h
+  match hx1 : x.run s with
+  | .error e => rw [hx1] at h; cases h
+  | .ok (a, s₁) =>
+    rw [hx1] at h
+    cases h
+    exact hx s a _ hx1
+
+private theorem AppendsOnly.listFoldlM {α} (l : List α) (f : PUnit → α → EmitM PUnit)
+    (hf : ∀ x ∈ l, ∀ u, AppendsOnly (f u x)) :
+    ∀ (init : PUnit), AppendsOnly (List.foldlM f init l) := by
+  induction l with
+  | nil => intro init; rw [List.foldlM_nil]; exact .pure _
+  | cons a l ih =>
+    intro init
+    rw [List.foldlM_cons]
+    exact .bind (hf a (by simp) init)
+      (fun u => ih (fun x hx => hf x (by simp [hx])) u)
+
+theorem AppendsOnly.arrayForM {α} (xs : Array α) (f : α → EmitM PUnit)
+    (hf : ∀ x ∈ xs, AppendsOnly (f x)) : AppendsOnly (Array.forM f xs) := by
+  show AppendsOnly (Array.foldlM (fun _ => f) PUnit.unit xs 0 xs.size)
+  rw [← Array.foldlM_toList]
+  exact AppendsOnly.listFoldlM xs.toList (fun _ => f)
+    (fun x hx _ => hf x (by simpa using hx)) PUnit.unit
+
+private theorem List.insertIdx_length_append {α} (l₁ l₂ : List α) (x : α) :
+    (l₁ ++ l₂).insertIdx l₁.length x = l₁ ++ x :: l₂ := by
+  induction l₁ with
+  | nil => simp [List.insertIdx]
+  | cons a l ih => simpa [List.insertIdx_succ_cons] using ih
+
+/-- Inserting at the recorded boundary of a grown stream lands exactly at
+    the boundary: the splice arithmetic `compileBankSum` relies on. -/
+theorem insertIdx!_at_prefix {α} (xs d : Array α) (x : α) :
+    (xs ++ d).insertIdx! xs.size x = xs ++ #[x] ++ d := by
+  unfold Array.insertIdx!
+  split
+  · apply Array.ext'
+    rw [Array.toList_insertIdx]
+    simpa using List.insertIdx_length_append xs.toList d.toList x
+  · rename_i h
+    exact absurd (by simp : xs.size ≤ (xs ++ d).size) h
+
+-- ─────────────────────────────────────────────────────────────
+-- Concrete run/step lemmas (StateT over Except, definitional)
+-- ─────────────────────────────────────────────────────────────
+
+theorem run_allocReg (s : EmitSt) :
+    (allocReg).run s = .ok (s.nextReg, { s with nextReg := s.nextReg + 1 }) := rfl
+
+theorem run_emit (i : NInstr) (s : EmitSt) :
+    (emit i).run s = .ok (PUnit.unit,
+      { s with instrs := s.instrs.push i,
+               instrStages := s.instrStages.push s.curStage }) := rfl
+
+/-- Peel one `StateT.bind` off a successful run. -/
+theorem step_ok {α β} {x : EmitM α} {f : α → EmitM β} {s : EmitSt} {r : β} {s' : EmitSt}
+    (h : (StateT.bind x f).run s = .ok (r, s')) :
+    ∃ a s₁, x.run s = .ok (a, s₁) ∧ (f a).run s₁ = .ok (r, s') := by
+  match hx : x.run s with
+  | .error e =>
+    exfalso
+    have : (StateT.bind x f).run s = .error e := by
+      show (x s >>= _) = _
+      show (x.run s >>= _) = _
+      rw [hx]; rfl
+    rw [this] at h; cases h
+  | .ok (a, s₁) =>
+    refine ⟨a, s₁, rfl, ?_⟩
+    have : (StateT.bind x f).run s = (f a).run s₁ := by
+      show (x s >>= _) = _
+      show (x.run s >>= _) = _
+      rw [hx]; rfl
+    rw [this] at h; exact h
+
+theorem step_pure {α β} (a : α) (f : α → EmitM β) (s : EmitSt) :
+    (StateT.bind (pure a) f).run s = (f a).run s := rfl
+theorem step_get {β} (f : EmitSt → EmitM β) (s : EmitSt) :
+    (StateT.bind get f).run s = (f s).run s := rfl
+theorem step_allocReg {β} (f : Nat → EmitM β) (s : EmitSt) :
+    (StateT.bind allocReg f).run s
+      = (f s.nextReg).run { s with nextReg := s.nextReg + 1 } := rfl
+theorem step_modify {β} (g : EmitSt → EmitSt) (f : PUnit → EmitM β) (s : EmitSt) :
+    (StateT.bind (modify g) f).run s = (f PUnit.unit).run (g s) := rfl
+theorem step_emit {β} (i : NInstr) (f : PUnit → EmitM β) (s : EmitSt) :
+    (StateT.bind (emit i) f).run s = (f PUnit.unit).run
+      { s with instrs := s.instrs.push i,
+               instrStages := s.instrStages.push s.curStage } := rfl
+theorem step_throw {α β} (e : String) (f : α → EmitM β) (s : EmitSt) :
+    (StateT.bind (throw e) f).run s = .error e := rfl
+theorem run_pure' {α} (a : α) (s : EmitSt) : (pure a : EmitM α).run s = .ok (a, s) := rfl
+
+set_option maxHeartbeats 1000000 in
+theorem compileBankSum_stream
+    (arena : ExprArena) (hw : arena.wf = true) (bound count : Nat)
+    (tables : Array ExprId) (body : ExprId) (dynCount? : Option ExprId) (idxId : Nat)
+    (hts : ∀ t ∈ tables, t.idx < bound) (hb : body.idx < bound)
+    (hdc : ∀ d ∈ dynCount?, d.idx < bound)
+    (hT : ∀ t ∈ tables, AppendsOnly (compileNode arena hw t))
+    (hC : ∀ dc ∈ dynCount?, AppendsOnly (compileNode arena hw dc (some .int)))
+    (hB : AppendsOnly (compileNode arena hw body))
+    (s : EmitSt) (r : CompileResult) (s' : EmitSt)
+    (h : (compileBankSum arena hw bound count tables body dynCount? idxId hts hb hdc).run s
+          = .ok (r, s')) :
+    ∃ (pre bodyIns : Array NInstr) (acc : Nat) (ty : Tropical.Parse.ScalarKind)
+      (countOp? : Option NOperand) (contribOp : NOperand),
+      s'.instrs = s.instrs ++ pre
+        ++ #[instrReduceBegin acc (.const (Lean.JsonNumber.fromNat 0) ty) count ty countOp? idxId]
+        ++ bodyIns
+        ++ #[instrScalar "Add" acc #[.reg acc ty, contribOp] ty, instrReduceEnd acc ty]
+      ∧ r = .scalar (.reg acc ty) ty := by
+  rw [compileBankSum.eq_def] at h
+  cases dynCount? with
+  | none =>
+    simp only [bind] at h
+    -- 1. tables + count (the loop-invariant prefix)
+    obtain ⟨_, s1, hFor, h⟩ := step_ok h
+    obtain ⟨dT, hdT⟩ := AppendsOnly.arrayForM _ _
+      (fun x _ => AppendsOnly.discard (hT x.val x.property)) s _ s1 hFor
+    rw [step_pure, step_allocReg, step_get, step_get] at h
+    -- 2. the body
+    obtain ⟨contrib, s6, hbody, h⟩ := step_ok h
+    obtain ⟨dB, hdB⟩ := hB _ contrib s6 hbody
+    simp only at hdB
+    -- 3. the tail: array-valued body dies on throw; scalar body emits the region
+    cases hIA : contrib.isArray with
+    | true => rw [if_pos (by rw [hIA])] at h; rw [step_throw] at h; cases h
+    | false =>
+      rw [if_neg (by rw [hIA]; exact Bool.false_ne_true)] at h
+      rw [step_pure, step_modify, step_emit, step_emit, step_modify, run_pure'] at h
+      simp only [Except.ok.injEq, Prod.mk.injEq] at h
+      obtain ⟨hr, hs⟩ := h
+      subst hr; subst hs
+      refine ⟨dT, dB, s1.nextReg,
+        (if (contrib.scalarType == Parse.ScalarKind.bool) = true
+          then Parse.ScalarKind.int else contrib.scalarType),
+        none, contrib.op, ?_, rfl⟩
+      rw [hdB, hdT, insertIdx!_at_prefix]
+      simp only [Array.push_eq_append, Array.append_assoc]
+      rfl
+  | some dc =>
+    simp only [bind] at h
+    obtain ⟨_, s1, hFor, h⟩ := step_ok h
+    obtain ⟨dT, hdT⟩ := AppendsOnly.arrayForM _ _
+      (fun x _ => AppendsOnly.discard (hT x.val x.property)) s _ s1 hFor
+    -- the runtime effective count compiles with the tables (loop-invariant)
+    obtain ⟨cres, s2, hcnt, h⟩ := step_ok h
+    obtain ⟨dC, hdC⟩ := hC dc rfl s1 cres s2 hcnt
+    cases hCA : cres.isArray with
+    | true => rw [if_pos (by rw [hCA])] at h; rw [step_throw] at h; cases h
+    | false =>
+      rw [if_neg (by rw [hCA]; exact Bool.false_ne_true)] at h
+      rw [step_pure, step_pure, step_allocReg, step_get, step_get] at h
+      obtain ⟨contrib, s6, hbody, h⟩ := step_ok h
+      obtain ⟨dB, hdB⟩ := hB _ contrib s6 hbody
+      simp only at hdB
+      cases hIA : contrib.isArray with
+      | true => rw [if_pos (by rw [hIA])] at h; rw [step_throw] at h; cases h
+      | false =>
+        rw [if_neg (by rw [hIA]; exact Bool.false_ne_true)] at h
+        rw [step_pure, step_modify, step_emit, step_emit, step_modify, run_pure'] at h
+        simp only [Except.ok.injEq, Prod.mk.injEq] at h
+        obtain ⟨hr, hs⟩ := h
+        subst hr; subst hs
+        refine ⟨dT ++ dC, dB, s2.nextReg,
+          (if (contrib.scalarType == Parse.ScalarKind.bool) = true
+            then Parse.ScalarKind.int else contrib.scalarType),
+          some cres.op, contrib.op, ?_, rfl⟩
+        rw [hdB, hdC, hdT, insertIdx!_at_prefix]
+        simp only [Array.push_eq_append, Array.append_assoc]
+        rfl
+
+
+-- ─────────────────────────────────────────────────────────────
+-- WS-B + WS-D: the region's assumed semantics, and THE one assumption
+-- ─────────────────────────────────────────────────────────────
+
+/-- The number of iterations a region actually runs (WS-B,
+    trip-count-as-data): the static capacity, or the runtime effective
+    count CLAMPED to `[0, capacity]` at the loop head. The clamp is part
+    of the semantics, not a side condition — see `regionTrips_le`. -/
+def regionTrips (capacity : Nat) (dyn? : Option Int) : Nat :=
+  match dyn? with
+  | none => capacity
+  | some d => min d.toNat capacity
+
+/-- **WS-B.** A bank whose runtime count exceeds capacity provably runs a
+    PREFIX — it can never read past the tables (which fill to capacity). -/
+theorem regionTrips_le (capacity : Nat) (dyn? : Option Int) :
+    regionTrips capacity dyn? ≤ capacity := by
+  cases dyn? with
+  | none => exact Nat.le_refl _
+  | some d => exact Nat.min_le_right _ _
+
+/-- **REDUCE_REGION_EXECUTES_IN_ARRAY_ORDER** — the single trusted
+    assumption left under the bank order-preservation theorem (WS-D), in
+    one sentence:
+
+    > `ReduceBegin acc init n [dyn]` … `ReduceEnd acc` executes its body
+    > for `i = 0, 1, …, trips−1` in INCREASING order, where
+    > `trips = min (max dyn 0) n` (`n` when no dyn operand rides the
+    > instruction), accumulating `acc := op acc body(i)` — no
+    > reassociation, no vectorization across `i`.
+
+    This function is that sentence's Lean transcription: the region's
+    denotation is `refFold` over the clamped prefix, in array order. The
+    assumption itself — that each backend's ReduceBegin/ReduceEnd
+    execution implements THIS function — is not a Lean proposition (the
+    execution is C++/LLVM/MSL); it is discharged by inspection, one
+    sentence per backend:
+
+    - `EmitLlvm.lean` `"ReduceBegin"`/`"ReduceEnd"` (the JIT and the wasm
+      emitter share this emitter): `icmp slt/sgt + select` clamp to
+      `[0, loopCount]` before the loop blocks open; `rd_cond` tests
+      `i < bound`, the body stores `acc`, `rd` steps `i + 1` — a single
+      scalar chain in increasing order.
+    - `EmitMsl.lean` `"ReduceBegin"`/`"ReduceEnd"` (Metal):
+      `min(max(dyn, 0L), loopCount)` bound before the loop;
+      `for (long rd = 0; rd < bound; ++rd)` with a scalar accumulator
+      local — same shape, same order.
+
+    Everything else — that the two builder branches are the same tree
+    (`unrollBanks_modalBankSigTable`), that the fold is the array-order
+    fold (`denote_unrollBanks_bankSum`), that nesting composes row-major
+    (`unrollBanks_bankSum_nested`), that the emitted stream has exactly
+    the region shape with the tables hoisted before it
+    (`compileBankSum_stream`), and that an over-capacity live count runs
+    a prefix (`regionTrips_le`) — is a theorem. -/
+def regionDenotation {α : Type _} (op : α → α → α) (init : α)
+    (body : Nat → α) (capacity : Nat) (dyn? : Option Int) : α :=
+  Tropical.EmitArrow.refFold op init body (regionTrips capacity dyn?)
+
+/-- The capstone corollary: read through the named assumption
+    (`regionDenotation`), a STATIC region computes exactly what the
+    unrolled realization computes, for ANY carrier and any denotation
+    that is a homomorphism on `add` alone — the two realizations perform
+    the same operations on the same operands in the same sequence, so
+    bit-identity is a corollary of the determinism of `op`, floats
+    included. -/
+theorem regionDenotation_static_eq_unrolled {α : Type _}
+    (d : Tropical.EmitArrow.Sig → α) (op : α → α → α) (z : α)
+    (hadd : ∀ a b, d (Tropical.EmitArrow.add a b) = op (d a) (d b))
+    (hz : d (Tropical.EmitArrow.litI 0) = z)
+    {n : Nat} {ts : Array Tropical.EmitArrow.Sig}
+    {b : Tropical.EmitArrow.Sig} {ii : Nat} :
+    regionDenotation op z
+        (fun j => d (Tropical.EmitArrow.instLoop ii j
+          (Tropical.EmitArrow.unrollBanks b))) n none
+      = d (Tropical.EmitArrow.unrollBanks (.bankSum n ts b none ii)) := by
+  rw [Tropical.EmitArrow.denote_unrollBanks_bankSum d op z hadd hz]
+  rfl
+
+end Tropical.Ir.Emit
+

--- a/lean/Tropical/Plan.lean
+++ b/lean/Tropical/Plan.lean
@@ -183,6 +183,11 @@ def PlanOp.ofString? : String → Option PlanOp
   | "Select" => some .select | "Clamp" => some .clamp
   | _ => none
 
+/-- The scalar-op wire table is a left inverse of its encoder. -/
+theorem PlanOp.ofString_name (op : PlanOp) :
+    PlanOp.ofString? op.name = some op := by
+  cases op <;> rfl
+
 /-- Classification of the signature (properties of an op symbol, so a total
     predicate with a default arm is fine — unlike the emit algebras, which must
     be exhaustive). -/

--- a/lean/Tropical/Testing/ClockLaws.lean
+++ b/lean/Tropical/Testing/ClockLaws.lean
@@ -1,0 +1,94 @@
+import Tropical.Testing.ArrowFixtures
+import Tropical.EmitArrow.ClockAlgebra
+
+/-!
+# ClockLaws — the ArrowLaws fixture clocks, as theorems (slice 3b, WS-3/4)
+
+`Tropicaltest/ArrowLaws.lean` certifies laws 1/2/4/5 by rendering both
+sides of each fixture pair and comparing SHA256. This module states the
+same four equations as theorems over the SAME fixture `Sig` values — a
+universal statement where the gates sample. The generic laws
+(`EmitArrow/ClockAlgebra.lean`) quantify over every rail expression; these
+instances pin the actual `Testing/ArrowFixtures.lean` trees to them, so
+the audio gates and the theorems provably speak about the same objects.
+
+What this changes about the golden set: the per-law-instance audio gates
+were carrying BOTH the algebra claim (LHS clock ≡ RHS clock as integers)
+and the backend claim (the engine renders a given plan as frozen). The
+algebra half is now these theorems, for all clocks; the gates' remaining
+job is the backend half, for which one gate per backend path suffices.
+Nothing is deleted here — shrinking the gate set is a separate,
+now-licensed move (see the handoff's "what this does not replace").
+
+Laws 3 and 6 are OUT of this fragment, deliberately:
+* **Law 3 (diagonal)** is a program-graph property (shared vs duplicated
+  dry instance under CSE), not a clock-expression identity.
+* **Law 6 (reverse/flanger commute)** is a value-datapath law — the ±δ
+  tap sum reassociates in float (the slice-5 finding,
+  `ArrowLaws.lean`). The proof boundary landing exactly on the
+  empirical boundary is evidence the fragment is carved right.
+-/
+
+namespace Tropical.EmitArrow
+
+open Tropical.Ir
+
+-- Rail derivations for the fixture ingredients: the deltas are `toInt`
+-- boundaries (their float seconds→samples math is behind the door), the
+-- clock is the root clock.
+
+/-- `deltaLit` (hence `delta1`/`delta2`) is a boundary: a closed-form
+    Q32.32 integer sample count entering the rail through `toInt`. -/
+def deltaLit_rail (mantissa : Int) (exponent : Nat) :
+    OnClockRail (deltaLit mantissa exponent) := .boundary _
+
+def delta1_rail : OnClockRail delta1 := .boundary _
+def delta2_rail : OnClockRail delta2 := .boundary _
+
+-- The four law pairs, as derivations of the fixture trees…
+
+def invLawLhs_rail : OnClockRail invLawLhsClock :=
+  .sub (.add rootClock_rail delta1_rail) delta1_rail
+def invLawRhs_rail : OnClockRail invLawRhsClock := rootClock_rail
+
+def addLawLhs_rail : OnClockRail addLawLhsClock :=
+  .sub (.sub rootClock_rail delta1_rail) delta2_rail
+def addLawRhs_rail : OnClockRail addLawRhsClock :=
+  .sub rootClock_rail (.add delta1_rail delta2_rail)
+
+def revInvolutionLhs_rail : OnClockRail revInvolutionLhsClock :=
+  .neg (.neg rootClock_rail)
+def revInvolutionRhs_rail : OnClockRail revInvolutionRhsClock := rootClock_rail
+
+def revSwapLhs_rail : OnClockRail revSwapLhsClock :=
+  .neg (.sub rootClock_rail delta1_rail)
+def revSwapRhs_rail : OnClockRail revSwapRhsClock :=
+  .add (.neg rootClock_rail) delta1_rail
+
+-- …and the four laws, each an instance of its universal form. Under
+-- CLOCK_RAIL_IS_EXACT (the one named hypothesis,
+-- `EmitArrow/ClockAlgebra.lean`), each equation pushes forward to a
+-- bit-identical i64 clock on the wire — which is exactly what the audio
+-- gates observe as byte-identical renders.
+
+/-- **Law 1 (inverse/cancellation)**: `(clk+δ₁)−δ₁ = clk`. -/
+theorem invLaw_denote (env : ClockEnv) :
+    denoteClock invLawLhs_rail env = denoteClock invLawRhs_rail env :=
+  warp_inv rootClock_rail delta1_rail env
+
+/-- **Law 2 (additive delay)**: `(clk−δ₁)−δ₂ = clk−(δ₁+δ₂)`. -/
+theorem addLaw_denote (env : ClockEnv) :
+    denoteClock addLawLhs_rail env = denoteClock addLawRhs_rail env :=
+  warp_assoc rootClock_rail delta1_rail delta2_rail env
+
+/-- **Law 4 (reverse involution)**: `−(−clk) = clk`. -/
+theorem revInvolution_denote (env : ClockEnv) :
+    denoteClock revInvolutionLhs_rail env = denoteClock revInvolutionRhs_rail env :=
+  rev_involution rootClock_rail env
+
+/-- **Law 5 (reverse conjugates delay)**: `−(clk−δ₁) = (−clk)+δ₁`. -/
+theorem revSwap_denote (env : ClockEnv) :
+    denoteClock revSwapLhs_rail env = denoteClock revSwapRhs_rail env :=
+  rev_swap rootClock_rail delta1_rail env
+
+end Tropical.EmitArrow

--- a/lean/Tropical/Tropicaltest/ArrowLaws.lean
+++ b/lean/Tropical/Tropicaltest/ArrowLaws.lean
@@ -14,13 +14,17 @@ open Tropical.Plan
 -- Slice 3. The warp arrow laws are certified as AUDIO goldens: build the law's
 -- LHS and RHS as two EmitArrow carrier programs (a single FixedSinOsc clocked at
 -- two algebraically-equal clock expressions), render both, and assert the
--- rendered audio is byte-identical (SHA256). The laws hold byte-exactly because
--- warps are integer add/sub on the Q32.32 fixed-point clock — exact and
--- associative — so the two sides feed the oscillator a bit-identical int64 clock
--- and render bit-identical audio, EVEN THOUGH the emitted plans differ (no
--- algebraic tree normalization). The render bridge reuses the production session
--- path: buildClockCarrier (EmitArrow) → Strata.run → Core.check → compileSession
--- (the carrier as a one-instance root wired to the dac) → FlatPlan → renderIrBytes.
+-- rendered audio is byte-identical (SHA256). Since slice 3b the algebra half is
+-- a THEOREM, not prose: the fixture clock pairs denote equal integers for EVERY
+-- clock expression on the fixed rail (`Testing/ClockLaws.lean` instances of the
+-- universal laws in `EmitArrow/ClockAlgebra.lean`; trusted base = the one named
+-- hypothesis CLOCK_RAIL_IS_EXACT). These gates carry the remaining half — the
+-- BACKEND renders a given plan as frozen — so the two sides feed the oscillator
+-- a bit-identical int64 clock and render bit-identical audio, EVEN THOUGH the
+-- emitted plans differ (no algebraic tree normalization). The render bridge
+-- reuses the production session path: buildClockCarrier (EmitArrow) →
+-- Strata.run → Core.check → compileSession (the carrier as a one-instance root
+-- wired to the dac) → FlatPlan → renderIrBytes.
 
 open Tropical.Ir (Arena ProgramIdx)
 

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -14,6 +14,7 @@ import Tropical.Compile
 import Tropical.EmitArrow
 import Tropical.Stdlib
 import Tropical.Testing.ArrowFixtures
+import Tropical.Testing.ClockLaws
 import Tropical.Testing.EngineMirror
 import Tropical.Testing.PlanWire
 import Lean.Data.Json


### PR DESCRIPTION
## Summary

- prove that static bank realization preserves the exact left-fold tree and array order, without assuming associativity
- prove the emitted ReduceBegin/body/Add/ReduceEnd region shape under the emitter's append-only contract
- carve out the integer clock rail and prove its warp identities for every admitted expression
- model i64 folding as canonical representatives of integers modulo 2^64 and prove wrap range, canonicalization, residue, and ring compatibility
- pin every all-integer foldOp route, including division/modulo zero guards, comparisons, truthiness, bitwise operations, valid and refused shifts, casts, clamp, and select
- prove the PlanOp wire-name parser round trip

## Proof boundary

- bank execution still has one named backend premise: reduce regions execute in array order
- clock theorems cover the integer clock rail; backend render gates remain in place
- Float constant folding, float-to-int truncation, and transcendental semantics are not claimed here

## Validation

- make lean: 183 jobs passed
- ./lean/.lake/build/bin/tropicaltest: 118/118 passed
- git diff --check passed
- no sorry, admit, or axiom in ConstFoldLaws