### PR TITLE
Add the Reversible native control surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
 
 jobs:
+  reversible:
+    name: Reversible Swift build and test
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build native app package
+        run: swift build --package-path reversible
+      - name: Test native app package
+        run: swift test --package-path reversible
+
   typecheck:
     name: TypeScript type-check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ reversible-build:
 reversible-test:
 	swift test --package-path reversible
 
-# macOS release packaging. The bundle gate compiles a live grouped-room graph
+# macOS release packaging. The bundle gate compiles a canonical source graph
 # after relocating the app beneath the system temporary directory.
 reversible-bundle: build lean
 	reversible/scripts/bundle-app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build repl run lean mcp-lean clean validate test-lean-engine
+.PHONY: build repl run lean mcp-lean clean validate test-lean-engine reversible-build reversible-test
 
 ROOT := $(shell pwd)
 BUILD_DIR := $(ROOT)/build
@@ -63,3 +63,11 @@ validate: build lean
 # Behavioral MCP protocol suites against the live Lean engine.
 test-lean-engine: build lean
 	TROPICAL_ENGINE_CMD="./lean/.lake/build/bin/frontend --rpc" bun test mcp/errors.test.ts mcp/wire_dac.test.ts
+
+# Native Reversible gates. SwiftUI is a macOS surface; Linux CI must not
+# pretend to compile it.
+reversible-build:
+	swift build --package-path reversible
+
+reversible-test:
+	swift test --package-path reversible

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build repl run lean mcp-lean clean validate test-lean-engine reversible-build reversible-test
+.PHONY: build repl run lean mcp-lean clean validate test-lean-engine reversible-build reversible-test reversible-bundle reversible-bundle-smoke
 
 ROOT := $(shell pwd)
 BUILD_DIR := $(ROOT)/build
@@ -71,3 +71,11 @@ reversible-build:
 
 reversible-test:
 	swift test --package-path reversible
+
+# macOS release packaging. The bundle gate compiles a live grouped-room graph
+# after relocating the app beneath the system temporary directory.
+reversible-bundle: build lean
+	reversible/scripts/bundle-app
+
+reversible-bundle-smoke: reversible-bundle
+	node reversible/scripts/smoke-bundle.mjs

--- a/lean/Tropical/Playground/Decode.lean
+++ b/lean/Tropical/Playground/Decode.lean
@@ -419,17 +419,41 @@ def modalClassificationDrift : Array String := Id.run do
       drift := drift.push kind
   return drift
 
-/-- The vocabulary as JSON — the ONE description of the node kinds, GENERATED
-    from the port-spec table (the hand-maintained `nodeSchema` this replaces
-    was the third copy, and the class of bug this file exists to kill). Per
-    kind: outlet color and ports; per port: inlet facts (accepts/multi), knob
-    facts (default, write discipline, display metadata), and `owner` when the
-    knob parameterizes another port's normal. Clients RENDER this — nothing
-    the engine knows may be re-encoded client-side. The connection rule rides
-    along: `outlet→inlet` valid iff `outlet.color ∈ inlet.accepts`; a modal
-    outlet into a signal inlet REALIZES at the seam; a control outlet is a
-    constant stream; signal into a modal inlet is the one hard type error. -/
-def vocabularyJson : Json :=
+/-- The stable wire identity for the engine-owned vocabulary envelope. The
+    version changes only when the response contract changes incompatibly; the
+    fingerprint below changes when its semantic payload changes. -/
+def vocabularySchema : String := "tropical_vocabulary"
+def vocabularySchemaVersion : Nat := 1
+
+/-- FNV-1a/64 over bytes, with UInt64 arithmetic providing the specified
+    modulo-2^64 wrap. This is a compatibility fingerprint, not a security
+    primitive: it gives every client a small deterministic identity for the
+    exact canonical vocabulary payload it decoded. -/
+def fnv1a64 (bytes : ByteArray) : UInt64 := Id.run do
+  let mut hash : UInt64 := 14695981039346656037
+  for byte in bytes do
+    hash := (hash ^^^ byte.toUInt64) * 1099511628211
+  return hash
+
+private def hexDigit (n : Nat) : Char :=
+  if n < 10 then Char.ofNat ('0'.toNat + n)
+  else Char.ofNat ('a'.toNat + n - 10)
+
+/-- A fixed-width lowercase spelling keeps the fingerprint stable across
+    platforms and independent of the host's integer formatting. -/
+def uint64Hex (value : UInt64) : String := Id.run do
+  let mut out := ""
+  for i in [0:16] do
+    let shift := 4 * (15 - i)
+    let nibble := ((value >>> shift.toUInt64) &&& 0xf).toNat
+    out := out.push (hexDigit nibble)
+  return out
+
+/-- The vocabulary's canonical SEMANTIC payload. Array order is authored table
+    order; `Json.compress` serializes object fields through Lean.Json's ordered
+    object map, so the byte spelling hashed below is deterministic. Schema and
+    fingerprint fields deliberately live outside this payload. -/
+def vocabularyPayloadJson : Json :=
   let portJson := fun (p : PortSpec) => Json.mkObj <|
     [("name", Json.str p.name)]
     ++ (if p.accepts.isEmpty then [] else
@@ -457,6 +481,36 @@ def vocabularyJson : Json :=
           | some d => Json.str (domStr d)
           | none => Json.null),
         ("ports", Json.arr ((portSpecs k).map portJson))]))]
+
+/-- Algorithm-labelled identity of `vocabularyPayloadJson`. The label is part
+    of the value so a future algorithm migration cannot be mistaken for a
+    semantic-table change. -/
+def vocabularyFingerprint : String :=
+  s!"fnv1a64:{uint64Hex (fnv1a64 vocabularyPayloadJson.compress.toUTF8)}"
+
+/-- The vocabulary as JSON — the ONE description of the node kinds, GENERATED
+    from the port-spec table (the hand-maintained `nodeSchema` this replaces
+    was the third copy, and the class of bug this file exists to kill). Per
+    kind: outlet color and ports; per port: inlet facts (accepts/multi), knob
+    facts (default, write discipline, display metadata), and `owner` when the
+    knob parameterizes another port's normal. Clients RENDER this — nothing
+    the engine knows may be re-encoded client-side. The connection rule rides
+    along: `outlet→inlet` valid iff `outlet.color ∈ inlet.accepts`; a modal
+    outlet into a signal inlet REALIZES at the seam; a control outlet is a
+    constant stream; signal into a modal inlet is the one hard type error. The
+    original `rule`/`colors`/`kinds` keys remain top-level for compatible
+    clients; schema metadata wraps that unchanged semantic payload. -/
+def vocabularyJson : Json :=
+  match vocabularyPayloadJson with
+  | .obj fields => .obj <|
+      fields.insert "schema" (Json.str vocabularySchema)
+        |>.insert "schema_version" (Lean.toJson vocabularySchemaVersion)
+        |>.insert "fingerprint" (Json.str vocabularyFingerprint)
+  | payload => Json.mkObj [
+      ("schema", Json.str vocabularySchema),
+      ("schema_version", Lean.toJson vocabularySchemaVersion),
+      ("fingerprint", Json.str vocabularyFingerprint),
+      ("payload", payload)]
 
 /-- The live param table: every node's continuous knobs as `(<id>.<knob>, default)`
     in scan order (node order, then knob order). The position IS the `ParamIdx` the

--- a/lean/Tropical/Tropicaltest/Vocabulary.lean
+++ b/lean/Tropical/Tropicaltest/Vocabulary.lean
@@ -65,6 +65,40 @@ def runVocabDriven (arena : Arena)
   let mut ok := true
   let mut covered := 0
   let mut issues : Array String := #[]
+  -- Served identifiers are protocol keys, not display labels: every kind must
+  -- occur exactly once, and an explicitly withheld implementation must never
+  -- leak into the surface vocabulary. Keep these as direct set facts in
+  -- addition to the compile-driven checks below, so a duplicate cannot pass by
+  -- compiling the same minimal patch twice.
+  let mut seen : Array String := #[]
+  for kind in vocabularyKinds do
+    if seen.contains kind then
+      ok := false
+      issues := issues.push s!"duplicate served kind: {kind}"
+    else
+      seen := seen.push kind
+  for kind in withheldKinds do
+    if vocabularyKinds.contains kind then
+      ok := false
+      issues := issues.push s!"withheld kind served: {kind}"
+  -- Envelope identity and the algorithm-labelled deterministic fingerprint are
+  -- part of the same vocabulary contract the generated patches exercise.
+  let schemaOk := (vocabularyJson.getObjVal? "schema").toOption
+      == some (Lean.Json.str vocabularySchema)
+    && (vocabularyJson.getObjVal? "schema_version").toOption
+      == some (Lean.toJson vocabularySchemaVersion)
+  let fingerprintOk := (vocabularyJson.getObjVal? "fingerprint").toOption
+      == some (Lean.Json.str vocabularyFingerprint)
+    && vocabularyFingerprint.startsWith "fnv1a64:"
+    && vocabularyFingerprint.length == "fnv1a64:".length + 16
+    && vocabularyFingerprint
+      == s!"fnv1a64:{uint64Hex (fnv1a64 vocabularyPayloadJson.compress.toUTF8)}"
+  if !schemaOk then
+    ok := false
+    issues := issues.push "vocabulary schema identifier/version missing or changed"
+  if !fingerprintOk then
+    ok := false
+    issues := issues.push "vocabulary fingerprint is not deterministic labelled FNV-1a/64"
   for kind in vocabularyKinds do
     if kind == "out" then continue
     let mut nodes : Array Lean.Json := #[]
@@ -112,10 +146,11 @@ def runVocabDriven (arena : Arena)
       let dead := unreadParamSlots plan
       if !dead.isEmpty then
         ok := false; issues := issues.push s!"{kind}: unread {dead}"
-  IO.println s!"        {covered} kinds, each compiled from a vocabulary-generated minimal patch:"
+  IO.println s!"        schema {vocabularySchema} v{vocabularySchemaVersion} · fingerprint {vocabularyFingerprint}"
+  IO.println s!"        {covered} non-sink served kinds compiled from vocabulary-generated minimal patches; all served identifiers unique, withheld absent:"
   IO.println s!"        result   {if issues.isEmpty then "every declared knob registers and is read" else toString issues}"
   if ok then
-    passGate "vocab-driven" "the served vocabulary drives a compiling patch per kind — declared knobs live, nothing unread"
+    passGate "vocab-driven" "versioned/fingerprinted vocabulary has unique served kinds, withholds unavailable kinds, and drives one compiling patch per kind — declared knobs live, nothing unread"
   else
     failGate "vocab-driven" s!"{issues}"
 

--- a/reversible/.gitignore
+++ b/reversible/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+.DS_Store
+*.xcodeproj

--- a/reversible/Package.swift
+++ b/reversible/Package.swift
@@ -8,6 +8,12 @@ let package = Package(
         .executableTarget(
             name: "Reversible",
             path: "Sources/Reversible"
+        ),
+        .testTarget(
+            name: "ReversibleTests",
+            dependencies: ["Reversible"],
+            path: "Tests/ReversibleTests",
+            resources: [.process("Fixtures")]
         )
     ]
 )

--- a/reversible/Package.swift
+++ b/reversible/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Reversible",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "Reversible",
+            path: "Sources/Reversible"
+        )
+    ]
+)

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -1,11 +1,9 @@
 # reversible
 
-Private. The Swift/macOS control surface for tropical — a native port of
-`playground/` (the Electron patch playground) from the `perf/dag-to-emit`
-branch. Downstream-only patching that lowers through the session → arrow
-slide; the master clock scrubs every voice, envelope, and reverb tail
-coherently because kernels are closed-form `f(τ, params)` — no state,
-so reverse is just receding τ.
+The Swift/macOS control surface for Tropical. It authors downstream-only patch
+graphs against the engine-owned vocabulary and drives the same served engine
+used by other native clients. The master clock scrubs closed-form kernels
+coherently because their output is a pure function `f(τ, params)`.
 
 ## Run
 
@@ -40,9 +38,7 @@ reversible/scripts/bundle-app
 ```
 
 The output is `build/Reversible.app`. The bundle contains the native app,
-Tropical frontend, and room-only grouped-carrier asset. It deliberately does
-not package the authored-score wet cache.
+Tropical frontend, and runtime library.
 
-The engine must be built from a branch that serves `load_patch_graph`
-(`perf/dag-to-emit` or later). Run the binary directly—never `lake exe`
+The engine must serve `load_patch_graph`. Run the binary directly—never `lake exe`
 (DYLD shadowing; see tropical/CLAUDE.md).

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -13,9 +13,13 @@ so reverse is just receding τ.
 swift run
 ```
 
-The app owns the Lean `frontend` binary over its newline-delimited
-JSON-RPC surface (`--rpc`) and plays audio out of the host's device
-(RtAudio) — the window is purely a control surface.
+The app owns the Lean `frontend` binary over its Unix-socket JSON-RPC
+surface (`--serve`, same newline-delimited framing as `--rpc`) and plays
+audio out of the host's device (RtAudio) — the window is purely a control
+surface. The socket carries a control/data plane split: `set_param`,
+`render_window`, and `playback_position` are answered synchronously in
+C++ and never queue behind the Lean control thread — that is what keeps
+knob writes and the Scope module's traces live through a long compile.
 
 Engine resolution order:
 1. `TROPICAL_ENGINE_BIN` env var (path to the `frontend` binary)

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -15,10 +15,11 @@ From the Tropical repository root:
 reversible/scripts/run-dev
 ```
 
-The app owns the Lean `frontend` binary over its Unix-socket JSON-RPC
-surface (`--serve`, same newline-delimited framing as `--rpc`) and plays
-audio out of the host's device (RtAudio) — the window is purely a control
-surface. The socket carries a control/data plane split: `set_param`,
+The app owns the Lean `frontend` binary and Unix-socket namespace. It uses
+independent graph, control, scope, and telemetry JSON-RPC connections over the
+served surface (`--serve`, with the same newline-delimited framing as `--rpc`),
+while audio plays out of the host's device (RtAudio). The window is purely a
+control surface. The server carries a control/data plane split: `set_param`,
 `render_window`, and `playback_position` are answered synchronously in
 C++ and never queue behind the Lean control thread — that is what keeps
 knob writes and the Scope module's traces live through a long compile.

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -1,0 +1,26 @@
+# reversible
+
+Private. The Swift/macOS control surface for tropical — a native port of
+`playground/` (the Electron patch playground) from the `perf/dag-to-emit`
+branch. Downstream-only patching that lowers through the session → arrow
+slide; the master clock scrubs every voice, envelope, and reverb tail
+coherently because kernels are closed-form `f(τ, params)` — no state,
+so reverse is just receding τ.
+
+## Run
+
+```bash
+swift run
+```
+
+The app owns the Lean `frontend` binary over its newline-delimited
+JSON-RPC surface (`--rpc`) and plays audio out of the host's device
+(RtAudio) — the window is purely a control surface.
+
+Engine resolution order:
+1. `TROPICAL_ENGINE_BIN` env var (path to the `frontend` binary)
+2. `~/tropical/lean/.lake/build/bin/frontend`
+
+The engine must be built from a branch that serves `load_patch_graph`
+(`perf/dag-to-emit` or later). Run the binary directly — never `lake exe`
+(DYLD shadowing; see tropical/CLAUDE.md).

--- a/reversible/README.md
+++ b/reversible/README.md
@@ -9,8 +9,10 @@ so reverse is just receding τ.
 
 ## Run
 
+From the Tropical repository root:
+
 ```bash
-swift run
+reversible/scripts/run-dev
 ```
 
 The app owns the Lean `frontend` binary over its Unix-socket JSON-RPC
@@ -22,9 +24,24 @@ C++ and never queue behind the Lean control thread — that is what keeps
 knob writes and the Scope module's traces live through a long compile.
 
 Engine resolution order:
-1. `TROPICAL_ENGINE_BIN` env var (path to the `frontend` binary)
-2. `~/tropical/lean/.lake/build/bin/frontend`
+
+1. `Reversible.app/Contents/Resources/Tropical/frontend`
+2. `TROPICAL_ENGINE_BIN` (an explicit developer/test override)
+
+`reversible/scripts/run-dev` resolves both the package and engine from the
+script's repository location. There is no implicit home-checkout fallback and
+the launcher's current working directory is irrelevant.
+
+Create a local ad-hoc-signed app bundle with:
+
+```bash
+reversible/scripts/bundle-app
+```
+
+The output is `build/Reversible.app`. The bundle contains the native app,
+Tropical frontend, and room-only grouped-carrier asset. It deliberately does
+not package the authored-score wet cache.
 
 The engine must be built from a branch that serves `load_patch_graph`
-(`perf/dag-to-emit` or later). Run the binary directly — never `lake exe`
+(`perf/dag-to-emit` or later). Run the binary directly—never `lake exe`
 (DYLD shadowing; see tropical/CLAUDE.md).

--- a/reversible/Resources/Icon-placeholder.txt
+++ b/reversible/Resources/Icon-placeholder.txt
@@ -1,0 +1,2 @@
+The release-machine bundle intentionally has no final artwork yet.
+CFBundleIconFile is omitted so macOS uses the standard application icon.

--- a/reversible/Resources/Icon-placeholder.txt
+++ b/reversible/Resources/Icon-placeholder.txt
@@ -1,2 +1,0 @@
-The release-machine bundle intentionally has no final artwork yet.
-CFBundleIconFile is omitted so macOS uses the standard application icon.

--- a/reversible/Resources/Info.plist
+++ b/reversible/Resources/Info.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Reversible</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array><string>rvpatch</string></array>
+      <key>CFBundleTypeName</key>
+      <string>Reversible Patch</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Owner</string>
+    </dict>
+  </array>
+  <key>CFBundleExecutable</key>
+  <string>Reversible</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.tropical.reversible</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Reversible</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array><string>public.json</string></array>
+      <key>UTTypeDescription</key>
+      <string>Reversible Patch</string>
+      <key>UTTypeIdentifier</key>
+      <string>dev.tropical.reversible.patch</string>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array><string>rvpatch</string></array>
+        <key>public.mime-type</key>
+        <string>application/vnd.tropical.rvpatch+json</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -1,0 +1,282 @@
+import SwiftUI
+
+// ── Jack geometry ───────────────────────────────────────────────────────────
+// Jack dots report their centers (in canvas space) up through a preference;
+// the wire layer reads the dictionary. The SwiftUI analog of app.js's
+// jackCenter() DOM query.
+struct JackID: Hashable {
+    let node: String
+    let dir: JackDir
+    let port: String
+}
+
+enum JackDir: Hashable { case input, output }
+
+struct JackCentersKey: PreferenceKey {
+    static var defaultValue: [JackID: CGPoint] = [:]
+    static func reduce(value: inout [JackID: CGPoint], nextValue: () -> [JackID: CGPoint]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+/// A wire drag in flight: from an outlet, tracking the pointer.
+struct PendingWire {
+    let fromNode: String
+    var cursor: CGPoint
+}
+
+struct CanvasView: View {
+    @EnvironmentObject var model: PatchModel
+    @State private var jackCenters: [JackID: CGPoint] = [:]
+    @State private var pendingWire: PendingWire?
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            DotGrid()
+            WiresView(jackCenters: jackCenters, pendingWire: pendingWire)
+            ForEach(model.order, id: \.self) { id in
+                if let node = model.nodes[id] {
+                    NodeView(node: node, pendingWire: $pendingWire)
+                        .offset(x: node.position.x, y: node.position.y)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .clipped()
+        .coordinateSpace(name: "canvas")
+        .onPreferenceChange(JackCentersKey.self) {
+            jackCenters = $0
+            model.jackGeometry = $0
+        }
+    }
+}
+
+/// The 22px dot grid backdrop (styles.css #canvas background-image).
+struct DotGrid: View {
+    var body: some View {
+        Canvas { ctx, size in
+            let step: CGFloat = 22
+            var y: CGFloat = step / 2
+            while y < size.height {
+                var x: CGFloat = step / 2
+                while x < size.width {
+                    ctx.fill(
+                        Path(ellipseIn: CGRect(x: x - 1, y: y - 1, width: 2, height: 2)),
+                        with: .color(Theme.dotGrid))
+                    x += step
+                }
+                y += step
+            }
+        }
+        .background(Theme.bg)
+    }
+}
+
+// ── Wires ───────────────────────────────────────────────────────────────────
+struct WiresView: View {
+    @EnvironmentObject var model: PatchModel
+    let jackCenters: [JackID: CGPoint]
+    let pendingWire: PendingWire?
+
+    private struct Edge: Identifiable {
+        let from: String
+        let to: String
+        let port: String
+        var id: String { "\(from)→\(to):\(port)" }
+    }
+
+    private var edges: [Edge] {
+        model.order.compactMap { model.nodes[$0] }.flatMap { n in
+            n.inputs.flatMap { port, srcs in
+                srcs.map { Edge(from: $0, to: n.id, port: port) }
+            }
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            ForEach(edges) { e in
+                if let a = jackCenters[JackID(node: e.from, dir: .output, port: "out")],
+                   let b = jackCenters[JackID(node: e.to, dir: .input, port: e.port)] {
+                    let path = wirePath(a, b)
+                    path.stroke(Theme.wire, lineWidth: 2.5)
+                        .opacity(0.85)
+                        // Fat invisible stroke = the click target for delete.
+                        .contentShape(path.strokedPath(StrokeStyle(lineWidth: 12)))
+                        .onTapGesture {
+                            model.deleteEdge(to: e.to, port: e.port, from: e.from)
+                        }
+                }
+            }
+            if let p = pendingWire,
+               let a = jackCenters[JackID(node: p.fromNode, dir: .output, port: "out")] {
+                wirePath(a, p.cursor)
+                    .stroke(Theme.jackHot, style: StrokeStyle(lineWidth: 2.5, dash: [5, 4]))
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private func wirePath(_ a: CGPoint, _ b: CGPoint) -> Path {
+        let dx = max(40, abs(b.x - a.x) * 0.5)
+        var p = Path()
+        p.move(to: a)
+        p.addCurve(
+            to: b,
+            control1: CGPoint(x: a.x + dx, y: a.y),
+            control2: CGPoint(x: b.x - dx, y: b.y))
+        return p
+    }
+}
+
+// ── Node ────────────────────────────────────────────────────────────────────
+struct NodeView: View {
+    @EnvironmentObject var model: PatchModel
+    let node: PatchNode
+    @Binding var pendingWire: PendingWire?
+    @State private var dragOrigin: CGPoint?
+
+    private var spec: NodeSpec { node.kind.spec }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            titleBar
+            body_
+            jacks
+        }
+        .frame(minWidth: 132, alignment: .leading)
+        .background(Theme.panel)
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.edge))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.35), radius: 9, y: 6)
+        .fixedSize()
+        .onTapGesture(count: 2) { model.deleteNode(node.id) }
+    }
+
+    private var titleBar: some View {
+        HStack(spacing: 6) {
+            Circle().fill(spec.accent).frame(width: 9, height: 9)
+            Text(spec.title).font(Theme.mono.bold()).foregroundStyle(Theme.text)
+            Spacer(minLength: 8)
+            Text(node.id).font(Theme.monoSmall).foregroundStyle(Theme.muted)
+        }
+        .padding(.horizontal, 9).padding(.vertical, 6)
+        .background(Theme.panel)
+        .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.edge), alignment: .bottom)
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 1, coordinateSpace: .named("canvas"))
+                .onChanged { g in
+                    let origin = dragOrigin ?? node.position
+                    dragOrigin = origin
+                    model.nodes[node.id]?.position = CGPoint(
+                        x: max(0, origin.x + g.translation.width),
+                        y: max(0, origin.y + g.translation.height))
+                }
+                .onEnded { _ in dragOrigin = nil }
+        )
+    }
+
+    @ViewBuilder
+    private var body_: some View {
+        // A knob whose name matches a wired inlet is overridden by the patch
+        // cord (e.g. `freq` driven by a Knob node), so hide it.
+        let shown = spec.knobs.filter { (node.inputs[$0.name] ?? []).isEmpty }
+        if !shown.isEmpty {
+            HStack(alignment: .top, spacing: 8) {
+                ForEach(shown, id: \.name) { k in
+                    KnobView(node: node, knob: k)
+                }
+            }
+            .padding(.horizontal, 9).padding(.vertical, 8)
+        }
+    }
+
+    private var jacks: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 7) {
+                ForEach(spec.inlets, id: \.self) { port in
+                    JackView(node: node, port: port, dir: .input, pendingWire: $pendingWire)
+                }
+            }
+            Spacer(minLength: 16)
+            VStack(alignment: .trailing, spacing: 7) {
+                ForEach(spec.outlets, id: \.self) { port in
+                    JackView(node: node, port: port, dir: .output, pendingWire: $pendingWire)
+                }
+            }
+        }
+        .padding(.horizontal, 4).padding(.bottom, 6)
+    }
+}
+
+// ── Jack ────────────────────────────────────────────────────────────────────
+struct JackView: View {
+    @EnvironmentObject var model: PatchModel
+    let node: PatchNode
+    let port: String
+    let dir: JackDir
+    @Binding var pendingWire: PendingWire?
+    @State private var armed = false
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if dir == .input { dot; label } else { label; dot }
+        }
+    }
+
+    private var label: some View {
+        Text(port).font(Theme.monoSmall).foregroundStyle(Theme.muted)
+    }
+
+    private var dot: some View {
+        Circle()
+            .fill(armed ? Theme.jackHot : Theme.jack)
+            .overlay(Circle().stroke(Color(hex: 0x555F72)))
+            .frame(width: 12, height: 12)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(
+                        key: JackCentersKey.self,
+                        value: [
+                            JackID(node: node.id, dir: dir, port: port):
+                                CGPoint(
+                                    x: geo.frame(in: .named("canvas")).midX,
+                                    y: geo.frame(in: .named("canvas")).midY)
+                        ])
+                })
+            .gesture(dir == .output ? wireDrag : nil)
+    }
+
+    /// Drag from an outlet; drop on an inlet dot. The drop target is resolved
+    /// by hit-testing the reported jack centers (nearest inlet within reach) —
+    /// the SwiftUI analog of elementFromPoint.
+    private var wireDrag: some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .named("canvas"))
+            .onChanged { g in
+                armed = true
+                pendingWire = PendingWire(fromNode: node.id, cursor: g.location)
+            }
+            .onEnded { g in
+                armed = false
+                defer { pendingWire = nil }
+                if let hit = model.nearestInlet(to: g.location) {
+                    model.connect(from: node.id, to: hit.node, port: hit.port)
+                }
+            }
+    }
+}
+
+extension PatchModel {
+    /// Inlet hit-testing against the live jack geometry (12px dot + slop).
+    /// Centers live on CanvasView state; mirrored here each preference pass.
+    func nearestInlet(to point: CGPoint) -> (node: String, port: String)? {
+        var best: (JackID, CGFloat)?
+        for (id, c) in jackGeometry where id.dir == .input {
+            let d = hypot(c.x - point.x, c.y - point.y)
+            if d <= 14, d < (best?.1 ?? .infinity) { best = (id, d) }
+        }
+        guard let (id, _) = best else { return nil }
+        return (id.node, id.port)
+    }
+}

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -29,15 +29,32 @@ struct CanvasView: View {
     @EnvironmentObject var model: PatchModel
     @State private var jackCenters: [JackID: CGPoint] = [:]
     @State private var pendingWire: PendingWire?
+    // The plane is infinite in both axes: node positions are WORLD
+    // coordinates, `pan` maps world → view. Nodes render at world + pan, so
+    // jack centers (measured in the named space) already include the pan and
+    // wires/hit-tests need no second transform.
+    @State private var pan: CGSize = .zero
+    @State private var panOrigin: CGSize?
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            DotGrid()
+            DotGrid(pan: pan)
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { g in
+                            let o = panOrigin ?? pan
+                            panOrigin = o
+                            pan = CGSize(width: o.width + g.translation.width,
+                                         height: o.height + g.translation.height)
+                        }
+                        .onEnded { _ in panOrigin = nil }
+                )
             WiresView(jackCenters: jackCenters, pendingWire: pendingWire)
             ForEach(model.order, id: \.self) { id in
                 if let node = model.nodes[id] {
                     NodeView(node: node, pendingWire: $pendingWire)
-                        .offset(x: node.position.x, y: node.position.y)
+                        .offset(x: node.position.x + pan.width,
+                                y: node.position.y + pan.height)
                 }
             }
         }
@@ -51,14 +68,19 @@ struct CanvasView: View {
     }
 }
 
-/// The 22px dot grid backdrop (styles.css #canvas background-image).
+/// The 22px dot grid backdrop, phase-shifted by the pan so the plane reads
+/// as infinite (dots scroll with the world).
 struct DotGrid: View {
+    let pan: CGSize
+
     var body: some View {
         Canvas { ctx, size in
-            let step: CGFloat = 22
-            var y: CGFloat = step / 2
+            let step = Grid.unit
+            let ox = pan.width.truncatingRemainder(dividingBy: step)
+            let oy = pan.height.truncatingRemainder(dividingBy: step)
+            var y = oy - step
             while y < size.height {
-                var x: CGFloat = step / 2
+                var x = ox - step
                 while x < size.width {
                     ctx.fill(
                         Path(ellipseIn: CGRect(x: x - 1, y: y - 1, width: 2, height: 2)),
@@ -69,6 +91,7 @@ struct DotGrid: View {
             }
         }
         .background(Theme.bg)
+        .contentShape(Rectangle())
     }
 }
 
@@ -142,14 +165,17 @@ struct NodeView: View {
         VStack(alignment: .leading, spacing: 0) {
             titleBar
             body_
+            Spacer(minLength: 0)
             jacks
         }
-        .frame(minWidth: 132, alignment: .leading)
+        // VCV-style: every module has a defined footprint in grid units.
+        .frame(width: Double(spec.gridSize.w) * Grid.unit,
+               height: Double(spec.gridSize.h) * Grid.unit,
+               alignment: .topLeading)
         .background(Theme.panel)
         .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.edge))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: .black.opacity(0.35), radius: 9, y: 6)
-        .fixedSize()
         .onTapGesture(count: 2) { model.deleteNode(node.id) }
     }
 
@@ -169,9 +195,12 @@ struct NodeView: View {
                 .onChanged { g in
                     let origin = dragOrigin ?? node.position
                     dragOrigin = origin
-                    model.nodes[node.id]?.position = CGPoint(
-                        x: max(0, origin.x + g.translation.width),
-                        y: max(0, origin.y + g.translation.height))
+                    // Snap live (not on release): the module lands where it
+                    // reads, and wires re-route against the settled position.
+                    // World coords are unbounded — the plane is infinite.
+                    model.nodes[node.id]?.position = Grid.snap(CGPoint(
+                        x: origin.x + g.translation.width,
+                        y: origin.y + g.translation.height))
                 }
                 .onEnded { _ in dragOrigin = nil }
         )

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -78,9 +78,13 @@ struct NodeView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             titleBar
-            knobRow
-            Spacer(minLength: 0)
-            ports
+            if node.kind == .scope {
+                ScopeBody(node: node)
+            } else {
+                knobRow
+                Spacer(minLength: 0)
+                ports
+            }
         }
         // VCV-style: every module has a defined footprint in grid units.
         .frame(width: Double(spec.gridSize.w) * Grid.unit,

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -1,38 +1,16 @@
 import SwiftUI
 
-// ── Jack geometry ───────────────────────────────────────────────────────────
-// Jack dots report their centers (in canvas space) up through a preference;
-// the wire layer reads the dictionary. The SwiftUI analog of app.js's
-// jackCenter() DOM query.
-struct JackID: Hashable {
-    let node: String
-    let dir: JackDir
-    let port: String
-}
-
-enum JackDir: Hashable { case input, output }
-
-struct JackCentersKey: PreferenceKey {
-    static var defaultValue: [JackID: CGPoint] = [:]
-    static func reduce(value: inout [JackID: CGPoint], nextValue: () -> [JackID: CGPoint]) {
-        value.merge(nextValue()) { _, new in new }
-    }
-}
-
-/// A wire drag in flight: from an outlet, tracking the pointer.
-struct PendingWire {
-    let fromNode: String
-    var cursor: CGPoint
-}
-
+// Connections render as COLOR IDENTITY, not cables. Every node has a stable
+// hue; an outlet wears its node's color, an inlet wears a chip per connected
+// source. Fan-out reads as the same color at many inlets; fan-in as many
+// chips on one inlet. Patching is selection, not drag: an inlet's menu lists
+// ONLY the type-legal sources (control inlets → knobs, modal inlets → modal
+// nodes, cycle-formers omitted) — the discipline enforced by what's offered,
+// never by rejection.
 struct CanvasView: View {
     @EnvironmentObject var model: PatchModel
-    @State private var jackCenters: [JackID: CGPoint] = [:]
-    @State private var pendingWire: PendingWire?
     // The plane is infinite in both axes: node positions are WORLD
-    // coordinates, `pan` maps world → view. Nodes render at world + pan, so
-    // jack centers (measured in the named space) already include the pan and
-    // wires/hit-tests need no second transform.
+    // coordinates, `pan` maps world → view.
     @State private var pan: CGSize = .zero
     @State private var panOrigin: CGSize?
 
@@ -49,10 +27,9 @@ struct CanvasView: View {
                         }
                         .onEnded { _ in panOrigin = nil }
                 )
-            WiresView(jackCenters: jackCenters, pendingWire: pendingWire)
             ForEach(model.order, id: \.self) { id in
                 if let node = model.nodes[id] {
-                    NodeView(node: node, pendingWire: $pendingWire)
+                    NodeView(node: node)
                         .offset(x: node.position.x + pan.width,
                                 y: node.position.y + pan.height)
                 }
@@ -60,11 +37,6 @@ struct CanvasView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
-        .coordinateSpace(name: "canvas")
-        .onPreferenceChange(JackCentersKey.self) {
-            jackCenters = $0
-            model.jackGeometry = $0
-        }
     }
 }
 
@@ -95,68 +67,10 @@ struct DotGrid: View {
     }
 }
 
-// ── Wires ───────────────────────────────────────────────────────────────────
-struct WiresView: View {
-    @EnvironmentObject var model: PatchModel
-    let jackCenters: [JackID: CGPoint]
-    let pendingWire: PendingWire?
-
-    private struct Edge: Identifiable {
-        let from: String
-        let to: String
-        let port: String
-        var id: String { "\(from)→\(to):\(port)" }
-    }
-
-    private var edges: [Edge] {
-        model.order.compactMap { model.nodes[$0] }.flatMap { n in
-            n.inputs.flatMap { port, srcs in
-                srcs.map { Edge(from: $0, to: n.id, port: port) }
-            }
-        }
-    }
-
-    var body: some View {
-        ZStack {
-            ForEach(edges) { e in
-                if let a = jackCenters[JackID(node: e.from, dir: .output, port: "out")],
-                   let b = jackCenters[JackID(node: e.to, dir: .input, port: e.port)] {
-                    let path = wirePath(a, b)
-                    path.stroke(Theme.wire, lineWidth: 2.5)
-                        .opacity(0.85)
-                        // Fat invisible stroke = the click target for delete.
-                        .contentShape(path.strokedPath(StrokeStyle(lineWidth: 12)))
-                        .onTapGesture {
-                            model.deleteEdge(to: e.to, port: e.port, from: e.from)
-                        }
-                }
-            }
-            if let p = pendingWire,
-               let a = jackCenters[JackID(node: p.fromNode, dir: .output, port: "out")] {
-                wirePath(a, p.cursor)
-                    .stroke(Theme.jackHot, style: StrokeStyle(lineWidth: 2.5, dash: [5, 4]))
-                    .allowsHitTesting(false)
-            }
-        }
-    }
-
-    private func wirePath(_ a: CGPoint, _ b: CGPoint) -> Path {
-        let dx = max(40, abs(b.x - a.x) * 0.5)
-        var p = Path()
-        p.move(to: a)
-        p.addCurve(
-            to: b,
-            control1: CGPoint(x: a.x + dx, y: a.y),
-            control2: CGPoint(x: b.x - dx, y: b.y))
-        return p
-    }
-}
-
 // ── Node ────────────────────────────────────────────────────────────────────
 struct NodeView: View {
     @EnvironmentObject var model: PatchModel
     let node: PatchNode
-    @Binding var pendingWire: PendingWire?
     @State private var dragOrigin: CGPoint?
 
     private var spec: NodeSpec { node.kind.spec }
@@ -164,40 +78,46 @@ struct NodeView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             titleBar
-            body_
+            knobRow
             Spacer(minLength: 0)
-            jacks
+            ports
         }
         // VCV-style: every module has a defined footprint in grid units.
         .frame(width: Double(spec.gridSize.w) * Grid.unit,
                height: Double(spec.gridSize.h) * Grid.unit,
                alignment: .topLeading)
-        .background(Theme.panel)
-        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Theme.edge))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Theme.edge))
         .shadow(color: .black.opacity(0.35), radius: 9, y: 6)
-        .onTapGesture(count: 2) { model.deleteNode(node.id) }
     }
 
     private var titleBar: some View {
         HStack(spacing: 6) {
-            Circle().fill(spec.accent).frame(width: 9, height: 9)
+            Circle().fill(node.color).frame(width: 9, height: 9)
             Text(spec.title).font(Theme.mono.bold()).foregroundStyle(Theme.text)
             Spacer(minLength: 8)
             Text(node.id).font(Theme.monoSmall).foregroundStyle(Theme.muted)
+            if !spec.fixed {
+                Button {
+                    model.deleteNode(node.id)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Theme.muted)
+                }
+                .buttonStyle(.plain)
+                .help("remove module")
+            }
         }
         .padding(.horizontal, 9).padding(.vertical, 6)
-        .background(Theme.panel)
         .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.edge), alignment: .bottom)
         .contentShape(Rectangle())
         .gesture(
-            DragGesture(minimumDistance: 1, coordinateSpace: .named("canvas"))
+            DragGesture(minimumDistance: 1, coordinateSpace: .global)
                 .onChanged { g in
                     let origin = dragOrigin ?? node.position
                     dragOrigin = origin
-                    // Snap live (not on release): the module lands where it
-                    // reads, and wires re-route against the settled position.
-                    // World coords are unbounded — the plane is infinite.
+                    // Snap live: the module lands where it reads. World
+                    // coords are unbounded — the plane is infinite.
                     model.nodes[node.id]?.position = Grid.snap(CGPoint(
                         x: origin.x + g.translation.width,
                         y: origin.y + g.translation.height))
@@ -207,9 +127,9 @@ struct NodeView: View {
     }
 
     @ViewBuilder
-    private var body_: some View {
+    private var knobRow: some View {
         // A knob whose name matches a wired inlet is overridden by the patch
-        // cord (e.g. `freq` driven by a Knob node), so hide it.
+        // (e.g. `freq` driven by a Knob node), so hide it.
         let shown = spec.knobs.filter { (node.inputs[$0.name] ?? []).isEmpty }
         if !shown.isEmpty {
             HStack(alignment: .top, spacing: 8) {
@@ -221,91 +141,83 @@ struct NodeView: View {
         }
     }
 
-    private var jacks: some View {
+    private var ports: some View {
         HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 7) {
+            VStack(alignment: .leading, spacing: 4) {
                 ForEach(spec.inlets, id: \.self) { port in
-                    JackView(node: node, port: port, dir: .input, pendingWire: $pendingWire)
+                    InletView(node: node, port: port)
                 }
             }
-            Spacer(minLength: 16)
-            VStack(alignment: .trailing, spacing: 7) {
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 4) {
                 ForEach(spec.outlets, id: \.self) { port in
-                    JackView(node: node, port: port, dir: .output, pendingWire: $pendingWire)
+                    OutletView(node: node, port: port)
                 }
             }
         }
-        .padding(.horizontal, 4).padding(.bottom, 6)
+        .padding(.horizontal, 6).padding(.bottom, 6)
     }
 }
 
-// ── Jack ────────────────────────────────────────────────────────────────────
-struct JackView: View {
+// ── Ports ───────────────────────────────────────────────────────────────────
+/// An inlet: a menu of legal sources plus one color chip per connection.
+/// Tap a chip to disconnect. The menu is the whole patching gesture.
+struct InletView: View {
     @EnvironmentObject var model: PatchModel
     let node: PatchNode
     let port: String
-    let dir: JackDir
-    @Binding var pendingWire: PendingWire?
-    @State private var armed = false
+
+    private var sources: [String] { node.inputs[port] ?? [] }
 
     var body: some View {
-        HStack(spacing: 5) {
-            if dir == .input { dot; label } else { label; dot }
-        }
-    }
-
-    private var label: some View {
-        Text(port).font(Theme.monoSmall).foregroundStyle(Theme.muted)
-    }
-
-    private var dot: some View {
-        Circle()
-            .fill(armed ? Theme.jackHot : Theme.jack)
-            .overlay(Circle().stroke(Color(hex: 0x555F72)))
-            .frame(width: 12, height: 12)
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(
-                        key: JackCentersKey.self,
-                        value: [
-                            JackID(node: node.id, dir: dir, port: port):
-                                CGPoint(
-                                    x: geo.frame(in: .named("canvas")).midX,
-                                    y: geo.frame(in: .named("canvas")).midY)
-                        ])
-                })
-            .gesture(dir == .output ? wireDrag : nil)
-    }
-
-    /// Drag from an outlet; drop on an inlet dot. The drop target is resolved
-    /// by hit-testing the reported jack centers (nearest inlet within reach) —
-    /// the SwiftUI analog of elementFromPoint.
-    private var wireDrag: some Gesture {
-        DragGesture(minimumDistance: 0, coordinateSpace: .named("canvas"))
-            .onChanged { g in
-                armed = true
-                pendingWire = PendingWire(fromNode: node.id, cursor: g.location)
-            }
-            .onEnded { g in
-                armed = false
-                defer { pendingWire = nil }
-                if let hit = model.nearestInlet(to: g.location) {
-                    model.connect(from: node.id, to: hit.node, port: hit.port)
+        HStack(spacing: 4) {
+            Menu {
+                let legal = model.legalSources(for: node.id, port: port)
+                if legal.isEmpty {
+                    Text("no legal sources")
+                } else {
+                    ForEach(legal) { src in
+                        Button("\(src.kind.spec.title) · \(src.id)") {
+                            model.connect(from: src.id, to: node.id, port: port)
+                        }
+                    }
                 }
+            } label: {
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.muted)
             }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("patch a source into \(port)")
+
+            ForEach(sources, id: \.self) { src in
+                Circle()
+                    .fill(model.nodes[src]?.color ?? Theme.jack)
+                    .frame(width: 10, height: 10)
+                    .onTapGesture { model.deleteEdge(to: node.id, port: port, from: src) }
+                    .help("\(src) → \(port) · click to disconnect")
+            }
+
+            Text(port).font(Theme.monoSmall).foregroundStyle(Theme.muted)
+        }
     }
 }
 
-extension PatchModel {
-    /// Inlet hit-testing against the live jack geometry (12px dot + slop).
-    /// Centers live on CanvasView state; mirrored here each preference pass.
-    func nearestInlet(to point: CGPoint) -> (node: String, port: String)? {
-        var best: (JackID, CGFloat)?
-        for (id, c) in jackGeometry where id.dir == .input {
-            let d = hypot(c.x - point.x, c.y - point.y)
-            if d <= 14, d < (best?.1 ?? .infinity) { best = (id, d) }
+/// An outlet wears its node's identity color — find this color on other
+/// modules' inlets to read the patch.
+struct OutletView: View {
+    let node: PatchNode
+    let port: String
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(port).font(Theme.monoSmall).foregroundStyle(Theme.muted)
+            Circle()
+                .fill(node.color)
+                .frame(width: 10, height: 10)
+                .help("\(node.id) — this color marks its destinations")
         }
-        guard let (id, _) = best else { return nil }
-        return (id.node, id.port)
     }
 }

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -10,28 +10,28 @@ import SwiftUI
 struct CanvasView: View {
     @EnvironmentObject var model: PatchModel
     // The plane is infinite in both axes: node positions are WORLD
-    // coordinates, `pan` maps world → view.
-    @State private var pan: CGSize = .zero
+    // coordinates, model.pan maps world → view (on the model so arrange
+    // can bring the graph back into view).
     @State private var panOrigin: CGSize?
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            DotGrid(pan: pan)
+            DotGrid(pan: model.pan)
                 .gesture(
                     DragGesture(minimumDistance: 1)
                         .onChanged { g in
-                            let o = panOrigin ?? pan
+                            let o = panOrigin ?? model.pan
                             panOrigin = o
-                            pan = CGSize(width: o.width + g.translation.width,
-                                         height: o.height + g.translation.height)
+                            model.pan = CGSize(width: o.width + g.translation.width,
+                                               height: o.height + g.translation.height)
                         }
                         .onEnded { _ in panOrigin = nil }
                 )
             ForEach(model.order, id: \.self) { id in
                 if let node = model.nodes[id] {
                     NodeView(node: node)
-                        .offset(x: node.position.x + pan.width,
-                                y: node.position.y + pan.height)
+                        .offset(x: node.position.x + model.pan.width,
+                                y: node.position.y + model.pan.height)
                 }
             }
         }

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -4,17 +4,17 @@ import Foundation
 /// fatal crash (see reapEngineOnCrash), so it must be a `sig_atomic_t`, not a
 /// lock-guarded value — locking isn't async-signal-safe. Written only on
 /// spawn and reap.
-var gEngineChildPID: sig_atomic_t = 0
+nonisolated(unsafe) var gEngineChildPID: sig_atomic_t = 0
 
 /// Lifecycle/diagnostic events from the engine process — mirrors the
 /// Electron main-process `onStatus` channel.
-enum EngineEvent {
+enum EngineEvent: Sendable {
     case up
     case stderr(String)
     case exit(Int32)
 }
 
-enum EngineError: Error, LocalizedError {
+enum EngineError: Error, LocalizedError, Sendable {
     case binaryNotFound([String])
     case notRunning
     case exited
@@ -165,7 +165,8 @@ actor Engine {
         }
         p.terminationHandler = { [weak self] proc in
             events(.exit(proc.terminationStatus))
-            Task { await self?.childDidExit() }
+            guard let engine = self else { return }
+            Task { await engine.childDidExit() }
         }
 
         try p.run()

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -15,6 +15,7 @@ enum EngineEvent {
 }
 
 enum EngineError: Error, LocalizedError {
+    case binaryNotFound([String])
     case notRunning
     case exited
     case timeout(method: String)
@@ -23,6 +24,8 @@ enum EngineError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .binaryNotFound(let paths):
+            return "Tropical engine not found. Checked: \(paths.joined(separator: ", "))"
         case .notRunning: return "engine not started"
         case .exited: return "engine exited"
         case .timeout(let m): return "timeout: \(m)"
@@ -59,13 +62,46 @@ actor Engine {
     private var nextId = 1
     private let events: @Sendable (EngineEvent) -> Void
 
-    /// Resolution order: TROPICAL_ENGINE_BIN, then the default checkout.
-    static func resolveBinary() -> URL {
-        if let p = ProcessInfo.processInfo.environment["TROPICAL_ENGINE_BIN"] {
-            return URL(fileURLWithPath: p)
+    /// Resolution order: bundled engine, then an explicit developer/test
+    /// override. Development launchers set the override from their own repo
+    /// location; production never guesses a checkout under the user's home.
+    static func resolveBinary() throws -> URL {
+        var checked: [URL] = []
+        if let resources = Bundle.main.resourceURL {
+            let bundled = resources
+                .appendingPathComponent("Tropical", isDirectory: true)
+                .appendingPathComponent("frontend", isDirectory: false)
+            checked.append(bundled)
+            if FileManager.default.isExecutableFile(atPath: bundled.path) {
+                return bundled
+            }
         }
-        return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("tropical/lean/.lake/build/bin/frontend")
+        if let p = ProcessInfo.processInfo.environment["TROPICAL_ENGINE_BIN"] {
+            let explicit = URL(fileURLWithPath: p).standardizedFileURL
+            checked.append(explicit)
+            if FileManager.default.isExecutableFile(atPath: explicit.path) {
+                return explicit
+            }
+        }
+        throw EngineError.binaryNotFound(checked.map(\.path))
+    }
+
+    static func workingDirectory(for binary: URL) -> URL {
+        if let resources = Bundle.main.resourceURL {
+            let tropicalResources = resources.appendingPathComponent(
+                "Tropical", isDirectory: true
+            ).standardizedFileURL
+            if binary.standardizedFileURL.path.hasPrefix(tropicalResources.path + "/") {
+                return tropicalResources
+            }
+        }
+        // Explicit developer override points at
+        // <repo>/lean/.lake/build/bin/frontend.
+        return binary.deletingLastPathComponent()  // bin/
+            .deletingLastPathComponent()            // build/
+            .deletingLastPathComponent()            // .lake/
+            .deletingLastPathComponent()            // lean/
+            .deletingLastPathComponent()            // repo root
     }
 
     init(events: @escaping @Sendable (EngineEvent) -> Void) {
@@ -76,14 +112,9 @@ actor Engine {
         // Reap any engine orphaned by a PREVIOUS instance that died before
         // teardown (SIGKILL, crash) — the one gap the graceful path can't close.
         Engine.sweepOrphans()
-        let bin = Engine.resolveBinary()
-        // The engine expects to run from the repo root (stdlib paths etc.):
-        // bin is <root>/lean/.lake/build/bin/frontend, so root is 5 up.
-        let root = bin.deletingLastPathComponent()  // bin/
-            .deletingLastPathComponent()            // build/
-            .deletingLastPathComponent()            // .lake/
-            .deletingLastPathComponent()            // lean/
-            .deletingLastPathComponent()            // root
+        let bin = try Engine.resolveBinary()
+        // The engine resolves production assets relative to this owned root.
+        let root = Engine.workingDirectory(for: bin)
         // sockaddr_un caps the path at ~104 bytes, so the per-user temp dir
         // (short on macOS) rather than the app scratch dir.
         sockPath = FileManager.default.temporaryDirectory

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+/// Lifecycle/diagnostic events from the engine process — mirrors the
+/// Electron main-process `onStatus` channel.
+enum EngineEvent {
+    case up
+    case stderr(String)
+    case exit(Int32)
+}
+
+enum EngineError: Error, LocalizedError {
+    case notRunning
+    case exited
+    case timeout(method: String)
+    case rpc(String)
+    case engine(code: String, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notRunning: return "engine not started"
+        case .exited: return "engine exited"
+        case .timeout(let m): return "timeout: \(m)"
+        case .rpc(let s): return "RPC \(s)"
+        case .engine(let code, let message): return "\(code): \(message)"
+        }
+    }
+}
+
+/// Owns the native `frontend` binary (the Lean compiler + session + runtime
+/// FFI) over its newline-delimited JSON-RPC surface (`--rpc`). Audio plays
+/// out of the HOST's native device (RtAudio); the app is purely a control
+/// surface.
+///
+/// Transport mirrors playground/main.js: one JSON object per line on stdin;
+/// replies arrive on stdout, matched by `id`. Control-plane replies wrap an
+/// inner {status,data} in result.content[0].text; data-plane replies
+/// (set_param) are a plain `result`. We unwrap both.
+actor Engine {
+    private var process: Process?
+    private var stdin: FileHandle?
+    private var buf = ""
+    private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
+    private var nextId = 1
+    private let events: @Sendable (EngineEvent) -> Void
+
+    /// Resolution order: TROPICAL_ENGINE_BIN, then the default checkout.
+    static func resolveBinary() -> URL {
+        if let p = ProcessInfo.processInfo.environment["TROPICAL_ENGINE_BIN"] {
+            return URL(fileURLWithPath: p)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("tropical/lean/.lake/build/bin/frontend")
+    }
+
+    init(events: @escaping @Sendable (EngineEvent) -> Void) {
+        self.events = events
+    }
+
+    func start() throws {
+        let bin = Engine.resolveBinary()
+        // The engine expects to run from the repo root (stdlib paths etc.):
+        // bin is <root>/lean/.lake/build/bin/frontend, so root is 5 up.
+        let root = bin.deletingLastPathComponent()  // bin/
+            .deletingLastPathComponent()            // build/
+            .deletingLastPathComponent()            // .lake/
+            .deletingLastPathComponent()            // lean/
+            .deletingLastPathComponent()            // root
+        let p = Process()
+        p.executableURL = bin
+        p.arguments = ["--rpc"]
+        p.currentDirectoryURL = root
+        // The arrow patch-graph path does not route through syncCompile, but we
+        // set the var anyway so any session-path compile in this process also
+        // takes the session → resolved-root (arrow) path. Inert if ignored.
+        var env = ProcessInfo.processInfo.environment
+        env["TROPICAL_ARROW"] = "1"
+        p.environment = env
+
+        let inPipe = Pipe(), outPipe = Pipe(), errPipe = Pipe()
+        p.standardInput = inPipe
+        p.standardOutput = outPipe
+        p.standardError = errPipe
+
+        outPipe.fileHandleForReading.readabilityHandler = { [weak self] h in
+            let data = h.availableData
+            guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+            Task { await self?.consume(s) }
+        }
+        let events = self.events
+        errPipe.fileHandleForReading.readabilityHandler = { h in
+            let data = h.availableData
+            guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+            events(.stderr(s))
+        }
+        p.terminationHandler = { [weak self] proc in
+            events(.exit(proc.terminationStatus))
+            Task { await self?.failAllPending() }
+        }
+
+        try p.run()
+        process = p
+        stdin = inPipe.fileHandleForWriting
+        events(.up)
+    }
+
+    func kill() {
+        process?.terminationHandler = nil
+        process?.terminate()
+        process = nil
+        stdin = nil
+    }
+
+    private func failAllPending() {
+        let waiting = pending.values
+        pending.removeAll()
+        for c in waiting { c.resume(throwing: EngineError.exited) }
+        process = nil
+        stdin = nil
+    }
+
+    private func consume(_ chunk: String) {
+        buf += chunk
+        while let i = buf.firstIndex(of: "\n") {
+            let line = String(buf[..<i]).trimmingCharacters(in: .whitespaces)
+            buf = String(buf[buf.index(after: i)...])
+            guard !line.isEmpty, let data = line.data(using: .utf8),
+                  let msg = try? JSONDecoder().decode(JSONValue.self, from: data),
+                  let id = msg["id"]?.doubleValue,
+                  let cont = pending.removeValue(forKey: Int(id))
+            else { continue }
+            cont.resume(with: unwrap(msg))
+        }
+    }
+
+    /// Control-plane replies nest {status,data} as text in result.content[0];
+    /// data-plane replies are the bare result. Same unwrap as main.js.
+    private func unwrap(_ msg: JSONValue) -> Result<JSONValue, Error> {
+        if let err = msg["error"], err != .null {
+            let enc = (try? JSONEncoder().encode(err)).flatMap { String(data: $0, encoding: .utf8) }
+            return .failure(EngineError.rpc(enc ?? "unknown"))
+        }
+        let result = msg["result"] ?? .null
+        guard case .array(let content)? = result["content"],
+              let text = content.first?["text"]?.stringValue
+        else { return .success(result) }
+        guard let data = text.data(using: .utf8),
+              let inner = try? JSONDecoder().decode(JSONValue.self, from: data)
+        else { return .failure(EngineError.rpc("unparseable inner reply")) }
+        if inner["status"]?.stringValue == "ok" {
+            return .success(inner["data"] ?? .null)
+        }
+        return .failure(EngineError.engine(
+            code: inner["error"]?["code"]?.stringValue ?? "unknown",
+            message: inner["error"]?["message"]?.stringValue ?? "unknown"))
+    }
+
+    @discardableResult
+    func call(_ method: String, _ params: JSONValue = .object([:])) async throws -> JSONValue {
+        guard let stdin else { throw EngineError.notRunning }
+        let id = nextId
+        nextId += 1
+        let req = JSONValue.object([
+            "jsonrpc": .string("2.0"), "id": .number(Double(id)),
+            "method": .string(method), "params": params,
+        ])
+        var line = try JSONEncoder().encode(req)
+        line.append(0x0A)
+
+        // The compile+JIT is synchronous on the engine's one control thread, and
+        // a heavy kernel (a modal reverb) can take tens of seconds. A short
+        // timeout gives up while the engine is still grinding (the thread stays
+        // blocked, the late reply is dropped), so heavy compiles get a long leash
+        // while every other call still fails fast. NOTE: a diagnostic band-aid —
+        // the real fix is compiling off the control thread.
+        let timeout: Duration = method == "load_patch_graph" ? .seconds(180) : .seconds(30)
+        let timer = Task { [weak self] in
+            try await Task.sleep(for: timeout)
+            await self?.timeOut(id: id, method: method)
+        }
+        defer { timer.cancel() }
+
+        return try await withCheckedThrowingContinuation { cont in
+            pending[id] = cont
+            do { try stdin.write(contentsOf: line) } catch {
+                pending.removeValue(forKey: id)
+                cont.resume(throwing: error)
+            }
+        }
+    }
+
+    private func timeOut(id: Int, method: String) {
+        guard let cont = pending.removeValue(forKey: id) else { return }
+        cont.resume(throwing: EngineError.timeout(method: method))
+    }
+}

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -27,17 +27,27 @@ enum EngineError: Error, LocalizedError {
 }
 
 /// Owns the native `frontend` binary (the Lean compiler + session + runtime
-/// FFI) over its newline-delimited JSON-RPC surface (`--rpc`). Audio plays
+/// FFI) over its Unix-socket JSON-RPC surface (`--serve`). Audio plays
 /// out of the HOST's native device (RtAudio); the app is purely a control
 /// surface.
 ///
-/// Transport mirrors playground/main.js: one JSON object per line on stdin;
-/// replies arrive on stdout, matched by `id`. Control-plane replies wrap an
-/// inner {status,data} in result.content[0].text; data-plane replies
-/// (set_param) are a plain `result`. We unwrap both.
+/// Transport mirrors playground/main.js: one JSON object per line on the
+/// socket; replies are matched by `id`. The socket has a control/data plane
+/// SPLIT (tropical_socket.hpp): `set_param` / `render_window` /
+/// `playback_position` / `get_telemetry` are answered synchronously in C++
+/// and never queue behind the single Lean control thread — so knob writes
+/// and scope frames stay live through a long compile. Control-plane replies
+/// wrap an inner {status,data} in result.content[0].text; data-plane replies
+/// are a plain `result`. We unwrap both.
 actor Engine {
     private var process: Process?
-    private var stdin: FileHandle?
+    private var sock: FileHandle?
+    private var sockPath = ""
+    /// The child engine OUTLIVES the app unless someone reaps it — an orphaned
+    /// engine keeps the DAC (and whatever it was playing) alive forever. The
+    /// box holds the Process outside actor isolation so the app-termination
+    /// path (a synchronous, can't-await context) can always reach it.
+    private nonisolated let procBox = ProcessBox()
     private var buf = ""
     private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
     private var nextId = 1
@@ -56,7 +66,7 @@ actor Engine {
         self.events = events
     }
 
-    func start() throws {
+    func start() async throws {
         let bin = Engine.resolveBinary()
         // The engine expects to run from the repo root (stdlib paths etc.):
         // bin is <root>/lean/.lake/build/bin/frontend, so root is 5 up.
@@ -65,9 +75,13 @@ actor Engine {
             .deletingLastPathComponent()            // .lake/
             .deletingLastPathComponent()            // lean/
             .deletingLastPathComponent()            // root
+        // sockaddr_un caps the path at ~104 bytes, so the per-user temp dir
+        // (short on macOS) rather than the app scratch dir.
+        sockPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("reversible-\(ProcessInfo.processInfo.processIdentifier).sock").path
         let p = Process()
         p.executableURL = bin
-        p.arguments = ["--rpc"]
+        p.arguments = ["--serve", sockPath]
         p.currentDirectoryURL = root
         // The arrow patch-graph path does not route through syncCompile, but we
         // set the var anyway so any session-path compile in this process also
@@ -76,21 +90,20 @@ actor Engine {
         env["TROPICAL_ARROW"] = "1"
         p.environment = env
 
-        let inPipe = Pipe(), outPipe = Pipe(), errPipe = Pipe()
-        p.standardInput = inPipe
+        let outPipe = Pipe(), errPipe = Pipe()
+        p.standardInput = FileHandle.nullDevice   // serve mode never reads stdin
         p.standardOutput = outPipe
         p.standardError = errPipe
 
-        outPipe.fileHandleForReading.readabilityHandler = { [weak self] h in
-            let data = h.availableData
-            guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
-            Task { await self?.consume(s) }
-        }
         let events = self.events
-        errPipe.fileHandleForReading.readabilityHandler = { h in
-            let data = h.availableData
-            guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
-            events(.stderr(s))
+        // Serve mode replies on the socket; anything on stdout/stderr is
+        // diagnostic (e.g. "serving on <addr>").
+        for pipe in [outPipe, errPipe] {
+            pipe.fileHandleForReading.readabilityHandler = { h in
+                let data = h.availableData
+                guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+                events(.stderr(s))
+            }
         }
         p.terminationHandler = { [weak self] proc in
             events(.exit(proc.terminationStatus))
@@ -99,15 +112,74 @@ actor Engine {
 
         try p.run()
         process = p
-        stdin = inPipe.fileHandleForWriting
+        procBox.process = p
+        try await connectSocket()
         events(.up)
+    }
+
+    /// Synchronous child teardown for app exit (Cmd-Q, SIGTERM). Safe from
+    /// any thread; idempotent.
+    nonisolated func terminateChild() {
+        procBox.take()?.terminate()
+    }
+
+    /// The socket node appears once Engine.boot finishes and binds, so retry
+    /// until it accepts (or the process dies under us).
+    private func connectSocket() async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(20))
+        while ContinuousClock.now < deadline {
+            guard process?.isRunning == true else { throw EngineError.exited }
+            if let fd = Engine.connectOnce(path: sockPath) {
+                let h = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+                h.readabilityHandler = { [weak self] h in
+                    let data = h.availableData
+                    if data.isEmpty { h.readabilityHandler = nil; return }  // EOF
+                    guard let s = String(data: data, encoding: .utf8) else { return }
+                    Task { await self?.consume(s) }
+                }
+                sock = h
+                return
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw EngineError.timeout(method: "connect \(sockPath)")
+    }
+
+    private static func connectOnce(path: String) -> Int32? {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8CString)
+        guard bytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+            close(fd)
+            return nil
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { dst in
+            bytes.withUnsafeBytes { src in
+                dst.copyMemory(from: src)
+            }
+        }
+        let r = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard r == 0 else {
+            close(fd)
+            return nil
+        }
+        return fd
     }
 
     func kill() {
         process?.terminationHandler = nil
         process?.terminate()
         process = nil
-        stdin = nil
+        procBox.take()
+        sock?.readabilityHandler = nil
+        sock = nil
+        unlink(sockPath)
     }
 
     private func failAllPending() {
@@ -115,7 +187,10 @@ actor Engine {
         pending.removeAll()
         for c in waiting { c.resume(throwing: EngineError.exited) }
         process = nil
-        stdin = nil
+        procBox.take()
+        sock?.readabilityHandler = nil
+        sock = nil
+        unlink(sockPath)
     }
 
     private func consume(_ chunk: String) {
@@ -156,7 +231,7 @@ actor Engine {
 
     @discardableResult
     func call(_ method: String, _ params: JSONValue = .object([:])) async throws -> JSONValue {
-        guard let stdin else { throw EngineError.notRunning }
+        guard let sock else { throw EngineError.notRunning }
         let id = nextId
         nextId += 1
         let req = JSONValue.object([
@@ -170,8 +245,10 @@ actor Engine {
         // a heavy kernel (a modal reverb) can take tens of seconds. A short
         // timeout gives up while the engine is still grinding (the thread stays
         // blocked, the late reply is dropped), so heavy compiles get a long leash
-        // while every other call still fails fast. NOTE: a diagnostic band-aid —
-        // the real fix is compiling off the control thread.
+        // while other CONTROL calls still fail fast. Data-plane methods
+        // (set_param/render_window/playback_position) answer in C++ and never
+        // wait on that thread. NOTE: a diagnostic band-aid — the real fix is
+        // compiling off the control thread.
         let timeout: Duration = method == "load_patch_graph" ? .seconds(180) : .seconds(30)
         let timer = Task { [weak self] in
             try await Task.sleep(for: timeout)
@@ -181,7 +258,7 @@ actor Engine {
 
         return try await withCheckedThrowingContinuation { cont in
             pending[id] = cont
-            do { try stdin.write(contentsOf: line) } catch {
+            do { try sock.write(contentsOf: line) } catch {
                 pending.removeValue(forKey: id)
                 cont.resume(throwing: error)
             }
@@ -191,5 +268,23 @@ actor Engine {
     private func timeOut(id: Int, method: String) {
         guard let cont = pending.removeValue(forKey: id) else { return }
         cont.resume(throwing: EngineError.timeout(method: method))
+    }
+}
+
+/// Cross-isolation handle to the child process for the synchronous
+/// termination path. `take()` swaps out under the lock so terminate is
+/// sent at most once.
+private final class ProcessBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var proc: Process?
+
+    var process: Process? {
+        get { lock.withLock { proc } }
+        set { lock.withLock { proc = newValue } }
+    }
+
+    @discardableResult
+    func take() -> Process? {
+        lock.withLock { let p = proc; proc = nil; return p }
     }
 }

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// PID of the live child engine, or 0. Read from an async-signal handler on a
+/// fatal crash (see reapEngineOnCrash), so it must be a `sig_atomic_t`, not a
+/// lock-guarded value — locking isn't async-signal-safe. Written only on
+/// spawn and reap.
+var gEngineChildPID: sig_atomic_t = 0
+
 /// Lifecycle/diagnostic events from the engine process — mirrors the
 /// Electron main-process `onStatus` channel.
 enum EngineEvent {
@@ -67,6 +73,9 @@ actor Engine {
     }
 
     func start() async throws {
+        // Reap any engine orphaned by a PREVIOUS instance that died before
+        // teardown (SIGKILL, crash) — the one gap the graceful path can't close.
+        Engine.sweepOrphans()
         let bin = Engine.resolveBinary()
         // The engine expects to run from the repo root (stdlib paths etc.):
         // bin is <root>/lean/.lake/build/bin/frontend, so root is 5 up.
@@ -113,6 +122,7 @@ actor Engine {
         try p.run()
         process = p
         procBox.process = p
+        gEngineChildPID = sig_atomic_t(p.processIdentifier)
         try await connectSocket()
         events(.up)
     }
@@ -120,7 +130,51 @@ actor Engine {
     /// Synchronous child teardown for app exit (Cmd-Q, SIGTERM). Safe from
     /// any thread; idempotent.
     nonisolated func terminateChild() {
+        gEngineChildPID = 0
         procBox.take()?.terminate()
+    }
+
+    /// Reap engines orphaned by a PREVIOUS reversible instance that died
+    /// without running teardown (the app was SIGKILLed, or crashed before the
+    /// crash handler fired). A socket name embeds the OWNER app's pid
+    /// (`reversible-<pid>.sock`), so an orphan is an engine whose owner is no
+    /// longer alive. We skip live siblings (owner still running) and can't
+    /// touch our own engine (not spawned yet at sweep time). Best-effort: any
+    /// parse/exec failure just leaves the sweep a no-op.
+    nonisolated static func sweepOrphans() {
+        let ps = Process()
+        ps.executableURL = URL(fileURLWithPath: "/bin/ps")
+        ps.arguments = ["-axo", "pid=,command="]
+        let pipe = Pipe()
+        ps.standardOutput = pipe
+        ps.standardError = FileHandle.nullDevice
+        guard (try? ps.run()) != nil else { return }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        ps.waitUntilExit()
+        guard let out = String(data: data, encoding: .utf8) else { return }
+
+        let me = getpid()
+        for raw in out.split(separator: "\n") {
+            let line = String(raw).trimmingCharacters(in: .whitespaces)
+            guard line.range(of: "frontend --serve") != nil,
+                  let sockRange = line.range(
+                    of: #"/\S*reversible-[0-9]+\.sock"#, options: .regularExpression)
+            else { continue }
+            let sockPath = String(line[sockRange])
+            // Owner pid = the run of digits in `reversible-<pid>.sock`.
+            let owner = pid_t(sockPath
+                .drop(while: { !$0.isNumber })
+                .prefix(while: { $0.isNumber })) ?? -1
+            guard owner > 0, owner != me else { continue }
+            // owner reachable (alive, or alive-but-not-ours) → a live instance
+            // still owns this engine; leave it be.
+            if Darwin.kill(owner, 0) == 0 || errno == EPERM { continue }
+            // Engine's own pid is the first ps column.
+            guard let sp = line.firstIndex(of: " "),
+                  let childPID = pid_t(line[..<sp]) else { continue }
+            Darwin.kill(childPID, SIGKILL)
+            unlink(sockPath)
+        }
     }
 
     /// The socket node appears once Engine.boot finishes and binds, so retry
@@ -173,6 +227,7 @@ actor Engine {
     }
 
     func kill() {
+        gEngineChildPID = 0
         process?.terminationHandler = nil
         process?.terminate()
         process = nil
@@ -183,6 +238,7 @@ actor Engine {
     }
 
     private func failAllPending() {
+        gEngineChildPID = 0
         let waiting = pending.values
         pending.removeAll()
         for c in waiting { c.resume(throwing: EngineError.exited) }

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -19,6 +19,7 @@ enum EngineError: Error, LocalizedError {
     case notRunning
     case exited
     case timeout(method: String)
+    case pendingLimit(lane: String, limit: Int)
     case rpc(String)
     case engine(code: String, message: String)
 
@@ -29,8 +30,26 @@ enum EngineError: Error, LocalizedError {
         case .notRunning: return "engine not started"
         case .exited: return "engine exited"
         case .timeout(let m): return "timeout: \(m)"
+        case .pendingLimit(let lane, let limit):
+            return "RPC \(lane) has \(limit) pending requests"
         case .rpc(let s): return "RPC \(s)"
         case .engine(let code, let message): return "\(code): \(message)"
+        }
+    }
+}
+
+enum EngineRPCLane: String, Sendable {
+    case graph
+    case control
+    case scope
+    case telemetry
+
+    static func lane(for method: String) -> EngineRPCLane {
+        switch method {
+        case "set_param", "playback_position": return .control
+        case "render_window": return .scope
+        case "get_telemetry", "audio_status": return .telemetry
+        default: return .graph
         }
     }
 }
@@ -40,26 +59,25 @@ enum EngineError: Error, LocalizedError {
 /// out of the HOST's native device (RtAudio); the app is purely a control
 /// surface.
 ///
-/// Transport mirrors playground/main.js: one JSON object per line on the
-/// socket; replies are matched by `id`. The socket has a control/data plane
-/// SPLIT (tropical_socket.hpp): `set_param` / `render_window` /
-/// `playback_position` / `get_telemetry` are answered synchronously in C++
-/// and never queue behind the single Lean control thread — so knob writes
-/// and scope frames stay live through a long compile. Control-plane replies
-/// wrap an inner {status,data} in result.content[0].text; data-plane replies
-/// are a plain `result`. We unwrap both.
+/// Transport mirrors playground/main.js: one JSON object per line, replies
+/// matched by `id`. One supervisor owns the process/socket namespace, while
+/// graph, control, scope, and telemetry each use an independent connection
+/// and bounded request table. The server's C++ data-plane methods therefore
+/// never sit behind a compile response's bytes on the client. Control-plane
+/// replies wrap an inner {status,data} in result.content[0].text; data-plane
+/// replies are a plain `result`. Each lane unwraps both forms.
 actor Engine {
     private var process: Process?
-    private var sock: FileHandle?
     private var sockPath = ""
     /// The child engine OUTLIVES the app unless someone reaps it — an orphaned
     /// engine keeps the DAC (and whatever it was playing) alive forever. The
     /// box holds the Process outside actor isolation so the app-termination
     /// path (a synchronous, can't-await context) can always reach it.
     private nonisolated let procBox = ProcessBox()
-    private var buf = ""
-    private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
-    private var nextId = 1
+    private var graphRPC: RPCConnection?
+    private var controlRPC: RPCConnection?
+    private var scopeRPC: RPCConnection?
+    private var telemetryRPC: RPCConnection?
     private let events: @Sendable (EngineEvent) -> Void
 
     /// Resolution order: bundled engine, then an explicit developer/test
@@ -147,14 +165,20 @@ actor Engine {
         }
         p.terminationHandler = { [weak self] proc in
             events(.exit(proc.terminationStatus))
-            Task { await self?.failAllPending() }
+            Task { await self?.childDidExit() }
         }
 
         try p.run()
         process = p
         procBox.process = p
         gEngineChildPID = sig_atomic_t(p.processIdentifier)
-        try await connectSocket()
+        do {
+            try await connectLanes()
+        } catch {
+            terminateChild()
+            await closeLanes(error: error)
+            throw error
+        }
         events(.up)
     }
 
@@ -208,21 +232,24 @@ actor Engine {
         }
     }
 
-    /// The socket node appears once Engine.boot finishes and binds, so retry
-    /// until it accepts (or the process dies under us).
-    private func connectSocket() async throws {
+    /// The socket node appears once Engine.boot finishes and binds. Establish
+    /// the compiler lane while checking child liveness, then attach the three
+    /// independent data lanes to the ready server.
+    private func connectLanes() async throws {
         let deadline = ContinuousClock.now.advanced(by: .seconds(20))
         while ContinuousClock.now < deadline {
             guard process?.isRunning == true else { throw EngineError.exited }
-            if let fd = Engine.connectOnce(path: sockPath) {
-                let h = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
-                h.readabilityHandler = { [weak self] h in
-                    let data = h.availableData
-                    if data.isEmpty { h.readabilityHandler = nil; return }  // EOF
-                    guard let s = String(data: data, encoding: .utf8) else { return }
-                    Task { await self?.consume(s) }
-                }
-                sock = h
+            if let fd = RPCConnection.connectOnce(path: sockPath) {
+                graphRPC = RPCConnection(lane: .graph, fileDescriptor: fd)
+                controlRPC = try await RPCConnection.connect(
+                    lane: .control, path: sockPath
+                )
+                scopeRPC = try await RPCConnection.connect(
+                    lane: .scope, path: sockPath
+                )
+                telemetryRPC = try await RPCConnection.connect(
+                    lane: .telemetry, path: sockPath
+                )
                 return
             }
             try await Task.sleep(for: .milliseconds(100))
@@ -230,131 +257,43 @@ actor Engine {
         throw EngineError.timeout(method: "connect \(sockPath)")
     }
 
-    private static func connectOnce(path: String) -> Int32? {
-        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return nil }
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let bytes = Array(path.utf8CString)
-        guard bytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
-            close(fd)
-            return nil
-        }
-        withUnsafeMutableBytes(of: &addr.sun_path) { dst in
-            bytes.withUnsafeBytes { src in
-                dst.copyMemory(from: src)
-            }
-        }
-        let r = withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-                Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard r == 0 else {
-            close(fd)
-            return nil
-        }
-        return fd
-    }
-
-    func kill() {
+    func kill() async {
         gEngineChildPID = 0
         process?.terminationHandler = nil
         process?.terminate()
         process = nil
         procBox.take()
-        sock?.readabilityHandler = nil
-        sock = nil
+        await closeLanes(error: EngineError.exited)
         unlink(sockPath)
     }
 
-    private func failAllPending() {
+    private func childDidExit() async {
         gEngineChildPID = 0
-        let waiting = pending.values
-        pending.removeAll()
-        for c in waiting { c.resume(throwing: EngineError.exited) }
         process = nil
         procBox.take()
-        sock?.readabilityHandler = nil
-        sock = nil
+        await closeLanes(error: EngineError.exited)
         unlink(sockPath)
     }
 
-    private func consume(_ chunk: String) {
-        buf += chunk
-        while let i = buf.firstIndex(of: "\n") {
-            let line = String(buf[..<i]).trimmingCharacters(in: .whitespaces)
-            buf = String(buf[buf.index(after: i)...])
-            guard !line.isEmpty, let data = line.data(using: .utf8),
-                  let msg = try? JSONDecoder().decode(JSONValue.self, from: data),
-                  let id = msg["id"]?.doubleValue,
-                  let cont = pending.removeValue(forKey: Int(id))
-            else { continue }
-            cont.resume(with: unwrap(msg))
-        }
-    }
-
-    /// Control-plane replies nest {status,data} as text in result.content[0];
-    /// data-plane replies are the bare result. Same unwrap as main.js.
-    private func unwrap(_ msg: JSONValue) -> Result<JSONValue, Error> {
-        if let err = msg["error"], err != .null {
-            let enc = (try? JSONEncoder().encode(err)).flatMap { String(data: $0, encoding: .utf8) }
-            return .failure(EngineError.rpc(enc ?? "unknown"))
-        }
-        let result = msg["result"] ?? .null
-        guard case .array(let content)? = result["content"],
-              let text = content.first?["text"]?.stringValue
-        else { return .success(result) }
-        guard let data = text.data(using: .utf8),
-              let inner = try? JSONDecoder().decode(JSONValue.self, from: data)
-        else { return .failure(EngineError.rpc("unparseable inner reply")) }
-        if inner["status"]?.stringValue == "ok" {
-            return .success(inner["data"] ?? .null)
-        }
-        return .failure(EngineError.engine(
-            code: inner["error"]?["code"]?.stringValue ?? "unknown",
-            message: inner["error"]?["message"]?.stringValue ?? "unknown"))
+    private func closeLanes(error: Error) async {
+        let lanes = [graphRPC, controlRPC, scopeRPC, telemetryRPC]
+        graphRPC = nil
+        controlRPC = nil
+        scopeRPC = nil
+        telemetryRPC = nil
+        for lane in lanes { await lane?.close(error: error) }
     }
 
     @discardableResult
     func call(_ method: String, _ params: JSONValue = .object([:])) async throws -> JSONValue {
-        guard let sock else { throw EngineError.notRunning }
-        let id = nextId
-        nextId += 1
-        let req = JSONValue.object([
-            "jsonrpc": .string("2.0"), "id": .number(Double(id)),
-            "method": .string(method), "params": params,
-        ])
-        var line = try JSONEncoder().encode(req)
-        line.append(0x0A)
-
-        // The compile+JIT is synchronous on the engine's one control thread, and
-        // a heavy kernel (a modal reverb) can take tens of seconds. A short
-        // timeout gives up while the engine is still grinding (the thread stays
-        // blocked, the late reply is dropped), so heavy compiles get a long leash
-        // while other CONTROL calls still fail fast. Data-plane methods
-        // (set_param/render_window/playback_position) answer in C++ and never
-        // wait on that thread. NOTE: a diagnostic band-aid — the real fix is
-        // compiling off the control thread.
-        let timeout: Duration = method == "load_patch_graph" ? .seconds(180) : .seconds(30)
-        let timer = Task { [weak self] in
-            try await Task.sleep(for: timeout)
-            await self?.timeOut(id: id, method: method)
+        let connection: RPCConnection? = switch EngineRPCLane.lane(for: method) {
+        case .graph: graphRPC
+        case .control: controlRPC
+        case .scope: scopeRPC
+        case .telemetry: telemetryRPC
         }
-        defer { timer.cancel() }
-
-        return try await withCheckedThrowingContinuation { cont in
-            pending[id] = cont
-            do { try sock.write(contentsOf: line) } catch {
-                pending.removeValue(forKey: id)
-                cont.resume(throwing: error)
-            }
-        }
-    }
-
-    private func timeOut(id: Int, method: String) {
-        guard let cont = pending.removeValue(forKey: id) else { return }
-        cont.resume(throwing: EngineError.timeout(method: method))
+        guard let connection else { throw EngineError.notRunning }
+        return try await connection.call(method, params)
     }
 }
 

--- a/reversible/Sources/Reversible/EngineVocabulary.swift
+++ b/reversible/Sources/Reversible/EngineVocabulary.swift
@@ -1,0 +1,645 @@
+import Foundation
+
+// MARK: - Engine-owned protocol identifiers
+
+/// A node-kind identifier served by the engine. This is deliberately a string
+/// value rather than an exhaustive enum: a newly served kind must decode without
+/// a Swift semantic edit.
+struct NodeKindID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init?(rawValue: String) {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    init(validating rawValue: String) throws {
+        try Self.validate(rawValue, label: "node kind")
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        do {
+            try self.init(validating: value)
+        } catch {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: error.localizedDescription
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    private static func validate(_ value: String, label: String) throws {
+        guard !value.isEmpty,
+              value == value.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            throw EngineVocabularyError.invalidIdentifier(label: label, value: value)
+        }
+    }
+}
+
+/// Connection colors are also engine-owned identifiers. Keeping them open
+/// avoids recreating the engine's signal/modal/control enum in Swift.
+struct PortColorID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init?(rawValue: String) {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    init(validating rawValue: String) throws {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            throw EngineVocabularyError.invalidIdentifier(label: "port color", value: rawValue)
+        }
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        do {
+            try self.init(validating: value)
+        } catch {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: error.localizedDescription
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+/// The write discipline is descriptive response data. The client always uses
+/// the unified `set_param` method and never dispatches on this identifier.
+struct WriteDisciplineID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init?(rawValue: String) {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    init(validating rawValue: String) throws {
+        guard !rawValue.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            throw EngineVocabularyError.invalidIdentifier(label: "write discipline", value: rawValue)
+        }
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        do {
+            try self.init(validating: value)
+        } catch {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: error.localizedDescription
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+// MARK: - Served descriptors
+
+struct PortDescriptor: Decodable, Equatable, Sendable {
+    let name: String
+    let accepts: [PortColorID]
+    let multi: Bool
+    let defaultValue: Double?
+    let discipline: WriteDisciplineID?
+    let min: Double?
+    let max: Double?
+    let logarithmic: Bool?
+    let unit: String?
+    let owner: String?
+
+    var isInlet: Bool { !accepts.isEmpty }
+    var isParameter: Bool { defaultValue != nil }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case accepts
+        case multi
+        case defaultValue = "default"
+        case discipline
+        case min
+        case max
+        case logarithmic = "log"
+        case unit
+        case owner
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+
+        if container.contains(.accepts) {
+            accepts = try container.decode([PortColorID].self, forKey: .accepts)
+            multi = try container.decode(Bool.self, forKey: .multi)
+        } else {
+            guard !container.contains(.multi) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .multi,
+                    in: container,
+                    debugDescription: "multi is valid only when accepts is present"
+                )
+            }
+            accepts = []
+            multi = false
+        }
+
+        let parameterKeys: [CodingKeys] = [
+            .defaultValue, .discipline, .min, .max, .logarithmic, .unit,
+        ]
+        if parameterKeys.contains(where: container.contains) {
+            defaultValue = try container.decode(Double.self, forKey: .defaultValue)
+            discipline = try container.decode(WriteDisciplineID.self, forKey: .discipline)
+            min = try container.decode(Double.self, forKey: .min)
+            max = try container.decode(Double.self, forKey: .max)
+            logarithmic = try container.decode(Bool.self, forKey: .logarithmic)
+            unit = try container.decode(String.self, forKey: .unit)
+        } else {
+            defaultValue = nil
+            discipline = nil
+            min = nil
+            max = nil
+            logarithmic = nil
+            unit = nil
+        }
+        owner = try container.decodeIfPresent(String.self, forKey: .owner)
+    }
+}
+
+struct NodeDescriptor: Decodable, Equatable, Sendable {
+    let kind: NodeKindID
+    let outlet: PortColorID?
+    let ports: [PortDescriptor]
+
+    func port(named name: String) -> PortDescriptor? {
+        ports.first { $0.name == name }
+    }
+
+    var inlets: [PortDescriptor] { ports.filter(\.isInlet) }
+    var parameters: [PortDescriptor] { ports.filter(\.isParameter) }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case outlet
+        case ports
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try container.decode(NodeKindID.self, forKey: .kind)
+        guard container.contains(.outlet) else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.outlet,
+                .init(codingPath: decoder.codingPath, debugDescription: "outlet is required; use null for a sink")
+            )
+        }
+        outlet = try container.decodeIfPresent(PortColorID.self, forKey: .outlet)
+        ports = try container.decode([PortDescriptor].self, forKey: .ports)
+    }
+}
+
+struct EngineVocabulary: Decodable, Equatable, Sendable {
+    static let supportedSchemaID = "tropical_vocabulary"
+    static let supportedSchemaVersion = 1
+
+    let schemaID: String
+    let schemaVersion: Int
+    let fingerprint: String
+    let rule: String
+    let colors: [PortColorID]
+    let kinds: [NodeDescriptor]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaID = "schema"
+        case schemaVersion = "schema_version"
+        case fingerprint
+        case rule
+        case colors
+        case kinds
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaID = try container.decode(String.self, forKey: .schemaID)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        fingerprint = try container.decode(String.self, forKey: .fingerprint)
+        rule = try container.decode(String.self, forKey: .rule)
+        colors = try container.decode([PortColorID].self, forKey: .colors)
+        kinds = try container.decode([NodeDescriptor].self, forKey: .kinds)
+        try validate(withholding: [])
+    }
+
+    /// Decode and validate one complete response. Withheld kind IDs come from
+    /// the caller's compatibility policy; this type contains no hard-coded
+    /// engine kind list.
+    static func decode(
+        from data: Data,
+        withholding withheldKinds: Set<NodeKindID> = []
+    ) throws -> EngineVocabulary {
+        let vocabulary = try JSONDecoder().decode(EngineVocabulary.self, from: data)
+        try vocabulary.validate(withholding: withheldKinds)
+        return vocabulary
+    }
+
+    func descriptor(for kind: NodeKindID) -> NodeDescriptor? {
+        kinds.first { $0.kind == kind }
+    }
+
+    func validate(withholding withheldKinds: Set<NodeKindID>) throws {
+        guard schemaID == Self.supportedSchemaID else {
+            throw EngineVocabularyError.unsupportedSchemaID(schemaID)
+        }
+        guard schemaVersion == Self.supportedSchemaVersion else {
+            throw EngineVocabularyError.unsupportedSchemaVersion(schemaVersion)
+        }
+        guard Self.isValidFingerprint(fingerprint) else {
+            throw EngineVocabularyError.invalidFingerprint(fingerprint)
+        }
+        guard !rule.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw EngineVocabularyError.emptyRule
+        }
+        guard !colors.isEmpty else {
+            throw EngineVocabularyError.emptyColors
+        }
+        guard !kinds.isEmpty else {
+            throw EngineVocabularyError.emptyKinds
+        }
+
+        var seenColors = Set<PortColorID>()
+        for color in colors where !seenColors.insert(color).inserted {
+            throw EngineVocabularyError.duplicateColor(color)
+        }
+
+        var seenKinds = Set<NodeKindID>()
+        for node in kinds {
+            guard seenKinds.insert(node.kind).inserted else {
+                throw EngineVocabularyError.duplicateKind(node.kind)
+            }
+            if withheldKinds.contains(node.kind) {
+                throw EngineVocabularyError.withheldKindServed(node.kind)
+            }
+            if let outlet = node.outlet, !seenColors.contains(outlet) {
+                throw EngineVocabularyError.undeclaredOutletColor(kind: node.kind, color: outlet)
+            }
+            try validate(node, declaredColors: seenColors)
+        }
+    }
+
+    private func validate(
+        _ node: NodeDescriptor,
+        declaredColors: Set<PortColorID>
+    ) throws {
+        var seenPorts = Set<String>()
+        for port in node.ports {
+            guard !port.name.isEmpty,
+                  port.name == port.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            else {
+                throw EngineVocabularyError.invalidPortName(kind: node.kind, name: port.name)
+            }
+            guard seenPorts.insert(port.name).inserted else {
+                throw EngineVocabularyError.duplicatePort(kind: node.kind, port: port.name)
+            }
+
+            var seenAccepts = Set<PortColorID>()
+            for color in port.accepts {
+                guard declaredColors.contains(color) else {
+                    throw EngineVocabularyError.undeclaredAcceptedColor(
+                        kind: node.kind,
+                        port: port.name,
+                        color: color
+                    )
+                }
+                guard seenAccepts.insert(color).inserted else {
+                    throw EngineVocabularyError.duplicateAcceptedColor(
+                        kind: node.kind,
+                        port: port.name,
+                        color: color
+                    )
+                }
+            }
+            if port.multi && !port.isInlet {
+                throw EngineVocabularyError.multiOnNonInlet(kind: node.kind, port: port.name)
+            }
+
+            if port.isParameter {
+                guard let defaultValue = port.defaultValue,
+                      let min = port.min,
+                      let max = port.max,
+                      let logarithmic = port.logarithmic,
+                      defaultValue.isFinite,
+                      min.isFinite,
+                      max.isFinite,
+                      min < max,
+                      (min...max).contains(defaultValue)
+                else {
+                    throw EngineVocabularyError.invalidParameterRange(kind: node.kind, port: port.name)
+                }
+                if logarithmic && min <= 0 {
+                    throw EngineVocabularyError.nonPositiveLogMinimum(kind: node.kind, port: port.name)
+                }
+            } else if port.owner != nil {
+                throw EngineVocabularyError.ownerOnNonParameter(kind: node.kind, port: port.name)
+            } else if !port.isInlet {
+                throw EngineVocabularyError.inertPort(kind: node.kind, port: port.name)
+            }
+        }
+
+        for port in node.ports {
+            guard let owner = port.owner else { continue }
+            guard owner != port.name,
+                  let ownerPort = node.port(named: owner),
+                  ownerPort.isInlet
+            else {
+                throw EngineVocabularyError.invalidOwner(
+                    kind: node.kind,
+                    port: port.name,
+                    owner: owner
+                )
+            }
+        }
+    }
+
+    private static func isValidFingerprint(_ value: String) -> Bool {
+        let prefix = "fnv1a64:"
+        guard value.hasPrefix(prefix) else { return false }
+        let digest = value.dropFirst(prefix.count)
+        return digest.count == 16 && digest.allSatisfy {
+            ("0"..."9").contains(String($0))
+                || ("a"..."f").contains(String($0))
+        }
+    }
+}
+
+enum EngineVocabularyError: Error, Equatable, LocalizedError {
+    case invalidIdentifier(label: String, value: String)
+    case unsupportedSchemaID(String)
+    case unsupportedSchemaVersion(Int)
+    case invalidFingerprint(String)
+    case emptyRule
+    case emptyColors
+    case emptyKinds
+    case duplicateColor(PortColorID)
+    case duplicateKind(NodeKindID)
+    case withheldKindServed(NodeKindID)
+    case undeclaredOutletColor(kind: NodeKindID, color: PortColorID)
+    case invalidPortName(kind: NodeKindID, name: String)
+    case duplicatePort(kind: NodeKindID, port: String)
+    case undeclaredAcceptedColor(kind: NodeKindID, port: String, color: PortColorID)
+    case duplicateAcceptedColor(kind: NodeKindID, port: String, color: PortColorID)
+    case multiOnNonInlet(kind: NodeKindID, port: String)
+    case invalidParameterRange(kind: NodeKindID, port: String)
+    case nonPositiveLogMinimum(kind: NodeKindID, port: String)
+    case ownerOnNonParameter(kind: NodeKindID, port: String)
+    case invalidOwner(kind: NodeKindID, port: String, owner: String)
+    case inertPort(kind: NodeKindID, port: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidIdentifier(let label, let value):
+            return "invalid \(label) identifier: '\(value)'"
+        case .unsupportedSchemaID(let value):
+            return "unsupported vocabulary schema: '\(value)'"
+        case .unsupportedSchemaVersion(let value):
+            return "unsupported vocabulary schema version: \(value)"
+        case .invalidFingerprint(let value):
+            return "invalid vocabulary fingerprint: '\(value)'"
+        case .emptyRule:
+            return "vocabulary connection rule is empty"
+        case .emptyColors:
+            return "vocabulary declares no connection colors"
+        case .emptyKinds:
+            return "vocabulary declares no served kinds"
+        case .duplicateColor(let color):
+            return "duplicate vocabulary color: '\(color.rawValue)'"
+        case .duplicateKind(let kind):
+            return "duplicate served kind: '\(kind.rawValue)'"
+        case .withheldKindServed(let kind):
+            return "withheld kind was served: '\(kind.rawValue)'"
+        case .undeclaredOutletColor(let kind, let color):
+            return "kind '\(kind.rawValue)' uses undeclared outlet color '\(color.rawValue)'"
+        case .invalidPortName(let kind, let name):
+            return "kind '\(kind.rawValue)' has invalid port name '\(name)'"
+        case .duplicatePort(let kind, let port):
+            return "kind '\(kind.rawValue)' has duplicate port '\(port)'"
+        case .undeclaredAcceptedColor(let kind, let port, let color):
+            return "kind '\(kind.rawValue)' port '\(port)' accepts undeclared color '\(color.rawValue)'"
+        case .duplicateAcceptedColor(let kind, let port, let color):
+            return "kind '\(kind.rawValue)' port '\(port)' repeats accepted color '\(color.rawValue)'"
+        case .multiOnNonInlet(let kind, let port):
+            return "kind '\(kind.rawValue)' non-inlet port '\(port)' is multi"
+        case .invalidParameterRange(let kind, let port):
+            return "kind '\(kind.rawValue)' parameter '\(port)' has an invalid default/range"
+        case .nonPositiveLogMinimum(let kind, let port):
+            return "kind '\(kind.rawValue)' logarithmic parameter '\(port)' has a non-positive minimum"
+        case .ownerOnNonParameter(let kind, let port):
+            return "kind '\(kind.rawValue)' non-parameter port '\(port)' declares an owner"
+        case .invalidOwner(let kind, let port, let owner):
+            return "kind '\(kind.rawValue)' parameter '\(port)' has invalid owner '\(owner)'"
+        case .inertPort(let kind, let port):
+            return "kind '\(kind.rawValue)' port '\(port)' is neither an inlet nor a parameter"
+        }
+    }
+}
+
+// MARK: - Descriptor-derived connection checks
+
+enum ConnectionTypeDecision: Equatable, Sendable {
+    case allowed
+    case invalidExistingConnectionCount(Int)
+    case unknownSourceKind(NodeKindID)
+    case unknownDestinationKind(NodeKindID)
+    case sourceHasNoOutlet(NodeKindID)
+    case unknownDestinationPort(kind: NodeKindID, port: String)
+    case destinationPortIsNotInlet(kind: NodeKindID, port: String)
+    case incompatibleColor(outlet: PortColorID, accepts: [PortColorID])
+    case inletAtCapacity(kind: NodeKindID, port: String)
+}
+
+extension EngineVocabulary {
+    /// Type and arity only. Node identity, duplicate-edge, and cycle checks
+    /// remain authored-graph concerns; every fact used here comes from the
+    /// decoded descriptors.
+    func connectionDecision(
+        from sourceKind: NodeKindID,
+        to destinationKind: NodeKindID,
+        port portName: String,
+        existingConnectionCount: Int
+    ) -> ConnectionTypeDecision {
+        guard existingConnectionCount >= 0 else {
+            return .invalidExistingConnectionCount(existingConnectionCount)
+        }
+        guard let source = descriptor(for: sourceKind) else {
+            return .unknownSourceKind(sourceKind)
+        }
+        guard let destination = descriptor(for: destinationKind) else {
+            return .unknownDestinationKind(destinationKind)
+        }
+        guard let outlet = source.outlet else {
+            return .sourceHasNoOutlet(sourceKind)
+        }
+        guard let port = destination.port(named: portName) else {
+            return .unknownDestinationPort(kind: destinationKind, port: portName)
+        }
+        guard port.isInlet else {
+            return .destinationPortIsNotInlet(kind: destinationKind, port: portName)
+        }
+        guard port.accepts.contains(outlet) else {
+            return .incompatibleColor(outlet: outlet, accepts: port.accepts)
+        }
+        guard port.multi || existingConnectionCount == 0 else {
+            return .inletAtCapacity(kind: destinationKind, port: portName)
+        }
+        return .allowed
+    }
+
+    func canConnect(
+        from sourceKind: NodeKindID,
+        to destinationKind: NodeKindID,
+        port portName: String,
+        existingConnectionCount: Int
+    ) -> Bool {
+        connectionDecision(
+            from: sourceKind,
+            to: destinationKind,
+            port: portName,
+            existingConnectionCount: existingConnectionCount
+        ) == .allowed
+    }
+}
+
+// MARK: - Client-only presentation namespace
+
+/// Presentation-only overrides. Absence means the UI uses its generic visual
+/// treatment; it never supplies ports, ranges, defaults, or connection rules.
+struct NodeThemeOverride: Equatable, Sendable {
+    var displayName: String?
+    var accentRGB: UInt32?
+}
+
+struct EngineNodeThemeCatalog: Sendable {
+    private let overrides: [NodeKindID: NodeThemeOverride]
+
+    init(overrides: [NodeKindID: NodeThemeOverride] = [:]) {
+        self.overrides = overrides
+    }
+
+    func override(for kind: NodeKindID) -> NodeThemeOverride? {
+        overrides[kind]
+    }
+}
+
+/// Client monitor IDs cannot collide with served engine kinds because they use
+/// a distinct type and a mandatory `client.monitor.` namespace.
+struct ClientMonitorKindID: RawRepresentable, Codable, Hashable, Sendable {
+    static let namespace = "client.monitor."
+
+    let rawValue: String
+
+    init?(rawValue: String) {
+        let localName = rawValue.dropFirst(Self.namespace.count)
+        guard rawValue.hasPrefix(Self.namespace),
+              !localName.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    init(validating rawValue: String) throws {
+        let localName = rawValue.dropFirst(Self.namespace.count)
+        guard rawValue.hasPrefix(Self.namespace),
+              !localName.isEmpty,
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            throw ClientMonitorCatalogError.invalidMonitorID(rawValue)
+        }
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        do {
+            try self.init(validating: value)
+        } catch {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: error.localizedDescription
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+struct ClientMonitorDescriptor: Equatable, Sendable {
+    let kind: ClientMonitorKindID
+    let displayName: String
+    let theme: NodeThemeOverride?
+}
+
+struct ClientMonitorCatalog: Sendable {
+    let monitors: [ClientMonitorDescriptor]
+
+    init(monitors: [ClientMonitorDescriptor]) throws {
+        var seen = Set<ClientMonitorKindID>()
+        for monitor in monitors {
+            guard seen.insert(monitor.kind).inserted else {
+                throw ClientMonitorCatalogError.duplicateMonitor(monitor.kind)
+            }
+        }
+        self.monitors = monitors
+    }
+
+    func descriptor(for kind: ClientMonitorKindID) -> ClientMonitorDescriptor? {
+        monitors.first { $0.kind == kind }
+    }
+}
+
+enum ClientMonitorCatalogError: Error, Equatable, LocalizedError {
+    case invalidMonitorID(String)
+    case duplicateMonitor(ClientMonitorKindID)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidMonitorID(let value):
+            return "client monitor ID must begin with '\(ClientMonitorKindID.namespace)': '\(value)'"
+        case .duplicateMonitor(let kind):
+            return "duplicate client monitor: '\(kind.rawValue)'"
+        }
+    }
+}

--- a/reversible/Sources/Reversible/JSONValue.swift
+++ b/reversible/Sources/Reversible/JSONValue.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// A closed JSON term — the RPC surface is schemaless at the transport
+/// layer (each method returns its own shape), so replies land as a
+/// `JSONValue` and callers project the fields they know.
+enum JSONValue: Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+}
+
+extension JSONValue: Codable {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null }
+        else if let b = try? c.decode(Bool.self) { self = .bool(b) }
+        else if let n = try? c.decode(Double.self) { self = .number(n) }
+        else if let s = try? c.decode(String.self) { self = .string(s) }
+        else if let a = try? c.decode([JSONValue].self) { self = .array(a) }
+        else if let o = try? c.decode([String: JSONValue].self) { self = .object(o) }
+        else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath, debugDescription: "unrecognized JSON term"))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .null: try c.encodeNil()
+        case .bool(let b): try c.encode(b)
+        case .number(let n): try c.encode(n)
+        case .string(let s): try c.encode(s)
+        case .array(let a): try c.encode(a)
+        case .object(let o): try c.encode(o)
+        }
+    }
+}
+
+extension JSONValue {
+    subscript(key: String) -> JSONValue? {
+        if case .object(let o) = self { return o[key] }
+        return nil
+    }
+
+    var stringValue: String? { if case .string(let s) = self { return s }; return nil }
+    var doubleValue: Double? { if case .number(let n) = self { return n }; return nil }
+    var boolValue: Bool? {
+        switch self {
+        case .bool(let b): return b
+        // Some engine fields arrive as 0/1.
+        case .number(let n): return n != 0
+        default: return nil
+        }
+    }
+}

--- a/reversible/Sources/Reversible/KnobView.swift
+++ b/reversible/Sources/Reversible/KnobView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 /// Every continuous knob is a live param slot `<id>.<knob>` — a vertical
 /// drag (180px = full sweep) drives the running kernel with no relower
 /// (only topology edits recompile). A glided knob eases via
-/// set_param_glide; freq-anchored knobs go phase-continuous via
-/// set_param_freq; the rest do a raw set_param write.
+/// The client always emits `set_param`; the loaded plan owns whether the
+/// accepted write is raw, glided, phase-anchored, or a velocity rebase.
 struct KnobView: View {
     @EnvironmentObject var model: PatchModel
     let node: PatchNode

--- a/reversible/Sources/Reversible/KnobView.swift
+++ b/reversible/Sources/Reversible/KnobView.swift
@@ -48,10 +48,14 @@ struct KnobView: View {
                         center: UnitPoint(x: 0.5, y: 0.38),
                         startRadius: 0, endRadius: 27))
                 .overlay(Circle().stroke(Theme.edge))
+            // Pointer sits 5px in from the top edge; the ROTATED view is the
+            // full 38px square, so the pivot is the dial center (CSS
+            // transform-origin 50% 14px ≡ 5 + 14 = 19 = center).
             RoundedRectangle(cornerRadius: 2)
                 .fill(Theme.jackHot)
                 .frame(width: 2, height: 13)
                 .offset(y: 5)
+                .frame(width: 38, height: 38, alignment: .top)
                 .rotationEffect(.degrees(angle), anchor: .center)
         }
         .frame(width: 38, height: 38)

--- a/reversible/Sources/Reversible/KnobView.swift
+++ b/reversible/Sources/Reversible/KnobView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Knob face: 38px dial, pointer sweeping −135°…+135° (styles.css .knob).
+/// Interaction (vertical drag → live param drive) lands in the next commit;
+/// this renders value + angle so the canvas is visually complete.
+struct KnobView: View {
+    @EnvironmentObject var model: PatchModel
+    let node: PatchNode
+    let knob: KnobSpec
+
+    private var value: Double { node.values[knob.name] ?? knob.def }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            dial
+            Text(knob.name).font(Theme.monoTiny).foregroundStyle(Theme.muted)
+            Text(knob.format(value)).font(Theme.monoTiny).foregroundStyle(Theme.text)
+        }
+        .frame(width: 54)
+    }
+
+    private var dial: some View {
+        let angle = -135 + knob.toNorm(value) * 270
+        return ZStack(alignment: .top) {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [Color(hex: 0x39404E), Theme.panel],
+                        center: UnitPoint(x: 0.5, y: 0.38),
+                        startRadius: 0, endRadius: 27))
+                .overlay(Circle().stroke(Theme.edge))
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Theme.jackHot)
+                .frame(width: 2, height: 13)
+                .offset(y: 5)
+                .rotationEffect(.degrees(angle), anchor: .center)
+        }
+        .frame(width: 38, height: 38)
+    }
+}

--- a/reversible/Sources/Reversible/KnobView.swift
+++ b/reversible/Sources/Reversible/KnobView.swift
@@ -1,18 +1,37 @@
 import SwiftUI
 
-/// Knob face: 38px dial, pointer sweeping −135°…+135° (styles.css .knob).
-/// Interaction (vertical drag → live param drive) lands in the next commit;
-/// this renders value + angle so the canvas is visually complete.
+/// Knob: 38px dial, pointer sweeping −135°…+135° (styles.css .knob).
+/// Every continuous knob is a live param slot `<id>.<knob>` — a vertical
+/// drag (180px = full sweep) drives the running kernel with no relower
+/// (only topology edits recompile). A glided knob eases via
+/// set_param_glide; freq-anchored knobs go phase-continuous via
+/// set_param_freq; the rest do a raw set_param write.
 struct KnobView: View {
     @EnvironmentObject var model: PatchModel
     let node: PatchNode
     let knob: KnobSpec
+    @State private var dragStartNorm: Double?
 
     private var value: Double { node.values[knob.name] ?? knob.def }
 
     var body: some View {
         VStack(spacing: 2) {
             dial
+                .contentShape(Circle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { g in
+                            let t0 = dragStartNorm ?? knob.toNorm(value)
+                            dragStartNorm = t0
+                            let v = knob.fromNorm(t0 - g.translation.height / 180)
+                            model.nodes[node.id]?.values[knob.name] = v
+                            model.sendKnob(node, knob, v)
+                        }
+                        .onEnded { _ in
+                            dragStartNorm = nil
+                            model.sendKnob(node, knob, value)
+                        }
+                )
             Text(knob.name).font(Theme.monoTiny).foregroundStyle(Theme.muted)
             Text(knob.format(value)).font(Theme.monoTiny).foregroundStyle(Theme.text)
         }

--- a/reversible/Sources/Reversible/LatestValueBuffer.swift
+++ b/reversible/Sources/Reversible/LatestValueBuffer.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Bounded coalescing for one continuous gesture while a write is in flight.
+/// The first value is stored on initialization. Later pointer events collapse
+/// to the newest value, except that the first direction-turning point is kept
+/// ahead of the final value. At most three unsent values exist before the first
+/// request is issued, and at most two while that request is in flight.
+struct LatestValueBuffer {
+    private var firstPending: Double?
+    private var latest: Double?
+    private var reversal: Double?
+    private var lastObserved: Double
+    private var direction = 0
+    private var capturedReversal = false
+
+    init(first: Double) {
+        firstPending = first
+        lastObserved = first
+    }
+
+    var pendingCount: Int {
+        (firstPending == nil ? 0 : 1)
+            + (reversal == nil ? 0 : 1)
+            + (latest == nil ? 0 : 1)
+    }
+
+    mutating func offer(_ value: Double) {
+        guard value.isFinite else { return }
+        let delta = value - lastObserved
+        let nextDirection = delta == 0 ? 0 : (delta > 0 ? 1 : -1)
+        if !capturedReversal, direction != 0, nextDirection != 0,
+           nextDirection != direction {
+            reversal = lastObserved
+            capturedReversal = true
+        }
+        if nextDirection != 0 { direction = nextDirection }
+        lastObserved = value
+        latest = value
+    }
+
+    mutating func pop() -> Double? {
+        if let firstPending {
+            self.firstPending = nil
+            return firstPending
+        }
+        if let reversal {
+            self.reversal = nil
+            if latest == reversal { latest = nil }
+            return reversal
+        }
+        defer { latest = nil }
+        return latest
+    }
+}

--- a/reversible/Sources/Reversible/ModalScopeMath.swift
+++ b/reversible/Sources/Reversible/ModalScopeMath.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// Fixed sampling geometry of the qualified five-mode phase view.
+///
+/// The canvas contains 896 points spanning twice that base width: 1,792 source
+/// samples, or 40.6349206 ms at 44.1 kHz. The extra 1,792-sample search region
+/// lets each mode choose its own centered positive-going zero crossing without
+/// changing the shared linear time axis.
+struct ModalScopeProfile: Equatable, Sendable {
+    let sampleRate: Double
+    let displaySamples: Int
+    let searchSamples: Int
+    let warmupSamples: Int
+    let timeCompression: Double
+    let pointBudget: Int
+    let framesPerSecond: Double
+
+    static let qualified = ModalScopeProfile(
+        sampleRate: 44_100,
+        displaySamples: 896,
+        searchSamples: 1_792,
+        warmupSamples: 64,
+        timeCompression: 2,
+        pointBudget: 896 + 1_792 + 64,
+        framesPerSecond: 60
+    )
+
+    var linearSpanSamples: Double {
+        Double(displaySamples) * timeCompression
+    }
+
+    var linearSpanSeconds: Double {
+        linearSpanSamples / sampleRate
+    }
+}
+
+/// The exact +a/-a exponential pair used by one projected fundamental.
+struct ModalPairedEnvelope: Equatable, Sendable {
+    let strikeTime: Double
+    let slowDecay: Double
+    let fastDecay: Double
+    let amplitude: Double
+
+    func value(at sceneTime: Double) -> Double {
+        guard sceneTime.isFinite else { return 0 }
+        let age = sceneTime - strikeTime
+        guard age > 0 else { return 0 }
+        return abs(amplitude) * (
+            exp(-slowDecay * age) - exp(-fastDecay * age)
+        )
+    }
+
+    func samples(firstSceneTime: Double, sceneStep: Double, count: Int) -> [Double] {
+        guard firstSceneTime.isFinite, sceneStep.isFinite, count > 0 else { return [] }
+        return (0..<count).map { index in
+            value(at: firstSceneTime + Double(index) * sceneStep)
+        }
+    }
+
+    var peak: Double {
+        guard slowDecay > 0, fastDecay > slowDecay else { return 0 }
+        let peakTime = log(fastDecay / slowDecay) / (fastDecay - slowDecay)
+        return abs(amplitude) * (
+            exp(-slowDecay * peakTime) - exp(-fastDecay * peakTime)
+        )
+    }
+}
+
+struct ModalScopeLock: Equatable, Sendable {
+    let offset: Double
+    let center: Double
+    let span: Double
+    let centerValue: Double
+    let values: [Double]
+    let peak: Double
+    let active: Bool
+    let locked: Bool
+
+    static let empty = ModalScopeLock(
+        offset: 0,
+        center: 0,
+        span: 0,
+        centerValue: 0,
+        values: [],
+        peak: 0,
+        active: false,
+        locked: false
+    )
+}
+
+struct ModalScopeFrame: Equatable, Sendable {
+    let stride: Int
+    let cycles: Double
+    let timeSpanSeconds: Double
+    let displayEnvelope: Double
+    let lock: ModalScopeLock
+
+    /// Restore the exact audible-now envelope after phase selection.
+    var displayedValues: [Double] {
+        lock.values.map { ModalScopeMath.applyEnvelope($0, displayEnvelope: displayEnvelope) }
+    }
+}
+
+enum ModalScopeMath {
+    /// The accepted canvas keeps eight percent of fixed headroom. It never
+    /// derives a new scale from a frame, so modal amplitude remains visible.
+    static let displayHeadroom = 1.08
+
+    static func displayScale(sharedFullScale: Double) -> Double {
+        sharedFullScale * displayHeadroom
+    }
+
+    static func visibleCycles(
+        frequency: Double,
+        profile: ModalScopeProfile = .qualified
+    ) -> Double {
+        guard frequency > 0, profile.sampleRate > 0,
+              profile.displaySamples > 0, profile.timeCompression > 0
+        else { return 0 }
+        return frequency * profile.linearSpanSamples / profile.sampleRate
+    }
+
+    static func normalizedAmplitude(_ value: Double, fullScale: Double) -> Double {
+        guard value.isFinite, fullScale > 0 else { return 0 }
+        return max(-1, min(1, value / fullScale))
+    }
+
+    static func extractCarrier(
+        values: [Double],
+        envelopes: [Double],
+        envelopeFloor: Double = 1e-12
+    ) -> [Double] {
+        values.enumerated().map { index, value in
+            guard envelopes.indices.contains(index) else { return 0 }
+            let envelope = envelopes[index]
+            guard value.isFinite, envelope.isFinite, abs(envelope) > envelopeFloor
+            else { return 0 }
+            return value / envelope
+        }
+    }
+
+    static func applyEnvelope(_ carrierValue: Double, displayEnvelope: Double) -> Double {
+        guard carrierValue.isFinite, displayEnvelope >= 0 else { return 0 }
+        return carrierValue * displayEnvelope
+    }
+
+    /// Linear interpolation with the same endpoint clamping as the JS oracle.
+    static func sampleLinear(_ values: [Double], at position: Double) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let left = max(0, min(values.count - 1, Int(floor(position))))
+        let right = min(values.count - 1, left + 1)
+        let fraction = position - Double(left)
+        let leftValue = values[left].isFinite ? values[left] : 0
+        let rightValue = values[right].isFinite ? values[right] : 0
+        return leftValue + (rightValue - leftValue) * fraction
+    }
+
+    /// Choose the nearest eligible positive-going zero crossing to the middle
+    /// of the available projection, then sample a linear, centered window.
+    /// Each overlaid mode calls this independently.
+    static func centeredWindow(
+        _ values: [Double],
+        outputLength: Int,
+        spanLength: Double
+    ) -> ModalScopeLock {
+        guard values.count >= 2, outputLength >= 2, spanLength > 0 else {
+            return .empty
+        }
+
+        let length = max(2, outputLength)
+        let span = min(spanLength, Double(values.count - 1))
+        let halfSpan = span / 2
+        let target = Double(values.count - 1) / 2
+        let minimumCenter = halfSpan
+        let maximumCenter = Double(values.count - 1) - halfSpan
+
+        var searchPeak = 0.0
+        for raw in values {
+            let value = raw.isFinite ? raw : 0
+            searchPeak = max(searchPeak, abs(value))
+        }
+
+        var crossing = -1.0
+        if searchPeak >= 1e-12, minimumCenter <= maximumCenter {
+            let armLevel = searchPeak * 0.08
+            var armed = (values[0].isFinite ? values[0] : 0) < -armLevel
+            var bestDistance = Double.infinity
+
+            for index in 1..<values.count {
+                let previous = values[index - 1].isFinite ? values[index - 1] : 0
+                let current = values[index].isFinite ? values[index] : 0
+                if current < -armLevel { armed = true }
+                if armed, previous < 0, current >= 0 {
+                    let width = current - previous
+                    let candidate = Double(index - 1) + (width == 0 ? 0 : -previous / width)
+                    if candidate >= minimumCenter, candidate <= maximumCenter {
+                        let distance = abs(candidate - target)
+                        if distance < bestDistance {
+                            crossing = candidate
+                            bestDistance = distance
+                        }
+                    }
+                }
+            }
+
+            // A steep attack can miss the relative arming threshold even when
+            // its zero is usable. DC still fails because it never changes sign.
+            if crossing < 0 {
+                for index in 1..<values.count {
+                    let previous = values[index - 1].isFinite ? values[index - 1] : 0
+                    let current = values[index].isFinite ? values[index] : 0
+                    guard previous < 0, current >= 0 else { continue }
+                    let width = current - previous
+                    let candidate = Double(index - 1) + (width == 0 ? 0 : -previous / width)
+                    let distance = abs(candidate - target)
+                    if candidate >= minimumCenter, candidate <= maximumCenter,
+                       distance < bestDistance {
+                        crossing = candidate
+                        bestDistance = distance
+                    }
+                }
+            }
+        }
+
+        let center = crossing >= 0
+            ? crossing
+            : max(minimumCenter, min(maximumCenter, target))
+        let start = center - halfSpan
+        let step = span / Double(length - 1)
+        let lockedValues = (0..<length).map { index in
+            sampleLinear(values, at: start + Double(index) * step)
+        }
+        let peak = lockedValues.reduce(0) { max($0, abs($1)) }
+
+        return ModalScopeLock(
+            offset: start,
+            center: center,
+            span: span,
+            centerValue: sampleLinear(values, at: center),
+            values: lockedValues,
+            peak: peak,
+            active: peak >= 1e-12,
+            locked: crossing >= 0
+        )
+    }
+
+    /// Qualified projection transform: remove the exact paired envelope at
+    /// every source point, phase-lock the carrier, and retain the audible-now
+    /// envelope for fixed-scale restoration by the canvas.
+    static func frame(
+        values: [Double],
+        responseStart: Double,
+        stride: Int = 1,
+        frequency: Double,
+        envelope: ModalPairedEnvelope,
+        tauBase: Double,
+        velocity: Double,
+        playbackPosition: Double,
+        sharedFullScale: Double,
+        profile: ModalScopeProfile = .qualified
+    ) -> ModalScopeFrame {
+        let safeStride = max(1, stride)
+        let warmupPoints = Int(ceil(Double(profile.warmupSamples) / Double(safeStride)))
+        let displayPoints = Int(ceil(Double(profile.displaySamples) / Double(safeStride)))
+        let raw = warmupPoints < values.count ? Array(values.dropFirst(warmupPoints)) : []
+        let firstSample = responseStart + Double(warmupPoints * safeStride)
+        let envelopes = envelope.samples(
+            firstSceneTime: tauBase + velocity * firstSample / profile.sampleRate,
+            sceneStep: velocity * Double(safeStride) / profile.sampleRate,
+            count: raw.count
+        )
+        let carrier = extractCarrier(
+            values: raw,
+            envelopes: envelopes,
+            envelopeFloor: sharedFullScale * 1e-6
+        )
+        let spanPoints = profile.linearSpanSamples / Double(safeStride)
+        let lock = centeredWindow(
+            carrier,
+            outputLength: displayPoints,
+            spanLength: spanPoints
+        )
+        let audibleNow = tauBase + velocity * playbackPosition / profile.sampleRate
+
+        return ModalScopeFrame(
+            stride: safeStride,
+            cycles: visibleCycles(frequency: frequency, profile: profile),
+            timeSpanSeconds: profile.linearSpanSeconds,
+            displayEnvelope: envelope.value(at: audibleNow),
+            lock: lock
+        )
+    }
+}

--- a/reversible/Sources/Reversible/NodeKind.swift
+++ b/reversible/Sources/Reversible/NodeKind.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+
+/// How a knob writes to the running kernel: a raw slot write (steps at
+/// block rate), a closed-form glide (the engine re-anchors 3 ramp slots;
+/// the kernel eases f(τ) — click-free), or a phase-anchored freq change
+/// (the engine bumps the oscillator's phase offset so the waveform stays
+/// continuous across the pitch change).
+enum ParamSendMode {
+    case live      // set_param
+    case glide     // set_param_glide
+    case anchor    // set_param_freq
+}
+
+struct KnobSpec {
+    let name: String
+    let min: Double
+    let max: Double
+    let def: Double
+    var log = false
+    var unit = ""
+    var mode = ParamSendMode.live
+}
+
+/// Node vocabulary, 1:1 with the Lean arrow patch-graph `Node` cases
+/// (ported from playground/renderer/app.js KINDS). You patch DOWNSTREAM
+/// only; the frontend's lowering threads each effect's (possibly
+/// signal-modulated) warp onto the generators' clocks — totally
+/// composable, so effects stack freely.
+enum NodeKind: String, CaseIterable, Codable {
+    case source, knob, flange, sflange, fm, delay, reverse, mix, ring
+    case resonator, reverb, modalmix
+    case out
+}
+
+struct NodeSpec {
+    let title: String
+    let accent: Color
+    let summing: Bool
+    let inlets: [String]
+    let outlets: [String]
+    let knobs: [KnobSpec]
+    var modal = false
+    var fixed = false
+}
+
+extension NodeKind {
+    var spec: NodeSpec {
+        switch self {
+        case .source:
+            // Always a MorphOsc: morph = 0 is saw, morph = 1 is sine, so the
+            // morph knob is always meaningful. `freq` is a CONTROL inlet —
+            // patch a Knob to drive pitch from a live slot (only a knob;
+            // audio-rate into the pitch port is not FM).
+            return NodeSpec(
+                title: "Osc", accent: Color(hex: 0x6CC7FF), summing: false,
+                inlets: ["freq"], outlets: ["out"],
+                knobs: [
+                    // spans sub-Hz LFO → audio (log): dial it below ~1 Hz and
+                    // it's a slow ramp you can patch into a Reson `addr` to
+                    // scrub-trigger the resonance. A phasor is closed-form at
+                    // any rate, so there's no low-frequency floor in the engine.
+                    KnobSpec(name: "freq", min: 0.02, max: 2000, def: 220, log: true, unit: "Hz", mode: .anchor),
+                    KnobSpec(name: "morph", min: 0, max: 1, def: 0, mode: .glide),
+                ])
+        case .knob:
+            // A program that is nothing but a param with one output — for a
+            // value you want to PATCH (fan it out, or into a `freq`/`mod`
+            // control inlet). Every knob is live; this one is also a
+            // first-class wire source.
+            return NodeSpec(
+                title: "Knob", accent: Color(hex: 0xB7A4FF), summing: false,
+                inlets: [], outlets: ["out"],
+                knobs: [KnobSpec(name: "value", min: 0, max: 1000, def: 220)])
+        case .flange:
+            // static δ comb — the pure plain-warp slide. `depth` is the GLIDE
+            // prototype: its turns drive set_param_glide (closed-form ramp),
+            // so A/B it against any other (raw set_param) knob to hear the
+            // difference.
+            return NodeSpec(
+                title: "Flange", accent: Color(hex: 0xFFCC66), summing: false,
+                inlets: ["in"], outlets: ["out"],
+                knobs: [KnobSpec(name: "depth", min: 0.0001, max: 0.01, def: 0.002, log: true, unit: "s", mode: .glide)])
+        case .sflange:
+            // SIGNAL-modulated comb. Patch a signal into `mod` to sweep it;
+            // leave it open and the built-in LFO at `rate` drives the sweep.
+            // The signal-warp composes.
+            return NodeSpec(
+                title: "SwFlange", accent: Color(hex: 0xFFD089), summing: false,
+                inlets: ["in", "mod"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "depth", min: 0.0002, max: 0.02, def: 0.005, log: true, unit: "s", mode: .glide),
+                    KnobSpec(name: "rate", min: 0.02, max: 12, def: 0.3, log: true, unit: "Hz"),
+                ])
+        case .fm:
+            return NodeSpec(
+                title: "FM", accent: Color(hex: 0xFF9EC7), summing: false,
+                inlets: ["in"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "carrier", min: 20, max: 2000, def: 330, log: true, unit: "Hz", mode: .anchor),
+                    KnobSpec(name: "depth", min: 1, max: 400, def: 60, log: true, mode: .glide),
+                ])
+        case .delay:
+            return NodeSpec(
+                title: "Delay", accent: Color(hex: 0x86E8C0), summing: false,
+                inlets: ["in"], outlets: ["out"],
+                knobs: [KnobSpec(name: "amount", min: 0.0001, max: 0.02, def: 0.004, log: true, unit: "s", mode: .glide)])
+        case .reverse:
+            // clk -> -clk : the moat op, no parameter.
+            return NodeSpec(
+                title: "Reverse", accent: Color(hex: 0x7AD0AA), summing: false,
+                inlets: ["in"], outlets: ["out"], knobs: [])
+        case .mix:
+            return NodeSpec(
+                title: "Mix", accent: Color(hex: 0xC7CED9), summing: true,
+                inlets: ["in"], outlets: ["out"], knobs: [])
+        case .ring:
+            // multiplicative fan-in (⊗) — the ring-product twin of Mix's sum.
+            // Two inputs is ring modulation; input × an oscillator/LFO is a
+            // VCA. A downstream warp reclocks every factor (the slide
+            // distributes over the product).
+            return NodeSpec(
+                title: "Ring ⊗", accent: Color(hex: 0xD0A0E0), summing: true,
+                inlets: ["in"], outlets: ["out"], knobs: [])
+
+        // ── MODAL ISLAND ──────────────────────────────────────────────────
+        // The second arena: pole / exp-poly banks that compose by the residue
+        // calculus at BUILD time and realize to a Sig at their boundary. A
+        // modal OUTLET carries poles, not audio — it may feed a Sig inlet
+        // (realized at the seam by `lowerInput`) or another modal node; a
+        // modal INLET (Reverb/Modal∪) accepts ONLY a modal node (a Sig source
+        // there is ill-typed — see `wantsModal`).
+        case .resonator:
+            // A struck resonator: 6 harmonics of `freq` decaying at rate
+            // `decay`. A modal SOURCE struck at τ=0 — it rings then decays, so
+            // scrub the master clock to re-strike. Poles stay LIVE (the
+            // residue is emitted symbolically). The `addr` inlet is TEMPORAL,
+            // not spectral: patch a CF signal (LFO/env/osc) and its value
+            // BECOMES the bank's time-address (seconds into the impulse
+            // response) — an ABSOLUTE warp, so the resonance TRIGGERS as the
+            // signal crosses zero and scrubs/pitches with its slope. Unlike a
+            // downstream sflange (a ±δ vibrato around the master clock), this
+            // relocates the strike to the signal. Unpatched ⇒ reads the
+            // master clock as before.
+            return NodeSpec(
+                title: "Reson", accent: Color(hex: 0x4FD6C4), summing: false,
+                inlets: ["addr"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "freq", min: 20, max: 2000, def: 220, log: true, unit: "Hz"),
+                    KnobSpec(name: "decay", min: 0.5, max: 50, def: 4, log: true),
+                ],
+                modal: true)
+        case .reverb:
+            // A room bank (32 log-spaced modes, 60–6000 Hz) composed with its
+            // MODAL input by the residue calculus (voice ⋙ reverb). Modal in →
+            // modal out; only the room damping `rt60` is live. Feeds a Sig
+            // inlet (realized) or Modal∪.
+            //
+            // `dir` rotates the composed tail's poles in the s-plane (a live
+            // U(1) morph): 0 = forward decay, π = reverse (pre-verb), π/2 =
+            // decay↔frequency swap. Any continuous path forward→reverse
+            // crosses an undamped-ring axis; `window` nulls each mode AT its
+            // crossing (σ²/(σ²+w²)) — 0 = bare rotation (rings through the
+            // horizon), open = the click-free morph.
+            return NodeSpec(
+                title: "Reverb", accent: Color(hex: 0x3FB8B0), summing: false,
+                inlets: ["in"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "rt60", min: 0.2, max: 12, def: 2, log: true, unit: "sec"),
+                    // dir crossfades the tail's direction: 0 = forward, 1 =
+                    // reverse (pre-verb). Keeps σ/ω fixed so it stays audible
+                    // across the range (heard on re-strike/scrub).
+                    KnobSpec(name: "dir", min: 0, max: 1, def: 0),
+                    // decay SWAY: the room breathes — σ modulated on the
+                    // envelope clock only, so the tail's decay time undulates
+                    // while pitch holds. Continuous, stateless.
+                    KnobSpec(name: "sway", min: 0, max: 0.9, def: 0),
+                    KnobSpec(name: "rate", min: 0.05, max: 8, def: 0.3, log: true, unit: "Hz"),
+                ],
+                modal: true)
+        case .modalmix:
+            // Pole UNION (∪) of its modal inputs — the modal twin of Mix's
+            // sum. Many modal in → one modal out; no knobs (structural).
+            return NodeSpec(
+                title: "Modal ∪", accent: Color(hex: 0x6FE0D0), summing: true,
+                inlets: ["in"], outlets: ["out"], knobs: [],
+                modal: true)
+        case .out:
+            return NodeSpec(
+                title: "Out · dac", accent: Color(hex: 0xFF8A8A), summing: true,
+                inlets: ["in"], outlets: [], knobs: [],
+                fixed: true)
+        }
+    }
+
+    /// Control inlets accept a Knob node's output (a control value, not audio).
+    static let controlInlets: Set<String> = ["freq", "mod"]
+
+    /// Inlets that carry POLES, not audio: a modal node's input (Reverb's
+    /// `in`, Modal∪'s `in`). They accept ONLY a modal-output node — the
+    /// residue calculus composes pole banks at build time (`lowerModal`), and
+    /// a Sig source there would throw at compile. A Sig inlet, by contrast,
+    /// accepts either: a modal source realizes to a Sig at the seam
+    /// (`lowerInput`), but never the reverse.
+    static let modalInlets: Set<String> = ["reverb:in", "modalmix:in"]
+
+    func wantsModal(inlet: String) -> Bool {
+        Self.modalInlets.contains("\(rawValue):\(inlet)")
+    }
+}
+
+// ── Knob value ↔ normalized position math ─────────────────────────────────
+extension KnobSpec {
+    func toNorm(_ v: Double) -> Double {
+        if log { return (Foundation.log(v) - Foundation.log(min)) / (Foundation.log(max) - Foundation.log(min)) }
+        return (v - min) / (max - min)
+    }
+
+    func fromNorm(_ t: Double) -> Double {
+        let t = Swift.min(1, Swift.max(0, t))
+        if log { return exp(Foundation.log(min) + t * (Foundation.log(max) - Foundation.log(min))) }
+        return min + t * (max - min)
+    }
+
+    func format(_ v: Double) -> String {
+        switch unit {
+        case "s": return String(format: "%.\(v < 0.001 ? 2 : 1)fms", v * 1000)
+        case "sec": return String(format: "%.2fs", v)   // whole-second times (rt60)
+        case "Hz": return v >= 100 ? String(format: "%.0fHz", v) : String(format: "%.2fHz", v)
+        default: return String(format: "%.2f", v)
+        }
+    }
+}

--- a/reversible/Sources/Reversible/NodeKind.swift
+++ b/reversible/Sources/Reversible/NodeKind.swift
@@ -1,16 +1,5 @@
 import SwiftUI
 
-/// How a knob writes to the running kernel: a raw slot write (steps at
-/// block rate), a closed-form glide (the engine re-anchors 3 ramp slots;
-/// the kernel eases f(τ) — click-free), or a phase-anchored freq change
-/// (the engine bumps the oscillator's phase offset so the waveform stays
-/// continuous across the pitch change).
-enum ParamSendMode {
-    case live      // set_param
-    case glide     // set_param_glide
-    case anchor    // set_param_freq
-}
-
 struct KnobSpec {
     let name: String
     let min: Double
@@ -18,7 +7,6 @@ struct KnobSpec {
     let def: Double
     var log = false
     var unit = ""
-    var mode = ParamSendMode.live
 }
 
 /// Node vocabulary, 1:1 with the Lean arrow patch-graph `Node` cases
@@ -85,8 +73,8 @@ extension NodeKind {
                     // it's a slow ramp you can patch into a Reson `addr` to
                     // scrub-trigger the resonance. A phasor is closed-form at
                     // any rate, so there's no low-frequency floor in the engine.
-                    KnobSpec(name: "freq", min: 0.02, max: 2000, def: 220, log: true, unit: "Hz", mode: .anchor),
-                    KnobSpec(name: "morph", min: 0, max: 1, def: 0, mode: .glide),
+                    KnobSpec(name: "freq", min: 0.02, max: 2000, def: 220, log: true, unit: "Hz"),
+                    KnobSpec(name: "morph", min: 0, max: 1, def: 0),
                 ])
         case .knob:
             // A program that is nothing but a param with one output — for a
@@ -99,13 +87,12 @@ extension NodeKind {
                 knobs: [KnobSpec(name: "value", min: 0, max: 1000, def: 220)])
         case .flange:
             // static δ comb — the pure plain-warp slide. `depth` is the GLIDE
-            // prototype: its turns drive set_param_glide (closed-form ramp),
-            // so A/B it against any other (raw set_param) knob to hear the
-            // difference.
+            // prototype: the engine-owned discipline drives a closed-form
+            // ramp, so A/B it against a raw parameter to hear the difference.
             return NodeSpec(
                 title: "Flange", accent: Color(hex: 0xFFCC66), summing: false,
                 inlets: ["in"], outlets: ["out"],
-                knobs: [KnobSpec(name: "depth", min: 0.0001, max: 0.01, def: 0.002, log: true, unit: "s", mode: .glide)])
+                knobs: [KnobSpec(name: "depth", min: 0.0001, max: 0.01, def: 0.002, log: true, unit: "s")])
         case .sflange:
             // SIGNAL-modulated comb. Patch a signal into `mod` to sweep it;
             // leave it open and the built-in LFO at `rate` drives the sweep.
@@ -114,7 +101,7 @@ extension NodeKind {
                 title: "SwFlange", accent: Color(hex: 0xFFD089), summing: false,
                 inlets: ["in", "mod"], outlets: ["out"],
                 knobs: [
-                    KnobSpec(name: "depth", min: 0.0002, max: 0.02, def: 0.005, log: true, unit: "s", mode: .glide),
+                    KnobSpec(name: "depth", min: 0.0002, max: 0.02, def: 0.005, log: true, unit: "s"),
                     KnobSpec(name: "rate", min: 0.02, max: 12, def: 0.3, log: true, unit: "Hz"),
                 ])
         case .fm:
@@ -122,14 +109,14 @@ extension NodeKind {
                 title: "FM", accent: Color(hex: 0xFF9EC7), summing: false,
                 inlets: ["in"], outlets: ["out"],
                 knobs: [
-                    KnobSpec(name: "carrier", min: 20, max: 2000, def: 330, log: true, unit: "Hz", mode: .anchor),
-                    KnobSpec(name: "depth", min: 1, max: 400, def: 60, log: true, mode: .glide),
+                    KnobSpec(name: "carrier", min: 20, max: 2000, def: 330, log: true, unit: "Hz"),
+                    KnobSpec(name: "depth", min: 1, max: 400, def: 60, log: true),
                 ])
         case .delay:
             return NodeSpec(
                 title: "Delay", accent: Color(hex: 0x86E8C0), summing: false,
                 inlets: ["in"], outlets: ["out"],
-                knobs: [KnobSpec(name: "amount", min: 0.0001, max: 0.02, def: 0.004, log: true, unit: "s", mode: .glide)])
+                knobs: [KnobSpec(name: "amount", min: 0.0001, max: 0.02, def: 0.004, log: true, unit: "s")])
         case .reverse:
             // clk -> -clk : the moat op, no parameter.
             return NodeSpec(

--- a/reversible/Sources/Reversible/NodeKind.swift
+++ b/reversible/Sources/Reversible/NodeKind.swift
@@ -41,6 +41,25 @@ struct NodeSpec {
     let knobs: [KnobSpec]
     var modal = false
     var fixed = false
+
+    /// Module footprint in grid units (VCV-style: every module has a defined
+    /// width and height on the grid). Derived from content: 54px per knob +
+    /// chrome for width; title + knob block + jacks for height.
+    var gridSize: (w: Int, h: Int) {
+        let w = max(4, Int(ceil((Double(knobs.count) * 54 + Double(max(0, knobs.count - 1)) * 8 + 18) / Grid.unit)))
+        let h = knobs.isEmpty ? 3 : 6
+        return (w, h)
+    }
+}
+
+enum Grid {
+    static let unit: Double = 22
+
+    static func snap(_ p: CGPoint) -> CGPoint {
+        CGPoint(
+            x: (p.x / unit).rounded() * unit,
+            y: (p.y / unit).rounded() * unit)
+    }
 }
 
 extension NodeKind {

--- a/reversible/Sources/Reversible/NodeKind.swift
+++ b/reversible/Sources/Reversible/NodeKind.swift
@@ -29,6 +29,7 @@ struct KnobSpec {
 enum NodeKind: String, CaseIterable, Codable {
     case source, knob, flange, sflange, fm, delay, reverse, mix, ring
     case resonator, reverb, modalmix
+    case scope
     case out
 }
 
@@ -41,11 +42,17 @@ struct NodeSpec {
     let knobs: [KnobSpec]
     var modal = false
     var fixed = false
+    /// A monitor lives only on the surface: it is never serialized into the
+    /// engine graph (its connections select scope taps), and its knobs are
+    /// local view state, not live param slots.
+    var monitor = false
+    var gridOverride: (w: Int, h: Int)? = nil
 
     /// Module footprint in grid units (VCV-style: every module has a defined
     /// width and height on the grid). Derived from content: 54px per knob +
     /// chrome for width; title + knob block + jacks for height.
     var gridSize: (w: Int, h: Int) {
+        if let o = gridOverride { return o }
         let w = max(4, Int(ceil((Double(knobs.count) * 54 + Double(max(0, knobs.count - 1)) * 8 + 18) / Grid.unit)))
         let h = knobs.isEmpty ? 3 : 6
         return (w, h)
@@ -203,6 +210,20 @@ extension NodeKind {
                 title: "Modal ∪", accent: Color(hex: 0x6FE0D0), summing: true,
                 inlets: ["in"], outlets: ["out"], knobs: [],
                 modal: true)
+        case .scope:
+            // A MONITOR, not a processor: never enters the engine graph.
+            // Each channel selects a node whose tap slot the poller reads via
+            // `render_window` — random-access closed-form evaluation on the
+            // C++ data plane, so tracing is free of the audio path and stays
+            // live through compiles. Patching a channel to a non-Out node
+            // asks the next relower for `taps: true` (each tap re-emits its
+            // upstream cone, so taps are paid for only while a scope looks).
+            // `window` is view state (the trace's time span), not a param.
+            return NodeSpec(
+                title: "Scope", accent: Color(hex: 0x7FE08C), summing: false,
+                inlets: ["ch1", "ch2", "ch3", "ch4"], outlets: [],
+                knobs: [KnobSpec(name: "window", min: 0.002, max: 0.35, def: 0.02, log: true, unit: "s")],
+                monitor: true, gridOverride: (w: 16, h: 12))
         case .out:
             return NodeSpec(
                 title: "Out · dac", accent: Color(hex: 0xFF8A8A), summing: true,

--- a/reversible/Sources/Reversible/PatchDocument.swift
+++ b/reversible/Sources/Reversible/PatchDocument.swift
@@ -1,0 +1,182 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// The patch as a FILE. `PatchModel.serialize()` targets the engine — it drops
+/// monitors, positions, and hues because the kernel has no use for them. A
+/// document is the SURFACE: everything you'd lose by quitting, including the
+/// scope you left watching the mix and where you put it.
+///
+/// Deliberately a flat, hand-readable JSON term (same shape family as the
+/// engine graph) rather than an opaque archive: a patch is small, diffable,
+/// and worth being able to hand-edit.
+struct PatchDocument: Codable {
+    struct Node: Codable {
+        let id: String
+        let kind: NodeKind
+        let x: Double
+        let y: Double
+        let hue: Double
+        let values: [String: Double]
+        /// inlet port → ordered source node ids
+        let inputs: [String: [String]]
+    }
+
+    /// Bumped only on a breaking shape change; a reader refuses a version it
+    /// doesn't know rather than silently loading half a patch.
+    static let currentVersion = 1
+
+    var version = PatchDocument.currentVersion
+    var nodes: [Node]
+    /// stable z/render order (also the order inlet menus list sources in)
+    var order: [String]
+    var velocity: Double
+    var panX: Double
+    var panY: Double
+    var autoArrange: Bool
+
+    static let fileExtension = "rvpatch"
+
+    /// A dynamic UTI is fine here — the panels only need it to filter and to
+    /// stamp the extension, and a bare SwiftPM binary has no Info.plist to
+    /// declare an exported type in.
+    static var contentType: UTType {
+        UTType(filenameExtension: fileExtension) ?? .json
+    }
+}
+
+enum PatchDocumentError: LocalizedError {
+    case unsupportedVersion(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedVersion(let v):
+            return "patch version \(v) is newer than this build (\(PatchDocument.currentVersion))"
+        }
+    }
+}
+
+// ── Model ↔ document ──────────────────────────────────────────────────────
+extension PatchModel {
+    func makeDocument() -> PatchDocument {
+        PatchDocument(
+            nodes: order.compactMap { nodes[$0] }.map { n in
+                PatchDocument.Node(
+                    id: n.id, kind: n.kind,
+                    x: n.position.x, y: n.position.y, hue: n.hue,
+                    values: n.values, inputs: n.inputs)
+            },
+            order: order,
+            velocity: velocity,
+            panX: pan.width, panY: pan.height,
+            autoArrange: autoArrange)
+    }
+
+    /// Adopt a document as the live patch. Everything is rebuilt through the
+    /// same invariants `addNode` maintains — a knob absent from the file takes
+    /// its spec default, an inlet the spec no longer has is dropped, and an
+    /// edge to a node that isn't in the file is dropped — so a patch written by
+    /// an older build (or hand-edited) loads as the nearest VALID patch rather
+    /// than a half-wired one.
+    func apply(_ doc: PatchDocument) async throws {
+        guard doc.version <= PatchDocument.currentVersion else {
+            throw PatchDocumentError.unsupportedVersion(doc.version)
+        }
+        let known = Set(doc.nodes.map(\.id))
+        var fresh: [String: PatchNode] = [:]
+        for d in doc.nodes {
+            let spec = d.kind.spec
+            var values: [String: Double] = [:]
+            for k in spec.knobs { values[k.name] = d.values[k.name] ?? k.def }
+            var inputs: [String: [String]] = [:]
+            for p in spec.inlets {
+                inputs[p] = (d.inputs[p] ?? []).filter { known.contains($0) && $0 != d.id }
+            }
+            fresh[d.id] = PatchNode(
+                id: d.id, kind: d.kind,
+                position: CGPoint(x: d.x, y: d.y),
+                values: values, inputs: inputs, hue: d.hue)
+        }
+        nodes = fresh
+        // The file's order is authoritative, but never let it lose or invent a
+        // node (a hand-edit that forgets an id would make it unrenderable).
+        var seen = Set<String>()
+        order = doc.order.filter { known.contains($0) && seen.insert($0).inserted }
+            + doc.nodes.map(\.id).filter { !seen.contains($0) }
+        pan = CGSize(width: doc.panX, height: doc.panY)
+        autoArrange = doc.autoArrange
+        velocity = doc.velocity
+        // New nodes must not collide with loaded ids: resume the counter past
+        // the highest numeric suffix in the file.
+        adoptCounter(from: known)
+
+        await pushGraph()
+        // pushGraph re-applies a non-default velocity after a COLD compile, but
+        // a load whose graph happens to match what's already running skips the
+        // compile entirely — so drive the clock here regardless.
+        setVelocity(doc.velocity)
+    }
+
+    /// Reset to the boot patch (Out + one Osc), forgetting the file.
+    func newPatch() async {
+        nodes = [:]
+        order = []
+        pan = .zero
+        resetCounter()
+        seedBootPatch()
+        documentURL = nil
+        await pushGraph()
+        setVelocity(velocity)
+    }
+
+    // ── File I/O ──────────────────────────────────────────────────────────
+    func write(to url: URL) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try enc.encode(makeDocument()).write(to: url, options: .atomic)
+        documentURL = url
+        setStatus("saved · \(url.lastPathComponent)", isError: false)
+    }
+
+    func read(from url: URL) async throws {
+        let doc = try JSONDecoder().decode(PatchDocument.self, from: Data(contentsOf: url))
+        try await apply(doc)
+        documentURL = url
+        setStatus("loaded · \(url.lastPathComponent)", isError: false)
+    }
+
+    /// Save to the open file, or ask where if there isn't one yet.
+    func save() {
+        guard let url = documentURL else { return saveAs() }
+        do { try write(to: url) } catch {
+            setStatus("save: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    func saveAs() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [PatchDocument.contentType]
+        panel.nameFieldStringValue =
+            documentURL?.lastPathComponent ?? "patch.\(PatchDocument.fileExtension)"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, var url = panel.url else { return }
+        if url.pathExtension.isEmpty {
+            url.appendPathExtension(PatchDocument.fileExtension)
+        }
+        do { try write(to: url) } catch {
+            setStatus("save: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    func open() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [PatchDocument.contentType, .json]
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task {
+            do { try await read(from: url) } catch {
+                setStatus("open: \(error.localizedDescription)", isError: true)
+            }
+        }
+    }
+}

--- a/reversible/Sources/Reversible/PatchDocumentV2.swift
+++ b/reversible/Sources/Reversible/PatchDocumentV2.swift
@@ -1,0 +1,1030 @@
+import Foundation
+
+// MARK: - Version 2 authored document
+
+struct PatchDocumentV2: Codable, Equatable {
+    static let currentVersion = 2
+
+    var vocabulary: PatchVocabularyReferenceV2
+    var sceneMetadata: [String: JSONValue]
+    var nodes: [PatchNodeV2]
+    var monitors: [PatchClientMonitorV2]
+    var output: String?
+    var transport: PatchTransportV2
+    var presentation: PatchPresentationV2
+    var unknownFields: [String: JSONValue]
+
+    init(
+        vocabulary: PatchVocabularyReferenceV2,
+        sceneMetadata: [String: JSONValue],
+        nodes: [PatchNodeV2],
+        monitors: [PatchClientMonitorV2],
+        output: String?,
+        transport: PatchTransportV2,
+        presentation: PatchPresentationV2,
+        unknownFields: [String: JSONValue]
+    ) {
+        self.vocabulary = vocabulary
+        self.sceneMetadata = sceneMetadata
+        self.nodes = nodes
+        self.monitors = monitors
+        self.output = output
+        self.transport = transport
+        self.presentation = presentation
+        self.unknownFields = unknownFields
+    }
+
+    init(from decoder: Decoder) throws {
+        let raw = try JSONValue(from: decoder)
+        self = try Self.parse(raw, path: "$" )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try jsonValue.encode(to: encoder)
+    }
+
+    static func decode(from data: Data) throws -> PatchDocumentV2 {
+        try JSONDecoder().decode(PatchDocumentV2.self, from: data)
+    }
+
+    func encoded(prettyPrinted: Bool = true) throws -> Data {
+        let encoder = JSONEncoder()
+        if prettyPrinted {
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        } else {
+            encoder.outputFormatting = [.sortedKeys]
+        }
+        return try encoder.encode(self)
+    }
+
+    private static func parse(_ raw: JSONValue, path: String) throws -> PatchDocumentV2 {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let version = try PatchV2JSON.integer(
+            PatchV2JSON.take("version", from: &object, path: path),
+            path: "\(path).version"
+        )
+        guard version == currentVersion else {
+            throw PatchDocumentV2Error.unsupportedVersion(version)
+        }
+
+        let vocabulary = try PatchVocabularyReferenceV2.parse(
+            PatchV2JSON.take("vocabulary", from: &object, path: path),
+            path: "\(path).vocabulary"
+        )
+        let sceneMetadata = try PatchV2JSON.object(
+            PatchV2JSON.take("scene", from: &object, path: path),
+            path: "\(path).scene"
+        )
+        let nodeValues = try PatchV2JSON.array(
+            PatchV2JSON.take("nodes", from: &object, path: path),
+            path: "\(path).nodes"
+        )
+        let nodes = try nodeValues.enumerated().map {
+            try PatchNodeV2.parse($0.element, path: "\(path).nodes[\($0.offset)]")
+        }
+        let monitorValues = try PatchV2JSON.array(
+            PatchV2JSON.take("monitors", from: &object, path: path),
+            path: "\(path).monitors"
+        )
+        let monitors = try monitorValues.enumerated().map {
+            try PatchClientMonitorV2.parse($0.element, path: "\(path).monitors[\($0.offset)]")
+        }
+        let outputValue = try PatchV2JSON.take("output", from: &object, path: path)
+        let output: String?
+        if outputValue == .null {
+            output = nil
+        } else {
+            output = try PatchV2JSON.string(outputValue, path: "\(path).output")
+        }
+        let transport = try PatchTransportV2.parse(
+            PatchV2JSON.take("transport", from: &object, path: path),
+            path: "\(path).transport"
+        )
+        let presentation = try PatchPresentationV2.parse(
+            PatchV2JSON.take("presentation", from: &object, path: path),
+            path: "\(path).presentation"
+        )
+
+        return PatchDocumentV2(
+            vocabulary: vocabulary,
+            sceneMetadata: sceneMetadata,
+            nodes: nodes,
+            monitors: monitors,
+            output: output,
+            transport: transport,
+            presentation: presentation,
+            unknownFields: object
+        )
+    }
+
+    var jsonValue: JSONValue {
+        var object = unknownFields
+        object["version"] = .number(Double(Self.currentVersion))
+        object["vocabulary"] = vocabulary.jsonValue
+        object["scene"] = .object(sceneMetadata)
+        object["nodes"] = .array(nodes.map(\.jsonValue))
+        object["monitors"] = .array(monitors.map(\.jsonValue))
+        object["output"] = output.map(JSONValue.string) ?? .null
+        object["transport"] = transport.jsonValue
+        object["presentation"] = presentation.jsonValue
+        return .object(object)
+    }
+}
+
+struct PatchVocabularyReferenceV2: Equatable {
+    var schemaID: String
+    var schemaVersion: Int
+    var fingerprint: String
+    var unknownFields: [String: JSONValue]
+
+    init(
+        schemaID: String,
+        schemaVersion: Int,
+        fingerprint: String,
+        unknownFields: [String: JSONValue]
+    ) {
+        self.schemaID = schemaID
+        self.schemaVersion = schemaVersion
+        self.fingerprint = fingerprint
+        self.unknownFields = unknownFields
+    }
+
+    init(vocabulary: EngineVocabulary) {
+        schemaID = vocabulary.schemaID
+        schemaVersion = vocabulary.schemaVersion
+        fingerprint = vocabulary.fingerprint
+        unknownFields = [:]
+    }
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let schemaID = try PatchV2JSON.string(
+            PatchV2JSON.take("schema", from: &object, path: path),
+            path: "\(path).schema"
+        )
+        let schemaVersion = try PatchV2JSON.integer(
+            PatchV2JSON.take("schema_version", from: &object, path: path),
+            path: "\(path).schema_version"
+        )
+        let fingerprint = try PatchV2JSON.string(
+            PatchV2JSON.take("fingerprint", from: &object, path: path),
+            path: "\(path).fingerprint"
+        )
+        return Self(
+            schemaID: schemaID,
+            schemaVersion: schemaVersion,
+            fingerprint: fingerprint,
+            unknownFields: object
+        )
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["schema"] = .string(schemaID)
+        object["schema_version"] = .number(Double(schemaVersion))
+        object["fingerprint"] = .string(fingerprint)
+        return .object(object)
+    }
+}
+
+struct PatchNodeV2: Equatable {
+    var id: String
+    var kind: NodeKindID
+    /// Structural JSON remains lossless; the client does not reduce it to
+    /// numeric knobs or discard fields it cannot currently render.
+    var structuralParams: [String: JSONValue]
+    /// inlet name -> exact authored source order.
+    var inputs: [String: [String]]
+    var unknownFields: [String: JSONValue]
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let id = try PatchV2JSON.string(
+            PatchV2JSON.take("id", from: &object, path: path),
+            path: "\(path).id"
+        )
+        let kindText = try PatchV2JSON.string(
+            PatchV2JSON.take("kind", from: &object, path: path),
+            path: "\(path).kind"
+        )
+        let kind = try NodeKindID(validating: kindText)
+        let params = try PatchV2JSON.object(
+            PatchV2JSON.take("params", from: &object, path: path),
+            path: "\(path).params"
+        )
+        let inputs = try PatchV2JSON.inputs(
+            PatchV2JSON.take("in", from: &object, path: path),
+            path: "\(path).in"
+        )
+        return Self(
+            id: id,
+            kind: kind,
+            structuralParams: params,
+            inputs: inputs,
+            unknownFields: object
+        )
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["id"] = .string(id)
+        object["kind"] = .string(kind.rawValue)
+        object["params"] = .object(structuralParams)
+        object["in"] = PatchV2JSON.inputsValue(inputs)
+        return .object(object)
+    }
+}
+
+struct PatchClientMonitorV2: Equatable {
+    var id: String
+    var kind: ClientMonitorKindID
+    var state: [String: JSONValue]
+    var inputs: [String: [String]]
+    var unknownFields: [String: JSONValue]
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let id = try PatchV2JSON.string(
+            PatchV2JSON.take("id", from: &object, path: path),
+            path: "\(path).id"
+        )
+        let kindText = try PatchV2JSON.string(
+            PatchV2JSON.take("kind", from: &object, path: path),
+            path: "\(path).kind"
+        )
+        let kind = try ClientMonitorKindID(validating: kindText)
+        let state = try PatchV2JSON.object(
+            PatchV2JSON.take("state", from: &object, path: path),
+            path: "\(path).state"
+        )
+        let inputs = try PatchV2JSON.inputs(
+            PatchV2JSON.take("in", from: &object, path: path),
+            path: "\(path).in"
+        )
+        return Self(id: id, kind: kind, state: state, inputs: inputs, unknownFields: object)
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["id"] = .string(id)
+        object["kind"] = .string(kind.rawValue)
+        object["state"] = .object(state)
+        object["in"] = PatchV2JSON.inputsValue(inputs)
+        return .object(object)
+    }
+}
+
+struct PatchTransportV2: Equatable {
+    var velocity: Double
+    var position: Double?
+    var unknownFields: [String: JSONValue]
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let velocity = try PatchV2JSON.number(
+            PatchV2JSON.take("velocity", from: &object, path: path),
+            path: "\(path).velocity"
+        )
+        let position: Double?
+        if let value = object.removeValue(forKey: "position") {
+            position = value == .null ? nil : try PatchV2JSON.number(value, path: "\(path).position")
+        } else {
+            position = nil
+        }
+        return Self(velocity: velocity, position: position, unknownFields: object)
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["velocity"] = .number(velocity)
+        if let position {
+            object["position"] = .number(position)
+        }
+        return .object(object)
+    }
+}
+
+struct PatchPositionV2: Equatable {
+    var x: Double
+    var y: Double
+    var hue: Double
+    var unknownFields: [String: JSONValue]
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let x = try PatchV2JSON.number(
+            PatchV2JSON.take("x", from: &object, path: path),
+            path: "\(path).x"
+        )
+        let y = try PatchV2JSON.number(
+            PatchV2JSON.take("y", from: &object, path: path),
+            path: "\(path).y"
+        )
+        let hue = try PatchV2JSON.number(
+            PatchV2JSON.take("hue", from: &object, path: path),
+            path: "\(path).hue"
+        )
+        return Self(x: x, y: y, hue: hue, unknownFields: object)
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["x"] = .number(x)
+        object["y"] = .number(y)
+        object["hue"] = .number(hue)
+        return .object(object)
+    }
+}
+
+struct PatchPresentationV2: Equatable {
+    var order: [String]
+    var positions: [String: PatchPositionV2]
+    var panX: Double
+    var panY: Double
+    var autoArrange: Bool
+    var unknownFields: [String: JSONValue]
+
+    fileprivate static func parse(_ raw: JSONValue, path: String) throws -> Self {
+        var object = try PatchV2JSON.object(raw, path: path)
+        let order = try PatchV2JSON.strings(
+            PatchV2JSON.take("order", from: &object, path: path),
+            path: "\(path).order"
+        )
+        let rawPositions = try PatchV2JSON.object(
+            PatchV2JSON.take("positions", from: &object, path: path),
+            path: "\(path).positions"
+        )
+        var positions: [String: PatchPositionV2] = [:]
+        for id in rawPositions.keys.sorted() {
+            positions[id] = try PatchPositionV2.parse(
+                rawPositions[id]!,
+                path: "\(path).positions.\(id)"
+            )
+        }
+        let panX = try PatchV2JSON.number(
+            PatchV2JSON.take("pan_x", from: &object, path: path),
+            path: "\(path).pan_x"
+        )
+        let panY = try PatchV2JSON.number(
+            PatchV2JSON.take("pan_y", from: &object, path: path),
+            path: "\(path).pan_y"
+        )
+        let autoArrange = try PatchV2JSON.bool(
+            PatchV2JSON.take("auto_arrange", from: &object, path: path),
+            path: "\(path).auto_arrange"
+        )
+        return Self(
+            order: order,
+            positions: positions,
+            panX: panX,
+            panY: panY,
+            autoArrange: autoArrange,
+            unknownFields: object
+        )
+    }
+
+    fileprivate var jsonValue: JSONValue {
+        var object = unknownFields
+        object["order"] = .array(order.map(JSONValue.string))
+        object["positions"] = .object(positions.mapValues(\.jsonValue))
+        object["pan_x"] = .number(panX)
+        object["pan_y"] = .number(panY)
+        object["auto_arrange"] = .bool(autoArrange)
+        return .object(object)
+    }
+}
+
+// MARK: - Explicit v1 migration
+
+struct PatchDocumentV1Migrator {
+    static func migrate(
+        data: Data,
+        vocabulary: EngineVocabulary
+    ) throws -> PatchDocumentMigrationResult {
+        let raw = try JSONDecoder().decode(JSONValue.self, from: data)
+        var root = try PatchV2JSON.object(raw, path: "$")
+        let version = try PatchV2JSON.integer(
+            PatchV2JSON.take("version", from: &root, path: "$"),
+            path: "$.version"
+        )
+        guard version == 1 else {
+            throw PatchDocumentV2Error.expectedV1(version)
+        }
+
+        let rawNodes = try PatchV2JSON.array(
+            PatchV2JSON.take("nodes", from: &root, path: "$"),
+            path: "$.nodes"
+        )
+        let order = try PatchV2JSON.strings(
+            PatchV2JSON.take("order", from: &root, path: "$"),
+            path: "$.order"
+        )
+        let velocity = try PatchV2JSON.number(
+            PatchV2JSON.take("velocity", from: &root, path: "$"),
+            path: "$.velocity"
+        )
+        let panX = try PatchV2JSON.number(
+            PatchV2JSON.take("panX", from: &root, path: "$"),
+            path: "$.panX"
+        )
+        let panY = try PatchV2JSON.number(
+            PatchV2JSON.take("panY", from: &root, path: "$"),
+            path: "$.panY"
+        )
+        let autoArrange = try PatchV2JSON.bool(
+            PatchV2JSON.take("autoArrange", from: &root, path: "$"),
+            path: "$.autoArrange"
+        )
+
+        var nodes: [PatchNodeV2] = []
+        var monitors: [PatchClientMonitorV2] = []
+        var positions: [String: PatchPositionV2] = [:]
+        var facts: [PatchMigrationFact] = [
+            .init(code: .sourceVersion, path: "$.version", detail: "decoded raw v1 JSON"),
+        ]
+
+        for (index, rawNode) in rawNodes.enumerated() {
+            let path = "$.nodes[\(index)]"
+            var object = try PatchV2JSON.object(rawNode, path: path)
+            let id = try PatchV2JSON.string(
+                PatchV2JSON.take("id", from: &object, path: path),
+                path: "\(path).id"
+            )
+            let kindText = try PatchV2JSON.string(
+                PatchV2JSON.take("kind", from: &object, path: path),
+                path: "\(path).kind"
+            )
+            let x = try PatchV2JSON.number(
+                PatchV2JSON.take("x", from: &object, path: path),
+                path: "\(path).x"
+            )
+            let y = try PatchV2JSON.number(
+                PatchV2JSON.take("y", from: &object, path: path),
+                path: "\(path).y"
+            )
+            let hue = try PatchV2JSON.number(
+                PatchV2JSON.take("hue", from: &object, path: path),
+                path: "\(path).hue"
+            )
+            let values = try PatchV2JSON.object(
+                PatchV2JSON.take("values", from: &object, path: path),
+                path: "\(path).values"
+            )
+            let inputs = try PatchV2JSON.inputs(
+                PatchV2JSON.take("inputs", from: &object, path: path),
+                path: "\(path).inputs"
+            )
+            positions[id] = PatchPositionV2(x: x, y: y, hue: hue, unknownFields: [:])
+
+            if kindText == "scope" {
+                let monitorKind = try ClientMonitorKindID(validating: "client.monitor.scope")
+                monitors.append(PatchClientMonitorV2(
+                    id: id,
+                    kind: monitorKind,
+                    state: values,
+                    inputs: inputs,
+                    unknownFields: PatchV2JSON.preserveLegacyUnknown(
+                        object,
+                        collidingWith: ["id", "kind", "state", "in"]
+                    )
+                ))
+                facts.append(.init(
+                    code: .separatedClientMonitor,
+                    path: path,
+                    detail: "preserved legacy scope as client.monitor.scope"
+                ))
+            } else {
+                let kind = try NodeKindID(validating: kindText)
+                nodes.append(PatchNodeV2(
+                    id: id,
+                    kind: kind,
+                    structuralParams: values,
+                    inputs: inputs,
+                    unknownFields: PatchV2JSON.preserveLegacyUnknown(
+                        object,
+                        collidingWith: ["id", "kind", "params", "in"]
+                    )
+                ))
+                facts.append(.init(
+                    code: .preservedAuthoredNode,
+                    path: path,
+                    detail: "preserved \(id) as kind \(kindText)"
+                ))
+            }
+            for key in object.keys.sorted() {
+                facts.append(.init(
+                    code: .preservedUnknownNodeField,
+                    path: "\(path).\(key)",
+                    detail: "preserved unknown v1 node field"
+                ))
+            }
+        }
+
+        let outputCandidates = nodes.filter { $0.kind.rawValue == "out" }.map(\.id)
+        let output = outputCandidates.count == 1 ? outputCandidates[0] : nil
+        for key in root.keys.sorted() {
+            facts.append(.init(
+                code: .preservedUnknownTopLevelField,
+                path: "$.\(key)",
+                detail: "preserved unknown v1 top-level field"
+            ))
+        }
+        facts.append(.init(
+            code: .explicitSaveRequired,
+            path: "$",
+            detail: "migration is in memory; an explicit save is required to write v2"
+        ))
+
+        let document = PatchDocumentV2(
+            vocabulary: PatchVocabularyReferenceV2(vocabulary: vocabulary),
+            sceneMetadata: [
+                "migration_source": .string("rvpatch-v1"),
+            ],
+            nodes: nodes,
+            monitors: monitors,
+            output: output,
+            transport: PatchTransportV2(velocity: velocity, position: nil, unknownFields: [:]),
+            presentation: PatchPresentationV2(
+                order: order,
+                positions: positions,
+                panX: panX,
+                panY: panY,
+                autoArrange: autoArrange,
+                unknownFields: [:]
+            ),
+            unknownFields: PatchV2JSON.preserveLegacyUnknown(
+                root,
+                collidingWith: [
+                    "version", "vocabulary", "scene", "nodes", "monitors",
+                    "output", "transport", "presentation",
+                ]
+            )
+        )
+        let validation = document.validate(against: vocabulary)
+        return PatchDocumentMigrationResult(
+            document: document,
+            report: PatchMigrationReport(facts: facts, blockers: validation.blockers)
+        )
+    }
+}
+
+struct PatchDocumentMigrationResult: Equatable {
+    var document: PatchDocumentV2
+    var report: PatchMigrationReport
+    /// Migration never writes through to the opened v1 URL. The UI may clear
+    /// this state only after the user invokes an explicit v2 save operation.
+    let requiresExplicitV2Save = true
+}
+
+struct PatchMigrationReport: Equatable {
+    var facts: [PatchMigrationFact]
+    var blockers: [PatchDocumentBlocker]
+
+    var canCompile: Bool { blockers.isEmpty }
+}
+
+struct PatchMigrationFact: Equatable {
+    enum Code: String, Equatable {
+        case sourceVersion
+        case preservedAuthoredNode
+        case separatedClientMonitor
+        case preservedUnknownTopLevelField
+        case preservedUnknownNodeField
+        case explicitSaveRequired
+    }
+
+    var code: Code
+    var path: String
+    var detail: String
+}
+
+// MARK: - Loss-aware validation
+
+struct PatchDocumentValidationReport: Equatable {
+    var blockers: [PatchDocumentBlocker]
+    var canCompile: Bool { blockers.isEmpty }
+}
+
+struct PatchDocumentBlocker: Equatable {
+    enum Code: String, Equatable {
+        case vocabularyMismatch
+        case invalidID
+        case duplicateID
+        case invalidOrder
+        case invalidPosition
+        case nonFiniteNumber
+        case danglingEdge
+        case selfEdge
+        case monitorAsEngineSource
+        case unknownKind
+        case unknownPort
+        case incompatibleConnection
+        case arityExceeded
+        case cycle
+        case invalidOutput
+    }
+
+    var code: Code
+    var path: String
+    var detail: String
+}
+
+extension PatchDocumentV2 {
+    func validate(against vocabulary: EngineVocabulary? = nil) -> PatchDocumentValidationReport {
+        var blockers: [PatchDocumentBlocker] = []
+        let block: (PatchDocumentBlocker.Code, String, String) -> Void = { code, path, detail in
+            blockers.append(.init(code: code, path: path, detail: detail))
+        }
+
+        if let vocabulary,
+           vocabulary.schemaID != self.vocabulary.schemaID
+            || vocabulary.schemaVersion != self.vocabulary.schemaVersion
+            || vocabulary.fingerprint != self.vocabulary.fingerprint {
+            block(.vocabularyMismatch, "$.vocabulary", "document vocabulary does not match the running engine")
+        }
+
+        let allItems: [(id: String, path: String)] =
+            nodes.enumerated().map { ($0.element.id, "$.nodes[\($0.offset)].id") }
+            + monitors.enumerated().map { ($0.element.id, "$.monitors[\($0.offset)].id") }
+        var seenIDs = Set<String>()
+        for item in allItems {
+            if item.id.isEmpty || item.id != item.id.trimmingCharacters(in: .whitespacesAndNewlines) {
+                block(.invalidID, item.path, "ID must be nonempty with no surrounding whitespace")
+            }
+            if !seenIDs.insert(item.id).inserted {
+                block(.duplicateID, item.path, "duplicate ID '\(item.id)'")
+            }
+        }
+        let allIDs = Set(allItems.map(\.id))
+
+        var seenOrder = Set<String>()
+        for (index, id) in presentation.order.enumerated() {
+            if !allIDs.contains(id) {
+                block(.invalidOrder, "$.presentation.order[\(index)]", "order contains unknown ID '\(id)'")
+            } else if !seenOrder.insert(id).inserted {
+                block(.invalidOrder, "$.presentation.order[\(index)]", "order repeats ID '\(id)'")
+            }
+        }
+        for id in allItems.map(\.id) where !seenOrder.contains(id) {
+            block(.invalidOrder, "$.presentation.order", "order omits ID '\(id)'")
+        }
+        for id in presentation.positions.keys.sorted() where !allIDs.contains(id) {
+            block(.invalidPosition, "$.presentation.positions.\(id)", "position belongs to unknown ID")
+        }
+        for item in allItems {
+            guard let position = presentation.positions[item.id] else {
+                block(.invalidPosition, "$.presentation.positions", "missing position for '\(item.id)'")
+                continue
+            }
+            if !position.x.isFinite || !position.y.isFinite || !position.hue.isFinite {
+                block(.invalidPosition, "$.presentation.positions.\(item.id)", "position/hue must be finite")
+            }
+        }
+        if !presentation.panX.isFinite || !presentation.panY.isFinite {
+            block(.invalidPosition, "$.presentation", "canvas pan must be finite")
+        }
+        if !transport.velocity.isFinite || transport.position?.isFinite == false {
+            block(.nonFiniteNumber, "$.transport", "transport coordinates must be finite")
+        }
+
+        validateFiniteJSON(&blockers)
+
+        let nodeIDs = Set(nodes.map(\.id))
+        let monitorIDs = Set(monitors.map(\.id))
+        for (nodeIndex, node) in nodes.enumerated() {
+            for port in node.inputs.keys.sorted() {
+                let sources = node.inputs[port] ?? []
+                for (sourceIndex, source) in sources.enumerated() {
+                    let path = "$.nodes[\(nodeIndex)].in.\(port)[\(sourceIndex)]"
+                    if source == node.id {
+                        block(.selfEdge, path, "self edge '\(source)' -> '\(node.id)'")
+                    } else if monitorIDs.contains(source) {
+                        block(.monitorAsEngineSource, path, "client monitor '\(source)' cannot feed an engine node")
+                    } else if !nodeIDs.contains(source) {
+                        block(.danglingEdge, path, "unknown source ID '\(source)'")
+                    }
+                }
+            }
+        }
+        for (monitorIndex, monitor) in monitors.enumerated() {
+            for port in monitor.inputs.keys.sorted() {
+                for (sourceIndex, source) in (monitor.inputs[port] ?? []).enumerated() {
+                    let path = "$.monitors[\(monitorIndex)].in.\(port)[\(sourceIndex)]"
+                    if source == monitor.id {
+                        block(.selfEdge, path, "monitor cannot observe itself")
+                    } else if !nodeIDs.contains(source) {
+                        block(.danglingEdge, path, "monitor source '\(source)' is not an engine node")
+                    }
+                }
+            }
+        }
+
+        if let vocabulary {
+            validateVocabularySemantics(vocabulary, blockers: &blockers)
+        }
+        validateOutput(vocabulary: vocabulary, blockers: &blockers)
+        validateCycles(blockers: &blockers)
+        return PatchDocumentValidationReport(blockers: blockers)
+    }
+
+    private func validateVocabularySemantics(
+        _ vocabulary: EngineVocabulary,
+        blockers: inout [PatchDocumentBlocker]
+    ) {
+        for (nodeIndex, node) in nodes.enumerated() {
+            guard vocabulary.descriptor(for: node.kind) != nil else {
+                blockers.append(.init(
+                    code: .unknownKind,
+                    path: "$.nodes[\(nodeIndex)].kind",
+                    detail: "kind '\(node.kind.rawValue)' is not served by this engine"
+                ))
+                continue
+            }
+            for port in node.inputs.keys.sorted() {
+                guard vocabulary.descriptor(for: node.kind)?.port(named: port)?.isInlet == true else {
+                    blockers.append(.init(
+                        code: .unknownPort,
+                        path: "$.nodes[\(nodeIndex)].in.\(port)",
+                        detail: "port '\(port)' is not a served inlet on '\(node.kind.rawValue)'"
+                    ))
+                    continue
+                }
+                for (sourceIndex, sourceID) in (node.inputs[port] ?? []).enumerated() {
+                    guard let source = nodes.first(where: { $0.id == sourceID }) else { continue }
+                    let decision = vocabulary.connectionDecision(
+                        from: source.kind,
+                        to: node.kind,
+                        port: port,
+                        existingConnectionCount: sourceIndex
+                    )
+                    switch decision {
+                    case .allowed:
+                        break
+                    case .inletAtCapacity:
+                        blockers.append(.init(
+                            code: .arityExceeded,
+                            path: "$.nodes[\(nodeIndex)].in.\(port)[\(sourceIndex)]",
+                            detail: "single inlet has more than one authored source"
+                        ))
+                    case .unknownSourceKind, .unknownDestinationKind:
+                        // The node-level unknown-kind blocker is more precise and
+                        // the original edge remains serialized.
+                        break
+                    default:
+                        blockers.append(.init(
+                            code: .incompatibleConnection,
+                            path: "$.nodes[\(nodeIndex)].in.\(port)[\(sourceIndex)]",
+                            detail: "descriptor-derived connection rejection: \(decision)"
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    private func validateOutput(
+        vocabulary: EngineVocabulary?,
+        blockers: inout [PatchDocumentBlocker]
+    ) {
+        guard let output else {
+            blockers.append(.init(
+                code: .invalidOutput,
+                path: "$.output",
+                detail: "document must select exactly one output"
+            ))
+            return
+        }
+        guard let selected = nodes.first(where: { $0.id == output }) else {
+            blockers.append(.init(
+                code: .invalidOutput,
+                path: "$.output",
+                detail: "output '\(output)' is not an authored engine node"
+            ))
+            return
+        }
+        guard let vocabulary else { return }
+        guard vocabulary.descriptor(for: selected.kind)?.outlet == nil else {
+            blockers.append(.init(
+                code: .invalidOutput,
+                path: "$.output",
+                detail: "selected output kind '\(selected.kind.rawValue)' is not an engine sink"
+            ))
+            return
+        }
+        let sinks = nodes.filter {
+            vocabulary.descriptor(for: $0.kind)?.outlet == nil
+        }
+        if sinks.count != 1 || sinks[0].id != output {
+            blockers.append(.init(
+                code: .invalidOutput,
+                path: "$.nodes",
+                detail: "document must author one engine sink matching $.output"
+            ))
+        }
+    }
+
+    private func validateCycles(blockers: inout [PatchDocumentBlocker]) {
+        let nodeByID = Dictionary(nodes.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        var state: [String: Int] = [:]
+        var stack: [String] = []
+        var found = false
+
+        func visit(_ id: String) {
+            guard !found, let node = nodeByID[id] else { return }
+            state[id] = 1
+            stack.append(id)
+            for port in node.inputs.keys.sorted() {
+                for source in node.inputs[port] ?? [] where nodeByID[source] != nil {
+                    if state[source] == 1 {
+                        let start = stack.firstIndex(of: source) ?? 0
+                        let cycle = Array(stack[start...]) + [source]
+                        blockers.append(.init(
+                            code: .cycle,
+                            path: "$.nodes",
+                            detail: cycle.joined(separator: " -> ")
+                        ))
+                        found = true
+                        return
+                    }
+                    if state[source] == nil { visit(source) }
+                    if found { return }
+                }
+            }
+            _ = stack.popLast()
+            state[id] = 2
+        }
+
+        for node in nodes where state[node.id] == nil {
+            visit(node.id)
+            if found { break }
+        }
+    }
+
+    private func validateFiniteJSON(_ blockers: inout [PatchDocumentBlocker]) {
+        func walk(_ value: JSONValue, path: String) {
+            switch value {
+            case .number(let number) where !number.isFinite:
+                blockers.append(.init(
+                    code: .nonFiniteNumber,
+                    path: path,
+                    detail: "JSON number must be finite"
+                ))
+            case .array(let values):
+                for (index, value) in values.enumerated() {
+                    walk(value, path: "\(path)[\(index)]")
+                }
+            case .object(let object):
+                for key in object.keys.sorted() {
+                    walk(object[key]!, path: "\(path).\(key)")
+                }
+            default:
+                break
+            }
+        }
+
+        walk(.object(sceneMetadata), path: "$.scene")
+        walk(.object(unknownFields), path: "$.__unknown")
+        walk(.object(vocabulary.unknownFields), path: "$.vocabulary.__unknown")
+        walk(.object(transport.unknownFields), path: "$.transport.__unknown")
+        walk(.object(presentation.unknownFields), path: "$.presentation.__unknown")
+        for (index, node) in nodes.enumerated() {
+            walk(.object(node.structuralParams), path: "$.nodes[\(index)].params")
+            walk(.object(node.unknownFields), path: "$.nodes[\(index)].__unknown")
+        }
+        for (index, monitor) in monitors.enumerated() {
+            walk(.object(monitor.state), path: "$.monitors[\(index)].state")
+            walk(.object(monitor.unknownFields), path: "$.monitors[\(index)].__unknown")
+        }
+        for id in presentation.positions.keys.sorted() {
+            if let position = presentation.positions[id] {
+                walk(.object(position.unknownFields), path: "$.presentation.positions.\(id).__unknown")
+            }
+        }
+    }
+}
+
+enum PatchDocumentV2Error: Error, Equatable, LocalizedError {
+    case unsupportedVersion(Int)
+    case expectedV1(Int)
+    case missing(path: String)
+    case type(path: String, expected: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedVersion(let version):
+            return "unsupported patch document version \(version); expected 2"
+        case .expectedV1(let version):
+            return "v1 migrator received document version \(version)"
+        case .missing(let path):
+            return "missing required patch field \(path)"
+        case .type(let path, let expected):
+            return "invalid patch field \(path); expected \(expected)"
+        }
+    }
+}
+
+// MARK: - Closed JSON shape helpers
+
+private enum PatchV2JSON {
+    /// V1 had no reserved knowledge of v2 field names. Preserve an unknown v1
+    /// field even if its name now collides with a typed v2 key by nesting only
+    /// those collisions in a migration envelope. If the source already used
+    /// the envelope name, that original value is nested too.
+    static func preserveLegacyUnknown(
+        _ fields: [String: JSONValue],
+        collidingWith reserved: Set<String>
+    ) -> [String: JSONValue] {
+        let envelope = "_legacy_v1_reserved_fields"
+        var direct: [String: JSONValue] = [:]
+        var collisions: [String: JSONValue] = [:]
+        for key in fields.keys.sorted() {
+            if reserved.contains(key) || key == envelope {
+                collisions[key] = fields[key]
+            } else {
+                direct[key] = fields[key]
+            }
+        }
+        if !collisions.isEmpty {
+            direct[envelope] = .object(collisions)
+        }
+        return direct
+    }
+
+    static func take(
+        _ key: String,
+        from object: inout [String: JSONValue],
+        path: String
+    ) throws -> JSONValue {
+        guard let value = object.removeValue(forKey: key) else {
+            throw PatchDocumentV2Error.missing(path: "\(path).\(key)")
+        }
+        return value
+    }
+
+    static func object(_ value: JSONValue, path: String) throws -> [String: JSONValue] {
+        guard case .object(let object) = value else {
+            throw PatchDocumentV2Error.type(path: path, expected: "object")
+        }
+        return object
+    }
+
+    static func array(_ value: JSONValue, path: String) throws -> [JSONValue] {
+        guard case .array(let array) = value else {
+            throw PatchDocumentV2Error.type(path: path, expected: "array")
+        }
+        return array
+    }
+
+    static func string(_ value: JSONValue, path: String) throws -> String {
+        guard case .string(let string) = value else {
+            throw PatchDocumentV2Error.type(path: path, expected: "string")
+        }
+        return string
+    }
+
+    static func strings(_ value: JSONValue, path: String) throws -> [String] {
+        let values = try array(value, path: path)
+        return try values.enumerated().map {
+            try string($0.element, path: "\(path)[\($0.offset)]")
+        }
+    }
+
+    static func number(_ value: JSONValue, path: String) throws -> Double {
+        guard case .number(let number) = value else {
+            throw PatchDocumentV2Error.type(path: path, expected: "number")
+        }
+        return number
+    }
+
+    static func integer(_ value: JSONValue, path: String) throws -> Int {
+        let number = try number(value, path: path)
+        guard number.isFinite,
+              number.rounded(.towardZero) == number,
+              number >= Double(Int.min),
+              number <= Double(Int.max)
+        else {
+            throw PatchDocumentV2Error.type(path: path, expected: "integer")
+        }
+        return Int(number)
+    }
+
+    static func bool(_ value: JSONValue, path: String) throws -> Bool {
+        guard case .bool(let bool) = value else {
+            throw PatchDocumentV2Error.type(path: path, expected: "boolean")
+        }
+        return bool
+    }
+
+    static func inputs(_ value: JSONValue, path: String) throws -> [String: [String]] {
+        let object = try object(value, path: path)
+        var inputs: [String: [String]] = [:]
+        for port in object.keys.sorted() {
+            inputs[port] = try strings(object[port]!, path: "\(path).\(port)")
+        }
+        return inputs
+    }
+
+    static func inputsValue(_ inputs: [String: [String]]) -> JSONValue {
+        .object(inputs.mapValues { .array($0.map(JSONValue.string)) })
+    }
+}

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -318,7 +318,7 @@ final class PatchModel: ObservableObject {
             // except a COLD first compile, which seeds master.velocity at its
             // default (1). Re-apply a non-default scrub so the slider and the
             // running clock agree (no-op if equal).
-            if velocity != 1 { params.send("set_param_velocity", "master.velocity", velocity) }
+            if velocity != 1 { params.send("master.velocity", velocity) }
             await refreshScopeTaps()
             setStatus(audioOn ? "playing" : "compiled", isError: false)
         } catch {
@@ -334,16 +334,12 @@ final class PatchModel: ObservableObject {
         // A monitor's knobs (Scope `window`) are view state, not param slots.
         guard !node.kind.spec.monitor else { return }
         let name = "\(node.id).\(knob.name)"
-        switch knob.mode {
-        case .live: params.send("set_param", name, value)
-        case .glide: params.send("set_param_glide", name, value)
-        case .anchor: params.send("set_param_freq", name, value)
-        }
+        params.send(name, value)
     }
 
     func setVelocity(_ v: Double) {
         velocity = v
-        params.send("set_param_velocity", "master.velocity", v)
+        params.send("master.velocity", v)
     }
 
     // ── Transport ─────────────────────────────────────────────────────────
@@ -546,22 +542,31 @@ private final class EventBox: @unchecked Sendable {
 /// as the slot default, after which subsequent turns are live.
 @MainActor
 final class ParamSender {
-    private var pending: [String: (method: String, value: Double)] = [:]
+    private var pending: [String: LatestValueBuffer] = [:]
     private var busy: Set<String> = []
     private weak var model: PatchModel?
 
     init(model: PatchModel) { self.model = model }
 
-    func send(_ method: String, _ name: String, _ value: Double) {
-        pending[name] = (method, value)
-        guard !busy.contains(name) else { return }
+    func send(_ name: String, _ value: Double) {
+        guard value.isFinite else { return }
+        if busy.contains(name) {
+            pending[name]?.offer(value)
+            return
+        }
         busy.insert(name)
+        pending[name] = LatestValueBuffer(first: value)
         Task { [weak self] in
-            defer { self?.busy.remove(name) }
-            while let (m, v) = self?.pending.removeValue(forKey: name) {
+            defer {
+                self?.busy.remove(name)
+                self?.pending.removeValue(forKey: name)
+            }
+            while let v = self?.pending[name]?.pop() {
                 guard let engine = self?.model?.engine else { return }
                 do {
-                    try await engine.call(m, .object(["name": .string(name), "value": .number(v)]))
+                    _ = try await engine.call("set_param", .object([
+                        "name": .string(name), "value": .number(v)
+                    ]))
                 } catch {
                     self?.model?.schedulePush()
                     return

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -24,6 +24,9 @@ final class PatchModel: ObservableObject {
     @Published var statusIsError = false
     @Published var audioOn = false
     @Published var velocity: Double = 1
+    /// Live jack-dot centers in canvas space, mirrored from the canvas's
+    /// preference pass — the hit-test surface for wire drops.
+    var jackGeometry: [JackID: CGPoint] = [:]
 
     let engine: Engine
     private var counter = 0

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -103,18 +103,24 @@ final class PatchModel: ObservableObject {
         forward = { event in Task { @MainActor in box.handler?(event) } }
         engine = Engine(events: forward)
         box.handler = { [weak self] event in self?.handle(event) }
+        // Every exit path must reap the child engine or it orphans with the
+        // DAC running (see AppDelegate).
+        AppDelegate.onTerminate = { [engine] in engine.terminateChild() }
 
-        do { try startEngine() } catch {
-            setStatus("engine: \(error.localizedDescription)", isError: true)
-        }
+        startEngine()
         addNode(.out, at: CGPoint(x: 1180, y: 360))
         addNode(.source, at: CGPoint(x: 120, y: 200))
         setStatus("engine up · patch something", isError: false)
+        startScopePolling()
     }
 
-    private func startEngine() throws {
+    private func startEngine() {
         let e = engine
-        Task { try await e.start() }
+        Task { [weak self] in
+            do { try await e.start() } catch {
+                self?.setStatus("engine: \(error.localizedDescription)", isError: true)
+            }
+        }
     }
 
     private func handle(_ event: EngineEvent) {
@@ -187,6 +193,10 @@ final class PatchModel: ObservableObject {
               !(to.inputs[port] ?? []).contains(fromId)
         else { return false }
         let fromIsKnob = from.kind == .knob
+        // A sink (Out, Scope) has no outlet, so it is never a source — except
+        // the final mix, which is always tappable (`__root__.out`), so Out may
+        // feed a Scope channel.
+        if from.kind.spec.outlets.isEmpty && !(to.kind == .scope && from.kind == .out) { return false }
         // A knob is a control value: it may only drive a control inlet (freq/mod).
         if fromIsKnob && !NodeKind.controlInlets.contains(port) { return false }
         // `freq` is control-only — audio-rate into the pitch port is not FM.
@@ -218,10 +228,19 @@ final class PatchModel: ObservableObject {
     }
 
     // ── Serialization → load_patch_graph ─────────────────────────────────
+    /// Taps cost kernel compute (each re-emits its upstream cone), so request
+    /// them only while a scope channel actually watches a node. Out is exempt:
+    /// the final-mix slot `__root__.out` exists in every compile.
+    var tapsWanted: Bool {
+        nodes.values.contains { n in
+            n.kind == .scope && n.allInputs.contains { nodes[$0]?.kind != .out }
+        }
+    }
+
     func serialize() -> JSONValue {
         var out: [JSONValue] = []
         for id in order {
-            guard let n = nodes[id] else { continue }
+            guard let n = nodes[id], !n.kind.spec.monitor else { continue }
             let spec = n.kind.spec
             var params: [String: JSONValue] = [:]
             for k in spec.knobs { params[k.name] = .number(n.values[k.name] ?? k.def) }
@@ -239,6 +258,7 @@ final class PatchModel: ObservableObject {
         return .object([
             "nodes": .array(out),
             "out": outNode.map { .string($0.id) } ?? .null,
+            "taps": .bool(tapsWanted),
         ])
     }
 
@@ -252,6 +272,8 @@ final class PatchModel: ObservableObject {
         }
     }
 
+    private var lastPushed: JSONValue?
+
     func pushGraph() async {
         if pushInFlight { pushAgain = true; return }
         pushInFlight = true
@@ -259,6 +281,10 @@ final class PatchModel: ObservableObject {
             pushInFlight = false
             if pushAgain { pushAgain = false; schedulePush() }
         }
+        // A monitor-only edit (e.g. scoping the Out mix) leaves the engine
+        // graph byte-identical — skip the recompile, not just debounce it.
+        let graph = serialize()
+        if graph == lastPushed { return }
         do {
             // The compile+JIT is synchronous on the engine's single control
             // thread, so a heavy node (e.g. a modal reverb: ~10⁵ IR lines →
@@ -266,14 +292,17 @@ final class PatchModel: ObservableObject {
             // "compiling" is distinguishable from "hung" — the acute failure
             // mode of the live-patch loop.
             setStatus("compiling…", isError: false)
-            try await engine.call("load_patch_graph", serialize())
+            try await engine.call("load_patch_graph", graph)
+            lastPushed = graph
             // A relower transfers slots by name, so a live scrub survives it —
             // except a COLD first compile, which seeds master.velocity at its
             // default (1). Re-apply a non-default scrub so the slider and the
             // running clock agree (no-op if equal).
             if velocity != 1 { params.send("set_param_velocity", "master.velocity", velocity) }
+            await refreshScopeTaps()
             setStatus(audioOn ? "playing" : "compiled", isError: false)
         } catch {
+            lastPushed = nil
             setStatus("compile: \(error.localizedDescription)", isError: true)
         }
     }
@@ -282,6 +311,8 @@ final class PatchModel: ObservableObject {
     lazy var params = ParamSender(model: self)
 
     func sendKnob(_ node: PatchNode, _ knob: KnobSpec, _ value: Double) {
+        // A monitor's knobs (Scope `window`) are view state, not param slots.
+        guard !node.kind.spec.monitor else { return }
         let name = "\(node.id).\(knob.name)"
         switch knob.mode {
         case .live: params.send("set_param", name, value)
@@ -356,6 +387,113 @@ final class PatchModel: ObservableObject {
                 await self?.pollTelemetry()
             }
         }
+    }
+
+    // ── Scope taps ────────────────────────────────────────────────────────
+    // A scope channel names a NODE; the engine names a SLOT. After each
+    // compile `list_scope_taps` rebinds node id → `__root__.tap:<id>` (a node
+    // that failed to lower simply has no tap and its trace goes dark). The
+    // final mix is the one slot that exists in every compile, so Out maps
+    // statically — no taps build required to watch the output.
+    private var scopeTapSlots: [String: String] = [:]
+
+    /// Latest triggered trace per scope channel, keyed "<scopeId>.<port>".
+    @Published var scopeTraces: [String: [Double]] = [:]
+
+    func scopeSlot(for sourceId: String) -> String? {
+        if nodes[sourceId]?.kind == .out { return "__root__.out" }
+        return scopeTapSlots[sourceId]
+    }
+
+    private func refreshScopeTaps() async {
+        guard tapsWanted else { scopeTapSlots = [:]; return }
+        guard let r = try? await engine.call("list_scope_taps"),
+              case .array(let taps)? = r["taps"] else { return }
+        var map: [String: String] = [:]
+        for t in taps {
+            guard let name = t["name"]?.stringValue,
+                  let slot = t["slot"]?.stringValue, name != "out" else { continue }
+            map[name] = slot
+        }
+        scopeTapSlots = map
+    }
+
+    // ── Scope poll loop ───────────────────────────────────────────────────
+    // `render_window` + `playback_position` are data-plane methods: answered
+    // synchronously in C++ off the audio thread, never queued behind the Lean
+    // control thread — so the trace stays live through a compile and works
+    // with the transport stopped (the kernel is closed-form; a frozen clock
+    // just yields a still waveform). One serial loop, so a slow frame can
+    // never pile up requests.
+    static let sampleRate = 44100.0
+    private var scopeTask: Task<Void, Never>?
+
+    private func startScopePolling() {
+        scopeTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(33))
+                guard !Task.isCancelled else { return }
+                await self?.pollScopes()
+            }
+        }
+    }
+
+    private func pollScopes() async {
+        let scopes = order.compactMap { nodes[$0] }
+            .filter { $0.kind == .scope && !$0.allInputs.isEmpty }
+        guard !scopes.isEmpty else {
+            if !scopeTraces.isEmpty { scopeTraces = [:] }
+            return
+        }
+        guard let pos = try? await engine.call("playback_position"),
+              let position = pos["position"]?.doubleValue else { return }
+        var fresh: [String: [Double]] = [:]
+        for scope in scopes {
+            let window = scope.values["window"] ?? 0.02
+            let count = min(8192, max(128, Int(window * Self.sampleRate)))
+            // Fetch 2× the display span so the trigger can align a full
+            // window ending at the live head.
+            let fetch = min(16384, count * 2)
+            let start = max(0, Int(position) - fetch)
+            var slots: [String] = [], keys: [String] = []
+            for port in scope.kind.spec.inlets {
+                guard let src = scope.inputs[port]?.first,
+                      let slot = scopeSlot(for: src) else { continue }
+                slots.append(slot)
+                keys.append("\(scope.id).\(port)")
+            }
+            guard !slots.isEmpty,
+                  let r = try? await engine.call("render_window", .object([
+                      "start": .number(Double(start)),
+                      "count": .number(Double(fetch)),
+                      "slots": .array(slots.map(JSONValue.string)),
+                  ])),
+                  case .array(let chans)? = r["values"] else { continue }
+            for (i, key) in keys.enumerated() {
+                guard i < chans.count, case .array(let raw) = chans[i] else { continue }
+                let samples = raw.compactMap(\.doubleValue)
+                let t = Self.triggerIndex(samples, display: count)
+                fresh[key] = Array(samples[t..<min(t + count, samples.count)])
+            }
+        }
+        scopeTraces = fresh
+    }
+
+    /// Rising level-trigger with hysteresis (the playground scope's port of
+    /// tui/scope/trigger.ts): arm below −h, fire on the first climb past +h,
+    /// searching only far enough back that a full display window remains.
+    static func triggerIndex(_ s: [Double], display: Int) -> Int {
+        let searchEnd = s.count - display
+        guard searchEnd > 0 else { return 0 }
+        let peak = s.reduce(0) { max($0, abs($1)) }
+        let h = peak * 0.05
+        guard h > 0 else { return 0 }
+        var armed = false
+        for i in 0..<searchEnd {
+            if s[i] < -h { armed = true }
+            else if armed && s[i] >= h { return i }
+        }
+        return 0
     }
 
     private func pollTelemetry() async {

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -32,6 +32,11 @@ final class PatchModel: ObservableObject {
     @Published var statusIsError = false
     @Published var audioOn = false
     @Published var velocity: Double = 1
+    /// World → view offset for the infinite plane. Lives on the model so
+    /// arrange can bring the graph back into view.
+    @Published var pan: CGSize = .zero
+    /// When on, every topology edit re-runs the rank layout.
+    @Published var autoArrange = false
 
     /// Sources an inlet may legally take — the connection UI shows ONLY
     /// these (the type discipline enforced by omission: control inlets
@@ -39,6 +44,49 @@ final class PatchModel: ObservableObject {
     func legalSources(for nodeId: String, port: String) -> [PatchNode] {
         order.compactMap { nodes[$0] }
             .filter { canConnect(from: $0.id, to: nodeId, port: port) }
+    }
+
+    // ── Topological layout ────────────────────────────────────────────────
+    /// Rank = longest path from the sources (0 = no inputs). Total on a DAG;
+    /// the graph is acyclic by construction (canConnect rejects back-edges),
+    /// and the visit guard keeps a hypothetical bug from recursing forever.
+    func topologicalRanks() -> [String: Int] {
+        var memo: [String: Int] = [:]
+        func rank(_ id: String) -> Int {
+            if let r = memo[id] { return r }
+            memo[id] = 0
+            guard let n = nodes[id] else { return 0 }
+            let r = n.allInputs.map { rank($0) + 1 }.max() ?? 0
+            memo[id] = r
+            return r
+        }
+        for id in nodes.keys { _ = rank(id) }
+        return memo
+    }
+
+    /// One row per rank, sources at the top, dac at the bottom; within a row
+    /// modules keep their current left-to-right order (the mental map
+    /// survives the tidy). Positions land on the grid by construction.
+    func arrangeByRank() {
+        let ranks = topologicalRanks()
+        let rows = Dictionary(grouping: nodes.values) { ranks[$0.id] ?? 0 }
+        let margin = 2.0 * Grid.unit
+        let gap = 2.0 * Grid.unit
+        let rowPitch = 8.0 * Grid.unit   // tallest module (6u) + breathing room
+        withAnimation(.snappy(duration: 0.35)) {
+            for (r, members) in rows {
+                var x = margin
+                for n in members.sorted(by: { $0.position.x < $1.position.x }) {
+                    nodes[n.id]?.position = CGPoint(x: x, y: margin + Double(r) * rowPitch)
+                    x += Double(n.kind.spec.gridSize.w) * Grid.unit + gap
+                }
+            }
+            pan = .zero   // bring the arranged graph back into view
+        }
+    }
+
+    private func autoArrangeIfOn() {
+        if autoArrange { arrangeByRank() }
     }
 
     let engine: Engine
@@ -106,6 +154,7 @@ final class PatchModel: ObservableObject {
             hue: Double((counter * 137) % 360))
         nodes[id] = n
         order.append(id)
+        autoArrangeIfOn()
         return n
     }
 
@@ -117,6 +166,7 @@ final class PatchModel: ObservableObject {
             for p in m.inputs.keys { m.inputs[p]?.removeAll { $0 == id } }
             nodes[m.id] = m
         }
+        autoArrangeIfOn()
         schedulePush()
     }
 
@@ -155,6 +205,7 @@ final class PatchModel: ObservableObject {
         if !to.kind.spec.summing { to.inputs[port] = [] }   // single inlet: replace
         to.inputs[port, default: []].append(fromId)
         nodes[toId] = to
+        autoArrangeIfOn()
         schedulePush()
     }
 
@@ -162,6 +213,7 @@ final class PatchModel: ObservableObject {
         guard var to = nodes[toId] else { return }
         to.inputs[port]?.removeAll { $0 == fromId }
         nodes[toId] = to
+        autoArrangeIfOn()
         schedulePush()
     }
 

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -37,6 +37,9 @@ final class PatchModel: ObservableObject {
     @Published var pan: CGSize = .zero
     /// When on, every topology edit re-runs the rank layout.
     @Published var autoArrange = false
+    /// The file this patch came from / saves to (nil = never saved). Drives
+    /// the window title and whether ⌘S needs to ask.
+    @Published var documentURL: URL?
 
     /// Sources an inlet may legally take — the connection UI shows ONLY
     /// these (the type discipline enforced by omission: control inlets
@@ -91,6 +94,18 @@ final class PatchModel: ObservableObject {
 
     let engine: Engine
     private var counter = 0
+
+    // Node ids are "<kind><n>" and must stay unique for the lifetime of a
+    // patch — a loaded file carries ids the counter has never issued, so the
+    // counter resumes past the highest one rather than restarting at 0.
+    func adoptCounter(from ids: some Sequence<String>) {
+        counter = ids.reduce(0) { hi, id in
+            max(hi, Int(id.drop(while: { !$0.isNumber })) ?? 0)
+        }
+    }
+
+    func resetCounter() { counter = 0 }
+
     private var pushTask: Task<Void, Never>?
     private var pushInFlight = false
     private var pushAgain = false
@@ -108,8 +123,7 @@ final class PatchModel: ObservableObject {
         AppDelegate.onTerminate = { [engine] in engine.terminateChild() }
 
         startEngine()
-        addNode(.out, at: CGPoint(x: 1180, y: 360))
-        addNode(.source, at: CGPoint(x: 120, y: 200))
+        seedBootPatch()
         setStatus("engine up · patch something", isError: false)
         startScopePolling()
     }
@@ -139,6 +153,12 @@ final class PatchModel: ObservableObject {
     func setStatus(_ text: String, isError: Bool) {
         status = text
         statusIsError = isError
+    }
+
+    /// The patch you start with, and the one `New Patch` returns to.
+    func seedBootPatch() {
+        addNode(.out, at: CGPoint(x: 1180, y: 360))
+        addNode(.source, at: CGPoint(x: 120, y: 200))
     }
 
     // ── Node lifecycle ───────────────────────────────────────────────────

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -113,9 +113,10 @@ final class PatchModel: ObservableObject {
     init() {
         // Bounce engine events onto the main actor; Engine is created with a
         // plain sendable callback so the actor never touches UI state itself.
-        var forward: (@Sendable (EngineEvent) -> Void)!
         let box = EventBox()
-        forward = { event in Task { @MainActor in box.handler?(event) } }
+        let forward: @Sendable (EngineEvent) -> Void = { [box] event in
+            Task { @MainActor [box] in box.handler?(event) }
+        }
         engine = Engine(events: forward)
         box.handler = { [weak self] event in self?.handle(event) }
         // Every exit path must reap the child engine or it orphans with the
@@ -534,6 +535,8 @@ final class PatchModel: ObservableObject {
 /// and the @MainActor model that wants to receive the events.
 private final class EventBox: @unchecked Sendable {
     @MainActor var handler: ((EngineEvent) -> Void)?
+
+    @MainActor init() {}
 }
 
 /// Live param drive: set the `param:<name>` slot on the running kernel — no

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -235,10 +235,12 @@ final class PatchModel: ObservableObject {
                 try await engine.call("start_audio")
                 audioOn = true
                 setStatus("playing", isError: false)
+                startTelemetry()
             } else {
                 try await engine.call("stop_audio")
                 audioOn = false
                 setStatus("stopped", isError: false)
+                stopTelemetry()
             }
         } catch {
             setStatus(error.localizedDescription, isError: true)
@@ -247,11 +249,63 @@ final class PatchModel: ObservableObject {
 
     /// The engine (audio + DAC) is a separate process that OUTLIVES a window
     /// reload — a fresh surface must not assume audio is off. Ask the engine
-    /// its real state and adopt it.
+    /// its real state and adopt it, otherwise the transport shows "start"
+    /// while sound keeps playing with no way to stop it.
     func syncAudioState() async {
         guard let st = try? await engine.call("audio_status"),
               st["is_running"]?.boolValue == true, !audioOn else { return }
         audioOn = true
+        startTelemetry()
+    }
+
+    // ── Live audio-load telemetry ─────────────────────────────────────────
+    // Compile latency is one failure mode; RUNTIME cost is the other, and
+    // it's the one that's silent. A heavy kernel (a modal reverb: ~200 modes
+    // × transcendentals per sample) can blow the ~11.6 ms buffer deadline
+    // (512 frames @ 44.1k), and RtAudio responds to a missed deadline by
+    // emitting a zero buffer → "no sound" with a perfectly healthy compile.
+    // The DAC already counts it (`audio_status`); poll it so the meter reads
+    // "load 130% · ⚠ xruns" instead of leaving you guessing.
+    private static let bufferMs = (512.0 / 44100.0) * 1000   // ≈ 11.61 ms deadline
+    private var telemetryTask: Task<Void, Never>?
+    private var telemetryInFlight = false
+    private var underrunBase = 0
+
+    func stopTelemetry() {
+        telemetryTask?.cancel()
+        telemetryTask = nil
+    }
+
+    func startTelemetry() {
+        stopTelemetry()
+        telemetryTask = Task { [weak self] in
+            if let self {
+                let st = try? await self.engine.call("audio_status")
+                self.underrunBase = Int(st?["stats"]?["underrunCount"]?.doubleValue ?? 0)
+            }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(750))
+                guard !Task.isCancelled else { return }
+                await self?.pollTelemetry()
+            }
+        }
+    }
+
+    private func pollTelemetry() async {
+        // Single-in-flight: the control thread is shared with compiles and
+        // knobs, so if a poll is stuck behind a long op we must NOT keep
+        // enqueuing more — that turns a slow compile into a pile-up.
+        if !audioOn || pushInFlight || telemetryInFlight || statusIsError { return }
+        telemetryInFlight = true
+        defer { telemetryInFlight = false }
+        guard let st = try? await engine.call("audio_status"),
+              let stats = st["stats"], stats != .null,
+              let maxMs = stats["maxCallbackMs"]?.doubleValue else { return }
+        let pct = Int((maxMs / Self.bufferMs * 100).rounded())
+        let xruns = max(0, Int(stats["underrunCount"]?.doubleValue ?? 0) - underrunBase)
+        let over = pct > 90 || xruns > 0
+        let xrunText = xruns > 0 ? " · ⚠ \(xruns) xrun\(xruns > 1 ? "s" : "") — dropout" : ""
+        setStatus("playing · load \(pct)%\(xrunText)", isError: over)
     }
 }
 

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -81,9 +81,9 @@ final class PatchModel: ObservableObject {
         if spec.fixed && nodes.values.contains(where: { $0.kind == kind }) { return nil }
         counter += 1
         let id = "\(kind.rawValue)\(counter)"
-        let pos = point ?? CGPoint(
+        let pos = Grid.snap(point ?? CGPoint(
             x: 80 + Double(counter % 6) * 34,
-            y: 90 + Double(counter % 6) * 30)
+            y: 90 + Double(counter % 6) * 30))
         var values: [String: Double] = [:]
         for k in spec.knobs { values[k.name] = k.def }
         var inputs: [String: [String]] = [:]

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -1,0 +1,290 @@
+import SwiftUI
+
+struct PatchNode: Identifiable {
+    let id: String
+    let kind: NodeKind
+    var position: CGPoint
+    var values: [String: Double]
+    /// inlet port → ordered source node ids
+    var inputs: [String: [String]]
+
+    var allInputs: [String] { inputs.values.flatMap { $0 } }
+}
+
+/// The patch graph + engine session, one object. TOPOLOGY RELOWERS, SCALARS
+/// ARE LIVE: every continuous knob is a live `param:<id>.<knob>` module slot —
+/// turning it drives `set_param` on the running kernel, no recompile. Only
+/// structural edits (add/remove/rewire) change the graph topology and trigger
+/// a relower + hot-swap.
+@MainActor
+final class PatchModel: ObservableObject {
+    @Published var nodes: [String: PatchNode] = [:]
+    @Published var order: [String] = []   // stable z/render order
+    @Published var status = "booting engine…"
+    @Published var statusIsError = false
+    @Published var audioOn = false
+    @Published var velocity: Double = 1
+
+    let engine: Engine
+    private var counter = 0
+    private var pushTask: Task<Void, Never>?
+    private var pushInFlight = false
+    private var pushAgain = false
+
+    init() {
+        // Bounce engine events onto the main actor; Engine is created with a
+        // plain sendable callback so the actor never touches UI state itself.
+        var forward: (@Sendable (EngineEvent) -> Void)!
+        let box = EventBox()
+        forward = { event in Task { @MainActor in box.handler?(event) } }
+        engine = Engine(events: forward)
+        box.handler = { [weak self] event in self?.handle(event) }
+
+        do { try startEngine() } catch {
+            setStatus("engine: \(error.localizedDescription)", isError: true)
+        }
+        addNode(.out, at: CGPoint(x: 1180, y: 360))
+        addNode(.source, at: CGPoint(x: 120, y: 200))
+        setStatus("engine up · patch something", isError: false)
+    }
+
+    private func startEngine() throws {
+        let e = engine
+        Task { try await e.start() }
+    }
+
+    private func handle(_ event: EngineEvent) {
+        switch event {
+        case .up:
+            setStatus("engine up", isError: false)
+            Task { await syncAudioState() }
+        case .exit(let code):
+            setStatus("engine exited (code \(code))", isError: true)
+        case .stderr(let text):
+            // Diagnostic only — the Electron app console.warn'd these.
+            FileHandle.standardError.write(Data("[engine] \(text)".utf8))
+        }
+    }
+
+    func setStatus(_ text: String, isError: Bool) {
+        status = text
+        statusIsError = isError
+    }
+
+    // ── Node lifecycle ───────────────────────────────────────────────────
+    @discardableResult
+    func addNode(_ kind: NodeKind, at point: CGPoint? = nil) -> PatchNode? {
+        let spec = kind.spec
+        if spec.fixed && nodes.values.contains(where: { $0.kind == kind }) { return nil }
+        counter += 1
+        let id = "\(kind.rawValue)\(counter)"
+        let pos = point ?? CGPoint(
+            x: 80 + Double(counter % 6) * 34,
+            y: 90 + Double(counter % 6) * 30)
+        var values: [String: Double] = [:]
+        for k in spec.knobs { values[k.name] = k.def }
+        var inputs: [String: [String]] = [:]
+        for p in spec.inlets { inputs[p] = [] }
+        let n = PatchNode(id: id, kind: kind, position: pos, values: values, inputs: inputs)
+        nodes[id] = n
+        order.append(id)
+        return n
+    }
+
+    func deleteNode(_ id: String) {
+        guard let n = nodes[id], !n.kind.spec.fixed else { return }
+        nodes.removeValue(forKey: id)
+        order.removeAll { $0 == id }
+        for var m in nodes.values {
+            for p in m.inputs.keys { m.inputs[p]?.removeAll { $0 == id } }
+            nodes[m.id] = m
+        }
+        schedulePush()
+    }
+
+    // ── Connection discipline ────────────────────────────────────────────
+    /// reachability for the cycle check (across all inlets)
+    private func reaches(_ a: String, _ target: String, _ seen: inout Set<String>) -> Bool {
+        if a == target { return true }
+        if seen.contains(a) { return false }
+        seen.insert(a)
+        guard let na = nodes[a] else { return false }
+        return na.allInputs.contains { reaches($0, target, &seen) }
+    }
+
+    func canConnect(from fromId: String, to toId: String, port: String) -> Bool {
+        guard fromId != toId,
+              let from = nodes[fromId], let to = nodes[toId],
+              to.kind.spec.inlets.contains(port),
+              !(to.inputs[port] ?? []).contains(fromId)
+        else { return false }
+        let fromIsKnob = from.kind == .knob
+        // A knob is a control value: it may only drive a control inlet (freq/mod).
+        if fromIsKnob && !NodeKind.controlInlets.contains(port) { return false }
+        // `freq` is control-only — audio-rate into the pitch port is not FM.
+        if !fromIsKnob && port == "freq" { return false }
+        // A modal inlet (Reverb/Modal∪) carries poles: only a modal node may
+        // drive it. (A modal outlet INTO a Sig inlet is fine — it realizes at
+        // the seam.)
+        if to.kind.wantsModal(inlet: port) && !from.kind.spec.modal { return false }
+        var seen = Set<String>()
+        if reaches(fromId, toId, &seen) { return false }   // would form a cycle
+        return true
+    }
+
+    func connect(from fromId: String, to toId: String, port: String) {
+        guard canConnect(from: fromId, to: toId, port: port), var to = nodes[toId] else { return }
+        if !to.kind.spec.summing { to.inputs[port] = [] }   // single inlet: replace
+        to.inputs[port, default: []].append(fromId)
+        nodes[toId] = to
+        schedulePush()
+    }
+
+    func deleteEdge(to toId: String, port: String, from fromId: String) {
+        guard var to = nodes[toId] else { return }
+        to.inputs[port]?.removeAll { $0 == fromId }
+        nodes[toId] = to
+        schedulePush()
+    }
+
+    // ── Serialization → load_patch_graph ─────────────────────────────────
+    func serialize() -> JSONValue {
+        var out: [JSONValue] = []
+        for id in order {
+            guard let n = nodes[id] else { continue }
+            let spec = n.kind.spec
+            var params: [String: JSONValue] = [:]
+            for k in spec.knobs { params[k.name] = .number(n.values[k.name] ?? k.def) }
+            var inputs: [String: JSONValue] = [:]
+            for p in spec.inlets { inputs[p] = .array((n.inputs[p] ?? []).map(JSONValue.string)) }
+            out.append(.object([
+                "id": .string(n.id),
+                "kind": .string(n.kind.rawValue),
+                "params": .object(params),
+                "sel": .object([:]),
+                "in": .object(inputs),
+            ]))
+        }
+        let outNode = nodes.values.first { $0.kind == .out }
+        return .object([
+            "nodes": .array(out),
+            "out": outNode.map { .string($0.id) } ?? .null,
+        ])
+    }
+
+    // ── Relower push (debounced, single-in-flight) ────────────────────────
+    func schedulePush(after delay: Duration = .zero) {
+        pushTask?.cancel()
+        pushTask = Task { [weak self] in
+            if delay > .zero { try? await Task.sleep(for: delay) }
+            guard !Task.isCancelled else { return }
+            await self?.pushGraph()
+        }
+    }
+
+    func pushGraph() async {
+        if pushInFlight { pushAgain = true; return }
+        pushInFlight = true
+        defer {
+            pushInFlight = false
+            if pushAgain { pushAgain = false; schedulePush() }
+        }
+        do {
+            // The compile+JIT is synchronous on the engine's single control
+            // thread, so a heavy node (e.g. a modal reverb: ~10⁵ IR lines →
+            // seconds of LLVM) blocks here with no other signal. Show it, so
+            // "compiling" is distinguishable from "hung" — the acute failure
+            // mode of the live-patch loop.
+            setStatus("compiling…", isError: false)
+            try await engine.call("load_patch_graph", serialize())
+            // A relower transfers slots by name, so a live scrub survives it —
+            // except a COLD first compile, which seeds master.velocity at its
+            // default (1). Re-apply a non-default scrub so the slider and the
+            // running clock agree (no-op if equal).
+            if velocity != 1 { params.send("set_param_velocity", "master.velocity", velocity) }
+            setStatus(audioOn ? "playing" : "compiled", isError: false)
+        } catch {
+            setStatus("compile: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    // ── Live param drive ──────────────────────────────────────────────────
+    lazy var params = ParamSender(model: self)
+
+    func sendKnob(_ node: PatchNode, _ knob: KnobSpec, _ value: Double) {
+        let name = "\(node.id).\(knob.name)"
+        switch knob.mode {
+        case .live: params.send("set_param", name, value)
+        case .glide: params.send("set_param_glide", name, value)
+        case .anchor: params.send("set_param_freq", name, value)
+        }
+    }
+
+    func setVelocity(_ v: Double) {
+        velocity = v
+        params.send("set_param_velocity", "master.velocity", v)
+    }
+
+    // ── Transport ─────────────────────────────────────────────────────────
+    func toggleAudio() async {
+        do {
+            if !audioOn {
+                try await engine.call("start_audio")
+                audioOn = true
+                setStatus("playing", isError: false)
+            } else {
+                try await engine.call("stop_audio")
+                audioOn = false
+                setStatus("stopped", isError: false)
+            }
+        } catch {
+            setStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    /// The engine (audio + DAC) is a separate process that OUTLIVES a window
+    /// reload — a fresh surface must not assume audio is off. Ask the engine
+    /// its real state and adopt it.
+    func syncAudioState() async {
+        guard let st = try? await engine.call("audio_status"),
+              st["is_running"]?.boolValue == true, !audioOn else { return }
+        audioOn = true
+    }
+}
+
+/// Breaks the init-order knot between the Engine's @Sendable event callback
+/// and the @MainActor model that wants to receive the events.
+private final class EventBox: @unchecked Sendable {
+    @MainActor var handler: ((EngineEvent) -> Void)?
+}
+
+/// Live param drive: set the `param:<name>` slot on the running kernel — no
+/// recompile. Rapid drags coalesce to the latest value per name; a cold-start
+/// miss (slot not compiled yet) falls back to a relower that bakes the value
+/// as the slot default, after which subsequent turns are live.
+@MainActor
+final class ParamSender {
+    private var pending: [String: (method: String, value: Double)] = [:]
+    private var busy: Set<String> = []
+    private weak var model: PatchModel?
+
+    init(model: PatchModel) { self.model = model }
+
+    func send(_ method: String, _ name: String, _ value: Double) {
+        pending[name] = (method, value)
+        guard !busy.contains(name) else { return }
+        busy.insert(name)
+        Task { [weak self] in
+            defer { self?.busy.remove(name) }
+            while let (m, v) = self?.pending.removeValue(forKey: name) {
+                guard let engine = self?.model?.engine else { return }
+                do {
+                    try await engine.call(m, .object(["name": .string(name), "value": .number(v)]))
+                } catch {
+                    self?.model?.schedulePush()
+                    return
+                }
+            }
+        }
+    }
+}

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -7,8 +7,16 @@ struct PatchNode: Identifiable {
     var values: [String: Double]
     /// inlet port → ordered source node ids
     var inputs: [String: [String]]
+    /// Identity hue (degrees). Connections render as COLOR, not cables: an
+    /// inlet wears the hues of its sources, so fan-out is the same color
+    /// appearing at many inlets. Golden-angle spacing keeps neighbors apart.
+    let hue: Double
 
     var allInputs: [String] { inputs.values.flatMap { $0 } }
+
+    var color: Color {
+        Color(hue: hue / 360, saturation: 0.62, brightness: 0.88)
+    }
 }
 
 /// The patch graph + engine session, one object. TOPOLOGY RELOWERS, SCALARS
@@ -24,9 +32,14 @@ final class PatchModel: ObservableObject {
     @Published var statusIsError = false
     @Published var audioOn = false
     @Published var velocity: Double = 1
-    /// Live jack-dot centers in canvas space, mirrored from the canvas's
-    /// preference pass — the hit-test surface for wire drops.
-    var jackGeometry: [JackID: CGPoint] = [:]
+
+    /// Sources an inlet may legally take — the connection UI shows ONLY
+    /// these (the type discipline enforced by omission: control inlets
+    /// list knobs, modal inlets list modal nodes, cycle-formers absent).
+    func legalSources(for nodeId: String, port: String) -> [PatchNode] {
+        order.compactMap { nodes[$0] }
+            .filter { canConnect(from: $0.id, to: nodeId, port: port) }
+    }
 
     let engine: Engine
     private var counter = 0
@@ -88,7 +101,9 @@ final class PatchModel: ObservableObject {
         for k in spec.knobs { values[k.name] = k.def }
         var inputs: [String: [String]] = [:]
         for p in spec.inlets { inputs[p] = [] }
-        let n = PatchNode(id: id, kind: kind, position: pos, values: values, inputs: inputs)
+        let n = PatchNode(
+            id: id, kind: kind, position: pos, values: values, inputs: inputs,
+            hue: Double((counter * 137) % 360))
         nodes[id] = n
         order.append(id)
         return n

--- a/reversible/Sources/Reversible/RPCConnection.swift
+++ b/reversible/Sources/Reversible/RPCConnection.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// One framed JSON-RPC socket with its own request IDs, pending bound, timeout
+/// state, and read buffer. Compiler, control, scope, and telemetry each own an
+/// instance, so a large response or blocked control-plane compile on one
+/// connection cannot sit in front of another lane's bytes.
+actor RPCConnection {
+    private let lane: EngineRPCLane
+    private let pendingLimit: Int
+    private var socket: FileHandle?
+    private var buffer = ""
+    private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
+    private var nextID = 1
+    private var terminalError: Error?
+
+    init(
+        lane: EngineRPCLane,
+        fileDescriptor: Int32,
+        pendingLimit: Int = 128
+    ) {
+        self.lane = lane
+        self.pendingLimit = pendingLimit
+        let handle = FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
+        socket = handle
+        handle.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                Task { await self?.close(error: EngineError.exited) }
+                return
+            }
+            guard let text = String(data: data, encoding: .utf8) else { return }
+            Task { await self?.consume(text) }
+        }
+    }
+
+    static func connect(
+        lane: EngineRPCLane,
+        path: String,
+        timeout: Duration = .seconds(5)
+    ) async throws -> RPCConnection {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if let fd = connectOnce(path: path) {
+                return RPCConnection(lane: lane, fileDescriptor: fd)
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        throw EngineError.timeout(method: "connect \(lane.rawValue)")
+    }
+
+    nonisolated static func connectOnce(path: String) -> Int32? {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8CString)
+        guard bytes.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+            Darwin.close(fd)
+            return nil
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            bytes.withUnsafeBytes { source in
+                destination.copyMemory(from: source)
+            }
+        }
+        let result = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { pointer in
+                Darwin.connect(
+                    fd,
+                    pointer,
+                    socklen_t(MemoryLayout<sockaddr_un>.size)
+                )
+            }
+        }
+        guard result == 0 else {
+            Darwin.close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    @discardableResult
+    func call(
+        _ method: String,
+        _ params: JSONValue = .object([:])
+    ) async throws -> JSONValue {
+        if let terminalError { throw terminalError }
+        guard let socket else { throw EngineError.notRunning }
+        guard pending.count < pendingLimit else {
+            throw EngineError.pendingLimit(lane: lane.rawValue, limit: pendingLimit)
+        }
+
+        let id = nextID
+        nextID += 1
+        let request = JSONValue.object([
+            "jsonrpc": .string("2.0"),
+            "id": .number(Double(id)),
+            "method": .string(method),
+            "params": params,
+        ])
+        var line = try JSONEncoder().encode(request)
+        line.append(0x0A)
+
+        let timeout: Duration = method == "load_patch_graph"
+            ? .seconds(180) : .seconds(30)
+        let timer = Task { [weak self] in
+            try await Task.sleep(for: timeout)
+            await self?.timeOut(id: id, method: method)
+        }
+        defer { timer.cancel() }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            pending[id] = continuation
+            do {
+                try socket.write(contentsOf: line)
+            } catch {
+                pending.removeValue(forKey: id)
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    func close(error: Error) {
+        guard terminalError == nil else { return }
+        terminalError = error
+        socket?.readabilityHandler = nil
+        socket = nil
+        let waiters = pending.values
+        pending.removeAll()
+        for waiter in waiters { waiter.resume(throwing: error) }
+    }
+
+    private func timeOut(id: Int, method: String) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: EngineError.timeout(method: method))
+    }
+
+    private func consume(_ chunk: String) {
+        buffer += chunk
+        while let newline = buffer.firstIndex(of: "\n") {
+            let line = String(buffer[..<newline])
+                .trimmingCharacters(in: .whitespaces)
+            buffer = String(buffer[buffer.index(after: newline)...])
+            guard !line.isEmpty,
+                  let data = line.data(using: .utf8),
+                  let message = try? JSONDecoder().decode(JSONValue.self, from: data),
+                  let wireID = message["id"]?.doubleValue,
+                  let continuation = pending.removeValue(forKey: Int(wireID))
+            else { continue }
+            continuation.resume(with: unwrap(message))
+        }
+    }
+
+    /// Control-plane replies nest `{status,data}` as text while data-plane
+    /// replies are bare JSON-RPC results.
+    private func unwrap(_ message: JSONValue) -> Result<JSONValue, Error> {
+        if let error = message["error"], error != .null {
+            let encoded = (try? JSONEncoder().encode(error)).flatMap {
+                String(data: $0, encoding: .utf8)
+            }
+            return .failure(EngineError.rpc(encoded ?? "unknown"))
+        }
+        let result = message["result"] ?? .null
+        guard case .array(let content)? = result["content"],
+              let text = content.first?["text"]?.stringValue
+        else { return .success(result) }
+        guard let data = text.data(using: .utf8),
+              let inner = try? JSONDecoder().decode(JSONValue.self, from: data)
+        else { return .failure(EngineError.rpc("unparseable inner reply")) }
+        if inner["status"]?.stringValue == "ok" {
+            return .success(inner["data"] ?? .null)
+        }
+        return .failure(EngineError.engine(
+            code: inner["error"]?["code"]?.stringValue ?? "unknown",
+            message: inner["error"]?["message"]?.stringValue ?? "unknown"
+        ))
+    }
+}

--- a/reversible/Sources/Reversible/RPCConnection.swift
+++ b/reversible/Sources/Reversible/RPCConnection.swift
@@ -26,11 +26,13 @@ actor RPCConnection {
             let data = handle.availableData
             if data.isEmpty {
                 handle.readabilityHandler = nil
-                Task { await self?.close(error: EngineError.exited) }
+                guard let connection = self else { return }
+                Task { await connection.close(error: EngineError.exited) }
                 return
             }
             guard let text = String(data: data, encoding: .utf8) else { return }
-            Task { await self?.consume(text) }
+            guard let connection = self else { return }
+            Task { await connection.consume(text) }
         }
     }
 

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -2,6 +2,17 @@ import SwiftUI
 
 @main
 struct ReversibleApp: App {
+    // A bare SwiftPM executable is not an .app bundle, so macOS launches it
+    // as a background process — no Dock icon, window never activated. Claim
+    // regular-app status and take focus, or `swift run` shows nothing.
+    init() {
+        DispatchQueue.main.async {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            NSApp.windows.first?.makeKeyAndOrderFront(nil)
+        }
+    }
+
     var body: some Scene {
         WindowGroup("tropical playground") {
             RootView()

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -28,16 +28,16 @@ struct RootView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ToolbarView()
             CanvasView()
             footer
         }
         .background(Theme.bg)
+        .toolbar { PatchToolbar(model: model) }
         .environmentObject(model)
     }
 
     private var footer: some View {
-        Text("drag from an outlet (right) to an inlet (left) to patch downstream · drag a knob vertically to tweak · double-click a node to delete · the patch lowers through the arrow slide on every edit")
+        Text("＋ on an inlet patches a source (only legal ones are offered) · click a color chip to disconnect · an outlet's color marks its destinations · drag a knob vertically · the patch lowers through the arrow slide on every edit")
             .font(Theme.monoSmall)
             .foregroundStyle(Theme.muted)
             .lineLimit(1)

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+@main
+struct ReversibleApp: App {
+    var body: some Scene {
+        WindowGroup("tropical playground") {
+            RootView()
+                .frame(minWidth: 1100, minHeight: 700)
+                .preferredColorScheme(.dark)
+        }
+        .defaultSize(width: 1400, height: 900)
+    }
+}
+
+/// Placeholder root until the canvas lands (commit 4). Kept buildable so
+/// every commit in the port runs.
+struct RootView: View {
+    var body: some View {
+        ZStack {
+            Theme.bg.ignoresSafeArea()
+            Text("tropical")
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundStyle(Theme.muted)
+        }
+    }
+}

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+/// Async-signal-safe last resort. A fatal crash (SIGSEGV/SIGABRT/…) never
+/// reaches applicationWillTerminate, so reap the engine right here: `kill` is
+/// on the async-signal-safe list, unlike the Process API or any dispatch hop.
+/// Then restore the default disposition and re-raise so the crash still cores
+/// and reports normally.
+private func reapEngineOnCrash(_ sig: Int32) {
+    let pid = gEngineChildPID
+    if pid > 0 { kill(pid_t(pid), SIGKILL) }
+    signal(sig, SIG_DFL)
+    raise(sig)
+}
+
 /// The app spawns the engine as a CHILD, but the kernel doesn't reap children
 /// with their parent: any exit that skips teardown leaves an orphaned engine
 /// holding the DAC — audio that nothing can stop. Funnel every exit path
@@ -41,6 +53,11 @@ struct ReversibleApp: App {
             src.setEventHandler { NSApp.terminate(nil) }
             src.resume()
             Self.signalSources.append(src)
+        }
+        // Crashes are catchable (unlike an uncatchable SIGKILL of the app,
+        // which only the startup sweep covers); reap the engine before dying.
+        for sig in [SIGSEGV, SIGABRT, SIGILL, SIGFPE, SIGBUS] {
+            signal(sig, reapEngineOnCrash)
         }
     }
 

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -30,6 +30,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct ReversibleApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    // The model lives at APP scope, not in RootView: the File menu commands
+    // are scene-level and need the same object the canvas is editing.
+    @StateObject private var model = PatchModel()
 
     // Signal sources must stay referenced or the handler dies with them.
     private static var signalSources: [DispatchSourceSignal] = []
@@ -63,16 +66,32 @@ struct ReversibleApp: App {
 
     var body: some Scene {
         WindowGroup("tropical playground") {
-            RootView()
+            RootView(model: model)
                 .frame(minWidth: 1100, minHeight: 700)
                 .preferredColorScheme(.dark)
         }
         .defaultSize(width: 1400, height: 900)
+        .commands {
+            // Stock File-menu verbs with their stock shortcuts — a patch is a
+            // document, so it should behave like one.
+            CommandGroup(replacing: .newItem) {
+                Button("New Patch") { Task { await model.newPatch() } }
+                    .keyboardShortcut("n")
+                Button("Open Patch…") { model.open() }
+                    .keyboardShortcut("o")
+            }
+            CommandGroup(replacing: .saveItem) {
+                Button("Save") { model.save() }
+                    .keyboardShortcut("s")
+                Button("Save As…") { model.saveAs() }
+                    .keyboardShortcut("s", modifiers: [.command, .shift])
+            }
+        }
     }
 }
 
 struct RootView: View {
-    @StateObject private var model = PatchModel()
+    @ObservedObject var model: PatchModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -82,6 +101,9 @@ struct RootView: View {
         .background(Theme.bg)
         .toolbar { PatchToolbar(model: model) }
         .environmentObject(model)
+        // Title tracks the open file, so the window says which patch this is.
+        .navigationTitle(model.documentURL?.deletingPathExtension().lastPathComponent
+                         ?? "untitled patch")
     }
 
     private var footer: some View {

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -12,15 +12,27 @@ struct ReversibleApp: App {
     }
 }
 
-/// Placeholder root until the canvas lands (commit 4). Kept buildable so
-/// every commit in the port runs.
 struct RootView: View {
+    @StateObject private var model = PatchModel()
+
     var body: some View {
-        ZStack {
-            Theme.bg.ignoresSafeArea()
-            Text("tropical")
-                .font(.system(size: 13, weight: .bold, design: .monospaced))
-                .foregroundStyle(Theme.muted)
+        VStack(spacing: 0) {
+            CanvasView()
+            footer
         }
+        .background(Theme.bg)
+        .environmentObject(model)
+    }
+
+    private var footer: some View {
+        Text("drag from an outlet (right) to an inlet (left) to patch downstream · drag a knob vertically to tweak · double-click a node to delete · the patch lowers through the arrow slide on every edit")
+            .font(Theme.monoSmall)
+            .foregroundStyle(Theme.muted)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 5)
+            .background(Theme.panel)
+            .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.edge), alignment: .top)
     }
 }

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -17,6 +17,7 @@ struct RootView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            ToolbarView()
             CanvasView()
             footer
         }

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -17,6 +17,7 @@ private func reapEngineOnCrash(_ sig: Int32) {
 /// holding the DAC — audio that nothing can stop. Funnel every exit path
 /// (Cmd-Q, last window closed, SIGTERM/SIGINT) through willTerminate, where
 /// the model has registered the engine's synchronous child-kill.
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     static var onTerminate: (() -> Void)?
 

--- a/reversible/Sources/Reversible/ReversibleApp.swift
+++ b/reversible/Sources/Reversible/ReversibleApp.swift
@@ -1,7 +1,27 @@
 import SwiftUI
 
+/// The app spawns the engine as a CHILD, but the kernel doesn't reap children
+/// with their parent: any exit that skips teardown leaves an orphaned engine
+/// holding the DAC — audio that nothing can stop. Funnel every exit path
+/// (Cmd-Q, last window closed, SIGTERM/SIGINT) through willTerminate, where
+/// the model has registered the engine's synchronous child-kill.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    static var onTerminate: (() -> Void)?
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        Self.onTerminate?()
+    }
+}
+
 @main
 struct ReversibleApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
+
+    // Signal sources must stay referenced or the handler dies with them.
+    private static var signalSources: [DispatchSourceSignal] = []
+
     // A bare SwiftPM executable is not an .app bundle, so macOS launches it
     // as a background process — no Dock icon, window never activated. Claim
     // regular-app status and take focus, or `swift run` shows nothing.
@@ -10,6 +30,17 @@ struct ReversibleApp: App {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
+        }
+        // A raw signal's default action exits without running willTerminate,
+        // orphaning the engine — reroute SIGTERM/SIGINT into the normal
+        // termination path (signal handlers can't touch AppKit; a dispatch
+        // source runs on the main queue and can).
+        for sig in [SIGTERM, SIGINT] {
+            signal(sig, SIG_IGN)
+            let src = DispatchSource.makeSignalSource(signal: sig, queue: .main)
+            src.setEventHandler { NSApp.terminate(nil) }
+            src.resume()
+            Self.signalSources.append(src)
         }
     }
 

--- a/reversible/Sources/Reversible/ScopeView.swift
+++ b/reversible/Sources/Reversible/ScopeView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// The Scope body: a CRT well fed by the model's poll loop, plus a footer of
+/// channel inlets and the window knob. Traces wear their SOURCE's identity
+/// color — the same hue that marks that node's outlet everywhere else — so a
+/// multi-trace scope reads with no legend.
+struct ScopeBody: View {
+    @EnvironmentObject var model: PatchModel
+    let node: PatchNode
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScopeDisplay(node: node)
+                .padding(.horizontal, 8).padding(.top, 8)
+            footer
+        }
+    }
+
+    private var footer: some View {
+        HStack(alignment: .center, spacing: 12) {
+            let inlets = node.kind.spec.inlets
+            VStack(alignment: .leading, spacing: 4) {
+                InletView(node: node, port: inlets[0])
+                InletView(node: node, port: inlets[1])
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                InletView(node: node, port: inlets[2])
+                InletView(node: node, port: inlets[3])
+            }
+            Spacer(minLength: 8)
+            if let knob = node.kind.spec.knobs.first {
+                KnobView(node: node, knob: knob)
+            }
+        }
+        .padding(.horizontal, 9).padding(.vertical, 6)
+    }
+}
+
+struct ScopeDisplay: View {
+    @EnvironmentObject var model: PatchModel
+    let node: PatchNode
+
+    /// (source color, samples) per connected channel, port order.
+    private var traces: [(Color, [Double])] {
+        node.kind.spec.inlets.compactMap { port in
+            guard let src = node.inputs[port]?.first,
+                  let s = model.scopeTraces["\(node.id).\(port)"], s.count > 1
+            else { return nil }
+            return (model.nodes[src]?.color ?? Theme.text, s)
+        }
+    }
+
+    var body: some View {
+        Canvas { ctx, size in
+            let mid = size.height / 2
+            var axis = Path()
+            axis.move(to: CGPoint(x: 0, y: mid))
+            axis.addLine(to: CGPoint(x: size.width, y: mid))
+            ctx.stroke(axis, with: .color(Theme.edge.opacity(0.7)), lineWidth: 1)
+
+            let traces = traces
+            // One shared scale (unity floor): relative levels stay honest,
+            // and a hot signal autoscales instead of clipping the well.
+            let peak = max(1.0, traces.flatMap(\.1).reduce(0) { max($0, abs($1)) })
+            let half = mid - 3
+            for (color, s) in traces {
+                ctx.stroke(Self.tracePath(s, size: size, mid: mid, half: half, peak: peak),
+                           with: .color(color), lineWidth: 1.3)
+            }
+        }
+        .background(Color(hex: 0x0C0F14), in: RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.edge))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// A wide window overruns the pixel budget, so bin to per-column min/max
+    /// strips (the classic scope raster — envelope survives, aliasing doesn't);
+    /// a short window draws the plain polyline.
+    static func tracePath(_ s: [Double], size: CGSize, mid: Double, half: Double, peak: Double) -> Path {
+        var p = Path()
+        let n = s.count
+        let cols = max(1, Int(size.width))
+        let y: (Double) -> Double = { mid - ($0 / peak) * half }
+        if n <= cols * 2 {
+            for (i, v) in s.enumerated() {
+                let pt = CGPoint(x: size.width * Double(i) / Double(n - 1), y: y(v))
+                if i == 0 { p.move(to: pt) } else { p.addLine(to: pt) }
+            }
+        } else {
+            for c in 0..<cols {
+                let a = c * n / cols, b = max(a + 1, (c + 1) * n / cols)
+                var lo = s[a], hi = s[a]
+                for v in s[a..<b] { lo = min(lo, v); hi = max(hi, v) }
+                let x = (Double(c) + 0.5) * size.width / Double(cols)
+                // A flat column still needs ink: pad to a minimum strip.
+                p.move(to: CGPoint(x: x, y: y(hi)))
+                p.addLine(to: CGPoint(x: x, y: max(y(lo), y(hi) + 0.8)))
+            }
+        }
+        return p
+    }
+}

--- a/reversible/Sources/Reversible/Theme.swift
+++ b/reversible/Sources/Reversible/Theme.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// The playground palette, 1:1 with renderer/styles.css `:root`.
+enum Theme {
+    static let bg = Color(hex: 0x16181D)
+    static let panel = Color(hex: 0x20242C)
+    static let panel2 = Color(hex: 0x272C36)
+    static let edge = Color(hex: 0x3A4150)
+    static let text = Color(hex: 0xD7DCE5)
+    static let muted = Color(hex: 0x8A93A3)
+    static let jack = Color(hex: 0x4A5365)
+    static let jackHot = Color(hex: 0xCDD6E6)
+    static let wire = Color(hex: 0x6F7B92)
+    static let err = Color(hex: 0xF08A8A)
+    static let dotGrid = Color(hex: 0x232733)
+
+    static let transportOff = Color(hex: 0x2C6E4A)
+    static let transportOn = Color(hex: 0x8A3C3C)
+    static let clockOn = Color(hex: 0x2C5A6E)
+    static let scrubAccent = Color(hex: 0x4FD6C4)   // reversing — the moat gesture
+
+    static let mono = Font.system(size: 13, design: .monospaced)
+    static let monoSmall = Font.system(size: 11, design: .monospaced)
+    static let monoTiny = Font.system(size: 10, design: .monospaced)
+}
+
+extension Color {
+    init(hex: UInt32) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -63,7 +63,8 @@ struct PatchToolbar: ToolbarContent {
 /// Master clock (global time-warp scrub). One control rides
 /// `master.velocity`, the base clock of EVERY generator, so a scrub
 /// reverses / freezes / varispeeds the whole patch — voices, envelopes, and
-/// the modal reverb tail — coherently. `set_param_velocity` re-bases the
+/// the modal reverb tail—coherently. The engine's `set_param` velocity
+/// discipline re-bases the
 /// τ-origin (`master.tau_base`) so the change is value-continuous
 /// (click-free). Closed-form: nothing downstream holds history, so reverse
 /// is just f(τ) read at receding τ.

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -1,62 +1,44 @@
 import SwiftUI
 
-struct ToolbarView: View {
-    @EnvironmentObject var model: PatchModel
+/// Native window-toolbar content: add-module menu, master clock, transport,
+/// status. Custom chrome only where no native widget exists (the clock
+/// cluster); everything else is stock.
+struct PatchToolbar: ToolbarContent {
+    @ObservedObject var model: PatchModel
 
-    var body: some View {
-        HStack(spacing: 10) {
-            Text("tropical")
-                .font(Theme.mono.bold())
-                .foregroundStyle(Color(hex: 0xAEB8C8))
-            palette
-            Spacer()
-            ClockView()
-            transport
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            Menu {
+                ForEach(NodeKind.allCases.filter { !$0.spec.fixed }, id: \.self) { kind in
+                    Button(kind.spec.title) { model.addNode(kind) }
+                }
+            } label: {
+                Label("Add Module", systemImage: "plus")
+            }
+            .help("add a module to the patch")
+        }
+
+        ToolbarItem { ClockView() }
+
+        ToolbarItem {
+            Button {
+                Task { await model.toggleAudio() }
+            } label: {
+                Label(model.audioOn ? "Stop" : "Start",
+                      systemImage: model.audioOn ? "stop.fill" : "play.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(model.audioOn ? Theme.transportOn : Theme.transportOff)
+            .help(model.audioOn ? "stop audio" : "start audio")
+        }
+
+        ToolbarItem {
             Text(model.status)
-                .font(Theme.mono)
+                .font(Theme.monoSmall)
                 .foregroundStyle(model.statusIsError ? Theme.err : Theme.muted)
                 .lineLimit(1)
-                .frame(minWidth: 220, alignment: .trailing)
+                .frame(minWidth: 180, alignment: .trailing)
         }
-        .padding(.horizontal, 12).padding(.vertical, 8)
-        .background(Theme.panel)
-        .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.edge), alignment: .bottom)
-    }
-
-    private var palette: some View {
-        HStack(spacing: 6) {
-            ForEach(NodeKind.allCases.filter { !$0.spec.fixed }, id: \.self) { kind in
-                Button {
-                    model.addNode(kind)
-                } label: {
-                    HStack(spacing: 5) {
-                        Circle().fill(kind.spec.accent).frame(width: 8, height: 8)
-                        Text(kind.spec.title).font(Theme.mono)
-                    }
-                    .padding(.horizontal, 9).padding(.vertical, 5)
-                    .background(Theme.panel2)
-                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.edge))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var transport: some View {
-        Button {
-            Task { await model.toggleAudio() }
-        } label: {
-            Text(model.audioOn ? "■ stop audio" : "▶ start audio")
-                .font(Theme.mono.bold())
-                .foregroundStyle(Color(hex: 0xEAF6EE))
-                .padding(.horizontal, 14).padding(.vertical, 6)
-                .background(model.audioOn ? Theme.transportOn : Theme.transportOff)
-                .overlay(RoundedRectangle(cornerRadius: 6)
-                    .stroke(model.audioOn ? Color(hex: 0xB25151) : Color(hex: 0x3C8A5E)))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-        }
-        .buttonStyle(.plain)
     }
 }
 
@@ -72,17 +54,15 @@ struct ClockView: View {
     @EnvironmentObject var model: PatchModel
 
     var body: some View {
-        HStack(spacing: 6) {
-            Text("clock").font(Theme.monoSmall).foregroundStyle(Theme.muted)
-            clockButton("⏴", on: model.velocity < 0, help: "reverse (−1×)") {
-                model.setVelocity(model.velocity < 0 ? 1 : -1)   // toggle reverse
+        HStack(spacing: 8) {
+            Picker("clock", selection: transportBinding) {
+                Image(systemName: "backward.fill").tag(Transport.reverse)
+                Image(systemName: "pause.fill").tag(Transport.freeze)
+                Image(systemName: "play.fill").tag(Transport.play)
             }
-            clockButton("⏸", on: model.velocity == 0, help: "freeze (0×)") {
-                model.setVelocity(model.velocity == 0 ? 1 : 0)
-            }
-            clockButton("⏵", on: model.velocity == 1, help: "play (1×)") {
-                model.setVelocity(1)
-            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
             Slider(
                 value: Binding(
                     get: { model.velocity },
@@ -98,31 +78,36 @@ struct ClockView: View {
                 .monospacedDigit()
                 .frame(minWidth: 44, alignment: .trailing)
         }
-        .padding(.horizontal, 8).padding(.vertical, 3)
-        .background(Theme.panel2)
-        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.edge))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
         .help("global time-warp — scrubs every voice, envelope, and reverb tail coherently (closed-form, no state)")
+    }
+
+    private enum Transport: Hashable { case reverse, freeze, play, free }
+
+    /// The segmented control reflects the three detents; a slider value off
+    /// any detent selects nothing (`.free`).
+    private var transportBinding: Binding<Transport> {
+        Binding(
+            get: {
+                switch model.velocity {
+                case -1: .reverse
+                case 0: .freeze
+                case 1: .play
+                default: .free
+                }
+            },
+            set: { t in
+                switch t {
+                case .reverse: model.setVelocity(-1)
+                case .freeze: model.setVelocity(0)
+                case .play: model.setVelocity(1)
+                case .free: break
+                }
+            })
     }
 
     /// Snap near the musically meaningful rates (mirrors app.js detents).
     private func detented(_ v: Double) -> Double {
         for d in [0.0, 1.0, -1.0, 2.0, -2.0] where abs(v - d) < 0.06 { return d }
         return v
-    }
-
-    private func clockButton(_ label: String, on: Bool, help: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(label)
-                .font(Theme.mono)
-                .foregroundStyle(on ? Color(hex: 0xEAF3F6) : Theme.text)
-                .padding(.horizontal, 7).padding(.vertical, 2)
-                .background(on ? Theme.clockOn : Theme.panel)
-                .overlay(RoundedRectangle(cornerRadius: 5)
-                    .stroke(on ? Color(hex: 0x3F86A8) : Theme.edge))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-        }
-        .buttonStyle(.plain)
-        .help(help)
     }
 }

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct ToolbarView: View {
+    @EnvironmentObject var model: PatchModel
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("tropical")
+                .font(Theme.mono.bold())
+                .foregroundStyle(Color(hex: 0xAEB8C8))
+            palette
+            Spacer()
+            ClockView()
+            transport
+            Text(model.status)
+                .font(Theme.mono)
+                .foregroundStyle(model.statusIsError ? Theme.err : Theme.muted)
+                .lineLimit(1)
+                .frame(minWidth: 220, alignment: .trailing)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(Theme.panel)
+        .overlay(Rectangle().frame(height: 1).foregroundStyle(Theme.edge), alignment: .bottom)
+    }
+
+    private var palette: some View {
+        HStack(spacing: 6) {
+            ForEach(NodeKind.allCases.filter { !$0.spec.fixed }, id: \.self) { kind in
+                Button {
+                    model.addNode(kind)
+                } label: {
+                    HStack(spacing: 5) {
+                        Circle().fill(kind.spec.accent).frame(width: 8, height: 8)
+                        Text(kind.spec.title).font(Theme.mono)
+                    }
+                    .padding(.horizontal, 9).padding(.vertical, 5)
+                    .background(Theme.panel2)
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.edge))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var transport: some View {
+        Button {
+            Task { await model.toggleAudio() }
+        } label: {
+            Text(model.audioOn ? "■ stop audio" : "▶ start audio")
+                .font(Theme.mono.bold())
+                .foregroundStyle(Color(hex: 0xEAF6EE))
+                .padding(.horizontal, 14).padding(.vertical, 6)
+                .background(model.audioOn ? Theme.transportOn : Theme.transportOff)
+                .overlay(RoundedRectangle(cornerRadius: 6)
+                    .stroke(model.audioOn ? Color(hex: 0xB25151) : Color(hex: 0x3C8A5E)))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Master clock (global time-warp scrub). One control rides
+/// `master.velocity`, the base clock of EVERY generator, so a scrub
+/// reverses / freezes / varispeeds the whole patch — voices, envelopes, and
+/// the modal reverb tail — coherently. `set_param_velocity` re-bases the
+/// τ-origin (`master.tau_base`) so the change is value-continuous
+/// (click-free). Closed-form: nothing downstream holds history, so reverse
+/// is just f(τ) read at receding τ.
+/// 1 = play · 0 = freeze · −1 = reverse · |v| > 1 = varispeed.
+struct ClockView: View {
+    @EnvironmentObject var model: PatchModel
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text("clock").font(Theme.monoSmall).foregroundStyle(Theme.muted)
+            clockButton("⏴", on: model.velocity < 0, help: "reverse (−1×)") {
+                model.setVelocity(model.velocity < 0 ? 1 : -1)   // toggle reverse
+            }
+            clockButton("⏸", on: model.velocity == 0, help: "freeze (0×)") {
+                model.setVelocity(model.velocity == 0 ? 1 : 0)
+            }
+            clockButton("⏵", on: model.velocity == 1, help: "play (1×)") {
+                model.setVelocity(1)
+            }
+            Slider(
+                value: Binding(
+                    get: { model.velocity },
+                    set: { model.setVelocity(detented($0)) }),
+                in: -2...2)
+                .frame(width: 120)
+                .tint(Theme.scrubAccent)
+            Text(String(format: "%.2f×", model.velocity))
+                .font(Theme.monoSmall)
+                .foregroundStyle(
+                    model.velocity < 0 ? Theme.scrubAccent :
+                    model.velocity == 0 ? Theme.muted : Theme.text)
+                .monospacedDigit()
+                .frame(minWidth: 44, alignment: .trailing)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 3)
+        .background(Theme.panel2)
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Theme.edge))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .help("global time-warp — scrubs every voice, envelope, and reverb tail coherently (closed-form, no state)")
+    }
+
+    /// Snap near the musically meaningful rates (mirrors app.js detents).
+    private func detented(_ v: Double) -> Double {
+        for d in [0.0, 1.0, -1.0, 2.0, -2.0] where abs(v - d) < 0.06 { return d }
+        return v
+    }
+
+    private func clockButton(_ label: String, on: Bool, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(Theme.mono)
+                .foregroundStyle(on ? Color(hex: 0xEAF3F6) : Theme.text)
+                .padding(.horizontal, 7).padding(.vertical, 2)
+                .background(on ? Theme.clockOn : Theme.panel)
+                .overlay(RoundedRectangle(cornerRadius: 5)
+                    .stroke(on ? Color(hex: 0x3F86A8) : Theme.edge))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -18,6 +18,24 @@ struct PatchToolbar: ToolbarContent {
             .help("add a module to the patch")
         }
 
+        // Rank layout: one row per topological rank, sources at the top,
+        // dac at the bottom — the DAG's own order as geometry. `auto`
+        // re-runs it on every topology edit.
+        ToolbarItem {
+            ControlGroup {
+                Button {
+                    model.arrangeByRank()
+                } label: {
+                    Label("Arrange", systemImage: "square.stack.3d.down.right")
+                }
+                .help("lay out modules in rows by topological rank")
+                Toggle(isOn: $model.autoArrange) {
+                    Label("Auto", systemImage: "arrow.trianglehead.2.clockwise")
+                }
+                .help("re-arrange on every topology edit")
+            }
+        }
+
         ToolbarItem { ClockView() }
 
         ToolbarItem {

--- a/reversible/Tests/ReversibleTests/EngineRPCLaneTests.swift
+++ b/reversible/Tests/ReversibleTests/EngineRPCLaneTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Reversible
+
+final class EngineRPCLaneTests: XCTestCase {
+    func testTrafficClassesHaveIndependentConnections() {
+        XCTAssertEqual(EngineRPCLane.lane(for: "load_patch_graph"), .graph)
+        XCTAssertEqual(EngineRPCLane.lane(for: "get_vocabulary"), .graph)
+        XCTAssertEqual(EngineRPCLane.lane(for: "set_param"), .control)
+        XCTAssertEqual(EngineRPCLane.lane(for: "playback_position"), .control)
+        XCTAssertEqual(EngineRPCLane.lane(for: "render_window"), .scope)
+        XCTAssertEqual(EngineRPCLane.lane(for: "get_telemetry"), .telemetry)
+        XCTAssertEqual(EngineRPCLane.lane(for: "audio_status"), .telemetry)
+    }
+}

--- a/reversible/Tests/ReversibleTests/EngineVocabularyTests.swift
+++ b/reversible/Tests/ReversibleTests/EngineVocabularyTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+final class EngineVocabularyTests: XCTestCase {
+    func testDecodesUnknownFutureKindWithoutSemanticEdit() throws {
+        let withheld = Set([try NodeKindID(validating: "bloomgong")])
+        let vocabulary = try EngineVocabulary.decode(
+            from: fixture(named: "vocabulary-valid-future-kind"),
+            withholding: withheld
+        )
+
+        XCTAssertEqual(vocabulary.schemaID, "tropical_vocabulary")
+        XCTAssertEqual(vocabulary.schemaVersion, 1)
+        XCTAssertEqual(vocabulary.fingerprint, "fnv1a64:0123456789abcdef")
+        XCTAssertEqual(vocabulary.colors.map(\.rawValue), ["signal", "modal", "control"])
+
+        let futureID = try NodeKindID(validating: "future_modal_cloud")
+        let future = try XCTUnwrap(vocabulary.descriptor(for: futureID))
+        XCTAssertEqual(future.outlet?.rawValue, "modal")
+        XCTAssertEqual(future.ports.map(\.name), ["frequency", "rate"])
+
+        let frequency = try XCTUnwrap(future.port(named: "frequency"))
+        XCTAssertEqual(frequency.accepts.map(\.rawValue), ["control"])
+        XCTAssertFalse(frequency.multi)
+        XCTAssertEqual(frequency.defaultValue, 440)
+        XCTAssertEqual(frequency.discipline?.rawValue, "future_anchor")
+        XCTAssertEqual(frequency.min, 20)
+        XCTAssertEqual(frequency.max, 20_000)
+        XCTAssertEqual(frequency.logarithmic, true)
+        XCTAssertEqual(frequency.unit, "Hz")
+
+        let rate = try XCTUnwrap(future.port(named: "rate"))
+        XCTAssertEqual(rate.owner, "frequency")
+    }
+
+    func testConnectionTypeAndArityComeOnlyFromDescriptors() throws {
+        let vocabulary = try EngineVocabulary.decode(
+            from: fixture(named: "vocabulary-valid-future-kind")
+        )
+        let control = try NodeKindID(validating: "control_source")
+        let future = try NodeKindID(validating: "future_modal_cloud")
+        let sink = try NodeKindID(validating: "modal_sink")
+
+        XCTAssertEqual(
+            vocabulary.connectionDecision(
+                from: control,
+                to: future,
+                port: "frequency",
+                existingConnectionCount: 0
+            ),
+            .allowed
+        )
+        XCTAssertEqual(
+            vocabulary.connectionDecision(
+                from: future,
+                to: sink,
+                port: "in",
+                existingConnectionCount: 0
+            ),
+            .allowed
+        )
+        XCTAssertEqual(
+            vocabulary.connectionDecision(
+                from: future,
+                to: sink,
+                port: "in",
+                existingConnectionCount: 1
+            ),
+            .inletAtCapacity(kind: sink, port: "in")
+        )
+        XCTAssertEqual(
+            vocabulary.connectionDecision(
+                from: control,
+                to: sink,
+                port: "in",
+                existingConnectionCount: 0
+            ),
+            .incompatibleColor(
+                outlet: try PortColorID(validating: "control"),
+                accepts: [try PortColorID(validating: "modal")]
+            )
+        )
+        XCTAssertEqual(
+            vocabulary.connectionDecision(
+                from: sink,
+                to: future,
+                port: "frequency",
+                existingConnectionCount: 0
+            ),
+            .sourceHasNoOutlet(sink)
+        )
+    }
+
+    func testRejectsDuplicateKinds() throws {
+        XCTAssertThrowsError(
+            try EngineVocabulary.decode(from: fixture(named: "vocabulary-invalid-duplicate-kind"))
+        ) { error in
+            XCTAssertEqual(
+                error as? EngineVocabularyError,
+                .duplicateKind(try! NodeKindID(validating: "duplicate"))
+            )
+        }
+    }
+
+    func testRejectsDuplicatePorts() throws {
+        XCTAssertThrowsError(
+            try EngineVocabulary.decode(from: fixture(named: "vocabulary-invalid-duplicate-port"))
+        ) { error in
+            XCTAssertEqual(
+                error as? EngineVocabularyError,
+                .duplicatePort(
+                    kind: try! NodeKindID(validating: "duplicated_ports"),
+                    port: "in"
+                )
+            )
+        }
+    }
+
+    func testRejectsSuppliedWithheldKindIfServed() throws {
+        let withheld = Set([try NodeKindID(validating: "bloomgong")])
+        XCTAssertThrowsError(
+            try EngineVocabulary.decode(
+                from: fixture(named: "vocabulary-invalid-withheld-kind"),
+                withholding: withheld
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? EngineVocabularyError,
+                .withheldKindServed(try! NodeKindID(validating: "bloomgong"))
+            )
+        }
+    }
+
+    func testRejectsUnsupportedSchemaVersion() throws {
+        let data = Data(
+            """
+            {
+              "schema": "tropical_vocabulary",
+              "schema_version": 2,
+              "fingerprint": "fnv1a64:0123456789abcdef",
+              "rule": "engine-owned",
+              "colors": ["signal"],
+              "kinds": [{"kind": "future", "outlet": "signal", "ports": []}]
+            }
+            """.utf8
+        )
+        XCTAssertThrowsError(try EngineVocabulary.decode(from: data)) { error in
+            XCTAssertEqual(error as? EngineVocabularyError, .unsupportedSchemaVersion(2))
+        }
+    }
+
+    func testClientMonitorsAndThemesRemainPresentationOnly() throws {
+        XCTAssertThrowsError(try ClientMonitorKindID(validating: "scope"))
+
+        let scopeID = try ClientMonitorKindID(validating: "client.monitor.scope")
+        let monitor = ClientMonitorDescriptor(
+            kind: scopeID,
+            displayName: "Scope",
+            theme: NodeThemeOverride(displayName: nil, accentRGB: 0x7FE08C)
+        )
+        let monitors = try ClientMonitorCatalog(monitors: [monitor])
+        XCTAssertEqual(monitors.descriptor(for: scopeID), monitor)
+
+        let future = try NodeKindID(validating: "future_modal_cloud")
+        let themes = EngineNodeThemeCatalog()
+        XCTAssertNil(themes.override(for: future))
+    }
+
+    private func fixture(named name: String) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/document-v1-unknown.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/document-v1-unknown.json
@@ -1,0 +1,48 @@
+{
+  "autoArrange": false,
+  "nodes": [
+    {
+      "hue": 20,
+      "id": "source1",
+      "inputs": {"freq": []},
+      "kind": "source",
+      "values": {"freq": 220},
+      "x": 20,
+      "y": 40
+    },
+    {
+      "hue": 60,
+      "id": "processor2",
+      "inputs": {"in": ["source1"], "unknown_port": ["source1"]},
+      "kind": "future_processor",
+      "values": {"unknown_value": {"shape": [1, 2, 3]}},
+      "x": 160,
+      "y": 40
+    },
+    {
+      "future_node_field": {"must": "survive"},
+      "hue": 90,
+      "id": "mystery3",
+      "inputs": {"future_port": ["missing9", "mystery3"]},
+      "kind": "future_unserved_kind",
+      "values": {"future_structural": {"rows": [[1, 2], [3, 4]]}},
+      "x": 300,
+      "y": 40
+    },
+    {
+      "hue": 180,
+      "id": "out4",
+      "inputs": {"in": ["processor2", "mystery3"]},
+      "kind": "out",
+      "values": {},
+      "x": 500,
+      "y": 40
+    }
+  ],
+  "order": ["source1", "processor2", "mystery3", "out4"],
+  "panX": 0,
+  "panY": 0,
+  "unknown_top_field": {"must": "survive"},
+  "velocity": 1,
+  "version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/document-v1-valid.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/document-v1-valid.json
@@ -1,0 +1,39 @@
+{
+  "autoArrange": true,
+  "nodes": [
+    {
+      "hue": 20,
+      "id": "source1",
+      "inputs": {"freq": []},
+      "kind": "source",
+      "values": {"freq": 330, "future_value": {"curve": [0, 1, 0]}},
+      "vendor_node": {"kept": true},
+      "x": 20,
+      "y": 40
+    },
+    {
+      "hue": 180,
+      "id": "out2",
+      "inputs": {"in": ["source1"]},
+      "kind": "out",
+      "values": {},
+      "x": 120,
+      "y": 240
+    },
+    {
+      "hue": 100,
+      "id": "scope3",
+      "inputs": {"ch1": ["source1"], "ch2": [], "ch3": [], "ch4": []},
+      "kind": "scope",
+      "values": {"window": 0.04063},
+      "x": 300,
+      "y": 40
+    }
+  ],
+  "order": ["source1", "out2", "scope3"],
+  "panX": -12,
+  "panY": 8,
+  "velocity": -1,
+  "vendor_top": {"author": "future-client"},
+  "version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/document-v2-cycle.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/document-v2-cycle.json
@@ -1,0 +1,43 @@
+{
+  "monitors": [],
+  "nodes": [
+    {
+      "id": "processor1",
+      "in": {"in": ["processor2"]},
+      "kind": "future_processor",
+      "params": {}
+    },
+    {
+      "id": "processor2",
+      "in": {"in": ["processor1"]},
+      "kind": "future_processor",
+      "params": {}
+    },
+    {
+      "id": "out3",
+      "in": {"in": ["processor1"]},
+      "kind": "out",
+      "params": {}
+    }
+  ],
+  "output": "out3",
+  "presentation": {
+    "auto_arrange": false,
+    "order": ["processor1", "processor2", "out3"],
+    "pan_x": 0,
+    "pan_y": 0,
+    "positions": {
+      "out3": {"hue": 180, "x": 500, "y": 40},
+      "processor1": {"hue": 60, "x": 20, "y": 40},
+      "processor2": {"hue": 120, "x": 260, "y": 40}
+    }
+  },
+  "scene": {},
+  "transport": {"velocity": 1},
+  "version": 2,
+  "vocabulary": {
+    "fingerprint": "fnv1a64:4444444444444444",
+    "schema": "tropical_vocabulary",
+    "schema_version": 1
+  }
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/document-v2-valid.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/document-v2-valid.json
@@ -1,0 +1,63 @@
+{
+  "monitors": [
+    {
+      "id": "scope5",
+      "in": {"ch1": ["processor3"]},
+      "kind": "client.monitor.scope",
+      "state": {"window": 0.04063},
+      "vendor_monitor": "kept"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "source1",
+      "in": {"freq": []},
+      "kind": "source",
+      "params": {"freq": 440},
+      "vendor_node": {"kept": true}
+    },
+    {
+      "id": "control2",
+      "in": {},
+      "kind": "control_source",
+      "params": {"value": 0.5}
+    },
+    {
+      "id": "processor3",
+      "in": {"in": ["source1"]},
+      "kind": "future_processor",
+      "params": {"future_structural": [1, {"nested": true}]}
+    },
+    {
+      "id": "out4",
+      "in": {"in": ["processor3"]},
+      "kind": "out",
+      "params": {}
+    }
+  ],
+  "output": "out4",
+  "presentation": {
+    "auto_arrange": false,
+    "order": ["source1", "control2", "processor3", "out4", "scope5"],
+    "pan_x": 11,
+    "pan_y": -9,
+    "positions": {
+      "control2": {"hue": 80, "x": 20, "y": 140},
+      "out4": {"hue": 180, "x": 500, "y": 40},
+      "processor3": {"hue": 120, "x": 260, "y": 40},
+      "scope5": {"hue": 100, "x": 260, "y": 240},
+      "source1": {"hue": 20, "x": 20, "y": 40}
+    },
+    "workspace": "patch"
+  },
+  "scene": {"id": "fixture-scene", "title": "Future-safe patch"},
+  "transport": {"position": 44100, "velocity": 1, "vendor_clock": "kept"},
+  "vendor_top": {"kept": [1, 2, 3]},
+  "version": 2,
+  "vocabulary": {
+    "fingerprint": "fnv1a64:4444444444444444",
+    "schema": "tropical_vocabulary",
+    "schema_version": 1,
+    "vendor_vocabulary": true
+  }
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/document-vocabulary-v1.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/document-vocabulary-v1.json
@@ -1,0 +1,55 @@
+{
+  "colors": ["signal", "control"],
+  "fingerprint": "fnv1a64:4444444444444444",
+  "kinds": [
+    {
+      "kind": "source",
+      "outlet": "signal",
+      "ports": [
+        {
+          "accepts": ["control"],
+          "default": 220,
+          "discipline": "anchor",
+          "log": true,
+          "max": 2000,
+          "min": 0.02,
+          "multi": false,
+          "name": "freq",
+          "unit": "Hz"
+        }
+      ]
+    },
+    {
+      "kind": "control_source",
+      "outlet": "control",
+      "ports": [
+        {
+          "default": 0,
+          "discipline": "raw",
+          "log": false,
+          "max": 1,
+          "min": 0,
+          "name": "value",
+          "unit": ""
+        }
+      ]
+    },
+    {
+      "kind": "future_processor",
+      "outlet": "signal",
+      "ports": [
+        {"accepts": ["signal"], "multi": false, "name": "in"}
+      ]
+    },
+    {
+      "kind": "out",
+      "outlet": null,
+      "ports": [
+        {"accepts": ["signal"], "multi": true, "name": "in"}
+      ]
+    }
+  ],
+  "rule": "outlet color must be accepted by inlet",
+  "schema": "tropical_vocabulary",
+  "schema_version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/modal-scope-js-oracle-v1.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/modal-scope-js-oracle-v1.json
@@ -1,0 +1,203 @@
+{
+  "schema": "modal_scope_js_oracle_1",
+  "sourceCommit": "07a6b2517f8d24c8822d67e0337c0fd99d016bd8",
+  "profile": {
+    "sampleRate": 44100,
+    "displaySamples": 896,
+    "searchSamples": 1792,
+    "warmupSamples": 64,
+    "timeCompression": 2,
+    "pointBudget": 2752,
+    "fps": 60,
+    "fullScale": 0.040566876298965736,
+    "displayScale": 0.043812226402883
+  },
+  "sampleIndices": [0, 1, 111, 223, 447, 448, 672, 894, 895],
+  "cases": [
+    {
+      "name": "chord-1-mode-1",
+      "input": {
+        "frequency": 55,
+        "slowDecay": 0.42,
+        "fastDecay": 5.22,
+        "amplitude": 0.055,
+        "phase": 4.799926459,
+        "strikeTime": 0.06,
+        "responseStart": 19298,
+        "playbackPosition": 22050,
+        "stride": 1
+      },
+      "expected": {
+        "offset": 578.1017791260813,
+        "center": 1474.1017791260813,
+        "span": 1792,
+        "centerValue": 8.013338256840363e-16,
+        "peak": 0.9999917071991336,
+        "active": true,
+        "locked": true,
+        "displayEnvelope": 0.04018796844898594,
+        "cycles": 2.234920634920635,
+        "timeSpanSeconds": 0.040634920634920635,
+        "samples": [
+          { "index": 0, "value": -0.6728261898139695 },
+          { "index": 1, "value": -0.6611365116982604 },
+          { "index": 111, "value": 0.8433773237793672 },
+          { "index": 223, "value": 0.3716418394260984 },
+          { "index": 447, "value": -0.007844825339778427 },
+          { "index": 448, "value": 0.007844824911568269 },
+          { "index": 672, "value": -0.37164186531721877 },
+          { "index": 894, "value": 0.6611365839534304 },
+          { "index": 895, "value": 0.6728261898139715 }
+        ]
+      }
+    },
+    {
+      "name": "chord-1-mode-2",
+      "input": {
+        "frequency": 82.5,
+        "slowDecay": 0.42,
+        "fastDecay": 5.22,
+        "amplitude": 0.0495,
+        "phase": 4.233371994,
+        "strikeTime": 0.06,
+        "responseStart": 19298,
+        "playbackPosition": 22050,
+        "stride": 1
+      },
+      "expected": {
+        "offset": 630.0253620588444,
+        "center": 1526.0253620588444,
+        "span": 1792,
+        "centerValue": -2.7728470561316776e-16,
+        "peak": 0.9999761004935135,
+        "active": true,
+        "locked": true,
+        "displayEnvelope": 0.03616917160408735,
+        "cycles": 3.3523809523809525,
+        "timeSpanSeconds": 0.040634920634920635,
+        "samples": [
+          { "index": 0, "value": 0.8943758804362641 },
+          { "index": 1, "value": 0.8836016437078908 },
+          { "index": 111, "value": -0.9978437247123065 },
+          { "index": 223, "value": 0.8412546503792543 },
+          { "index": 447, "value": -0.011767100415566565 },
+          { "index": 448, "value": 0.011767098693113912 },
+          { "index": 672, "value": -0.8412546496920543 },
+          { "index": 894, "value": -0.8836019026775751 },
+          { "index": 895, "value": -0.8943758804362273 }
+        ]
+      }
+    },
+    {
+      "name": "chord-1-mode-3",
+      "input": {
+        "frequency": 132,
+        "slowDecay": 0.42,
+        "fastDecay": 5.22,
+        "amplitude": 0.04235,
+        "phase": 3.666817528,
+        "strikeTime": 0.06,
+        "responseStart": 19298,
+        "playbackPosition": 22050,
+        "stride": 1
+      },
+      "expected": {
+        "offset": 511.2317241660562,
+        "center": 1407.2317241660562,
+        "span": 1792,
+        "centerValue": 5.282232984349378e-16,
+        "peak": 0.9999851591188017,
+        "active": true,
+        "locked": true,
+        "displayEnvelope": 0.030944735705719175,
+        "cycles": 5.363809523809524,
+        "timeSpanSeconds": 0.040634920634920635,
+        "samples": [
+          { "index": 0, "value": 0.9098292004797172 },
+          { "index": 1, "value": 0.8935641387963552 },
+          { "index": 111, "value": -0.1045603252374579 },
+          { "index": 223, "value": -0.825469316047223 },
+          { "index": 447, "value": -0.018826123364574177 },
+          { "index": 448, "value": 0.0188261193770389 },
+          { "index": 672, "value": 0.8254693094482344 },
+          { "index": 894, "value": -0.893564517760828 },
+          { "index": 895, "value": -0.9098292004797176 }
+        ]
+      }
+    },
+    {
+      "name": "chord-1-mode-4",
+      "input": {
+        "frequency": 198,
+        "slowDecay": 0.42,
+        "fastDecay": 5.22,
+        "amplitude": 0.0374,
+        "phase": 3.100263062,
+        "strikeTime": 0.06,
+        "responseStart": 19298,
+        "playbackPosition": 22050,
+        "stride": 1
+      },
+      "expected": {
+        "offset": 512.783226475507,
+        "center": 1408.783226475507,
+        "span": 1792,
+        "centerValue": -2.2447321779139884e-15,
+        "peak": 0.9999892156567144,
+        "active": true,
+        "locked": true,
+        "displayEnvelope": 0.027327818545310443,
+        "cycles": 8.045714285714286,
+        "timeSpanSeconds": 0.040634920634920635,
+        "samples": [
+          { "index": 0, "value": -0.14311281446239496 },
+          { "index": 1, "value": -0.08701614044720965 },
+          { "index": 111, "value": -0.15648751952352266 },
+          { "index": 223, "value": -0.11391408657746487 },
+          { "index": 447, "value": -0.028236070795593732 },
+          { "index": 448, "value": 0.02823608500270352 },
+          { "index": 672, "value": 0.11391265139512274 },
+          { "index": 894, "value": 0.08701605272166286 },
+          { "index": 895, "value": 0.14311281446247856 }
+        ]
+      }
+    },
+    {
+      "name": "chord-1-mode-5",
+      "input": {
+        "frequency": 293.333333333,
+        "slowDecay": 0.42,
+        "fastDecay": 5.22,
+        "amplitude": 0.033,
+        "phase": 2.533708597,
+        "strikeTime": 0.06,
+        "responseStart": 19298,
+        "playbackPosition": 22050,
+        "stride": 1
+      },
+      "expected": {
+        "offset": 390.8348909250292,
+        "center": 1286.8348909250292,
+        "span": 1792,
+        "centerValue": -7.147060721024445e-16,
+        "peak": 0.9998769809854579,
+        "active": true,
+        "locked": true,
+        "displayEnvelope": 0.02411278106939157,
+        "cycles": 11.919576719563173,
+        "timeSpanSeconds": 0.040634920634920635,
+        "samples": [
+          { "index": 0, "value": 0.2499475730500212 },
+          { "index": 1, "value": 0.3299917008092419 },
+          { "index": 111, "value": -0.11600216110639977 },
+          { "index": 223, "value": 0.06351202009486906 },
+          { "index": 447, "value": -0.04182234351529367 },
+          { "index": 448, "value": 0.04182239812643786 },
+          { "index": 672, "value": -0.06351598635904518 },
+          { "index": 894, "value": -0.32999083828065306 },
+          { "index": 895, "value": -0.2499475730500317 }
+        ]
+      }
+    }
+  ]
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/package-smoke.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/package-smoke.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "schema": "reversible-package-smoke",
+  "version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-duplicate-kind.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-duplicate-kind.json
@@ -1,0 +1,11 @@
+{
+  "colors": ["signal"],
+  "fingerprint": "fnv1a64:1111111111111111",
+  "kinds": [
+    {"kind": "duplicate", "outlet": "signal", "ports": []},
+    {"kind": "duplicate", "outlet": "signal", "ports": []}
+  ],
+  "rule": "fixture",
+  "schema": "tropical_vocabulary",
+  "schema_version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-duplicate-port.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-duplicate-port.json
@@ -1,0 +1,17 @@
+{
+  "colors": ["signal"],
+  "fingerprint": "fnv1a64:2222222222222222",
+  "kinds": [
+    {
+      "kind": "duplicated_ports",
+      "outlet": "signal",
+      "ports": [
+        {"accepts": ["signal"], "multi": false, "name": "in"},
+        {"accepts": ["signal"], "multi": false, "name": "in"}
+      ]
+    }
+  ],
+  "rule": "fixture",
+  "schema": "tropical_vocabulary",
+  "schema_version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-withheld-kind.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/vocabulary-invalid-withheld-kind.json
@@ -1,0 +1,10 @@
+{
+  "colors": ["modal"],
+  "fingerprint": "fnv1a64:3333333333333333",
+  "kinds": [
+    {"kind": "bloomgong", "outlet": "modal", "ports": []}
+  ],
+  "rule": "fixture",
+  "schema": "tropical_vocabulary",
+  "schema_version": 1
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/vocabulary-valid-future-kind.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/vocabulary-valid-future-kind.json
@@ -1,0 +1,70 @@
+{
+  "colors": [
+    "signal",
+    "modal",
+    "control"
+  ],
+  "fingerprint": "fnv1a64:0123456789abcdef",
+  "kinds": [
+    {
+      "kind": "control_source",
+      "outlet": "control",
+      "ports": [
+        {
+          "default": 0.5,
+          "discipline": "raw",
+          "log": false,
+          "max": 1,
+          "min": 0,
+          "name": "value",
+          "unit": ""
+        }
+      ]
+    },
+    {
+      "kind": "future_modal_cloud",
+      "outlet": "modal",
+      "ports": [
+        {
+          "accepts": [
+            "control"
+          ],
+          "default": 440,
+          "discipline": "future_anchor",
+          "log": true,
+          "max": 20000,
+          "min": 20,
+          "multi": false,
+          "name": "frequency",
+          "unit": "Hz"
+        },
+        {
+          "default": 0.25,
+          "discipline": "future_slew",
+          "log": false,
+          "max": 4,
+          "min": 0,
+          "name": "rate",
+          "owner": "frequency",
+          "unit": "Hz"
+        }
+      ]
+    },
+    {
+      "kind": "modal_sink",
+      "outlet": null,
+      "ports": [
+        {
+          "accepts": [
+            "modal"
+          ],
+          "multi": false,
+          "name": "in"
+        }
+      ]
+    }
+  ],
+  "rule": "outlet color must be accepted by inlet",
+  "schema": "tropical_vocabulary",
+  "schema_version": 1
+}

--- a/reversible/Tests/ReversibleTests/LatestValueBufferTests.swift
+++ b/reversible/Tests/ReversibleTests/LatestValueBufferTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Reversible
+
+final class LatestValueBufferTests: XCTestCase {
+    func testFirstAndFinalAreRetainedDuringMonotonicGesture() {
+        var buffer = LatestValueBuffer(first: 0)
+        buffer.offer(0.2)
+        buffer.offer(0.4)
+        buffer.offer(0.9)
+
+        XCTAssertEqual(buffer.pendingCount, 2)
+        XCTAssertEqual(buffer.pop(), 0)
+        XCTAssertEqual(buffer.pop(), 0.9)
+        XCTAssertNil(buffer.pop())
+    }
+
+    func testOneTurningPointAndFinalAreRetained() {
+        var buffer = LatestValueBuffer(first: 0)
+        buffer.offer(0.4)
+        buffer.offer(0.8)
+        buffer.offer(0.7)
+        buffer.offer(0.3)
+
+        XCTAssertEqual(buffer.pendingCount, 3)
+        XCTAssertEqual(buffer.pop(), 0)
+        XCTAssertEqual(buffer.pop(), 0.8)
+        XCTAssertEqual(buffer.pop(), 0.3)
+        XCTAssertNil(buffer.pop())
+    }
+
+    func testQueueStaysBoundedAcrossAdversarialOscillation() {
+        var buffer = LatestValueBuffer(first: 0.5)
+        for index in 0..<10_000 {
+            buffer.offer(index.isMultiple(of: 2) ? 1 : 0)
+            XCTAssertLessThanOrEqual(buffer.pendingCount, 3)
+        }
+    }
+
+    func testNonFiniteEventsAreIgnored() {
+        var buffer = LatestValueBuffer(first: 0.25)
+        buffer.offer(.nan)
+        buffer.offer(.infinity)
+        XCTAssertEqual(buffer.pop(), 0.25)
+    }
+}

--- a/reversible/Tests/ReversibleTests/ModalScopeJSOracleParityTests.swift
+++ b/reversible/Tests/ReversibleTests/ModalScopeJSOracleParityTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+private struct ModalScopeOracleFixture: Decodable {
+    struct Profile: Decodable {
+        let sampleRate: Double
+        let displaySamples: Int
+        let searchSamples: Int
+        let warmupSamples: Int
+        let timeCompression: Double
+        let pointBudget: Int
+        let fps: Double
+        let fullScale: Double
+        let displayScale: Double
+    }
+
+    struct Case: Decodable {
+        struct Input: Decodable {
+            let frequency: Double
+            let slowDecay: Double
+            let fastDecay: Double
+            let amplitude: Double
+            let phase: Double
+            let strikeTime: Double
+            let responseStart: Double
+            let playbackPosition: Double
+            let stride: Int
+        }
+
+        struct Expected: Decodable {
+            struct Sample: Decodable {
+                let index: Int
+                let value: Double
+            }
+
+            let offset: Double
+            let center: Double
+            let span: Double
+            let centerValue: Double
+            let peak: Double
+            let active: Bool
+            let locked: Bool
+            let displayEnvelope: Double
+            let cycles: Double
+            let timeSpanSeconds: Double
+            let samples: [Sample]
+        }
+
+        let name: String
+        let input: Input
+        let expected: Expected
+    }
+
+    let schema: String
+    let sourceCommit: String
+    let profile: Profile
+    let sampleIndices: [Int]
+    let cases: [Case]
+}
+
+final class ModalScopeJSOracleParityTests: XCTestCase {
+    private static func loadFixture() throws -> ModalScopeOracleFixture {
+        let url = try XCTUnwrap(
+            Bundle.module.url(
+                forResource: "modal-scope-js-oracle-v1",
+                withExtension: "json"
+            )
+        )
+        return try JSONDecoder().decode(
+            ModalScopeOracleFixture.self,
+            from: Data(contentsOf: url)
+        )
+    }
+
+    private func projectionValues(
+        for item: ModalScopeOracleFixture.Case,
+        profile: ModalScopeProfile
+    ) -> [Double] {
+        let input = item.input
+        let envelope = ModalPairedEnvelope(
+            strikeTime: input.strikeTime,
+            slowDecay: input.slowDecay,
+            fastDecay: input.fastDecay,
+            amplitude: input.amplitude
+        )
+        return (0..<profile.pointBudget).map { index in
+            let sceneTime = (input.responseStart + Double(index)) / profile.sampleRate
+            return envelope.value(at: sceneTime) * cos(
+                2 * Double.pi * input.frequency * sceneTime + input.phase
+            )
+        }
+    }
+
+    private func frame(
+        for item: ModalScopeOracleFixture.Case,
+        fixture: ModalScopeOracleFixture
+    ) -> ModalScopeFrame {
+        let profile = ModalScopeProfile.qualified
+        return ModalScopeMath.frame(
+            values: projectionValues(for: item, profile: profile),
+            responseStart: item.input.responseStart,
+            stride: item.input.stride,
+            frequency: item.input.frequency,
+            envelope: ModalPairedEnvelope(
+                strikeTime: item.input.strikeTime,
+                slowDecay: item.input.slowDecay,
+                fastDecay: item.input.fastDecay,
+                amplitude: item.input.amplitude
+            ),
+            tauBase: 0,
+            velocity: 1,
+            playbackPosition: item.input.playbackPosition,
+            sharedFullScale: fixture.profile.fullScale,
+            profile: profile
+        )
+    }
+
+    func testQualifiedProfileMatchesAcceptedJSGeometry() throws {
+        let fixture = try Self.loadFixture()
+        let expected = fixture.profile
+        let actual = ModalScopeProfile.qualified
+
+        XCTAssertEqual(fixture.schema, "modal_scope_js_oracle_1")
+        XCTAssertEqual(fixture.sourceCommit, "07a6b2517f8d24c8822d67e0337c0fd99d016bd8")
+        XCTAssertEqual(actual.sampleRate, expected.sampleRate)
+        XCTAssertEqual(actual.displaySamples, expected.displaySamples)
+        XCTAssertEqual(actual.searchSamples, expected.searchSamples)
+        XCTAssertEqual(actual.warmupSamples, expected.warmupSamples)
+        XCTAssertEqual(actual.timeCompression, expected.timeCompression)
+        XCTAssertEqual(actual.pointBudget, expected.pointBudget)
+        XCTAssertEqual(actual.framesPerSecond, expected.fps)
+        XCTAssertEqual(actual.linearSpanSamples, 1_792)
+        XCTAssertEqual(actual.linearSpanSeconds, 1_792.0 / 44_100.0)
+        XCTAssertEqual(
+            ModalScopeMath.displayScale(sharedFullScale: expected.fullScale),
+            expected.displayScale,
+            accuracy: 1e-15
+        )
+    }
+
+    func testFiveIndependentModeFramesAgreeWithJSOracle() throws {
+        let fixture = try Self.loadFixture()
+        XCTAssertEqual(fixture.cases.count, 5)
+        var centers: [Double] = []
+
+        for item in fixture.cases {
+            let actual = frame(for: item, fixture: fixture)
+            let expected = item.expected
+            let lock = actual.lock
+            centers.append(lock.center)
+
+            XCTAssertEqual(actual.stride, item.input.stride, item.name)
+            XCTAssertEqual(actual.cycles, expected.cycles, accuracy: 1e-12, item.name)
+            XCTAssertEqual(
+                actual.timeSpanSeconds,
+                expected.timeSpanSeconds,
+                accuracy: 1e-15,
+                item.name
+            )
+            XCTAssertEqual(
+                actual.displayEnvelope,
+                expected.displayEnvelope,
+                accuracy: 1e-12,
+                item.name
+            )
+            XCTAssertEqual(lock.offset, expected.offset, accuracy: 2e-7, item.name)
+            XCTAssertEqual(lock.center, expected.center, accuracy: 2e-7, item.name)
+            XCTAssertEqual(lock.span, expected.span, accuracy: 1e-12, item.name)
+            XCTAssertEqual(lock.peak, expected.peak, accuracy: 2e-7, item.name)
+            XCTAssertEqual(lock.active, expected.active, item.name)
+            XCTAssertEqual(lock.locked, expected.locked, item.name)
+            XCTAssertEqual(lock.values.count, ModalScopeProfile.qualified.displaySamples)
+            XCTAssertLessThan(abs(lock.centerValue), 1e-12, item.name)
+            XCTAssertLessThan(abs(lock.centerValue - expected.centerValue), 1e-12, item.name)
+            XCTAssertLessThan(lock.values[447], 0, item.name)
+            XCTAssertGreaterThan(lock.values[448], 0, item.name)
+
+            for sample in expected.samples {
+                XCTAssertEqual(
+                    lock.values[sample.index],
+                    sample.value,
+                    accuracy: 2e-7,
+                    "\(item.name) sample \(sample.index)"
+                )
+            }
+
+            let restoredPeak = actual.displayedValues.reduce(0) { max($0, abs($1)) }
+            XCTAssertEqual(
+                restoredPeak,
+                lock.peak * actual.displayEnvelope,
+                accuracy: 1e-14,
+                item.name
+            )
+            XCTAssertLessThan(
+                abs(restoredPeak / actual.displayEnvelope - 1),
+                0.001,
+                item.name
+            )
+        }
+
+        // A shared canvas does not imply a shared trigger: all five carriers
+        // choose their own interpolated center.
+        XCTAssertEqual(Set(centers.map { Int(floor($0)) }).count, 5)
+    }
+
+    func testPointwiseEnvelopeRemovalRecoversCarrierBeforeLock() throws {
+        let fixture = try Self.loadFixture()
+        let item = try XCTUnwrap(fixture.cases.first)
+        let profile = ModalScopeProfile.qualified
+        let envelope = ModalPairedEnvelope(
+            strikeTime: item.input.strikeTime,
+            slowDecay: item.input.slowDecay,
+            fastDecay: item.input.fastDecay,
+            amplitude: item.input.amplitude
+        )
+        let values = projectionValues(for: item, profile: profile)
+        let warmup = profile.warmupSamples
+        let raw = Array(values.dropFirst(warmup))
+        let firstSceneTime = (item.input.responseStart + Double(warmup)) / profile.sampleRate
+        let envelopes = envelope.samples(
+            firstSceneTime: firstSceneTime,
+            sceneStep: 1 / profile.sampleRate,
+            count: raw.count
+        )
+        let carrier = ModalScopeMath.extractCarrier(
+            values: raw,
+            envelopes: envelopes,
+            envelopeFloor: fixture.profile.fullScale * 1e-6
+        )
+
+        for index in stride(from: 0, to: carrier.count, by: 137) {
+            let sceneTime = firstSceneTime + Double(index) / profile.sampleRate
+            let expected = cos(
+                2 * Double.pi * item.input.frequency * sceneTime + item.input.phase
+            )
+            XCTAssertEqual(carrier[index], expected, accuracy: 1e-12)
+        }
+    }
+
+    func testSilenceAndDCCannotMasqueradeAsCenteredLocks() {
+        let silence = ModalScopeMath.centeredWindow(
+            Array(repeating: 0, count: 2_688),
+            outputLength: 896,
+            spanLength: 1_792
+        )
+        let dc = ModalScopeMath.centeredWindow(
+            Array(repeating: 0.02, count: 2_688),
+            outputLength: 896,
+            spanLength: 1_792
+        )
+
+        XCTAssertFalse(silence.active)
+        XCTAssertFalse(silence.locked)
+        XCTAssertTrue(dc.active)
+        XCTAssertFalse(dc.locked)
+        XCTAssertEqual(
+            ModalScopeMath.extractCarrier(
+                values: [1, 2, .nan, 4],
+                envelopes: [0, 1e-14, 1, .infinity],
+                envelopeFloor: 1e-12
+            ),
+            [0, 0, 0, 0]
+        )
+    }
+}

--- a/reversible/Tests/ReversibleTests/PackageSmokeTests.swift
+++ b/reversible/Tests/ReversibleTests/PackageSmokeTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+final class PackageSmokeTests: XCTestCase {
+    func testFixtureResourcesAreBundledAndDecodable() throws {
+        let url = try XCTUnwrap(
+            Bundle.module.url(
+                forResource: "package-smoke",
+                withExtension: "json"
+            )
+        )
+        let value = try JSONDecoder().decode(
+            JSONValue.self,
+            from: Data(contentsOf: url)
+        )
+
+        XCTAssertEqual(value["schema"]?.stringValue, "reversible-package-smoke")
+        XCTAssertEqual(value["version"]?.doubleValue, 1)
+        XCTAssertEqual(value["enabled"]?.boolValue, true)
+    }
+}

--- a/reversible/Tests/ReversibleTests/PatchDocumentV2LosslessTests.swift
+++ b/reversible/Tests/ReversibleTests/PatchDocumentV2LosslessTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+final class PatchDocumentV2LosslessTests: XCTestCase {
+    func testV2RoundTripPreservesUnknownFieldsAndAuthoredOrder() throws {
+        let document = try PatchDocumentV2.decode(from: fixture("document-v2-valid"))
+        let report = document.validate(against: try vocabulary())
+
+        XCTAssertTrue(report.canCompile, "\(report.blockers)")
+        XCTAssertEqual(document.presentation.order, [
+            "source1", "control2", "processor3", "out4", "scope5",
+        ])
+        XCTAssertEqual(document.nodes[2].inputs["in"], ["source1"])
+        XCTAssertEqual(document.unknownFields["vendor_top"], .object(["kept": .array([.number(1), .number(2), .number(3)])]))
+        XCTAssertEqual(document.nodes[0].unknownFields["vendor_node"], .object(["kept": .bool(true)]))
+        XCTAssertEqual(document.monitors[0].unknownFields["vendor_monitor"], .string("kept"))
+
+        let roundTrip = try PatchDocumentV2.decode(from: document.encoded())
+        XCTAssertEqual(roundTrip, document)
+    }
+
+    func testV1MigrationSeparatesMonitorAndRequiresExplicitSave() throws {
+        let result = try PatchDocumentV1Migrator.migrate(
+            data: fixture("document-v1-valid"),
+            vocabulary: try vocabulary()
+        )
+        let repeated = try PatchDocumentV1Migrator.migrate(
+            data: fixture("document-v1-valid"),
+            vocabulary: try vocabulary()
+        )
+
+        XCTAssertTrue(result.requiresExplicitV2Save)
+        XCTAssertEqual(repeated.report, result.report)
+        XCTAssertTrue(result.report.canCompile, "\(result.report.blockers)")
+        XCTAssertEqual(result.document.nodes.map(\.id), ["source1", "out2"])
+        XCTAssertEqual(result.document.monitors.map(\.id), ["scope3"])
+        XCTAssertEqual(result.document.monitors[0].kind.rawValue, "client.monitor.scope")
+        XCTAssertEqual(result.document.monitors[0].inputs["ch1"], ["source1"])
+        XCTAssertEqual(result.document.nodes[0].structuralParams["future_value"], .object([
+            "curve": .array([.number(0), .number(1), .number(0)]),
+        ]))
+        XCTAssertEqual(result.document.unknownFields["vendor_top"], .object([
+            "author": .string("future-client"),
+        ]))
+        XCTAssertEqual(result.document.nodes[0].unknownFields["vendor_node"], .object([
+            "kept": .bool(true),
+        ]))
+        XCTAssertEqual(result.report.facts.last?.code, .explicitSaveRequired)
+        XCTAssertEqual(
+            result.report.facts.filter { $0.code == .preservedUnknownNodeField }.map(\.path),
+            ["$.nodes[0].vendor_node"]
+        )
+    }
+
+    func testV1UnknownDataStaysSerializableInBlockedV2Document() throws {
+        let result = try PatchDocumentV1Migrator.migrate(
+            data: fixture("document-v1-unknown"),
+            vocabulary: try vocabulary()
+        )
+        let codes = Set(result.report.blockers.map(\.code))
+
+        XCTAssertTrue(codes.contains(.unknownKind))
+        XCTAssertTrue(codes.contains(.unknownPort))
+        XCTAssertTrue(codes.contains(.danglingEdge))
+        XCTAssertTrue(codes.contains(.selfEdge))
+        XCTAssertFalse(result.report.canCompile)
+
+        let mystery = try XCTUnwrap(result.document.nodes.first { $0.id == "mystery3" })
+        XCTAssertEqual(mystery.kind.rawValue, "future_unserved_kind")
+        XCTAssertEqual(mystery.inputs["future_port"], ["missing9", "mystery3"])
+        XCTAssertEqual(mystery.structuralParams["future_structural"], .object([
+            "rows": .array([
+                .array([.number(1), .number(2)]),
+                .array([.number(3), .number(4)]),
+            ]),
+        ]))
+        XCTAssertEqual(mystery.unknownFields["future_node_field"], .object([
+            "must": .string("survive"),
+        ]))
+        XCTAssertEqual(result.document.unknownFields["unknown_top_field"], .object([
+            "must": .string("survive"),
+        ]))
+
+        let roundTrip = try PatchDocumentV2.decode(from: result.document.encoded())
+        XCTAssertEqual(roundTrip, result.document)
+    }
+
+    func testCycleIsReportedWithoutMutatingTopology() throws {
+        let document = try PatchDocumentV2.decode(from: fixture("document-v2-cycle"))
+        let report = document.validate(against: try vocabulary())
+
+        XCTAssertEqual(report.blockers.filter { $0.code == .cycle }.count, 1)
+        XCTAssertEqual(document.nodes[0].inputs["in"], ["processor2"])
+        XCTAssertEqual(document.nodes[1].inputs["in"], ["processor1"])
+    }
+
+    func testDescriptorArityColorFiniteAndOutputValidation() throws {
+        let engineVocabulary = try vocabulary()
+        var document = try PatchDocumentV2.decode(from: fixture("document-v2-valid"))
+        let processorIndex = try XCTUnwrap(document.nodes.firstIndex { $0.id == "processor3" })
+
+        document.nodes[processorIndex].inputs["in"] = ["source1", "source1"]
+        XCTAssertTrue(document.validate(against: engineVocabulary).blockers.contains {
+            $0.code == .arityExceeded
+        })
+
+        document.nodes[processorIndex].inputs["in"] = ["control2"]
+        XCTAssertTrue(document.validate(against: engineVocabulary).blockers.contains {
+            $0.code == .incompatibleConnection
+        })
+
+        document.nodes[processorIndex].structuralParams["not_finite"] = .number(.infinity)
+        document.output = nil
+        let blockers = document.validate(against: engineVocabulary).blockers
+        XCTAssertTrue(blockers.contains { $0.code == .nonFiniteNumber })
+        XCTAssertTrue(blockers.contains { $0.code == .invalidOutput })
+    }
+
+    private func vocabulary() throws -> EngineVocabulary {
+        try EngineVocabulary.decode(from: fixture("document-vocabulary-v1"))
+    }
+
+    private func fixture(_ name: String) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+}

--- a/reversible/scripts/bundle-app
+++ b/reversible/scripts/bundle-app
@@ -9,10 +9,8 @@ app_path="$build_root/Reversible.app"
 stage_path="$build_root/.Reversible.app.stage"
 swift_scratch="$build_root/reversible-swift-release"
 engine_bin=${TROPICAL_ENGINE_BIN:-"$repo_root/lean/.lake/build/bin/frontend"}
-room_asset="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.tgrm"
-room_manifest="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.json"
 
-for required in "$engine_bin" "$room_asset" "$room_manifest"; do
+for required in "$engine_bin"; do
   if test ! -f "$required"; then
     printf 'bundle-app: required input is missing: %s\n' "$required" >&2
     exit 1
@@ -31,13 +29,10 @@ fi
 
 rm -rf "$stage_path"
 mkdir -p "$stage_path/Contents/MacOS"
-mkdir -p "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room"
+mkdir -p "$stage_path/Contents/Resources/Tropical"
 cp "$package_root/Resources/Info.plist" "$stage_path/Contents/Info.plist"
-cp "$package_root/Resources/Icon-placeholder.txt" "$stage_path/Contents/Resources/Icon-placeholder.txt"
 cp "$app_bin" "$stage_path/Contents/MacOS/Reversible"
 cp "$engine_bin" "$stage_path/Contents/Resources/Tropical/frontend"
-cp "$room_asset" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
-cp "$room_manifest" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
 
 # The checkout frontend's development rpath points back into the checkout.
 # A release bundle must carry the dylib beside the embedded frontend and add a

--- a/reversible/scripts/bundle-app
+++ b/reversible/scripts/bundle-app
@@ -7,6 +7,7 @@ package_root="$repo_root/reversible"
 build_root="$repo_root/build"
 app_path="$build_root/Reversible.app"
 stage_path="$build_root/.Reversible.app.stage"
+swift_scratch="$build_root/reversible-swift-release"
 engine_bin=${TROPICAL_ENGINE_BIN:-"$repo_root/lean/.lake/build/bin/frontend"}
 room_asset="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.tgrm"
 room_manifest="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.json"
@@ -18,8 +19,10 @@ for required in "$engine_bin" "$room_asset" "$room_manifest"; do
   fi
 done
 
-swift build -c release --package-path "$package_root"
-swift_bin=$(swift build -c release --package-path "$package_root" --show-bin-path)
+swift build -c release --disable-sandbox --package-path "$package_root" \
+  --scratch-path "$swift_scratch"
+swift_bin=$(swift build -c release --package-path "$package_root" \
+  --disable-sandbox --scratch-path "$swift_scratch" --show-bin-path)
 app_bin="$swift_bin/Reversible"
 if test ! -x "$app_bin"; then
   printf 'bundle-app: Reversible product is missing: %s\n' "$app_bin" >&2
@@ -36,21 +39,35 @@ cp "$engine_bin" "$stage_path/Contents/Resources/Tropical/frontend"
 cp "$room_asset" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
 cp "$room_manifest" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
 
-# The built frontend normally locates libtropical through its executable-path
-# rpath. Copy the dylib when this checkout emits it separately.
+# The checkout frontend's development rpath points back into the checkout.
+# A release bundle must carry the dylib beside the embedded frontend and add a
+# loader-local rpath to the staged copy so relocation never depends on that
+# checkout path.
+copied_dylib=false
 for dylib in \
   "$repo_root/build/libtropical.dylib" \
   "$(dirname -- "$engine_bin")/libtropical.dylib"; do
   if test -f "$dylib"; then
     cp "$dylib" "$stage_path/Contents/Resources/Tropical/libtropical.dylib"
+    copied_dylib=true
     break
   fi
 done
+if test "$copied_dylib" != true; then
+  printf 'bundle-app: libtropical.dylib is missing beside the native build\n' >&2
+  exit 1
+fi
+if command -v install_name_tool >/dev/null 2>&1; then
+  install_name_tool -add_rpath @executable_path \
+    "$stage_path/Contents/Resources/Tropical/frontend"
+fi
 
 rm -rf "$app_path"
 mv "$stage_path" "$app_path"
 if command -v codesign >/dev/null 2>&1; then
   codesign --force --deep --sign - "$app_path"
+  codesign --verify --deep --strict "$app_path"
 fi
+plutil -lint "$app_path/Contents/Info.plist" >/dev/null
 
 printf '%s\n' "$app_path"

--- a/reversible/scripts/bundle-app
+++ b/reversible/scripts/bundle-app
@@ -57,7 +57,9 @@ if test "$copied_dylib" != true; then
   printf 'bundle-app: libtropical.dylib is missing beside the native build\n' >&2
   exit 1
 fi
-if command -v install_name_tool >/dev/null 2>&1; then
+if command -v install_name_tool >/dev/null 2>&1 \
+  && ! otool -l "$stage_path/Contents/Resources/Tropical/frontend" \
+    | grep -Fq 'path @executable_path '; then
   install_name_tool -add_rpath @executable_path \
     "$stage_path/Contents/Resources/Tropical/frontend"
 fi

--- a/reversible/scripts/bundle-app
+++ b/reversible/scripts/bundle-app
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+package_root="$repo_root/reversible"
+build_root="$repo_root/build"
+app_path="$build_root/Reversible.app"
+stage_path="$build_root/.Reversible.app.stage"
+engine_bin=${TROPICAL_ENGINE_BIN:-"$repo_root/lean/.lake/build/bin/frontend"}
+room_asset="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.tgrm"
+room_manifest="$repo_root/playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.json"
+
+for required in "$engine_bin" "$room_asset" "$room_manifest"; do
+  if test ! -f "$required"; then
+    printf 'bundle-app: required input is missing: %s\n' "$required" >&2
+    exit 1
+  fi
+done
+
+swift build -c release --package-path "$package_root"
+swift_bin=$(swift build -c release --package-path "$package_root" --show-bin-path)
+app_bin="$swift_bin/Reversible"
+if test ! -x "$app_bin"; then
+  printf 'bundle-app: Reversible product is missing: %s\n' "$app_bin" >&2
+  exit 1
+fi
+
+rm -rf "$stage_path"
+mkdir -p "$stage_path/Contents/MacOS"
+mkdir -p "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room"
+cp "$package_root/Resources/Info.plist" "$stage_path/Contents/Info.plist"
+cp "$package_root/Resources/Icon-placeholder.txt" "$stage_path/Contents/Resources/Icon-placeholder.txt"
+cp "$app_bin" "$stage_path/Contents/MacOS/Reversible"
+cp "$engine_bin" "$stage_path/Contents/Resources/Tropical/frontend"
+cp "$room_asset" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
+cp "$room_manifest" "$stage_path/Contents/Resources/Tropical/playground/assets/grouped-room/"
+
+# The built frontend normally locates libtropical through its executable-path
+# rpath. Copy the dylib when this checkout emits it separately.
+for dylib in \
+  "$repo_root/build/libtropical.dylib" \
+  "$(dirname -- "$engine_bin")/libtropical.dylib"; do
+  if test -f "$dylib"; then
+    cp "$dylib" "$stage_path/Contents/Resources/Tropical/libtropical.dylib"
+    break
+  fi
+done
+
+rm -rf "$app_path"
+mv "$stage_path" "$app_path"
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - "$app_path"
+fi
+
+printf '%s\n' "$app_path"

--- a/reversible/scripts/run-dev
+++ b/reversible/scripts/run-dev
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+engine_bin="$repo_root/lean/.lake/build/bin/frontend"
+
+if test ! -x "$engine_bin"; then
+  printf 'run-dev: Tropical engine is not built: %s\n' "$engine_bin" >&2
+  printf 'run-dev: run `make lean` from %s first\n' "$repo_root" >&2
+  exit 1
+fi
+
+export TROPICAL_ENGINE_BIN="$engine_bin"
+exec swift run --package-path "$repo_root/reversible" Reversible "$@"

--- a/reversible/scripts/smoke-bundle.mjs
+++ b/reversible/scripts/smoke-bundle.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { connect } from 'node:net'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+
+const scriptDir = dirname(new URL(import.meta.url).pathname)
+const repoRoot = resolve(scriptDir, '../..')
+const sourceApp = resolve(process.argv[2] ?? join(repoRoot, 'build/Reversible.app'))
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'reversible-bundle-smoke-'))
+const relocatedApp = join(temporaryRoot, basename(sourceApp))
+const tropicalRoot = join(relocatedApp, 'Contents/Resources/Tropical')
+const frontend = join(tropicalRoot, 'frontend')
+const carrier = join(
+  tropicalRoot,
+  'playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.tgrm',
+)
+const manifest = join(
+  tropicalRoot,
+  'playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.json',
+)
+const socketPath = join(temporaryRoot, 'engine.sock')
+
+function requireFile(path) {
+  if (!existsSync(path)) throw new Error(`bundle input is missing: ${path}`)
+}
+
+function filesBelow(path) {
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const child = join(path, entry.name)
+    return entry.isDirectory() ? filesBelow(child) : [child]
+  })
+}
+
+class RPCClient {
+  constructor(socket) {
+    this.socket = socket
+    this.buffer = ''
+    this.nextID = 1
+    this.pending = new Map()
+    socket.on('data', (chunk) => this.receive(chunk.toString()))
+    socket.on('error', (error) => this.fail(error))
+    socket.on('close', () => this.fail(new Error('engine socket closed')))
+  }
+
+  receive(text) {
+    this.buffer += text
+    let newline
+    while ((newline = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, newline).trim()
+      this.buffer = this.buffer.slice(newline + 1)
+      if (!line) continue
+      const message = JSON.parse(line)
+      const request = this.pending.get(message.id)
+      if (!request) continue
+      this.pending.delete(message.id)
+      clearTimeout(request.timer)
+      try {
+        if (message.error) throw new Error(JSON.stringify(message.error))
+        const envelope = message.result?.content?.[0]?.text
+        if (typeof envelope !== 'string') request.resolve(message.result)
+        else {
+          const inner = JSON.parse(envelope)
+          if (inner.status !== 'ok') {
+            throw new Error(`${inner.error?.code}: ${inner.error?.message}`)
+          }
+          request.resolve(inner.data)
+        }
+      } catch (error) {
+        request.reject(error)
+      }
+    }
+  }
+
+  call(method, params = {}) {
+    const id = this.nextID++
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`timeout: ${method}`))
+      }, 60_000)
+      this.pending.set(id, { resolve, reject, timer })
+      this.socket.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`)
+    })
+  }
+
+  fail(error) {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer)
+      request.reject(error)
+    }
+    this.pending.clear()
+  }
+
+  close() {
+    this.socket.destroy()
+    this.fail(new Error('client closed'))
+  }
+}
+
+async function connectWhenReady(engine) {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (engine.exitCode !== null) throw new Error(`embedded engine exited ${engine.exitCode}`)
+    if (existsSync(socketPath)) {
+      const socket = await new Promise((resolveSocket) => {
+        const candidate = connect({ path: socketPath })
+        candidate.once('connect', () => resolveSocket(candidate))
+        candidate.once('error', () => {
+          candidate.destroy()
+          resolveSocket(null)
+        })
+      })
+      if (socket) return new RPCClient(socket)
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100))
+  }
+  throw new Error(`could not connect to embedded engine at ${socketPath}`)
+}
+
+const modes = [
+  [211, 7.5, 1, 0], [211, 95.5, 1, 0],
+  [433, 8.65, 1, 0], [433, 100.35, 1, 0],
+  [887, 9.8, 1, 0], [887, 105.2, 1, 0],
+  [1511, 10.95, 1, 0], [1511, 110.05, 1, 0],
+  [2837, 12.1, 1, 0], [2837, 114.9, 1, 0],
+  [5081, 13.25, 1, 0], [5081, 119.75, 1, 0],
+]
+
+const node = (id, kind, params, inputs) => ({ id, kind, params, sel: {}, in: inputs })
+const graph = {
+  nodes: [
+    node('hit', 'string', { t: 0, modes }, {}),
+    node('position', 'glideknob', { value: 1 }, {}),
+    node(
+      'room',
+      'groupedroom',
+      { profile: 'clouds-current-radii-mono-v1' },
+      { in: ['hit'], position: ['position'] },
+    ),
+    node('out', 'out', {}, { in: ['room'] }),
+  ],
+  out: 'out',
+}
+
+let engine
+let client
+try {
+  requireFile(sourceApp)
+  cpSync(sourceApp, relocatedApp, { recursive: true })
+  for (const path of [frontend, join(tropicalRoot, 'libtropical.dylib'), carrier, manifest]) {
+    requireFile(path)
+  }
+  const forbidden = filesBelow(relocatedApp).filter((path) => (
+    path.endsWith('-scene-44100.f32le') || path.includes('groupedroomcache')
+  ))
+  if (forbidden.length) throw new Error(`bundle contains fixed wet-score data: ${forbidden}`)
+
+  engine = spawn(frontend, ['--serve', socketPath], {
+    cwd: tropicalRoot,
+    stdio: ['ignore', 'ignore', 'inherit'],
+  })
+  client = await connectWhenReady(engine)
+  const vocabulary = await client.call('get_vocabulary')
+  const realized = await client.call('load_patch_graph', graph)
+  const room = realized.nodes?.find((item) => item.id === 'room')
+  if (vocabulary.fingerprint !== realized.vocabulary_fingerprint) {
+    throw new Error('compile fingerprint differs from decoded vocabulary')
+  }
+  if (room?.kind !== 'groupedroom' || room?.status !== 'active') {
+    throw new Error(`live room was not active: ${JSON.stringify(room)}`)
+  }
+  console.log(JSON.stringify({
+    schema: 'reversible_bundle_smoke_1',
+    relocated_app: relocatedApp,
+    vocabulary_fingerprint: vocabulary.fingerprint,
+    program_version: realized.program_version,
+    control_version: realized.control_version,
+    taps: realized.taps?.map((tap) => tap.name),
+    room,
+    fixed_wet_score_files: 0,
+    status: 'pass',
+  }))
+} finally {
+  client?.close()
+  engine?.kill('SIGTERM')
+  rmSync(temporaryRoot, { recursive: true, force: true })
+}

--- a/reversible/scripts/smoke-bundle.mjs
+++ b/reversible/scripts/smoke-bundle.mjs
@@ -3,7 +3,7 @@
 import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
 import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
 
 const scriptDir = dirname(new URL(import.meta.url).pathname)
@@ -13,14 +13,6 @@ const temporaryRoot = mkdtempSync(join(tmpdir(), 'reversible-bundle-smoke-'))
 const relocatedApp = join(temporaryRoot, basename(sourceApp))
 const tropicalRoot = join(relocatedApp, 'Contents/Resources/Tropical')
 const frontend = join(tropicalRoot, 'frontend')
-const carrier = join(
-  tropicalRoot,
-  'playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.tgrm',
-)
-const manifest = join(
-  tropicalRoot,
-  'playground/assets/grouped-room/clouds-current-radii-mono-v1-44100.json',
-)
 const socketPath = join(temporaryRoot, 'engine.sock')
 
 function requireFile(path) {
@@ -119,27 +111,11 @@ async function connectWhenReady(engine) {
   throw new Error(`could not connect to embedded engine at ${socketPath}`)
 }
 
-const modes = [
-  [211, 7.5, 1, 0], [211, 95.5, 1, 0],
-  [433, 8.65, 1, 0], [433, 100.35, 1, 0],
-  [887, 9.8, 1, 0], [887, 105.2, 1, 0],
-  [1511, 10.95, 1, 0], [1511, 110.05, 1, 0],
-  [2837, 12.1, 1, 0], [2837, 114.9, 1, 0],
-  [5081, 13.25, 1, 0], [5081, 119.75, 1, 0],
-]
-
 const node = (id, kind, params, inputs) => ({ id, kind, params, sel: {}, in: inputs })
 const graph = {
   nodes: [
-    node('hit', 'string', { t: 0, modes }, {}),
-    node('position', 'glideknob', { value: 1 }, {}),
-    node(
-      'room',
-      'groupedroom',
-      { profile: 'clouds-current-radii-mono-v1' },
-      { in: ['hit'], position: ['position'] },
-    ),
-    node('out', 'out', {}, { in: ['room'] }),
+    node('tone', 'source', { freq: 220, morph: 0 }, {}),
+    node('out', 'out', {}, { in: ['tone'] }),
   ],
   out: 'out',
 }
@@ -149,13 +125,16 @@ let client
 try {
   requireFile(sourceApp)
   cpSync(sourceApp, relocatedApp, { recursive: true })
-  for (const path of [frontend, join(tropicalRoot, 'libtropical.dylib'), carrier, manifest]) {
+  for (const path of [frontend, join(tropicalRoot, 'libtropical.dylib')]) {
     requireFile(path)
   }
-  const forbidden = filesBelow(relocatedApp).filter((path) => (
-    path.endsWith('-scene-44100.f32le') || path.includes('groupedroomcache')
-  ))
-  if (forbidden.length) throw new Error(`bundle contains fixed wet-score data: ${forbidden}`)
+  const runtimeFiles = filesBelow(tropicalRoot)
+    .map((path) => relative(tropicalRoot, path))
+    .sort()
+  const expectedRuntimeFiles = ['frontend', 'libtropical.dylib']
+  if (JSON.stringify(runtimeFiles) !== JSON.stringify(expectedRuntimeFiles)) {
+    throw new Error(`unexpected embedded runtime files: ${runtimeFiles}`)
+  }
 
   engine = spawn(frontend, ['--serve', socketPath], {
     cwd: tropicalRoot,
@@ -164,22 +143,20 @@ try {
   client = await connectWhenReady(engine)
   const vocabulary = await client.call('get_vocabulary')
   const realized = await client.call('load_patch_graph', graph)
-  const room = realized.nodes?.find((item) => item.id === 'room')
-  if (vocabulary.fingerprint !== realized.vocabulary_fingerprint) {
-    throw new Error('compile fingerprint differs from decoded vocabulary')
+  const tone = realized.nodes?.find((item) => item.id === 'tone')
+  if (typeof vocabulary.fingerprint !== 'string' || !vocabulary.fingerprint.startsWith('fnv1a64:')) {
+    throw new Error(`invalid vocabulary fingerprint: ${vocabulary.fingerprint}`)
   }
-  if (room?.kind !== 'groupedroom' || room?.status !== 'active') {
-    throw new Error(`live room was not active: ${JSON.stringify(room)}`)
+  if (realized.ok !== true || tone?.kind !== 'source' || tone?.status !== 'active') {
+    throw new Error(`canonical source patch was not active: ${JSON.stringify(realized)}`)
   }
   console.log(JSON.stringify({
     schema: 'reversible_bundle_smoke_1',
     relocated_app: relocatedApp,
     vocabulary_fingerprint: vocabulary.fingerprint,
-    program_version: realized.program_version,
-    control_version: realized.control_version,
     taps: realized.taps?.map((tap) => tap.name),
-    room,
-    fixed_wet_score_files: 0,
+    node: tone,
+    packaged_runtime_files: runtimeFiles,
     status: 'pass',
   }))
 } finally {


### PR DESCRIPTION
## Scope

Add the canonical Reversible macOS control surface directly on `main`.

- import the standalone SwiftUI app as `reversible/`
- decode the engine-owned node vocabulary, including a versioned fingerprint
- bound live parameter writes and split RPC traffic lanes
- preserve lossless v2 patch documents
- add focused Swift fixtures/tests, native build gates, and relocatable bundle smoke
- bundle only the app, Tropical frontend, and `libtropical`

## Deliberately excluded

This branch was reconstructed from `main`; it does not descend from the closed
demo PR. It contains no demo scene or UI, grouped-room implementation or assets,
audition tooling, qualification streams, audio captures, validation logs, sprint
planning/evidence documents, or generated benchmark output.

The earlier graph-handshake/realized-truth/scope-snapshot work is also excluded.
Those patches were coupled to the demo runtime and must be reimplemented and
reviewed independently before the corresponding app features can return.

## Review shape

44 files: 40 belong to the `reversible/` package; the remaining four are the
Makefile gate, macOS CI job, and two focused Lean vocabulary-contract files.

## Validation

- `make validate`: pass
- `swift build --package-path reversible`: pass
- `make reversible-bundle-smoke`: pass after relocation and ad-hoc signing
  - embedded runtime files: `frontend`, `libtropical.dylib`
  - canonical `source -> out` graph compiled active
- `swift test`: locally blocked because the installed standalone Command Line
  Tools do not provide XCTest; the macOS CI job is the authoritative XCTest run

Draft until the macOS Swift job reports and the package boundary receives review.
