### PR TITLE
Add generation-pinned observation rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,8 @@ if(TROPICAL_BUILD_TESTS)
     target_include_directories(test_module_process PRIVATE engine ${LLVM_INCLUDE_DIRS})
     target_compile_definitions(test_module_process PRIVATE ${LLVM_DEFINITIONS})
     target_compile_features(test_module_process PRIVATE cxx_std_20)
-    target_link_libraries(test_module_process PRIVATE tropical_core)
+    target_link_libraries(test_module_process PRIVATE
+        tropical_core nlohmann_json::nlohmann_json)
     add_test(NAME current_module_process COMMAND test_module_process)
 
     if(TROPICAL_TSAN)

--- a/engine/c_api/tropical_c.cpp
+++ b/engine/c_api/tropical_c.cpp
@@ -327,6 +327,69 @@ bool tropical_runtime_load_ir_staged(tropical_runtime_t r, const char* ir_text, 
   catch (const std::exception& e) { set_error(e.what()); return false; }
 }
 
+bool tropical_runtime_load_ir_staged_generation(
+  tropical_runtime_t r, const char* ir_text, size_t ir_len,
+  const char* msl_source, size_t msl_len,
+  const char* coeff_ir, size_t coeff_len,
+  const char* manifest_json, size_t manifest_len,
+  tropical_runtime_generation_t* out_generation)
+{
+  if (out_generation) *out_generation = {};
+  if (!r || !ir_text || !manifest_json || !out_generation) return false;
+  try
+  {
+    const auto generation =
+      static_cast<tropical_runtime::FlatRuntime*>(r)
+        ->load_ir_staged_generation(
+          std::string(ir_text, ir_len),
+          msl_source ? std::string(msl_source, msl_len) : std::string{},
+          coeff_ir ? std::string(coeff_ir, coeff_len) : std::string{},
+          std::string(manifest_json, manifest_len));
+    out_generation->program_version = generation.program_version;
+    out_generation->control_version = generation.control_version;
+    return generation.program_version != 0;
+  }
+  catch (const std::exception& e) { set_error(e.what()); return false; }
+}
+
+bool tropical_runtime_load_ir_staged_with_observation_generation(
+  tropical_runtime_t r, const char* audio_ir, size_t audio_ir_len,
+  const char* audio_msl_source, size_t audio_msl_len,
+  const char* audio_coeff_ir, size_t audio_coeff_len,
+  const char* audio_manifest_json, size_t audio_manifest_len,
+  const char* observation_ir, size_t observation_ir_len,
+  const char* observation_coeff_ir, size_t observation_coeff_len,
+  const char* observation_manifest_json, size_t observation_manifest_len,
+  tropical_runtime_generation_t* out_generation)
+{
+  if (out_generation) *out_generation = {};
+  if (!r || !audio_ir || !audio_manifest_json || !observation_ir
+      || !observation_manifest_json || !out_generation)
+    return false;
+  try
+  {
+    const auto generation =
+      static_cast<tropical_runtime::FlatRuntime*>(r)
+        ->load_ir_staged_with_observation_generation(
+          std::string(audio_ir, audio_ir_len),
+          audio_msl_source
+            ? std::string(audio_msl_source, audio_msl_len) : std::string{},
+          audio_coeff_ir
+            ? std::string(audio_coeff_ir, audio_coeff_len) : std::string{},
+          std::string(audio_manifest_json, audio_manifest_len),
+          std::string(observation_ir, observation_ir_len),
+          observation_coeff_ir
+            ? std::string(observation_coeff_ir, observation_coeff_len)
+            : std::string{},
+          std::string(
+            observation_manifest_json, observation_manifest_len));
+    out_generation->program_version = generation.program_version;
+    out_generation->control_version = generation.control_version;
+    return generation.program_version != 0;
+  }
+  catch (const std::exception& e) { set_error(e.what()); return false; }
+}
+
 void tropical_runtime_set_sample_index(tropical_runtime_t r, uint64_t idx)
 {
   if (!r) return;

--- a/engine/c_api/tropical_c.h
+++ b/engine/c_api/tropical_c.h
@@ -13,6 +13,11 @@ typedef void* tropical_dac_t;
 typedef void* tropical_param_t;
 typedef void* tropical_runtime_t;
 
+typedef struct tropical_runtime_generation {
+  uint64_t program_version;
+  uint64_t control_version;
+} tropical_runtime_generation_t;
+
 typedef struct {
   uint64_t request_received;
   uint64_t activation_target_reserved;
@@ -165,6 +170,16 @@ bool             tropical_runtime_load_ir_msl(tropical_runtime_t, const char* ir
    state before publish and re-run after every control-plane slot write.
    Its outputs land in coef:<n> module slots the audio kernel reads. */
 bool             tropical_runtime_load_ir_staged(tropical_runtime_t, const char* ir_text, size_t ir_len, const char* msl_source, size_t msl_len, const char* coeff_ir, size_t coeff_len, const char* manifest_json, size_t manifest_len);
+
+/* Staged single-artifact load returning the exact program/control generation
+   pair constructed by this publication. The pair is written before the load
+   returns and is not sampled from mutable counters afterward. */
+bool             tropical_runtime_load_ir_staged_generation(tropical_runtime_t, const char* ir_text, size_t ir_len, const char* msl_source, size_t msl_len, const char* coeff_ir, size_t coeff_len, const char* manifest_json, size_t manifest_len, tropical_runtime_generation_t* out_generation);
+
+/* Atomic dual-artifact publication. The first staged artifact owns audio and
+   optional Metal execution; the second JIT-only artifact owns observation.
+   Controls project between differing slot layouts by exact manifest name. */
+bool             tropical_runtime_load_ir_staged_with_observation_generation(tropical_runtime_t, const char* audio_ir, size_t audio_ir_len, const char* audio_msl_source, size_t audio_msl_len, const char* audio_coeff_ir, size_t audio_coeff_len, const char* audio_manifest_json, size_t audio_manifest_len, const char* observation_ir, size_t observation_ir_len, const char* observation_coeff_ir, size_t observation_coeff_len, const char* observation_manifest_json, size_t observation_manifest_len, tropical_runtime_generation_t* out_generation);
 
 /* Control-plane/test-only: request a sample-clock reposition. JIT applies it
    at its next process-buffer boundary; Metal prepares and acknowledges an

--- a/engine/c_api/tropical_socket.cpp
+++ b/engine/c_api/tropical_socket.cpp
@@ -266,36 +266,95 @@ std::string SocketServer::handle_data(const std::string & line)
     if (method == "render_window")
     {
       const json & p = j.at("params");
-      const uint64_t start = p.at("start").get<uint64_t>();
-      uint32_t count = p.at("count").get<uint32_t>();
-      if (count > 16384u)
+      const uint32_t requested_count = p.at("count").get<uint32_t>();
+      if (requested_count == 0 || requested_count > 16384u)
         return json{{"jsonrpc", "2.0"}, {"id", id},
-                    {"error", {{"code", -32602}, {"message", "render_window: count too large (max 16384)"}}}}.dump();
+                    {"error", {{"code", -32602}, {"message", "render_window: count must be in [1,16384]"}}}}.dump();
+      const std::string anchor = p.value("anchor", std::string{});
+      if (!anchor.empty() && anchor != "playback")
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"error", {{"code", -32602}, {"message", "render_window: anchor must be 'playback'"}}}}.dump();
+      const bool playback_anchored = anchor == "playback";
+      if (!playback_anchored && !p.contains("start"))
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"error", {{"code", -32602}, {"message", "render_window: start is required without a playback anchor"}}}}.dump();
+      const uint64_t playback_position = playback_anchored
+        ? runtime_->current_sample_index()
+        : 0;
+      const uint64_t start = playback_anchored
+        ? (playback_position >= requested_count
+             ? playback_position - requested_count
+             : 0)
+        : p.at("start").get<uint64_t>();
+      const uint32_t point_budget =
+        p.value("point_budget", requested_count);
+      if (point_budget == 0 || point_budget > 16384u)
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"error", {{"code", -32602}, {"message", "render_window: point_budget must be in [1,16384]"}}}}.dump();
+      const uint32_t stride =
+        (requested_count + point_budget - 1) / point_budget;
+      const uint32_t count =
+        (requested_count + stride - 1) / stride;
       const auto names = p.at("slots").get<std::vector<std::string>>();
-      std::vector<uint32_t> ids;
-      ids.reserve(names.size());
-      for (const auto & nm : names)
+      std::vector<double> out(
+        static_cast<size_t>(count) * names.size(), 0.0);
+      const auto render = runtime_->render_window_observation_by_name(
+        start, count, stride, names, out.data());
+      if (!render.unknown_slot.empty())
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"error", {{"code", -32602}, {"message", "render_window: unknown slot '" + render.unknown_slot + "'"}}}}.dump();
+      if (render.status == tropical_runtime::RenderWindowStatus::Preempted)
       {
-        const uint32_t sid = runtime_->slot_index(nm);
-        if (sid == UINT32_MAX)
-          return json{{"jsonrpc", "2.0"}, {"id", id},
-                      {"error", {{"code", -32602}, {"message", "render_window: unknown slot '" + nm + "'"}}}}.dump();
-        ids.push_back(sid);
+        json result = {
+          {"start", start},
+          {"count", 0},
+          {"span", requested_count},
+          {"stride", stride},
+          {"preempted", true},
+          {"program_version", render.program_version},
+          {"control_version", render.control_version},
+          {"effective_sample_index", render.effective_sample_index},
+          {"values", json::array()},
+        };
+        if (playback_anchored)
+        {
+          result["anchor"] = "playback";
+          result["playback_position"] = playback_position;
+        }
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"result", std::move(result)}}.dump();
       }
-      std::vector<double> out(static_cast<size_t>(count) * ids.size(), 0.0);
-      if (!runtime_->render_window(start, count, ids.data(),
-                                   static_cast<uint32_t>(ids.size()), out.data()))
+      if (render.status == tropical_runtime::RenderWindowStatus::Unsupported)
         return json{{"jsonrpc", "2.0"}, {"id", id},
                     {"error", {{"code", -32603}, {"message", "render_window: active kernel is not fused"}}}}.dump();
+      if (render.status != tropical_runtime::RenderWindowStatus::Rendered)
+        return json{{"jsonrpc", "2.0"}, {"id", id},
+                    {"error", {{"code", -32602}, {"message", "render_window: invalid render request"}}}}.dump();
       json values = json::array();
-      for (size_t k = 0; k < ids.size(); ++k)
+      for (size_t k = 0; k < names.size(); ++k)
       {
         json ch = json::array();
         for (uint32_t i = 0; i < count; ++i) ch.push_back(out[k * count + i]);
         values.push_back(std::move(ch));
       }
+      json result = {
+        {"start", start},
+        {"count", count},
+        {"span", requested_count},
+        {"stride", stride},
+        {"preempted", false},
+        {"program_version", render.program_version},
+        {"control_version", render.control_version},
+        {"effective_sample_index", render.effective_sample_index},
+        {"values", std::move(values)},
+      };
+      if (playback_anchored)
+      {
+        result["anchor"] = "playback";
+        result["playback_position"] = playback_position;
+      }
       return json{{"jsonrpc", "2.0"}, {"id", id},
-                  {"result", {{"start", start}, {"count", count}, {"values", std::move(values)}}}}.dump();
+                  {"result", std::move(result)}}.dump();
     }
   }
   catch (const std::exception & e)

--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -76,6 +76,43 @@ double signed_sample_delta(uint64_t now, uint64_t then)
     : -static_cast<double>(then - now);
 }
 
+std::shared_ptr<const ObservationProgramImage>
+make_observation_program_image(
+  const KernelState & state, uint64_t program_version)
+{
+  auto image = std::make_shared<ObservationProgramImage>();
+  image->program_version = program_version;
+  image->mode = state.mode;
+  image->kernel = state.kernel;
+  image->coeff_kernel = state.coeff_kernel;
+  image->sample_rate = state.sample_rate;
+  image->register_count = state.registers.size();
+  image->temp_count = state.temps.size();
+  image->coeff_register_count = state.coeff_registers.size();
+  image->coeff_temp_count = state.coeff_temps.size();
+  image->array_storage = state.array_storage;
+  image->array_sizes = state.array_sizes;
+  image->param_ptrs = state.param_ptrs;
+  image->coeff_array_slots = state.coeff_array_slots;
+  image->slot_names = state.slot_names;
+  image->slot_lookup.reserve(image->slot_names.size());
+  for (uint32_t i = 0; i < image->slot_names.size(); ++i)
+    image->slot_lookup.emplace(image->slot_names[i], i);
+  return image;
+}
+
+std::shared_ptr<const ObservationControlImage>
+make_observation_control_image(
+  const KernelState & state, uint64_t control_version,
+  uint64_t effective_sample_index)
+{
+  auto image = std::make_shared<ObservationControlImage>();
+  image->control_version = control_version;
+  image->effective_sample_index = effective_sample_index;
+  image->slots = state.slots;
+  return image;
+}
+
 } // namespace
 
 FlatRuntime::FlatRuntime(unsigned int buffer_length)
@@ -237,7 +274,8 @@ FlatRuntime::publish_metal_control_snapshot_locked(
     state, tropical_metal::EpochTransitionKind::Continuous, 0,
     generation.target);
   if (scheduled.ok)
-    commit_control_snapshot(state, state_index, generation);
+    commit_control_snapshot(
+      state, state_index, generation, scheduled.effective_sample_index);
   else
     release_control_snapshot_reservation(state_index, generation);
   return scheduled;
@@ -392,6 +430,20 @@ bool FlatRuntime::publish_state(KernelState && new_state)
   // zero-init from the fresh kernel. The audio-owned clock is runtime-global,
   // so a state flip cannot repeat, skip, or race its sample position.
 
+  // Build the read-side image before moving the state. It contains only
+  // immutable metadata, JIT function pointers, and copied controls, so the
+  // observer never points into either movable KernelState slot.
+  const uint64_t program_version =
+    recompile_version_.load(std::memory_order_relaxed) + 1;
+  auto observation_program =
+    make_observation_program_image(new_state, program_version);
+  auto observation_controls = make_observation_control_image(
+    new_state, next_observation_control_version_++,
+    published_sample_index_.load(std::memory_order_acquire));
+  auto observation_snapshot = std::make_shared<ObservationSnapshot>();
+  observation_snapshot->program = std::move(observation_program);
+  observation_snapshot->controls = std::move(observation_controls);
+
   states_[inactive] = std::move(new_state);
   state_owners_[inactive].store(
     StorageOwner::Free, std::memory_order_release);
@@ -423,7 +475,12 @@ bool FlatRuntime::publish_state(KernelState && new_state)
       break;
   }
   active_state_.store(inactive, std::memory_order_release);
-  recompile_version_.fetch_add(1, std::memory_order_release);
+  recompile_version_.store(program_version, std::memory_order_release);
+  std::atomic_store_explicit(
+    &observation_snapshot_,
+    std::shared_ptr<const ObservationSnapshot>(
+      std::move(observation_snapshot)),
+    std::memory_order_release);
 #ifdef TROPICAL_METAL
   const bool metal = static_cast<bool>(states_[inactive].metal);
   metal_runtime_loaded_.store(metal, std::memory_order_release);
@@ -610,7 +667,8 @@ void FlatRuntime::release_control_snapshot_reservation(
 
 void FlatRuntime::commit_control_snapshot(
   KernelState & state, uint32_t state_index,
-  ControlGenerationReservation reservation)
+  ControlGenerationReservation reservation,
+  uint64_t effective_sample_index)
 {
   if (state_index == UINT32_MAX)
   {
@@ -646,6 +704,26 @@ void FlatRuntime::commit_control_snapshot(
   }
   std::atomic_ref(state.control_published_gen)
     .store(reservation.target, std::memory_order_release);
+  publish_observation_controls_locked(state, effective_sample_index);
+}
+
+void FlatRuntime::publish_observation_controls_locked(
+  const KernelState & state, uint64_t effective_sample_index)
+{
+  const auto current = std::atomic_load_explicit(
+    &observation_snapshot_, std::memory_order_acquire);
+  if (!current || !current->program) return;
+  if (effective_sample_index == UINT64_MAX)
+    effective_sample_index =
+      published_sample_index_.load(std::memory_order_acquire);
+  auto next = std::make_shared<ObservationSnapshot>();
+  next->program = current->program;
+  next->controls = make_observation_control_image(
+    state, next_observation_control_version_++, effective_sample_index);
+  std::atomic_store_explicit(
+    &observation_snapshot_,
+    std::shared_ptr<const ObservationSnapshot>(std::move(next)),
+    std::memory_order_release);
 }
 
 ParamDispatchResult FlatRuntime::dispatch_param_sync(
@@ -714,7 +792,8 @@ ParamDispatchResult FlatRuntime::dispatch_param_sync(
           + scheduled.error;
         return result;
       }
-      commit_control_snapshot(state, state_idx, reservation);
+      commit_control_snapshot(
+        state, state_idx, reservation, result.effective_sample_index);
       return result;
     }
   }
@@ -792,6 +871,8 @@ ParamDispatchResult FlatRuntime::dispatch_param_sync(
     {
       std::atomic_ref(state.control_published_gen)
         .store(reservation.target, std::memory_order_release);
+      publish_observation_controls_locked(
+        state, result.effective_sample_index);
       return result;
     }
 
@@ -828,7 +909,7 @@ ParamDispatchResult FlatRuntime::dispatch_param_sync_at_sample_index(
   result.observed_sample_index = sample_index;
   result.effective_sample_index = sample_index;
   if (result.ok)
-    publish_control_snapshot(state, state_idx);
+    publish_control_snapshot(state, state_idx, sample_index);
   return result;
 }
 

--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -95,6 +95,7 @@ make_observation_program_image(
   image->param_ptrs = state.param_ptrs;
   image->coeff_array_slots = state.coeff_array_slots;
   image->slot_names = state.slot_names;
+  image->initial_slots = state.slots;
   image->slot_lookup.reserve(image->slot_names.size());
   for (uint32_t i = 0; i < image->slot_names.size(); ++i)
     image->slot_lookup.emplace(image->slot_names[i], i);
@@ -103,13 +104,22 @@ make_observation_program_image(
 
 std::shared_ptr<const ObservationControlImage>
 make_observation_control_image(
-  const KernelState & state, uint64_t control_version,
+  const ObservationProgramImage & program,
+  const KernelState & audio_state, uint64_t control_version,
   uint64_t effective_sample_index)
 {
   auto image = std::make_shared<ObservationControlImage>();
   image->control_version = control_version;
   image->effective_sample_index = effective_sample_index;
-  image->slots = state.slots;
+  image->slots = program.initial_slots;
+  for (std::size_t i = 0;
+       i < audio_state.slot_names.size() && i < audio_state.slots.size(); ++i)
+  {
+    const auto found = program.slot_lookup.find(audio_state.slot_names[i]);
+    if (found != program.slot_lookup.end()
+        && found->second < image->slots.size())
+      image->slots[found->second] = audio_state.slots[i];
+  }
   return image;
 }
 
@@ -387,7 +397,8 @@ KernelState FlatRuntime::build_kernel_state(const tropical_plan5::ParsedPlan5 & 
 
 // Atomic double-buffer flip (CF-only: no by-name state transfer — see below).
 // Assumes new_state already carries a populated kernel handle.
-bool FlatRuntime::publish_state(KernelState && new_state)
+PublishedGeneration FlatRuntime::publish_state(
+  KernelState && new_state, const KernelState * observation_state)
 {
   std::lock_guard<std::mutex> lock(build_mutex_);
 #ifdef TROPICAL_METAL
@@ -433,12 +444,17 @@ bool FlatRuntime::publish_state(KernelState && new_state)
   // Build the read-side image before moving the state. It contains only
   // immutable metadata, JIT function pointers, and copied controls, so the
   // observer never points into either movable KernelState slot.
-  const uint64_t program_version =
-    recompile_version_.load(std::memory_order_relaxed) + 1;
+  const PublishedGeneration generation = {
+    recompile_version_.load(std::memory_order_relaxed) + 1,
+    next_observation_control_version_++,
+  };
+  const KernelState & observation_source = observation_state
+    ? *observation_state : new_state;
   auto observation_program =
-    make_observation_program_image(new_state, program_version);
+    make_observation_program_image(
+      observation_source, generation.program_version);
   auto observation_controls = make_observation_control_image(
-    new_state, next_observation_control_version_++,
+    *observation_program, new_state, generation.control_version,
     published_sample_index_.load(std::memory_order_acquire));
   auto observation_snapshot = std::make_shared<ObservationSnapshot>();
   observation_snapshot->program = std::move(observation_program);
@@ -475,7 +491,8 @@ bool FlatRuntime::publish_state(KernelState && new_state)
       break;
   }
   active_state_.store(inactive, std::memory_order_release);
-  recompile_version_.store(program_version, std::memory_order_release);
+  recompile_version_.store(
+    generation.program_version, std::memory_order_release);
   std::atomic_store_explicit(
     &observation_snapshot_,
     std::shared_ptr<const ObservationSnapshot>(
@@ -486,7 +503,7 @@ bool FlatRuntime::publish_state(KernelState && new_state)
   metal_runtime_loaded_.store(metal, std::memory_order_release);
   metal_audio_enabled_.store(metal, std::memory_order_release);
 #endif
-  return true;
+  return generation;
 }
 
 bool FlatRuntime::load_ir(const std::string & ir_text, const std::string & manifest_json)
@@ -506,50 +523,93 @@ bool FlatRuntime::load_ir_staged(const std::string & ir_text,
                                  const std::string & coeff_ir,
                                  const std::string & manifest_json)
 {
+  return load_ir_staged_generation(
+    ir_text, msl_source, coeff_ir, manifest_json).program_version != 0;
+}
+
+PublishedGeneration FlatRuntime::load_ir_staged_generation(
+  const std::string & ir_text, const std::string & msl_source,
+  const std::string & coeff_ir, const std::string & manifest_json)
+{
+  return load_ir_staged_with_observation_generation(
+    ir_text, msl_source, coeff_ir, manifest_json, {}, {}, {});
+}
+
+PublishedGeneration
+FlatRuntime::load_ir_staged_with_observation_generation(
+  const std::string & audio_ir, const std::string & audio_msl_source,
+  const std::string & audio_coeff_ir,
+  const std::string & audio_manifest_json,
+  const std::string & observation_ir,
+  const std::string & observation_coeff_ir,
+  const std::string & observation_manifest_json)
+{
   using json = nlohmann::json;
+  auto compile_jit_state = [this](
+      const std::string & kernel_ir,
+      const std::string & coefficient_ir,
+      const std::string & manifest_text) {
+    const json manifest = json::parse(manifest_text);
+    const std::string schema = manifest.value("schema", std::string{});
+    if (schema != "tropical_plan_5")
+      throw std::runtime_error(
+        "FlatRuntime: load_ir unsupported manifest schema '" + schema +
+        "'; expected 'tropical_plan_5'");
+    auto parsed = tropical_plan5::parse_plan5(manifest);
+    KernelState state = build_kernel_state(parsed);
+    state.mode = tropical_jit::CompilationMode::Fused;
 
-  const json manifest = json::parse(manifest_json);
-  const std::string schema = manifest.value("schema", std::string{});
-
-  if (schema != "tropical_plan_5")
-    throw std::runtime_error(
-      "FlatRuntime: load_ir unsupported manifest schema '" + schema +
-      "'; expected 'tropical_plan_5'");
-  tropical_plan5::ParsedPlan5 parsed = tropical_plan5::parse_plan5(manifest);
-
-  KernelState new_state = build_kernel_state(parsed);
-  // The IR path is always fused — Lean emits a single fused kernel.
-  new_state.mode = tropical_jit::CompilationMode::Fused;
-
-  // The JIT kernel loads ALWAYS — it keeps serving render_window (the
-  // scope) and the correctness reference even when audio runs on Metal.
-  auto kernel_result = tropical_jit::OrcJitEngine::instance().compile_ir_text(ir_text);
-  if (!kernel_result)
-  {
-    std::string err;
-    llvm::handleAllErrors(kernel_result.takeError(),
-      [&err](const llvm::ErrorInfoBase & e) { err = e.message(); });
-    throw std::runtime_error("FlatRuntime: IR JIT compilation failed: " + err);
-  }
-  new_state.kernel = *kernel_result;
-
-  if (!coeff_ir.empty())
-  {
-    // O0: the coefficient kernel runs once per control write — codegen
-    // quality is irrelevant, and O2 on its thousands-of-flops block is
-    // exactly the compile wall the stage-0 split removes.
-    auto coeff_result = tropical_jit::OrcJitEngine::instance().compile_ir_text(coeff_ir, true);
-    if (!coeff_result)
+    auto kernel_result =
+      tropical_jit::OrcJitEngine::instance().compile_ir_text(kernel_ir);
+    if (!kernel_result)
     {
       std::string err;
-      llvm::handleAllErrors(coeff_result.takeError(),
+      llvm::handleAllErrors(kernel_result.takeError(),
         [&err](const llvm::ErrorInfoBase & e) { err = e.message(); });
-      throw std::runtime_error("FlatRuntime: coefficient IR JIT compilation failed: " + err);
+      throw std::runtime_error(
+        "FlatRuntime: IR JIT compilation failed: " + err);
     }
-    new_state.coeff_kernel = *coeff_result;
-  }
+    state.kernel = *kernel_result;
 
-  if (!msl_source.empty())
+    if (!coefficient_ir.empty())
+    {
+      // Coefficient code runs only on control/observation lanes; O0 minimizes
+      // compile latency for what may be a large uniform instruction block.
+      auto coeff_result =
+        tropical_jit::OrcJitEngine::instance().compile_ir_text(
+          coefficient_ir, true);
+      if (!coeff_result)
+      {
+        std::string err;
+        llvm::handleAllErrors(coeff_result.takeError(),
+          [&err](const llvm::ErrorInfoBase & e) { err = e.message(); });
+        throw std::runtime_error(
+          "FlatRuntime: coefficient IR JIT compilation failed: " + err);
+      }
+      state.coeff_kernel = *coeff_result;
+    }
+
+    // Both artifacts must be fully initialized before the single publication.
+    publish_control_snapshot(state);
+    return state;
+  };
+
+  const bool has_observation_artifact =
+    !observation_ir.empty() || !observation_coeff_ir.empty()
+    || !observation_manifest_json.empty();
+  if (has_observation_artifact
+      && (observation_ir.empty() || observation_manifest_json.empty()))
+    throw std::invalid_argument(
+      "FlatRuntime: observation IR and manifest must be supplied together");
+
+  KernelState new_state = compile_jit_state(
+    audio_ir, audio_coeff_ir, audio_manifest_json);
+  std::unique_ptr<KernelState> observation_state;
+  if (has_observation_artifact)
+    observation_state = std::make_unique<KernelState>(compile_jit_state(
+      observation_ir, observation_coeff_ir, observation_manifest_json));
+
+  if (!audio_msl_source.empty())
   {
 #ifdef TROPICAL_METAL
     if (!metal_queue_ready_.load(std::memory_order_acquire))
@@ -571,7 +631,7 @@ bool FlatRuntime::load_ir_staged(const std::string & ir_text,
              .load(std::memory_order_relaxed)])
       column_floats += column.size();
     new_state.metal = tropical_metal::create(
-      msl_source, metal_render_tile_frames_,
+      audio_msl_source, metal_render_tile_frames_,
       static_cast<uint32_t>(new_state.slots.size()),
       static_cast<uint32_t>(column_floats), err);
     if (!new_state.metal)
@@ -582,12 +642,8 @@ bool FlatRuntime::load_ir_staged(const std::string & ir_text,
 #endif
   }
 
-  // Materialize coefficient slots before the state becomes visible to the
-  // audio thread or render_window — initial knob values exist, so a first
-  // buffer reading zero-initialized coefficient slots would be a bug.
-  publish_control_snapshot(new_state);
-
-  return publish_state(std::move(new_state));
+  return publish_state(
+    std::move(new_state), observation_state.get());
 }
 
 FlatRuntime::ControlGenerationReservation
@@ -719,7 +775,8 @@ void FlatRuntime::publish_observation_controls_locked(
   auto next = std::make_shared<ObservationSnapshot>();
   next->program = current->program;
   next->controls = make_observation_control_image(
-    state, next_observation_control_version_++, effective_sample_index);
+    *current->program, state, next_observation_control_version_++,
+    effective_sample_index);
   std::atomic_store_explicit(
     &observation_snapshot_,
     std::shared_ptr<const ObservationSnapshot>(std::move(next)),

--- a/engine/runtime/FlatRuntime.hpp
+++ b/engine/runtime/FlatRuntime.hpp
@@ -63,6 +63,15 @@ struct ParamDispatchResult
   uint64_t    effective_sample_index = 0;
 };
 
+// Exact graph generation created by one successful publication. Returning the
+// pair from inside the publication critical section avoids a compile caller
+// racing a subsequent control-only publication while sampling two counters.
+struct PublishedGeneration
+{
+  uint64_t program_version = 0;
+  uint64_t control_version = 0;
+};
+
 // Random-access observation retains an explicit cancellation outcome for
 // latest-only/superseded callers. Snapshot rendering itself does not preempt;
 // the status remains part of the wire contract so callers can discard partial
@@ -137,6 +146,7 @@ struct ObservationProgramImage
   std::vector<uint64_t> param_ptrs;
   std::vector<uint32_t> coeff_array_slots;
   std::vector<std::string> slot_names;
+  std::vector<double> initial_slots;
   std::unordered_map<std::string, uint32_t> slot_lookup;
 };
 
@@ -312,6 +322,25 @@ public:
    */
   bool load_ir_staged(const std::string & ir_text, const std::string & msl_source,
                       const std::string & coeff_ir, const std::string & manifest_json);
+
+  /** Publish one audio/observation artifact and return its exact initial pair. */
+  PublishedGeneration load_ir_staged_generation(
+    const std::string & ir_text, const std::string & msl_source,
+    const std::string & coeff_ir, const std::string & manifest_json);
+
+  /**
+   * Atomically publish distinct audio and observation artifacts. The audio
+   * artifact may own Metal execution; observation is JIT-only. Slot layouts
+   * may differ: each audio control image is projected by exact manifest name
+   * into the observation program's initial slot image.
+   */
+  PublishedGeneration load_ir_staged_with_observation_generation(
+    const std::string & audio_ir, const std::string & audio_msl_source,
+    const std::string & audio_coeff_ir,
+    const std::string & audio_manifest_json,
+    const std::string & observation_ir,
+    const std::string & observation_coeff_ir,
+    const std::string & observation_manifest_json);
 
   /**
    * Control-plane/test-only: reposition the active kernel's sample clock
@@ -1258,7 +1287,9 @@ private:
   // sample coordinate and performs the atomic double-buffer flip.
   // load_ir fills the kernel handle (via compile_ir_text) between them.
   KernelState build_kernel_state(const tropical_plan5::ParsedPlan5 & parsed);
-  bool publish_state(KernelState && new_state);
+  PublishedGeneration publish_state(
+    KernelState && new_state,
+    const KernelState * observation_state = nullptr);
 
 #ifdef TROPICAL_METAL
   tropical_metal::RenderEpochRequest make_metal_epoch_request(

--- a/engine/runtime/FlatRuntime.hpp
+++ b/engine/runtime/FlatRuntime.hpp
@@ -63,6 +63,27 @@ struct ParamDispatchResult
   uint64_t    effective_sample_index = 0;
 };
 
+// Random-access observation retains an explicit cancellation outcome for
+// latest-only/superseded callers. Snapshot rendering itself does not preempt;
+// the status remains part of the wire contract so callers can discard partial
+// work if a future observation scheduler adds cooperative cancellation.
+enum class RenderWindowStatus : uint8_t
+{
+  Rendered,
+  Preempted,
+  InvalidArgument,
+  Unsupported,
+};
+
+struct ObservationRenderResult
+{
+  RenderWindowStatus status = RenderWindowStatus::InvalidArgument;
+  uint64_t program_version = 0;
+  uint64_t control_version = 0;
+  uint64_t effective_sample_index = 0;
+  std::string unknown_slot;
+};
+
 // Explicit ownership for storage that is mutated off the audio thread.
 // These atomics deliberately live outside KernelState: KernelState is movable
 // during hot-swap, while ownership must remain at a stable address.
@@ -91,6 +112,63 @@ struct RuntimeOwnershipTestSeam
   std::atomic<bool> pause_after_dispatch_materialization{false};
   std::atomic<bool> dispatch_materialized{false};
   std::atomic<bool> release_dispatch{false};
+  std::atomic<bool> pause_after_observation_coordinate{false};
+  std::atomic<bool> observation_coordinate_completed{false};
+  std::atomic<bool> release_observation_coordinate{false};
+};
+
+// Immutable read-side program/control images for every random-access
+// observer. A slow reader retains one heap image while audio and control keep
+// publishing through their bounded ownership protocol; no pointer below
+// aliases either movable KernelState slot.
+struct ObservationProgramImage
+{
+  uint64_t program_version = 0;
+  tropical_jit::CompilationMode mode = tropical_jit::CompilationMode::Fused;
+  tropical_jit::NumericKernelFn kernel = nullptr;
+  tropical_jit::NumericKernelFn coeff_kernel = nullptr;
+  double sample_rate = 44100.0;
+  std::size_t register_count = 0;
+  std::size_t temp_count = 0;
+  std::size_t coeff_register_count = 0;
+  std::size_t coeff_temp_count = 0;
+  std::vector<std::vector<int64_t>> array_storage;
+  std::vector<uint64_t> array_sizes;
+  std::vector<uint64_t> param_ptrs;
+  std::vector<uint32_t> coeff_array_slots;
+  std::vector<std::string> slot_names;
+  std::unordered_map<std::string, uint32_t> slot_lookup;
+};
+
+struct ObservationControlImage
+{
+  uint64_t control_version = 0;
+  uint64_t effective_sample_index = 0;
+  std::vector<double> slots;
+};
+
+struct ObservationSnapshot
+{
+  std::shared_ptr<const ObservationProgramImage> program;
+  std::shared_ptr<const ObservationControlImage> controls;
+};
+
+// Mutable scratch is serialized only with other observers. Keeping it outside
+// the live state makes control publication and hot-swap independent of a slow
+// room/scope/telemetry consumer, while retaining allocation-free steady-state
+// frames and coefficient reuse.
+struct ObservationRenderWorkspace
+{
+  uint64_t program_version = 0;
+  uint64_t control_version = 0;
+  std::vector<int64_t> registers;
+  std::vector<int64_t> temps;
+  std::vector<int64_t> coeff_registers;
+  std::vector<int64_t> coeff_temps;
+  std::vector<double> materialized_slots;
+  std::vector<double> slots;
+  std::vector<std::vector<int64_t>> arrays;
+  std::vector<int64_t *> array_ptrs;
 };
 
 struct KernelState
@@ -706,66 +784,159 @@ public:
     }
   }
 
-  // ── Random-access render (scope / slave consumers) ─────────────────────────
-  // Render `count` samples starting at an arbitrary sample index, snapshotting
-  // the requested slots per sample. For a STATELESS (register-free) patch this
-  // is exact and safe to run concurrently with the audio thread: it renders
-  // into private scratch temps/slots so it never disturbs the live state, and
-  // holds build_mutex_ so a hot-swap can't rebuild the active state mid-render.
-  // `out` is slot-major: out[k*count + i] = value of slot_ids[k] at sample
-  // start_index+i. Fused mode only; returns false otherwise or on a bad slot id.
-  bool render_window(uint64_t start_index, uint32_t count,
-                     const uint32_t * slot_ids, uint32_t n_slots,
-                     double * out)
+  // ── Random-access observation (room / scope / telemetry consumers) ─────────
+  // Render `count` coordinates from one atomically acquired program/control
+  // image. `out` is slot-major: out[k*count+i] is slot_ids[k] at
+  // start_index+i*stride. This path never borrows a live KernelState or takes
+  // build_mutex_, so a paused observer cannot delay control or hot-swap.
+  RenderWindowStatus render_window_observation(
+    uint64_t start_index, uint32_t count, uint32_t stride,
+    const uint32_t * slot_ids, uint32_t n_slots, double * out,
+    std::shared_ptr<const ObservationSnapshot> snapshot = {})
   {
-    if (!out || (n_slots > 0 && !slot_ids)) return false;
-    std::lock_guard<std::mutex> lock(build_mutex_);
-    const uint32_t state_idx = active_state_.load(std::memory_order_acquire);
-    KernelState & active = states_[state_idx];
-    if (active.mode != tropical_jit::CompilationMode::Fused || active.kernel == nullptr)
-      return false;
+    if (!out || stride == 0 || (n_slots > 0 && !slot_ids))
+      return RenderWindowStatus::InvalidArgument;
+    if (!snapshot)
+      snapshot = std::atomic_load_explicit(
+        &observation_snapshot_, std::memory_order_acquire);
+    if (!snapshot || !snapshot->program || !snapshot->controls)
+      return RenderWindowStatus::Unsupported;
+    const ObservationProgramImage & program = *snapshot->program;
+    if (program.mode != tropical_jit::CompilationMode::Fused
+        || program.kernel == nullptr)
+      return RenderWindowStatus::Unsupported;
     for (uint32_t k = 0; k < n_slots; ++k)
-      if (slot_ids[k] >= active.slots.size()) return false;
+      if (slot_ids[k] >= snapshot->controls->slots.size())
+        return RenderWindowStatus::InvalidArgument;
 
-    // Private scratch, isolated from the audio thread. Holding build_mutex_
-    // excludes the inactive-state rebuild, so these copies can't tear
-    // structurally (no concurrent resize); a register-free patch never writes
-    // registers/arrays, so the audio thread and this render don't fight.
-    std::vector<int64_t>              registers = active.registers;
-    std::vector<int64_t>              temps     = active.temps;
-    std::vector<double>               slots     = active.slots;
-    std::vector<std::vector<int64_t>> arrays    = active.array_storage;
-    // Coefficient columns live in the same immutable published generation as
-    // the control slot snapshot.
-    if (!active.coeff_array_slots.empty())
+    std::lock_guard<std::mutex> observation_lock(observation_render_mutex_);
+    ObservationRenderWorkspace & workspace = observation_workspace_;
+    if (workspace.program_version != program.program_version)
     {
-      const uint32_t gen = std::atomic_ref(active.control_published_gen)
-                             .load(std::memory_order_acquire);
-      for (std::size_t j = 0; j < active.coeff_array_slots.size(); ++j)
-        arrays[active.coeff_array_slots[j]] = active.coeff_generations[gen][j];
+      workspace.registers.assign(program.register_count, 0);
+      workspace.temps.assign(program.temp_count, 0);
+      workspace.coeff_registers.assign(program.coeff_register_count, 0);
+      workspace.coeff_temps.assign(program.coeff_temp_count, 0);
+      workspace.materialized_slots.clear();
+      workspace.arrays = program.array_storage;
+      workspace.arrays.resize(program.array_sizes.size());
+      for (std::size_t a = 0; a < workspace.arrays.size(); ++a)
+        workspace.arrays[a].resize(
+          static_cast<std::size_t>(program.array_sizes[a]), 0);
+      workspace.array_ptrs.resize(workspace.arrays.size());
+      for (std::size_t a = 0; a < workspace.arrays.size(); ++a)
+        workspace.array_ptrs[a] = workspace.arrays[a].data();
+      workspace.program_version = program.program_version;
+      workspace.control_version = 0;
     }
-    std::vector<int64_t *>            array_ptrs(arrays.size());
-    for (size_t a = 0; a < arrays.size(); ++a) array_ptrs[a] = arrays[a].data();
+
+    // Re-materialize scalar coefficients and coefficient columns solely in
+    // observer-owned storage. Preserve the resulting scalar image across
+    // repeated reads of one control version; the main kernel may overwrite its
+    // per-frame slot scratch.
+    if (workspace.control_version != snapshot->controls->control_version
+        || workspace.materialized_slots.empty())
+    {
+      workspace.materialized_slots = snapshot->controls->slots;
+      double coeff_out = 0.0;
+      if (program.coeff_kernel)
+        program.coeff_kernel(
+          nullptr,
+          workspace.coeff_registers.data(),
+          workspace.array_ptrs.data(),
+          program.array_sizes.data(),
+          workspace.coeff_temps.data(),
+          program.sample_rate,
+          0,
+          program.param_ptrs.data(),
+          &coeff_out,
+          1,
+          workspace.materialized_slots.data());
+    }
+    workspace.control_version = snapshot->controls->control_version;
+    workspace.slots = workspace.materialized_slots;
 
     double scratch_out = 0.0;
     for (uint32_t i = 0; i < count; ++i)
     {
-      active.kernel(
+      program.kernel(
         nullptr,
-        registers.data(),
-        array_ptrs.data(),
-        active.array_sizes.data(),
-        temps.data(),
-        active.sample_rate,
-        start_index + i,
-        active.param_ptrs.data(),
+        workspace.registers.data(),
+        workspace.array_ptrs.data(),
+        program.array_sizes.data(),
+        workspace.temps.data(),
+        program.sample_rate,
+        start_index + static_cast<uint64_t>(i) * stride,
+        program.param_ptrs.data(),
         &scratch_out,
         1,
-        slots.data());
+        workspace.slots.data());
       for (uint32_t k = 0; k < n_slots; ++k)
-        out[static_cast<size_t>(k) * count + i] = slots[slot_ids[k]];
+        out[static_cast<size_t>(k) * count + i] =
+          workspace.slots[slot_ids[k]];
+      if (i == 0)
+      {
+        if (RuntimeOwnershipTestSeam * seam =
+              ownership_test_seam_.load(std::memory_order_acquire);
+            seam && seam->pause_after_observation_coordinate.load(
+              std::memory_order_acquire))
+        {
+          seam->observation_coordinate_completed.store(
+            true, std::memory_order_release);
+          while (!seam->release_observation_coordinate.load(
+            std::memory_order_acquire))
+            std::this_thread::yield();
+        }
+      }
     }
-    return true;
+    return RenderWindowStatus::Rendered;
+  }
+
+  // Resolve names and evaluate against the same pinned generation. A hot-swap
+  // cannot reinterpret an old room/tap name through the new program's layout.
+  ObservationRenderResult render_window_observation_by_name(
+    uint64_t start_index, uint32_t count, uint32_t stride,
+    const std::vector<std::string> & slot_names, double * out)
+  {
+    ObservationRenderResult result;
+    const auto snapshot = std::atomic_load_explicit(
+      &observation_snapshot_, std::memory_order_acquire);
+    if (!snapshot || !snapshot->program || !snapshot->controls)
+    {
+      result.status = RenderWindowStatus::Unsupported;
+      return result;
+    }
+    result.program_version = snapshot->program->program_version;
+    result.control_version = snapshot->controls->control_version;
+    result.effective_sample_index =
+      snapshot->controls->effective_sample_index;
+    std::vector<uint32_t> slot_ids;
+    slot_ids.reserve(slot_names.size());
+    for (const std::string & name : slot_names)
+    {
+      const auto found = snapshot->program->slot_lookup.find(name);
+      if (found == snapshot->program->slot_lookup.end())
+      {
+        result.status = RenderWindowStatus::InvalidArgument;
+        result.unknown_slot = name;
+        return result;
+      }
+      slot_ids.push_back(found->second);
+    }
+    result.status = render_window_observation(
+      start_index, count, stride,
+      slot_ids.data(), static_cast<uint32_t>(slot_ids.size()), out,
+      snapshot);
+    return result;
+  }
+
+  bool render_window(uint64_t start_index, uint32_t count,
+                     const uint32_t * slot_ids, uint32_t n_slots,
+                     double * out)
+  {
+    return render_window_observation(
+      start_index, count, 1, slot_ids, n_slots, out)
+      == RenderWindowStatus::Rendered;
   }
 
   // Monotonic counter bumped on every successful hot-swap (publish_state).
@@ -1032,9 +1203,13 @@ private:
     KernelState & state, uint32_t target);
   void commit_control_snapshot(
     KernelState & state, uint32_t state_index,
-    ControlGenerationReservation reservation);
+    ControlGenerationReservation reservation,
+    uint64_t effective_sample_index = UINT64_MAX);
   void release_control_snapshot_reservation(
     uint32_t state_index, ControlGenerationReservation reservation);
+  void publish_observation_controls_locked(
+    const KernelState & state,
+    uint64_t effective_sample_index = UINT64_MAX);
 
   void apply_fade_to_output()
   {
@@ -1109,11 +1284,13 @@ private:
   // visible together through one release-published generation word. Called
   // under build_mutex_, except while constructing an unpublished local state.
   void publish_control_snapshot(
-    KernelState & state, uint32_t state_index = UINT32_MAX)
+    KernelState & state, uint32_t state_index = UINT32_MAX,
+    uint64_t effective_sample_index = UINT64_MAX)
   {
     auto reservation = reserve_control_generation(state, state_index);
     materialize_control_snapshot(state, reservation.target);
-    commit_control_snapshot(state, state_index, reservation);
+    commit_control_snapshot(
+      state, state_index, reservation, effective_sample_index);
   }
 
   unsigned int buffer_length_;
@@ -1123,6 +1300,12 @@ private:
   std::array<std::array<std::atomic<StorageOwner>, 3>, 2>
     control_generation_owners_{};
   std::atomic<uint64_t> recompile_version_{0};
+  // C++ shared_ptr atomic free functions support the release SDK where the
+  // C++20 atomic<shared_ptr> specialization is unavailable.
+  std::shared_ptr<const ObservationSnapshot> observation_snapshot_;
+  uint64_t next_observation_control_version_ = 1;
+  std::mutex observation_render_mutex_;
+  ObservationRenderWorkspace observation_workspace_;
   std::atomic<uint64_t> ownership_failure_count_{0};
   std::atomic<RuntimeOwnershipTestSeam *> ownership_test_seam_{nullptr};
 

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -807,6 +807,168 @@ static void test_named_observation_pins_hot_swap_program()
   for (double value : next_values) ASSERT(value == 2.0);
 }
 
+// Audio and observation may be different compiled programs with unrelated
+// slot indices. One publication installs both; controls project by exact name
+// and the observation artifact owns its own coefficient materialization.
+static void test_separate_observation_artifact_projects_controls()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string audio_ir = wrap_loop(
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double 2.500000e-01, ptr %op, align 8\n");
+  const std::string observation_ir = wrap_loop(
+    "  %cp = getelementptr inbounds double, ptr %slots, i64 2\n"
+    "  %coef = load double, ptr %cp, align 8\n"
+    "  %tp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  store double %coef, ptr %tp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %coef, ptr %op, align 8\n");
+  const std::string observation_coeff_ir =
+    std::string("define void @kernel(") + KERNEL_SIG + ") {\n"
+      "entry:\n"
+      "  %xp = getelementptr inbounds double, ptr %slots, i64 1\n"
+      "  %x = load double, ptr %xp, align 8\n"
+      "  %c = fmul double %x, 2.000000e+00\n"
+      "  %cp = getelementptr inbounds double, ptr %slots, i64 2\n"
+      "  store double %c, ptr %cp, align 8\n"
+      "  ret void\n}\n";
+  const std::string audio_manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":1,"slot_names":["param:x"],
+    "slot_defaults":[3.0],"param_disciplines":[
+      {"name":"x","discipline":"raw","companions":[]}
+    ]})";
+  const std::string observation_manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":3,
+    "slot_names":["tap:mode","param:x","coeff:x2"],
+    "slot_defaults":[0.0,-1.0,-99.0],"param_disciplines":[]})";
+
+  const auto generation =
+    rt.load_ir_staged_with_observation_generation(
+      audio_ir, "", "", audio_manifest,
+      observation_ir, observation_coeff_ir, observation_manifest);
+  ASSERT(generation.program_version == rt.recompile_version());
+  rt.process();
+  for (double value : rt.outputBuffer) ASSERT(value == 0.25);
+
+  std::array<double, 4> values{};
+  auto observation = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:mode"}, values.data());
+  ASSERT(observation.status == tropical_runtime::RenderWindowStatus::Rendered);
+  ASSERT(observation.program_version == generation.program_version);
+  ASSERT(observation.control_version == generation.control_version);
+  for (double value : values) ASSERT(value == 6.0);
+
+  const auto update = rt.dispatch_param_sync("x", 7.0);
+  ASSERT(update.ok);
+  observation = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:mode"}, values.data());
+  ASSERT(observation.program_version == generation.program_version);
+  ASSERT(observation.control_version > generation.control_version);
+  for (double value : values) ASSERT(value == 14.0);
+  rt.process();
+  for (double value : rt.outputBuffer) ASSERT(value == 0.25);
+}
+
+// C generation APIs return the exact initial pair from their publication,
+// while a failed second-artifact compile publishes neither half and zeros its
+// out-param. Existing single-artifact behavior remains the first case here.
+static void test_publication_generation_tokens_and_atomic_failure()
+{
+  tropical_runtime_t handle = tropical_runtime_new(16);
+  ASSERT(handle != nullptr);
+  auto & rt = *static_cast<tropical_runtime::FlatRuntime *>(handle);
+  const std::string single_ir = wrap_loop(
+    "  %sp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  %v = load double, ptr %sp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const std::string single_manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":1,"slot_names":["tap:single"],
+    "slot_defaults":[1.25]})";
+  tropical_runtime_generation_t first{};
+  ASSERT(tropical_runtime_load_ir_staged_generation(
+    handle, single_ir.data(), single_ir.size(), nullptr, 0, nullptr, 0,
+    single_manifest.data(), single_manifest.size(), &first));
+  std::array<double, 2> values{};
+  auto rendered = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:single"}, values.data());
+  ASSERT(rendered.program_version == first.program_version);
+  ASSERT(rendered.control_version == first.control_version);
+  for (double value : values) ASSERT(value == 1.25);
+
+  const std::string audio_ir = wrap_loop(
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double 2.500000e-01, ptr %op, align 8\n");
+  const std::string observation_ir = wrap_loop(
+    "  %xp = getelementptr inbounds double, ptr %slots, i64 1\n"
+    "  %x = load double, ptr %xp, align 8\n"
+    "  %tp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  store double %x, ptr %tp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %x, ptr %op, align 8\n");
+  const std::string audio_manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":1,"slot_names":["param:x"],
+    "slot_defaults":[3.0],"param_disciplines":[
+      {"name":"x","discipline":"raw","companions":[]}
+    ]})";
+  const std::string observation_manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":2,
+    "slot_names":["tap:projected","param:x"],
+    "slot_defaults":[0.0,-1.0]})";
+  tropical_runtime_generation_t second{};
+  ASSERT(tropical_runtime_load_ir_staged_with_observation_generation(
+    handle,
+    audio_ir.data(), audio_ir.size(), nullptr, 0, nullptr, 0,
+    audio_manifest.data(), audio_manifest.size(),
+    observation_ir.data(), observation_ir.size(), nullptr, 0,
+    observation_manifest.data(), observation_manifest.size(), &second));
+  ASSERT(second.program_version == first.program_version + 1);
+  ASSERT(second.control_version > first.control_version);
+  rendered = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:projected"}, values.data());
+  ASSERT(rendered.program_version == second.program_version);
+  ASSERT(rendered.control_version == second.control_version);
+  for (double value : values) ASSERT(value == 3.0);
+
+  tropical_runtime_generation_t failed{99, 101};
+  const std::string replacement_audio = wrap_loop(
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double 7.500000e-01, ptr %op, align 8\n");
+  const std::string invalid_observation = "not LLVM IR";
+  ASSERT(!tropical_runtime_load_ir_staged_with_observation_generation(
+    handle,
+    replacement_audio.data(), replacement_audio.size(), nullptr, 0,
+    nullptr, 0, audio_manifest.data(), audio_manifest.size(),
+    invalid_observation.data(), invalid_observation.size(), nullptr, 0,
+    observation_manifest.data(), observation_manifest.size(), &failed));
+  ASSERT(failed.program_version == 0);
+  ASSERT(failed.control_version == 0);
+  ASSERT(rt.recompile_version() == second.program_version);
+  rt.process();
+  for (double value : rt.outputBuffer) ASSERT(value == 0.25);
+  rendered = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:projected"}, values.data());
+  ASSERT(rendered.program_version == second.program_version);
+  ASSERT(rendered.control_version == second.control_version);
+  for (double value : values) ASSERT(value == 3.0);
+  tropical_runtime_free(handle);
+}
+
 // Scalar coefficient materialization is cached per immutable control version.
 // Repeated frames cannot regress to the pre-coefficient slot image after the
 // main kernel overwrites its private scratch.
@@ -1431,6 +1593,10 @@ int main()
            test_observation_snapshot_does_not_block_control);
   run_test("named observation pins one strided hot-swap program",
            test_named_observation_pins_hot_swap_program);
+  run_test("separate observation artifact projects named controls",
+           test_separate_observation_artifact_projects_controls);
+  run_test("publication generation tokens and atomic dual failure",
+           test_publication_generation_tokens_and_atomic_failure);
   run_test("observation reuses materialized scalar coefficients",
            test_observation_reuses_materialized_scalar_coefficients);
   run_test("observation retains constant/banked array storage",

--- a/engine/tests/test_module_process.cpp
+++ b/engine/tests/test_module_process.cpp
@@ -10,8 +10,10 @@
  */
 
 #include "c_api/tropical_c.h"
+#include "c_api/tropical_socket.hpp"
 #include "dac/TropicalDAC.hpp"   // kDeviceOutputBound / clamp_to_device_bound
 #include "runtime/FlatRuntime.hpp"
+#include <nlohmann/json.hpp>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -26,6 +28,10 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 static int g_pass = 0;
 static int g_fail = 0;
@@ -107,6 +113,56 @@ static bool wait_for_true(
          && std::chrono::steady_clock::now() < deadline)
     std::this_thread::yield();
   return value.load(std::memory_order_acquire);
+}
+
+static bool socket_request(
+  const std::string & path, const std::string & request,
+  std::string & response)
+{
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) return false;
+  struct sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  if (path.size() >= sizeof(address.sun_path))
+  {
+    ::close(fd);
+    return false;
+  }
+  std::memcpy(address.sun_path, path.c_str(), path.size() + 1);
+  if (::connect(
+        fd, reinterpret_cast<struct sockaddr *>(&address),
+        sizeof(address)) != 0)
+  {
+    ::close(fd);
+    return false;
+  }
+  const std::string line = request + "\n";
+  std::size_t sent = 0;
+  while (sent < line.size())
+  {
+    const ssize_t n = ::send(fd, line.data() + sent, line.size() - sent, 0);
+    if (n <= 0)
+    {
+      ::close(fd);
+      return false;
+    }
+    sent += static_cast<std::size_t>(n);
+  }
+  response.clear();
+  std::array<char, 1024> buffer{};
+  while (response.find('\n') == std::string::npos)
+  {
+    const ssize_t n = ::recv(fd, buffer.data(), buffer.size(), 0);
+    if (n <= 0)
+    {
+      ::close(fd);
+      return false;
+    }
+    response.append(buffer.data(), static_cast<std::size_t>(n));
+  }
+  ::close(fd);
+  response.resize(response.find('\n'));
+  return true;
 }
 
 /**
@@ -605,6 +661,373 @@ static void test_param_dispatch_effective_boundary_races()
   ASSERT(rt.ownership_failure_count() == 0);
 }
 
+// One immutable observation generation remains coherent while a raw control
+// publication completes. The paused reader must neither block control nor tear
+// to the newly published slot image.
+static void test_observation_snapshot_does_not_block_control()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string ir = wrap_loop(
+    "  %xp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  %x = load double, ptr %xp, align 8\n"
+    "  %tp = getelementptr inbounds double, ptr %slots, i64 1\n"
+    "  store double %x, ptr %tp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %x, ptr %op, align 8\n");
+  const std::string manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":2,"slot_names":["param:x","tap:x"],
+    "slot_defaults":[1.0,0.0],"param_disciplines":[
+      {"name":"x","discipline":"raw","companions":[]}
+    ]})";
+  ASSERT(rt.load_ir(ir, manifest));
+
+  tropical_runtime::RuntimeOwnershipTestSeam seam;
+  seam.pause_after_observation_coordinate.store(
+    true, std::memory_order_relaxed);
+  rt.set_ownership_test_seam(&seam);
+  std::array<double, 64> old_values{};
+  tropical_runtime::ObservationRenderResult old_result;
+  std::jthread observer([&] {
+    old_result = rt.render_window_observation_by_name(
+      0, static_cast<uint32_t>(old_values.size()), 1,
+      {"tap:x"}, old_values.data());
+  });
+  const bool paused = wait_for_true(seam.observation_coordinate_completed);
+  if (!paused)
+  {
+    seam.release_observation_coordinate.store(
+      true, std::memory_order_release);
+    observer.join();
+    rt.set_ownership_test_seam(nullptr);
+    ASSERT(paused);
+  }
+
+  tropical_runtime::ParamDispatchResult control_result;
+  std::atomic<bool> control_done{false};
+  std::jthread control([&] {
+    control_result = rt.dispatch_param_sync("x", 0.5);
+    control_done.store(true, std::memory_order_release);
+  });
+  const bool completed_while_paused = wait_for_true(control_done);
+  seam.release_observation_coordinate.store(true, std::memory_order_release);
+  observer.join();
+  control.join();
+  rt.set_ownership_test_seam(nullptr);
+
+  ASSERT(completed_while_paused);
+  ASSERT(control_result.ok);
+  ASSERT(old_result.status == tropical_runtime::RenderWindowStatus::Rendered);
+  for (double value : old_values) ASSERT(value == 1.0);
+
+  std::array<double, 4> next_values{};
+  const auto next = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(next_values.size()), 1,
+    {"tap:x"}, next_values.data());
+  ASSERT(next.status == tropical_runtime::RenderWindowStatus::Rendered);
+  ASSERT(next.program_version == old_result.program_version);
+  ASSERT(next.control_version > old_result.control_version);
+  ASSERT(next.effective_sample_index ==
+         control_result.effective_sample_index);
+  for (double value : next_values) ASSERT(value == 0.5);
+}
+
+// Name resolution, strided coordinates, and evaluation all pin one program
+// image. A hot-swap while the old observer is paused cannot reinterpret the
+// old name through the new slot layout.
+static void test_named_observation_pins_hot_swap_program()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string coordinate_ir = wrap_loop(
+    "  %idx = add i64 %start_sample_index, %s\n"
+    "  %v = uitofp i64 %idx to double\n"
+    "  %sp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  store double %v, ptr %sp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const std::string value_ir = wrap_loop(
+    "  %sp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  %v = load double, ptr %sp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const auto manifest = [](const char * name, double value) {
+    return std::string(R"({"schema":"tropical_plan_5",
+      "config":{"sampleRate":44100},"register_count":0,
+      "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+      "sinks":[],"slot_count":1,"slot_names":[")") + name
+      + R"("],"slot_defaults":[)" + std::to_string(value) + R"(],
+      "param_disciplines":[]})";
+  };
+  ASSERT(rt.load_ir(coordinate_ir, manifest("tap:old", 0.0)));
+
+  tropical_runtime::RuntimeOwnershipTestSeam seam;
+  seam.pause_after_observation_coordinate.store(
+    true, std::memory_order_relaxed);
+  rt.set_ownership_test_seam(&seam);
+  std::array<double, 3> old_values{};
+  tropical_runtime::ObservationRenderResult old_result;
+  std::jthread old_observer([&] {
+    old_result = rt.render_window_observation_by_name(
+      10, static_cast<uint32_t>(old_values.size()), 3,
+      {"tap:old"}, old_values.data());
+  });
+  const bool paused = wait_for_true(seam.observation_coordinate_completed);
+  if (!paused)
+  {
+    seam.release_observation_coordinate.store(
+      true, std::memory_order_release);
+    old_observer.join();
+    rt.set_ownership_test_seam(nullptr);
+    ASSERT(paused);
+  }
+
+  ASSERT(rt.load_ir(value_ir, manifest("tap:new", 2.0)));
+  seam.release_observation_coordinate.store(true, std::memory_order_release);
+  old_observer.join();
+  rt.set_ownership_test_seam(nullptr);
+
+  ASSERT(old_result.status == tropical_runtime::RenderWindowStatus::Rendered);
+  ASSERT(old_values[0] == 10.0);
+  ASSERT(old_values[1] == 13.0);
+  ASSERT(old_values[2] == 16.0);
+
+  std::array<double, 4> next_values{};
+  const auto missing = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(next_values.size()), 1,
+    {"tap:old"}, next_values.data());
+  ASSERT(missing.status ==
+         tropical_runtime::RenderWindowStatus::InvalidArgument);
+  ASSERT(missing.unknown_slot == "tap:old");
+  const auto next = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(next_values.size()), 1,
+    {"tap:new"}, next_values.data());
+  ASSERT(next.status == tropical_runtime::RenderWindowStatus::Rendered);
+  ASSERT(next.program_version > old_result.program_version);
+  for (double value : next_values) ASSERT(value == 2.0);
+}
+
+// Scalar coefficient materialization is cached per immutable control version.
+// Repeated frames cannot regress to the pre-coefficient slot image after the
+// main kernel overwrites its private scratch.
+static void test_observation_reuses_materialized_scalar_coefficients()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string ir = wrap_loop(
+    "  %cp = getelementptr inbounds double, ptr %slots, i64 2\n"
+    "  %coef = load double, ptr %cp, align 8\n"
+    "  %tp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  store double %coef, ptr %tp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %coef, ptr %op, align 8\n");
+  const std::string coeff_ir = std::string("define void @kernel(")
+    + KERNEL_SIG + ") {\n"
+      "entry:\n"
+      "  %xp = getelementptr inbounds double, ptr %slots, i64 1\n"
+      "  %x = load double, ptr %xp, align 8\n"
+      "  %c = fmul double %x, 2.000000e+00\n"
+      "  %cp = getelementptr inbounds double, ptr %slots, i64 2\n"
+      "  store double %c, ptr %cp, align 8\n"
+      "  ret void\n}\n";
+  const std::string manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":3,
+    "slot_names":["tap:mode","param:x","coeff:x2"],
+    "slot_defaults":[0.0,3.0,-99.0],"param_disciplines":[
+      {"name":"x","discipline":"raw","companions":[]}
+    ]})";
+  ASSERT(rt.load_ir_staged(ir, "", coeff_ir, manifest));
+
+  const auto check_twice = [&](double expected) {
+    std::array<double, 4> values{};
+    for (unsigned int read = 0; read < 2; ++read)
+    {
+      const auto observation = rt.render_window_observation_by_name(
+        0, static_cast<uint32_t>(values.size()), 1,
+        {"tap:mode"}, values.data());
+      ASSERT(observation.status ==
+             tropical_runtime::RenderWindowStatus::Rendered);
+      for (double value : values) ASSERT(value == expected);
+    }
+  };
+  check_twice(6.0);
+  const auto update = rt.dispatch_param_sync("x", 7.0);
+  ASSERT(update.ok);
+  check_twice(14.0);
+}
+
+// Program publication retains constant/banked array contents, not merely their
+// shapes. The load-time coefficient pass seeds a regular array; after the
+// control flag changes, subsequent coefficient passes deliberately leave that
+// bank untouched, so observation can recover it only from the program image.
+static void test_observation_retains_constant_array_storage()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string ir = wrap_loop(
+    "  %a0p = getelementptr inbounds ptr, ptr %arrays, i64 0\n"
+    "  %a0 = load ptr, ptr %a0p, align 8\n"
+    "  %raw = load i64, ptr %a0, align 8\n"
+    "  %v = bitcast i64 %raw to double\n"
+    "  %tp = getelementptr inbounds double, ptr %slots, i64 1\n"
+    "  store double %v, ptr %tp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const std::string coeff_ir = std::string("define void @kernel(")
+    + KERNEL_SIG + ") {\n"
+      "entry:\n"
+      "  %fp = getelementptr inbounds double, ptr %slots, i64 0\n"
+      "  %flag = load double, ptr %fp, align 8\n"
+      "  %initialize = fcmp oeq double %flag, 0.000000e+00\n"
+      "  br i1 %initialize, label %write, label %done\n"
+      "write:\n"
+      "  %a0p = getelementptr inbounds ptr, ptr %arrays, i64 0\n"
+      "  %a0 = load ptr, ptr %a0p, align 8\n"
+      "  %raw = bitcast double 4.250000e+00 to i64\n"
+      "  store i64 %raw, ptr %a0, align 8\n"
+      "  br label %done\n"
+      "done:\n"
+      "  ret void\n}\n";
+  const std::string manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":1,"array_slot_sizes":[1],
+    "array_slot_names":["constant-bank"],"instance_functions":[],
+    "sinks":[],"slot_count":2,
+    "slot_names":["param:initialized","tap:bank"],
+    "slot_defaults":[0.0,0.0],"param_disciplines":[
+      {"name":"initialized","discipline":"raw","companions":[]}
+    ]})";
+  ASSERT(rt.load_ir_staged(ir, "", coeff_ir, manifest));
+  const auto initialized = rt.dispatch_param_sync("initialized", 1.0);
+  ASSERT(initialized.ok);
+
+  std::array<double, 4> values{};
+  const auto observation = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:bank"}, values.data());
+  ASSERT(observation.status == tropical_runtime::RenderWindowStatus::Rendered);
+  for (double value : values) ASSERT(value == 4.25);
+}
+
+// Coefficient columns are rebuilt in observer-owned arrays and change
+// coherently with the control image instead of borrowing an audio generation.
+static void test_observation_materializes_coefficient_columns()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string ir = wrap_loop(
+    "  %a0p = getelementptr inbounds ptr, ptr %arrays, i64 0\n"
+    "  %a0 = load ptr, ptr %a0p, align 8\n"
+    "  %raw = load i64, ptr %a0, align 8\n"
+    "  %v = bitcast i64 %raw to double\n"
+    "  %sp = getelementptr inbounds double, ptr %slots, i64 1\n"
+    "  store double %v, ptr %sp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const std::string coeff_ir = std::string("define void @kernel(")
+    + KERNEL_SIG + ") {\n"
+      "entry:\n"
+      "  %sp = getelementptr inbounds double, ptr %slots, i64 0\n"
+      "  %x = load double, ptr %sp, align 8\n"
+      "  %v = fmul double %x, 2.000000e+00\n"
+      "  %raw = bitcast double %v to i64\n"
+      "  %a0p = getelementptr inbounds ptr, ptr %arrays, i64 0\n"
+      "  %a0 = load ptr, ptr %a0p, align 8\n"
+      "  store i64 %raw, ptr %a0, align 8\n"
+      "  ret void\n}\n";
+  const std::string manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":1,"array_slot_sizes":[1],
+    "array_slot_names":["coef"],"coeff_array_slots":[0],
+    "instance_functions":[],"sinks":[],"slot_count":2,
+    "slot_names":["param:x","tap:column"],"slot_defaults":[1.0,0.0],
+    "param_disciplines":[
+      {"name":"x","discipline":"raw","companions":[]}
+    ]})";
+  ASSERT(rt.load_ir_staged(ir, "", coeff_ir, manifest));
+
+  std::array<double, 4> values{};
+  auto observation = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:column"}, values.data());
+  ASSERT(observation.status == tropical_runtime::RenderWindowStatus::Rendered);
+  for (double value : values) ASSERT(value == 2.0);
+
+  const auto update = rt.dispatch_param_sync("x", 3.0);
+  ASSERT(update.ok);
+  observation = rt.render_window_observation_by_name(
+    0, static_cast<uint32_t>(values.size()), 1,
+    {"tap:column"}, values.data());
+  ASSERT(observation.status == tropical_runtime::RenderWindowStatus::Rendered);
+  for (double value : values) ASSERT(value == 6.0);
+}
+
+// The playback-anchored socket form captures the authoritative runtime
+// position and returns it with one version-pinned, point-budgeted frame. The
+// explicit-start spelling remains accepted for existing callers.
+static void test_playback_anchored_observation_socket_frame()
+{
+  tropical_runtime::FlatRuntime rt(16);
+  const std::string ir = wrap_loop(
+    "  %idx = add i64 %start_sample_index, %s\n"
+    "  %v = uitofp i64 %idx to double\n"
+    "  %sp = getelementptr inbounds double, ptr %slots, i64 0\n"
+    "  store double %v, ptr %sp, align 8\n"
+    "  %op = getelementptr inbounds double, ptr %output_buffer, i64 %s\n"
+    "  store double %v, ptr %op, align 8\n");
+  const std::string manifest = R"({"schema":"tropical_plan_5",
+    "config":{"sampleRate":44100},"register_count":0,
+    "array_slot_count":0,"array_slot_sizes":[],"instance_functions":[],
+    "sinks":[],"slot_count":1,"slot_names":["tap:ramp"],
+    "slot_defaults":[0.0]})";
+  ASSERT(rt.load_ir(ir, manifest));
+  rt.process();
+  rt.process();
+  ASSERT(rt.current_sample_index() == 32);
+
+  const std::string socket_path =
+    "/tmp/tropical-observation-" + std::to_string(::getpid()) + ".sock";
+  tropical_socket::SocketServer server(&rt, socket_path);
+  ASSERT(server.start());
+
+  nlohmann::json request = {
+    {"jsonrpc", "2.0"}, {"id", 1}, {"method", "render_window"},
+    {"params", {
+      {"anchor", "playback"}, {"count", 6}, {"point_budget", 3},
+      {"slots", {"tap:ramp"}},
+    }},
+  };
+  std::string response_text;
+  ASSERT(socket_request(socket_path, request.dump(), response_text));
+  const auto response = nlohmann::json::parse(response_text);
+  const auto & result = response.at("result");
+  ASSERT(result.at("anchor") == "playback");
+  ASSERT(result.at("playback_position") == 32);
+  ASSERT(result.at("start") == 26);
+  ASSERT(result.at("span") == 6);
+  ASSERT(result.at("stride") == 2);
+  ASSERT(result.at("count") == 3);
+  ASSERT(!result.at("preempted").get<bool>());
+  ASSERT(result.at("program_version").get<uint64_t>() > 0);
+  ASSERT(result.at("control_version").get<uint64_t>() > 0);
+  ASSERT(result.at("values")[0][0] == 26.0);
+  ASSERT(result.at("values")[0][1] == 28.0);
+  ASSERT(result.at("values")[0][2] == 30.0);
+
+  request["id"] = 2;
+  request["params"] = {
+    {"start", 5}, {"count", 3}, {"slots", {"tap:ramp"}},
+  };
+  ASSERT(socket_request(socket_path, request.dump(), response_text));
+  const auto explicit_response = nlohmann::json::parse(response_text);
+  const auto & explicit_result = explicit_response.at("result");
+  ASSERT(explicit_result.at("start") == 5);
+  ASSERT(!explicit_result.contains("playback_position"));
+  ASSERT(explicit_result.at("values")[0][0] == 5.0);
+  ASSERT(explicit_result.at("values")[0][1] == 6.0);
+  ASSERT(explicit_result.at("values")[0][2] == 7.0);
+  server.stop();
+}
+
 // A coefficient transaction writes slot[1] = 2*slot[0], while the audio
 // kernel outputs slot[1] - 2*slot[0]. Old and new generations both produce
 // exact zero; any scalar/coeff publication tear is immediately nonzero.
@@ -1004,6 +1427,18 @@ int main()
            test_param_dispatch_exact_sample_replay);
   run_test("param dispatch effective-boundary races",
            test_param_dispatch_effective_boundary_races);
+  run_test("observation snapshot never blocks control publication",
+           test_observation_snapshot_does_not_block_control);
+  run_test("named observation pins one strided hot-swap program",
+           test_named_observation_pins_hot_swap_program);
+  run_test("observation reuses materialized scalar coefficients",
+           test_observation_reuses_materialized_scalar_coefficients);
+  run_test("observation retains constant/banked array storage",
+           test_observation_retains_constant_array_storage);
+  run_test("observation materializes coefficient columns privately",
+           test_observation_materializes_coefficient_columns);
+  run_test("playback-anchored observation socket frame",
+           test_playback_anchored_observation_socket_frame);
   run_test("coherent slot/coefficient generation", test_control_generation_coherence);
   run_test("hot-swap state handoff", test_hot_swap_state_handoff);
   run_test("owned generation survives two publications", test_generation_ownership_barrier);

--- a/lean/Tropical/Engine/Compile.lean
+++ b/lean/Tropical/Engine/Compile.lean
@@ -69,6 +69,29 @@ def buildKernelIr (plan : Tropical.Plan.FlatPlan) : EngineM (String × String) :
     | .ok s => pure s
   pure (ir, planJson)
 
+private structure KernelLoadArtifacts where
+  ir : String
+  msl : String
+  coeffIr : String
+  manifest : String
+
+private def buildLoadArtifacts (plan : Tropical.Plan.FlatPlan)
+    (stages? : Option (Array (Array (Option Tropical.Ir.Stage))))
+    (emitMsl : Bool) : EngineM KernelLoadArtifacts := do
+  let split ← match stages? with
+    | some blocks => Tropical.StagedLoad.splitTyped plan blocks
+    | none => Tropical.StagedLoad.split plan
+  let (ir, manifest) ← buildKernelIr split.audio
+  let coeffIr ← match Tropical.StagedLoad.coeffIr split with
+    | .error msg => internalError s!"EmitLlvm (coeff): {msg}"
+    | .ok s => pure s
+  let msl ← if emitMsl then
+      match Tropical.Ir.EmitMsl.emitKernel split.audio with
+      | .error msg => internalError s!"EmitMsl: {msg}"
+      | .ok s => pure s
+    else pure ""
+  pure { ir, msl, coeffIr, manifest }
+
 /-- Emit the plan's kernel artifacts and load them into the runtime: the
     stage-0 split first (Stage0.hoist, gated by `TROPICAL_STAGE0`), then
     LLVM IR for the audio kernel — and the coefficient kernel when
@@ -79,31 +102,34 @@ def buildKernelIr (plan : Tropical.Plan.FlatPlan) : EngineM (String × String) :
     buffer). Any emit failure errors BEFORE the load, so the
     previous kernel keeps playing — the same recoverable contract as the
     IR path. -/
+def loadKernelPublished (env : Env) (plan : Tropical.Plan.FlatPlan)
+    (stages? : Option (Array (Array (Option Tropical.Ir.Stage))) := none) :
+    EngineM Ffi.PublishedGeneration := do
+  let artifact ← buildLoadArtifacts plan stages? env.metalBackend
+  env.runtime.loadIrStagedGeneration
+    artifact.ir artifact.msl artifact.coeffIr artifact.manifest
+
+/-- Compatibility form for compile paths whose replies do not expose the
+    publication identity. -/
 def loadKernel (env : Env) (plan : Tropical.Plan.FlatPlan)
     (stages? : Option (Array (Array (Option Tropical.Ir.Stage))) := none) :
     EngineM Unit := do
-  let split ← match stages? with
-    | some blocks => Tropical.StagedLoad.splitTyped plan blocks
-    | none => Tropical.StagedLoad.split plan
-  let (ir, planJson) ← buildKernelIr split.audio
-  let coeffIr ← match Tropical.StagedLoad.coeffIr split with
-    | .error msg => internalError s!"EmitLlvm (coeff): {msg}"
-    | .ok s => pure s
-  if env.metalBackend then
-    -- Hoisted coefficient columns (banks-as-data) cross to the GPU as
-    -- a packed `coeff_columns` device buffer (`buffer(3)`): EmitMsl
-    -- emits column reads for the slots the split advertises, the
-    -- stage-0 coefficient kernel fills the generation-buffered storage
-    -- host-side in f64, and process() uploads the captured generation
-    -- per dispatch (f64→f32, like slots). So the metal backend runs
-    -- the SAME typed split as the JIT — coefficient math at knob rate
-    -- on CPU, the audio loop on GPU reading real columns.
-    let msl ← match Tropical.Ir.EmitMsl.emitKernel split.audio with
-      | .error msg => internalError s!"EmitMsl: {msg}"
-      | .ok s => pure s
-    env.runtime.loadIrStaged ir msl coeffIr planJson
-  else
-    env.runtime.loadIrStaged ir "" coeffIr planJson
+  let _ ← loadKernelPublished env plan stages?
+  pure ()
+
+/-- Compile and atomically publish separate audio and read-only observation
+    realizations. The observation artifact is always JIT-only and owns no
+    realtime storage; controls project into it by matching slot names. -/
+def loadKernelWithObservationPublished (env : Env)
+    (audioPlan observationPlan : Tropical.Plan.FlatPlan)
+    (audioStages observationStages : Array (Array (Option Tropical.Ir.Stage))) :
+    EngineM Ffi.PublishedGeneration := do
+  let audio ← buildLoadArtifacts audioPlan (some audioStages) env.metalBackend
+  let observation ←
+    buildLoadArtifacts observationPlan (some observationStages) false
+  env.runtime.loadIrStagedWithObservationGeneration
+    audio.ir audio.msl audio.coeffIr audio.manifest
+    observation.ir observation.coeffIr observation.manifest
 
 -- ── Snapshot compile (`wire()` in TS) ────────────────────────────────────────
 

--- a/lean/Tropical/Engine/Front.lean
+++ b/lean/Tropical/Engine/Front.lean
@@ -26,16 +26,59 @@ def handleListScopeTaps (env : Env) : EngineM Json := do
                 ("slot", Json.str tap.slot)]
   pure <| Json.mkObj [("taps", Json.arr taps)]
 
+private def selectedObservationTapNames (args : Json) : Array String :=
+  let visible := Tropical.Playground.tapNodeIds (Tropical.Playground.rawsOf args)
+  match args.getObjVal? "taps" with
+  | .ok (.arr taps) => taps.foldl (init := #[]) fun selected tap =>
+      match tap with
+      | Json.str name =>
+        if visible.contains name && !selected.contains name then
+          selected.push name
+        else selected
+      | _ => selected
+  | _ => #[]
+
+private def graphArtifactArgs (args : Json) (taps : Json)
+    (out? : Option String := none) : Json :=
+  match args with
+  | .obj fields =>
+    let fields := fields.insert "taps" taps
+    let fields := match out? with
+      | some out => fields.insert "out" (Json.str out)
+      | none => fields
+    .obj fields
+  | _ => args
+
 /-- EXPERIMENT (`load_patch_graph`): compile a downstream-only patch graph (the
     playground GUI) through the EmitArrow arrow lowering — `lowerGraph → normalize
     (the slide) → emitTerm` — to a session root, then the production
     `compileSession → buildKernelIr → loadIrStaged` tail. A compile failure
     errors BEFORE the load, so the previous kernel keeps playing. -/
 def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
-  let compiled ← match ← Tropical.Playground.compilePlan args with
-    | .error e => internalError e
-    | .ok p => pure p
-  loadKernel env compiled.plan (some compiled.stageBlocks)
+  let requestedTaps := selectedObservationTapNames args
+  let (compiled, publishedTaps, generation) ← if requestedTaps.isEmpty then
+      let compiled ← match ← Tropical.Playground.compilePlan args with
+        | .error e => internalError e
+        | .ok p => pure p
+      let generation ←
+        loadKernelPublished env compiled.plan (some compiled.stageBlocks)
+      pure (compiled, compiled.taps, generation)
+    else
+      -- Both artifacts retain the complete authored graph. Their distinct
+      -- reachability roots prune work safely, including when an observed node
+      -- also participates in the audible path.
+      let audioArgs := graphArtifactArgs args (Json.bool false)
+      let observationArgs := graphArtifactArgs args
+        (Json.arr (requestedTaps.map Json.str)) requestedTaps[0]?
+      let audio ← match ← Tropical.Playground.compilePlan audioArgs with
+        | .error e => internalError e
+        | .ok p => pure p
+      let observation ← match ← Tropical.Playground.compilePlan observationArgs with
+        | .error e => internalError e
+        | .ok p => pure p
+      let generation ← loadKernelWithObservationPublished env
+        audio.plan observation.plan audio.stageBlocks observation.stageBlocks
+      pure (audio, observation.taps, generation)
   -- Seed the session param mirror with the graph's knobs so `set_param` — which
   -- guards on the mirror, then drives the live `param:<name>` slot — reaches them
   -- without a relower. Replaces (not appends): the mirror tracks the current graph.
@@ -44,12 +87,13 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
   -- this graph's inspection points via `list_scope_taps` with no session wiring.
   env.state.modify (fun st => { st with
     params := Tropical.Playground.knobParams args
-    scopeTaps := compiled.taps
+    scopeTaps := publishedTaps
     paramDisciplines := compiled.plan.paramDisciplines })
   -- The realized-state report: facts about what compiled (active/excluded
   -- nodes, wired/normalled inputs, live params with disciplines, taps) —
   -- never warnings. `ok` stays for callers that only ever looked at it.
-  pure <| Tropical.Playground.realizedReport args compiled.taps
+  pure <| Tropical.Playground.realizedReportForGeneration args publishedTaps
+    generation.programVersion generation.controlVersion
 
 def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   wrap <| match name with

--- a/lean/Tropical/Engine/Front.lean
+++ b/lean/Tropical/Engine/Front.lean
@@ -38,15 +38,10 @@ private def selectedObservationTapNames (args : Json) : Array String :=
       | _ => selected
   | _ => #[]
 
-private def graphArtifactArgs (args : Json) (taps : Json)
-    (out? : Option String := none) : Json :=
+private def graphArtifactArgs (args : Json) (taps : Json) : Json :=
   match args with
   | .obj fields =>
-    let fields := fields.insert "taps" taps
-    let fields := match out? with
-      | some out => fields.insert "out" (Json.str out)
-      | none => fields
-    .obj fields
+    .obj (fields.insert "taps" taps)
   | _ => args
 
 /-- EXPERIMENT (`load_patch_graph`): compile a downstream-only patch graph (the
@@ -65,11 +60,13 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
       pure (compiled, compiled.taps, generation)
     else
       -- Both artifacts retain the complete authored graph. Their distinct
-      -- reachability roots prune work safely, including when an observed node
-      -- also participates in the audible path.
+      -- output sets prune work safely, including when an observed node also
+      -- participates in the audible path. Keep the authored final output as
+      -- observation port `out`; explicit probes are additional roots, never a
+      -- replacement that silently changes what the `out` binding means.
       let audioArgs := graphArtifactArgs args (Json.bool false)
       let observationArgs := graphArtifactArgs args
-        (Json.arr (requestedTaps.map Json.str)) requestedTaps[0]?
+        (Json.arr (requestedTaps.map Json.str))
       let audio ← match ← Tropical.Playground.compilePlan audioArgs with
         | .error e => internalError e
         | .ok p => pure p

--- a/lean/Tropical/Ffi.lean
+++ b/lean/Tropical/Ffi.lean
@@ -93,6 +93,17 @@ def Runtime.slotIndex? (rt : Runtime) (name : String) : IO (Option UInt32) := do
 opaque Runtime.loadIrStagedRaw (rt : @& Runtime) (irText : @& String) (mslSource : @& String)
     (coeffIr : @& String) (manifestJson : @& String) : IO Bool
 
+/-- Exact immutable program/control identity created by one runtime load. -/
+structure PublishedGeneration where
+  programVersion : UInt64
+  controlVersion : UInt64
+deriving Repr, BEq
+
+@[extern "shim_runtime_load_ir_staged_generation"]
+private opaque Runtime.loadIrStagedGenerationRaw
+    (rt : @& Runtime) (irText : @& String) (mslSource : @& String)
+    (coeffIr : @& String) (manifestJson : @& String) : IO (UInt64 × UInt64)
+
 /-- Staged load: LLVM IR → JIT (always), MSL → Metal when non-empty, plus an
     optional stage-0 coefficient kernel (`coeffIr`, empty = no split) —
     a second single-function module the engine runs once before publish and
@@ -102,6 +113,35 @@ def Runtime.loadIrStaged (rt : Runtime) (irText mslSource coeffIr manifestJson :
     IO Unit := do
   if !(← rt.loadIrStagedRaw irText mslSource coeffIr manifestJson) then
     throw <| IO.userError s!"runtime loadIrStaged failed: {← lastError}"
+
+/-- Generation-returning staged load for an atomic compile handshake. The pair
+    comes from the publication operation itself, rather than a later sample. -/
+def Runtime.loadIrStagedGeneration (rt : Runtime)
+    (irText mslSource coeffIr manifestJson : String) :
+    IO PublishedGeneration := do
+  let (programVersion, controlVersion) ←
+    rt.loadIrStagedGenerationRaw irText mslSource coeffIr manifestJson
+  pure { programVersion, controlVersion }
+
+@[extern "shim_runtime_load_ir_staged_with_observation_generation"]
+private opaque Runtime.loadIrStagedWithObservationGenerationRaw (rt : @& Runtime)
+    (irText : @& String) (mslSource : @& String) (coeffIr : @& String)
+    (manifestJson : @& String) (observationIr : @& String)
+    (observationCoeffIr : @& String) (observationManifestJson : @& String) :
+    IO (UInt64 × UInt64)
+
+/-- Atomically publish an audio/Metal staged artifact and a distinct JIT-only
+    observation projection. Matching controls are copied by slot name; program
+    storage and mutable workspaces remain disjoint. -/
+def Runtime.loadIrStagedWithObservationGeneration (rt : Runtime)
+    (irText mslSource coeffIr manifestJson : String)
+    (observationIr observationCoeffIr observationManifestJson : String) :
+    IO PublishedGeneration := do
+  let (programVersion, controlVersion) ←
+    rt.loadIrStagedWithObservationGenerationRaw
+      irText mslSource coeffIr manifestJson
+      observationIr observationCoeffIr observationManifestJson
+  pure { programVersion, controlVersion }
 
 /-- Control-plane/test-only: reposition the active kernel's sample clock
     (render verbs' `--start`). -/

--- a/lean/Tropical/Playground/Compile.lean
+++ b/lean/Tropical/Playground/Compile.lean
@@ -31,15 +31,21 @@ def compilePlanPure (arena : Arena) (resolved : Array (String × ProgramIdx)) (j
   let (g, paramTable) ← decodeGraph j
   let term ← lowerGraph g
   let (out, b0) := emitTerm (normalize term) {}
-  -- Per-node taps are opt-in (`"taps": true` in the request): they cost extra
-  -- kernel compute, so an audio-only consumer (the playground) omits them and
-  -- pays nothing. The final mix (`out`) is always tappable — its slot exists
-  -- regardless — so a scope attached to a taps-off patch still sees the output.
-  let emitTaps := match j.getObjVal? "taps" with | .ok (.bool b) => b | _ => false
+  -- Per-node taps are opt-in: `"taps": true` retains the inspection/debug
+  -- surface, while `"taps": ["id", ...]` emits only named projections. The
+  -- named form is the observation path: it avoids re-emitting every visible
+  -- node's upstream cone when a client needs a small explicit signal set. The
+  -- final mix (`out`) remains tappable regardless.
+  let visibleTapIds := tapNodeIds (rawsOf j)
+  let tapIds := match j.getObjVal? "taps" with
+    | .ok (.bool true) => visibleTapIds
+    | .ok (.arr requested) => requested.filterMap fun
+        | Json.str id => if visibleTapIds.contains id then some id else none
+        | _ => none
+    | _ => #[]
   -- Emit each user node's sub-term into the SAME builder (so instance names stay
   -- unique by `decls.size`), collecting `(id, signal)`. A node that fails to
   -- lower is simply not tapped.
-  let tapIds := if emitTaps then tapNodeIds (rawsOf j) else #[]
   let (tapSigs, b) : Array (String × Sig) × Builder :=
     tapIds.foldl (fun (acc : Array (String × Sig) × Builder) id =>
       match lowerAt g id with

--- a/lean/Tropical/Playground/Report.lean
+++ b/lean/Tropical/Playground/Report.lean
@@ -65,7 +65,8 @@ def paramDisciplinesOf (raws : Array Raw) :
     glide/anchor companion slots are the discipline's implementation detail,
     not surface. Plus the taps. The silence-with-`{ok:true}` class dies here:
     a patch that gracefully compiled to nothing now SAYS so, as facts. -/
-def realizedReport (args : Json) (taps : Array Tropical.ScopeTap) : Json := Id.run do
+def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
+    (programVersion controlVersion : UInt64) : Json := Id.run do
   let raws := rawsOf args
   let outId := match (args.getObjVal? "out").toOption with
     | some (.str s) => s
@@ -107,10 +108,22 @@ def realizedReport (args : Json) (taps : Array Tropical.ScopeTap) : Json := Id.r
         ("value", Json.num v), ("discipline", Json.str disc)])
   let tapsJ := taps.map fun tap =>
     Json.mkObj [("name", Json.str tap.name),
+      ("instance", Json.str tap.sourceInstance),
+      ("output", Json.str tap.sourceOutput),
       ("slot", Json.str tap.slot)]
-  return Json.mkObj [("ok", Json.bool true), ("nodes", Json.arr nodesJ),
+  return Json.mkObj [("ok", Json.bool true),
+    ("vocabulary_fingerprint", Json.str vocabularyFingerprint),
+    -- Keep this handshake's versions as JSON integers, matching render_window.
+    ("program_version", Lean.toJson programVersion.toNat),
+    ("control_version", Lean.toJson controlVersion.toNat),
+    ("nodes", Json.arr nodesJ),
     ("inputs", Json.arr inputsJ), ("params", Json.arr paramsJ),
     ("taps", Json.arr tapsJ)]
+
+/-- Pure-report compatibility seam for tests and non-publishing consumers.
+    Production loads always supply the exact runtime publication identity. -/
+def realizedReport (args : Json) (taps : Array Tropical.ScopeTap) : Json :=
+  realizedReportForGeneration args taps 0 0
 
 -- ── Scope taps ──────────────────────────────────────────────────────────────
 /-- For the arrow path the source instance is always the synthetic root, and

--- a/lean/ffi/shim.c
+++ b/lean/ffi/shim.c
@@ -89,6 +89,52 @@ LEAN_EXPORT lean_obj_res shim_runtime_load_ir_staged(b_lean_obj_arg rt, b_lean_o
   return lean_io_result_mk_ok(lean_box(ok));
 }
 
+static lean_obj_res box_runtime_generation(
+    const tropical_runtime_generation_t *generation) {
+  lean_obj_res pair = lean_alloc_ctor(0, 2, 0);
+  lean_ctor_set(pair, 0, lean_box_uint64(generation->program_version));
+  lean_ctor_set(pair, 1, lean_box_uint64(generation->control_version));
+  return pair;
+}
+
+LEAN_EXPORT lean_obj_res shim_runtime_load_ir_staged_generation(
+    b_lean_obj_arg rt, b_lean_obj_arg ir, b_lean_obj_arg msl,
+    b_lean_obj_arg coeff, b_lean_obj_arg manifest, lean_obj_arg world) {
+  (void)world;
+  const char *i = lean_string_cstr(ir);
+  const char *g = lean_string_cstr(msl);
+  const char *c = lean_string_cstr(coeff);
+  const char *m = lean_string_cstr(manifest);
+  tropical_runtime_generation_t generation = {0, 0};
+  bool ok = tropical_runtime_load_ir_staged_generation(
+      unwrap(rt), i, strlen(i), g, strlen(g), c, strlen(c), m, strlen(m),
+      &generation);
+  if (!ok) return io_err(tropical_last_error());
+  return lean_io_result_mk_ok(box_runtime_generation(&generation));
+}
+
+LEAN_EXPORT lean_obj_res shim_runtime_load_ir_staged_with_observation_generation(
+    b_lean_obj_arg rt,
+    b_lean_obj_arg ir, b_lean_obj_arg msl, b_lean_obj_arg coeff,
+    b_lean_obj_arg manifest, b_lean_obj_arg observation_ir,
+    b_lean_obj_arg observation_coeff, b_lean_obj_arg observation_manifest,
+    lean_obj_arg world) {
+  (void)world;
+  const char *i = lean_string_cstr(ir);
+  const char *g = lean_string_cstr(msl);
+  const char *c = lean_string_cstr(coeff);
+  const char *m = lean_string_cstr(manifest);
+  const char *oi = lean_string_cstr(observation_ir);
+  const char *oc = lean_string_cstr(observation_coeff);
+  const char *om = lean_string_cstr(observation_manifest);
+  tropical_runtime_generation_t generation = {0, 0};
+  bool ok = tropical_runtime_load_ir_staged_with_observation_generation(
+      unwrap(rt), i, strlen(i), g, strlen(g), c, strlen(c), m, strlen(m),
+      oi, strlen(oi), oc, strlen(oc), om, strlen(om), &generation);
+  if (!ok) return io_err(tropical_last_error());
+  return lean_io_result_mk_ok(box_runtime_generation(&generation));
+}
+
 LEAN_EXPORT lean_obj_res shim_runtime_set_sample_index(b_lean_obj_arg rt, uint64_t idx,
                                                        lean_obj_arg world) {
   (void)world;

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -75,6 +75,18 @@ struct NodeView: View {
 
     private var spec: NodeSpec { node.kind.spec }
 
+    private var truthBadge: (label: String, color: Color, help: String)? {
+        switch model.presentationStatus(for: node) {
+        case .active:
+            ("active", Theme.truthActive, "active in the running program")
+        case .excluded:
+            ("excluded", Theme.truthExcluded, "authored but excluded from the running program")
+        case .pending:
+            ("pending", Theme.truthPending, "awaiting realized compile truth")
+        case nil: nil
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             titleBar
@@ -100,6 +112,17 @@ struct NodeView: View {
             Circle().fill(node.color).frame(width: 9, height: 9)
             Text(spec.title).font(Theme.mono.bold()).foregroundStyle(Theme.text)
             Spacer(minLength: 8)
+            if let truthBadge {
+                Text(truthBadge.label)
+                    .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(truthBadge.color)
+                    .padding(.horizontal, 4).padding(.vertical, 2)
+                    .background(
+                        truthBadge.color.opacity(0.13),
+                        in: Capsule()
+                    )
+                    .help(truthBadge.help)
+            }
             Text(node.id).font(Theme.monoSmall).foregroundStyle(Theme.muted)
             if !spec.fixed {
                 Button {

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -78,6 +78,7 @@ actor Engine {
     private var controlRPC: RPCConnection?
     private var scopeRPC: RPCConnection?
     private var telemetryRPC: RPCConnection?
+    private var realizedPatches = RealizedPatchStore()
     private let events: @Sendable (EngineEvent) -> Void
 
     /// Resolution order: bundled engine, then an explicit developer/test
@@ -127,6 +128,7 @@ actor Engine {
     }
 
     func start() async throws {
+        realizedPatches = RealizedPatchStore()
         // Reap any engine orphaned by a PREVIOUS instance that died before
         // teardown (SIGKILL, crash) — the one gap the graceful path can't close.
         Engine.sweepOrphans()
@@ -264,6 +266,7 @@ actor Engine {
         process?.terminate()
         process = nil
         procBox.take()
+        realizedPatches = RealizedPatchStore()
         await closeLanes(error: EngineError.exited)
         unlink(sockPath)
     }
@@ -272,6 +275,7 @@ actor Engine {
         gEngineChildPID = 0
         process = nil
         procBox.take()
+        realizedPatches = RealizedPatchStore()
         await closeLanes(error: EngineError.exited)
         unlink(sockPath)
     }
@@ -285,8 +289,43 @@ actor Engine {
         for lane in lanes { await lane?.close(error: error) }
     }
 
+    func loadVocabulary() async throws -> EngineVocabulary {
+        let raw = try await callRaw("get_vocabulary")
+        let data = try JSONEncoder().encode(raw)
+        return try EngineVocabulary.decode(from: data)
+    }
+
+    /// Typed compiler lane. The expected vocabulary and ordered tap names come
+    /// from the model's already-adopted authored semantics; a mismatch is
+    /// rejected before the engine-side realized store advances.
+    @discardableResult
+    func loadPatchGraph(
+        _ graph: JSONValue,
+        expectedTapNames: [String],
+        vocabularyFingerprint: String
+    ) async throws -> CompileAdoption {
+        let raw = try await callRaw("load_patch_graph", graph)
+        let response = try PatchCompileResponse.decode(
+            raw,
+            expectedTapNames: expectedTapNames,
+            expectedVocabularyFingerprint: vocabularyFingerprint
+        )
+        return realizedPatches.adopt(response)
+    }
+
+    func currentRealizedPatch() -> RealizedPatch? {
+        realizedPatches.current
+    }
+
     @discardableResult
     func call(_ method: String, _ params: JSONValue = .object([:])) async throws -> JSONValue {
+        try await callRaw(method, params)
+    }
+
+    private func callRaw(
+        _ method: String,
+        _ params: JSONValue = .object([:])
+    ) async throws -> JSONValue {
         let connection: RPCConnection? = switch EngineRPCLane.lane(for: method) {
         case .graph: graphRPC
         case .control: controlRPC

--- a/reversible/Sources/Reversible/JSONValue.swift
+++ b/reversible/Sources/Reversible/JSONValue.swift
@@ -3,13 +3,41 @@ import Foundation
 /// A closed JSON term — the RPC surface is schemaless at the transport
 /// layer (each method returns its own shape), so replies land as a
 /// `JSONValue` and callers project the fields they know.
-enum JSONValue: Equatable {
+enum JSONValue: Equatable, Sendable {
     case null
     case bool(Bool)
     case number(Double)
     case string(String)
     case array([JSONValue])
     case object([String: JSONValue])
+}
+
+/// JSON numbers currently decode through Double. Protocol counters must stay
+/// inside its exact integer range; silently rounded generations are rejected.
+enum JSONExact {
+    static let largestExactlyRepresentableInteger = 9_007_199_254_740_991.0
+
+    static func uint64(_ value: JSONValue?) -> UInt64? {
+        guard let number = value?.doubleValue,
+              number.isFinite,
+              number >= 0,
+              number <= largestExactlyRepresentableInteger,
+              number.rounded(.towardZero) == number,
+              let exact = UInt64(exactly: number)
+        else { return nil }
+        return exact
+    }
+
+    static func int(_ value: JSONValue?) -> Int? {
+        guard let number = value?.doubleValue,
+              number.isFinite,
+              number >= 0,
+              number <= largestExactlyRepresentableInteger,
+              number.rounded(.towardZero) == number,
+              let exact = Int(exactly: number)
+        else { return nil }
+        return exact
+    }
 }
 
 extension JSONValue: Codable {

--- a/reversible/Sources/Reversible/KnobView.swift
+++ b/reversible/Sources/Reversible/KnobView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 /// Knob: 38px dial, pointer sweeping −135°…+135° (styles.css .knob).
-/// Every continuous knob is a live param slot `<id>.<knob>` — a vertical
-/// drag (180px = full sweep) drives the running kernel with no relower
-/// (only topology edits recompile). A glided knob eases via
-/// The client always emits `set_param`; the loaded plan owns whether the
-/// accepted write is raw, glided, phase-anchored, or a velocity rebase.
+/// A vertical drag (180px = full sweep) edits authored scalar truth. The
+/// realized handshake decides whether that scalar is live (`set_param`) or
+/// structural (relower); the client never guesses from a hard-coded knob list.
+/// For live values the loaded plan owns the write discipline: raw, glide,
+/// phase-anchor, or velocity rebase.
 struct KnobView: View {
     @EnvironmentObject var model: PatchModel
     let node: PatchNode
@@ -14,9 +14,32 @@ struct KnobView: View {
 
     private var value: Double { node.values[knob.name] ?? knob.def }
 
+    private var truthBadge: (label: String, color: Color, help: String) {
+        switch model.parameterStatus(for: node, knob: knob) {
+        case .live(let discipline):
+            ("live", Theme.truthActive, "live · \(discipline.rawValue)")
+        case .structural:
+            ("struct", Theme.truthExcluded, "structural · relowers on edit")
+        case .inactive:
+            ("inactive", Theme.truthPending, "inactive in the running patch")
+        }
+    }
+
     var body: some View {
         VStack(spacing: 2) {
             dial
+                .overlay(alignment: .bottomTrailing) {
+                    Text(truthBadge.label)
+                        .font(.system(size: 7, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(truthBadge.color)
+                        .padding(.horizontal, 3).padding(.vertical, 1)
+                        .background(
+                            truthBadge.color.opacity(0.16),
+                            in: Capsule()
+                        )
+                        .offset(x: 7, y: 4)
+                        .help(truthBadge.help)
+                }
                 .contentShape(Circle())
                 .gesture(
                     DragGesture(minimumDistance: 0)
@@ -24,12 +47,11 @@ struct KnobView: View {
                             let t0 = dragStartNorm ?? knob.toNorm(value)
                             dragStartNorm = t0
                             let v = knob.fromNorm(t0 - g.translation.height / 180)
-                            model.nodes[node.id]?.values[knob.name] = v
-                            model.sendKnob(node, knob, v)
+                            model.setKnob(node, knob, v)
                         }
                         .onEnded { _ in
                             dragStartNorm = nil
-                            model.sendKnob(node, knob, value)
+                            model.setKnob(node, knob, value)
                         }
                 )
             Text(knob.name).font(Theme.monoTiny).foregroundStyle(Theme.muted)

--- a/reversible/Sources/Reversible/ObservationSampler.swift
+++ b/reversible/Sources/Reversible/ObservationSampler.swift
@@ -1,0 +1,445 @@
+import CoreVideo
+import Foundation
+import SwiftUI
+
+struct ObservationChannel: Equatable, Hashable, Sendable {
+    let key: String
+    let slot: String
+}
+
+/// One version-pinned projection request. `span` is the full sample history;
+/// pointBudget permits deterministic engine-side striding without changing
+/// the identity or completeness of the returned channel set.
+struct ObservationBinding: Equatable, Sendable {
+    let expectedGeneration: EngineGeneration
+    let span: Int
+    let pointBudget: Int
+    let channels: [ObservationChannel]
+
+    init(
+        expectedGeneration: EngineGeneration,
+        span: Int,
+        pointBudget: Int,
+        channels: [ObservationChannel]
+    ) throws {
+        guard expectedGeneration.programVersion > 0,
+              expectedGeneration.controlVersion > 0,
+              (1...16_384).contains(span),
+              (1...16_384).contains(pointBudget),
+              !channels.isEmpty,
+              Set(channels.map(\.key)).count == channels.count,
+              channels.allSatisfy({ channel in
+                  !channel.key.isEmpty && !channel.slot.isEmpty
+                      && channel.key == channel.key.trimmingCharacters(
+                          in: .whitespacesAndNewlines
+                      )
+                      && channel.slot == channel.slot.trimmingCharacters(
+                          in: .whitespacesAndNewlines
+                      )
+              })
+        else { throw ObservationError.invalidBinding }
+        self.expectedGeneration = expectedGeneration
+        self.span = span
+        self.pointBudget = pointBudget
+        self.channels = channels
+    }
+
+    var requestJSON: JSONValue {
+        .object([
+            "anchor": .string("playback"),
+            "count": .number(Double(span)),
+            "point_budget": .number(Double(pointBudget)),
+            "slots": .array(channels.map { .string($0.slot) }),
+        ])
+    }
+
+    var expectedStride: Int {
+        (span + pointBudget - 1) / pointBudget
+    }
+
+    var expectedCount: Int {
+        (span + expectedStride - 1) / expectedStride
+    }
+}
+
+struct ObservationChannelFrame: Equatable, Sendable {
+    let channel: ObservationChannel
+    let values: [Double]
+}
+
+/// A complete playback-anchored response. All channels, timing metadata, and
+/// generation identity are published together or not at all.
+struct ObservationFrame: Equatable, Sendable {
+    let binding: ObservationBinding
+    let generation: EngineGeneration
+    let playbackPosition: UInt64
+    /// The engine's effective start for this playback-anchored projection
+    /// (`start` on the wire).
+    let effectiveStart: UInt64
+    let effectiveSampleIndex: UInt64
+    let count: Int
+    let stride: Int
+    let channels: [ObservationChannelFrame]
+}
+
+enum ObservationDecodedResponse: Equatable, Sendable {
+    case frame(ObservationFrame)
+    case preempted(generation: EngineGeneration)
+}
+
+enum ObservationError: Error, Equatable, LocalizedError, Sendable {
+    case invalidBinding
+    case missingField(String)
+    case invalidField(String)
+    case partialChannel(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBinding: return "invalid observation binding"
+        case .missingField(let path): return "observation response missing '\(path)'"
+        case .invalidField(let path): return "observation response has invalid '\(path)'"
+        case .partialChannel(let index):
+            return "observation response channel \(index) is partial or malformed"
+        }
+    }
+}
+
+enum ObservationResponseDecoder {
+    static func decode(
+        _ value: JSONValue,
+        for binding: ObservationBinding
+    ) throws -> ObservationDecodedResponse {
+        guard case .object(let object) = value else {
+            throw ObservationError.invalidField("response")
+        }
+        guard case .string("playback")? = object["anchor"] else {
+            throw object["anchor"] == nil
+                ? ObservationError.missingField("anchor")
+                : ObservationError.invalidField("anchor")
+        }
+        let playbackPosition = try exactUInt64(object, "playback_position")
+        let effectiveStart = try exactUInt64(object, "start")
+        let effectiveSampleIndex = try exactUInt64(
+            object, "effective_sample_index"
+        )
+        let count = try exactInt(object, "count")
+        let span = try exactInt(object, "span")
+        let stride = try exactInt(object, "stride")
+        let generation = EngineGeneration(
+            programVersion: try exactUInt64(object, "program_version"),
+            controlVersion: try exactUInt64(object, "control_version")
+        )
+        guard generation.programVersion > 0, generation.controlVersion > 0 else {
+            throw ObservationError.invalidField("generation")
+        }
+        guard span == binding.span else {
+            throw ObservationError.invalidField("span")
+        }
+        guard stride == binding.expectedStride else {
+            throw ObservationError.invalidField("stride")
+        }
+        let expectedStart = playbackPosition >= UInt64(binding.span)
+            ? playbackPosition - UInt64(binding.span)
+            : 0
+        guard effectiveStart == expectedStart else {
+            throw ObservationError.invalidField("start")
+        }
+        guard case .bool(let preempted)? = object["preempted"] else {
+            throw object["preempted"] == nil
+                ? ObservationError.missingField("preempted")
+                : ObservationError.invalidField("preempted")
+        }
+        guard case .array(let rawChannels)? = object["values"] else {
+            throw object["values"] == nil
+                ? ObservationError.missingField("values")
+                : ObservationError.invalidField("values")
+        }
+
+        if preempted {
+            guard count == 0, rawChannels.isEmpty else {
+                throw ObservationError.invalidField("preempted")
+            }
+            return .preempted(generation: generation)
+        }
+
+        guard count == binding.expectedCount else {
+            throw ObservationError.invalidField("count")
+        }
+        guard rawChannels.count == binding.channels.count else {
+            throw ObservationError.invalidField("values")
+        }
+        var channels: [ObservationChannelFrame] = []
+        channels.reserveCapacity(rawChannels.count)
+        for (index, rawChannel) in rawChannels.enumerated() {
+            guard case .array(let rawValues) = rawChannel,
+                  rawValues.count == count
+            else { throw ObservationError.partialChannel(index) }
+            var values: [Double] = []
+            values.reserveCapacity(count)
+            for rawValue in rawValues {
+                guard let sample = rawValue.doubleValue, sample.isFinite else {
+                    throw ObservationError.partialChannel(index)
+                }
+                values.append(sample)
+            }
+            channels.append(.init(
+                channel: binding.channels[index],
+                values: values
+            ))
+        }
+        return .frame(.init(
+            binding: binding,
+            generation: generation,
+            playbackPosition: playbackPosition,
+            effectiveStart: effectiveStart,
+            effectiveSampleIndex: effectiveSampleIndex,
+            count: count,
+            stride: stride,
+            channels: channels
+        ))
+    }
+
+    private static func exactUInt64(
+        _ object: [String: JSONValue], _ key: String
+    ) throws -> UInt64 {
+        guard let value = object[key] else {
+            throw ObservationError.missingField(key)
+        }
+        guard let exact = JSONExact.uint64(value) else {
+            throw ObservationError.invalidField(key)
+        }
+        return exact
+    }
+
+    private static func exactInt(
+        _ object: [String: JSONValue], _ key: String
+    ) throws -> Int {
+        guard let value = object[key] else {
+            throw ObservationError.missingField(key)
+        }
+        guard let exact = JSONExact.int(value) else {
+            throw ObservationError.invalidField(key)
+        }
+        return exact
+    }
+}
+
+protocol ObservationRPC: AnyObject, Sendable {
+    func call(_ method: String, _ params: JSONValue) async throws -> JSONValue
+}
+
+extension Engine: ObservationRPC {}
+
+/// Owns response validation and monotonic generation adoption away from the
+/// main actor. The wrapper below additionally refuses to enqueue concurrent
+/// display ticks.
+actor ObservationWorker {
+    private let rpc: any ObservationRPC
+    private var lastAcceptedGeneration: EngineGeneration?
+    private var activeSessionEpoch: UInt64 = 0
+
+    init(rpc: any ObservationRPC) {
+        self.rpc = rpc
+    }
+
+    func fetch(
+        _ binding: ObservationBinding,
+        sessionEpoch: UInt64 = 0
+    ) async throws -> ObservationFrame? {
+        guard sessionEpoch >= activeSessionEpoch else { return nil }
+        if sessionEpoch > activeSessionEpoch {
+            activeSessionEpoch = sessionEpoch
+            lastAcceptedGeneration = nil
+        }
+        let raw = try await rpc.call("render_window", binding.requestJSON)
+        guard sessionEpoch == activeSessionEpoch else { return nil }
+        switch try ObservationResponseDecoder.decode(raw, for: binding) {
+        case .preempted:
+            return nil
+        case .frame(let frame):
+            guard frame.generation.programVersion
+                    == binding.expectedGeneration.programVersion,
+                  frame.generation.controlVersion
+                    >= binding.expectedGeneration.controlVersion
+            else { return nil }
+            if let lastAcceptedGeneration,
+               lastAcceptedGeneration.programVersion == frame.generation.programVersion,
+               frame.generation.controlVersion
+                    < lastAcceptedGeneration.controlVersion {
+                return nil
+            }
+            lastAcceptedGeneration = frame.generation
+            return frame
+        }
+    }
+}
+
+/// Main-actor publication seam. At most one socket request exists at a time;
+/// a hot-swap changes the expected program immediately, so an old in-flight
+/// reply cannot become visible even if it completes successfully.
+@MainActor
+final class ObservationSampler: ObservableObject {
+    @Published private(set) var latestFrame: ObservationFrame?
+    @Published private(set) var droppedFrameCount = 0
+    private(set) var requestCount = 0
+    private(set) var hasRequestInFlight = false
+    var onFrame: ((ObservationFrame) -> Void)?
+
+    private let worker: ObservationWorker
+    private var expectedGeneration: EngineGeneration?
+    private var sessionEpoch: UInt64 = 0
+
+    init(rpc: any ObservationRPC) {
+        worker = ObservationWorker(rpc: rpc)
+    }
+
+    func adoptCompileGeneration(_ generation: EngineGeneration) {
+        expectedGeneration = generation
+        latestFrame = nil
+    }
+
+    func clear() {
+        sessionEpoch &+= 1
+        expectedGeneration = nil
+        latestFrame = nil
+    }
+
+    func request(_ binding: ObservationBinding) {
+        guard expectedGeneration == binding.expectedGeneration,
+              !hasRequestInFlight
+        else {
+            droppedFrameCount += 1
+            return
+        }
+        hasRequestInFlight = true
+        requestCount += 1
+        let requestEpoch = sessionEpoch
+        Task { [weak self] in
+            guard let self else { return }
+            defer { hasRequestInFlight = false }
+            do {
+                guard let frame = try await worker.fetch(
+                    binding,
+                    sessionEpoch: requestEpoch
+                ),
+                      requestEpoch == sessionEpoch,
+                      expectedGeneration == binding.expectedGeneration
+                else {
+                    droppedFrameCount += 1
+                    return
+                }
+                latestFrame = frame
+                onFrame?(frame)
+            } catch {
+                droppedFrameCount += 1
+            }
+        }
+    }
+}
+
+/// Pure request cadence used by the production display-link adapter and tests.
+struct ObservationCadence: Equatable, Sendable {
+    let framesPerSecond: Double
+    private(set) var nextDeadline: Double = 0
+
+    init(framesPerSecond: Double = 60) {
+        self.framesPerSecond = framesPerSecond
+    }
+
+    mutating func accepts(timestamp: Double) -> Bool {
+        guard timestamp.isFinite, framesPerSecond > 0 else { return false }
+        let period = 1 / framesPerSecond
+        let target = nextDeadline == 0 ? timestamp : nextDeadline
+        guard timestamp + 0.0005 >= target else { return false }
+        nextDeadline = timestamp - target > period
+            ? timestamp + period
+            : target + period
+        return true
+    }
+}
+
+/// CVDisplayLink is only a wake-up source. The callback never performs RPC or
+/// touches observable state; accepted ticks hop to MainActor, where the
+/// sampler's in-flight gate enforces backpressure.
+@MainActor
+final class ObservationDisplayLink {
+    private var displayLink: CVDisplayLink?
+    private let callbackState = CallbackState()
+
+    func start(_ action: @escaping @MainActor () -> Void) {
+        stop()
+        callbackState.install(action)
+        var candidate: CVDisplayLink?
+        guard CVDisplayLinkCreateWithActiveCGDisplays(&candidate) == kCVReturnSuccess,
+              let candidate else { return }
+        displayLink = candidate
+        CVDisplayLinkSetOutputCallback(
+            candidate,
+            { _, _, outputTime, _, _, context in
+                guard let context else { return kCVReturnError }
+                let state = Unmanaged<CallbackState>
+                    .fromOpaque(context).takeUnretainedValue()
+                state.receive(outputTime.pointee)
+                return kCVReturnSuccess
+            },
+            Unmanaged.passUnretained(callbackState).toOpaque()
+        )
+        CVDisplayLinkStart(candidate)
+    }
+
+    func stop() {
+        if let displayLink { CVDisplayLinkStop(displayLink) }
+        displayLink = nil
+        callbackState.clear()
+    }
+
+    deinit {
+        if let displayLink { CVDisplayLinkStop(displayLink) }
+    }
+
+    private final class CallbackState {
+        private let lock = NSLock()
+        private var cadence = ObservationCadence()
+        private var enqueued = false
+        private var action: (@MainActor () -> Void)?
+
+        func install(_ action: @escaping @MainActor () -> Void) {
+            lock.withLock {
+                cadence = ObservationCadence()
+                enqueued = false
+                self.action = action
+            }
+        }
+
+        func clear() {
+            lock.withLock {
+                enqueued = false
+                action = nil
+            }
+        }
+
+        func receive(_ timestamp: CVTimeStamp) {
+            let seconds: Double
+            if timestamp.videoTimeScale > 0 {
+                seconds = Double(timestamp.videoTime) / Double(timestamp.videoTimeScale)
+            } else {
+                seconds = Double(timestamp.hostTime) / CVGetHostClockFrequency()
+            }
+            let accepted = lock.withLock {
+                guard !enqueued, action != nil, cadence.accepts(timestamp: seconds)
+                else { return false }
+                enqueued = true
+                return true
+            }
+            guard accepted else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let action = lock.withLock { () -> (@MainActor () -> Void)? in
+                    self.enqueued = false
+                    return self.action
+                }
+                action?()
+            }
+        }
+    }
+}

--- a/reversible/Sources/Reversible/PatchDocument.swift
+++ b/reversible/Sources/Reversible/PatchDocument.swift
@@ -106,6 +106,7 @@ extension PatchModel {
         pan = CGSize(width: doc.panX, height: doc.panY)
         autoArrange = doc.autoArrange
         velocity = doc.velocity
+        advanceAuthoredRevision()
         // New nodes must not collide with loaded ids: resume the counter past
         // the highest numeric suffix in the file.
         adoptCounter(from: known)
@@ -114,7 +115,7 @@ extension PatchModel {
         // pushGraph re-applies a non-default velocity after a COLD compile, but
         // a load whose graph happens to match what's already running skips the
         // compile entirely — so drive the clock here regardless.
-        setVelocity(doc.velocity)
+        setVelocity(doc.velocity, force: true)
     }
 
     /// Reset to the boot patch (Out + one Osc), forgetting the file.

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -19,11 +19,69 @@ struct PatchNode: Identifiable {
     }
 }
 
-/// The patch graph + engine session, one object. TOPOLOGY RELOWERS, SCALARS
-/// ARE LIVE: every continuous knob is a live `param:<id>.<knob>` module slot —
-/// turning it drives `set_param` on the running kernel, no recompile. Only
-/// structural edits (add/remove/rewire) change the graph topology and trigger
-/// a relower + hot-swap.
+enum ScopeTraceProjection {
+    /// Preserve each scope's own 2× trigger-search horizon when several
+    /// different window sizes share one larger generation-pinned RPC.
+    static func triggeredSamples(_ values: [Double], displayCount: Int) -> [Double] {
+        guard displayCount > 0, !values.isEmpty else { return [] }
+        let horizon = min(values.count, min(16_384, displayCount * 2))
+        let suffix = Array(values.suffix(horizon))
+        let trigger = triggerIndex(suffix, display: displayCount)
+        return Array(suffix[trigger..<min(trigger + displayCount, suffix.count)])
+    }
+
+    /// Rising level-trigger with hysteresis (the playground scope's port of
+    /// tui/scope/trigger.ts).
+    static func triggerIndex(_ samples: [Double], display: Int) -> Int {
+        let searchEnd = samples.count - display
+        guard searchEnd > 0 else { return 0 }
+        let peak = samples.reduce(0) { max($0, abs($1)) }
+        let hysteresis = peak * 0.05
+        guard hysteresis > 0 else { return 0 }
+        var armed = false
+        for index in 0..<searchEnd {
+            if samples[index] < -hysteresis { armed = true }
+            else if armed && samples[index] >= hysteresis { return index }
+        }
+        return 0
+    }
+}
+
+enum ObservationTapSelection {
+    static func stableSourceIDs(
+        candidates: [String],
+        allowedEngineNodeIDs: Set<String>
+    ) -> [String] {
+        var seen = Set<String>()
+        return candidates.filter {
+            allowedEngineNodeIDs.contains($0) && seen.insert($0).inserted
+        }
+    }
+
+    static func expectedHandshakeNames(requestedSourceIDs: [String]) -> [String] {
+        ["out"] + requestedSourceIDs
+    }
+}
+
+enum PatchCompileState: Equatable, Sendable {
+    case idle
+    case compiling(authoredRevision: Int)
+    case running(authoredRevision: Int, generation: EngineGeneration)
+    case failed(authoredRevision: Int, message: String)
+    case superseded(compiledRevision: Int, currentRevision: Int)
+}
+
+enum NodePresentationStatus: Equatable, Sendable {
+    case active
+    case excluded
+    case pending
+}
+
+/// The patch graph + engine session, one object. The realized compile handshake
+/// owns scalar routing: live parameters drive `set_param`; structural values
+/// and topology edits relower and hot-swap. Authored revision and lowering
+/// compatibility remain separate so acknowledged live editing does not invent
+/// a structural invalidation.
 @MainActor
 final class PatchModel: ObservableObject {
     @Published var nodes: [String: PatchNode] = [:]
@@ -40,6 +98,11 @@ final class PatchModel: ObservableObject {
     /// The file this patch came from / saves to (nil = never saved). Drives
     /// the window title and whether ⌘S needs to ask.
     @Published var documentURL: URL?
+    @Published private(set) var vocabulary: EngineVocabulary?
+    @Published private(set) var authoredRevision = 0
+    @Published private(set) var realizedPatch: RealizedPatchSnapshot?
+    @Published private(set) var runningGeneration: EngineGeneration?
+    @Published private(set) var compileState: PatchCompileState = .idle
 
     /// Sources an inlet may legally take — the connection UI shows ONLY
     /// these (the type discipline enforced by omission: control inlets
@@ -47,6 +110,29 @@ final class PatchModel: ObservableObject {
     func legalSources(for nodeId: String, port: String) -> [PatchNode] {
         order.compactMap { nodes[$0] }
             .filter { canConnect(from: $0.id, to: nodeId, port: port) }
+    }
+
+    func presentationStatus(for node: PatchNode) -> NodePresentationStatus? {
+        guard !node.kind.spec.monitor else { return nil }
+        guard let realizedPatch,
+              realizedPatch.loweringRevision == loweringRevision,
+              let realizedNode = realizedPatch.patch.node(id: node.id)
+        else { return .pending }
+        return realizedNode.status == .active ? .active : .excluded
+    }
+
+    func parameterStatus(
+        for node: PatchNode,
+        knob: KnobSpec
+    ) -> RealizedParameterStatus {
+        if node.kind.spec.monitor { return .structural }
+        guard let realizedPatch,
+              realizedPatch.loweringRevision == loweringRevision
+        else { return .inactive }
+        return realizedPatch.patch.parameterStatus(
+            nodeID: node.id,
+            port: knob.name
+        )
     }
 
     // ── Topological layout ────────────────────────────────────────────────
@@ -93,6 +179,10 @@ final class PatchModel: ObservableObject {
     }
 
     let engine: Engine
+    private let observationSampler: ObservationSampler
+    private let observationDisplayLink: ObservationDisplayLink
+    private var truth = PatchTruthStore()
+    private var loweringRevision = 0
     private var counter = 0
 
     // Node ids are "<kind><n>" and must stay unique for the lifetime of a
@@ -117,8 +207,14 @@ final class PatchModel: ObservableObject {
         let forward: @Sendable (EngineEvent) -> Void = { [box] event in
             Task { @MainActor [box] in box.handler?(event) }
         }
-        engine = Engine(events: forward)
+        let engine = Engine(events: forward)
+        self.engine = engine
+        observationSampler = ObservationSampler(rpc: engine)
+        observationDisplayLink = ObservationDisplayLink()
         box.handler = { [weak self] event in self?.handle(event) }
+        observationSampler.onFrame = { [weak self] frame in
+            self?.adoptObservationFrame(frame)
+        }
         // Every exit path must reap the child engine or it orphans with the
         // DAC running (see AppDelegate).
         AppDelegate.onTerminate = { [engine] in engine.terminateChild() }
@@ -142,13 +238,40 @@ final class PatchModel: ObservableObject {
         switch event {
         case .up:
             setStatus("engine up", isError: false)
-            Task { await syncAudioState() }
+            Task { await synchronizeEngineState() }
         case .exit(let code):
+            vocabulary = nil
+            lastPushed = nil
+            truth.reset()
+            publishTruth()
+            observationSampler.clear()
+            scopeTraces = [:]
+            compileState = .idle
             setStatus("engine exited (code \(code))", isError: true)
         case .stderr(let text):
             // Diagnostic only — the Electron app console.warn'd these.
             FileHandle.standardError.write(Data("[engine] \(text)".utf8))
         }
+    }
+
+    private func synchronizeEngineState() async {
+        do {
+            vocabulary = try await engine.loadVocabulary()
+            await syncAudioState()
+            schedulePush()
+        } catch {
+            setStatus("engine vocabulary: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    private func publishTruth() {
+        realizedPatch = truth.realized
+        runningGeneration = truth.runningGeneration
+    }
+
+    func advanceAuthoredRevision(requiresCompile: Bool = true) {
+        authoredRevision += 1
+        if requiresCompile { loweringRevision += 1 }
     }
 
     func setStatus(_ text: String, isError: Bool) {
@@ -182,6 +305,8 @@ final class PatchModel: ObservableObject {
         nodes[id] = n
         order.append(id)
         autoArrangeIfOn()
+        advanceAuthoredRevision(requiresCompile: !kind.spec.monitor)
+        schedulePush()
         return n
     }
 
@@ -194,6 +319,7 @@ final class PatchModel: ObservableObject {
             nodes[m.id] = m
         }
         autoArrangeIfOn()
+        advanceAuthoredRevision()
         schedulePush()
     }
 
@@ -237,6 +363,7 @@ final class PatchModel: ObservableObject {
         to.inputs[port, default: []].append(fromId)
         nodes[toId] = to
         autoArrangeIfOn()
+        advanceAuthoredRevision()
         schedulePush()
     }
 
@@ -245,17 +372,35 @@ final class PatchModel: ObservableObject {
         to.inputs[port]?.removeAll { $0 == fromId }
         nodes[toId] = to
         autoArrangeIfOn()
+        advanceAuthoredRevision()
         schedulePush()
     }
 
     // ── Serialization → load_patch_graph ─────────────────────────────────
-    /// Taps cost kernel compute (each re-emits its upstream cone), so request
-    /// them only while a scope channel actually watches a node. Out is exempt:
-    /// the final-mix slot `__root__.out` exists in every compile.
-    var tapsWanted: Bool {
-        nodes.values.contains { n in
-            n.kind == .scope && n.allInputs.contains { nodes[$0]?.kind != .out }
+    /// Stable, explicit observation projection. Monitor order and inlet order
+    /// define the request; repeated sources are kept once, and Out is omitted
+    /// because its final-mix binding is always published as `out`.
+    var requestedTapNodeIDs: [String] {
+        var candidates: [String] = []
+        for id in order {
+            guard let monitor = nodes[id], monitor.kind.spec.monitor else { continue }
+            for port in monitor.kind.spec.inlets {
+                candidates.append(contentsOf: monitor.inputs[port] ?? [])
+            }
         }
+        let allowed = Set(nodes.values.compactMap { node in
+            node.kind != .out && !node.kind.spec.monitor ? node.id : nil
+        })
+        return ObservationTapSelection.stableSourceIDs(
+            candidates: candidates,
+            allowedEngineNodeIDs: allowed
+        )
+    }
+
+    private var expectedTapNames: [String] {
+        ObservationTapSelection.expectedHandshakeNames(
+            requestedSourceIDs: requestedTapNodeIDs
+        )
     }
 
     func serialize() -> JSONValue {
@@ -279,7 +424,7 @@ final class PatchModel: ObservableObject {
         return .object([
             "nodes": .array(out),
             "out": outNode.map { .string($0.id) } ?? .null,
-            "taps": .bool(tapsWanted),
+            "taps": .array(requestedTapNodeIDs.map(JSONValue.string)),
         ])
     }
 
@@ -296,6 +441,7 @@ final class PatchModel: ObservableObject {
     private var lastPushed: JSONValue?
 
     func pushGraph() async {
+        guard let vocabulary else { return }
         if pushInFlight { pushAgain = true; return }
         pushInFlight = true
         defer {
@@ -305,7 +451,22 @@ final class PatchModel: ObservableObject {
         // A monitor-only edit (e.g. scoping the Out mix) leaves the engine
         // graph byte-identical — skip the recompile, not just debounce it.
         let graph = serialize()
-        if graph == lastPushed { return }
+        let revision = authoredRevision
+        let compiledLoweringRevision = loweringRevision
+        if graph == lastPushed {
+            truth.retagCurrent(
+                authoredRevision: revision,
+                loweringRevision: compiledLoweringRevision
+            )
+            publishTruth()
+            if let runningGeneration {
+                compileState = .running(
+                    authoredRevision: revision,
+                    generation: runningGeneration
+                )
+            }
+            return
+        }
         do {
             // The compile+JIT is synchronous on the engine's single control
             // thread, so a heavy node (e.g. a modal reverb: ~10⁵ IR lines →
@@ -313,17 +474,64 @@ final class PatchModel: ObservableObject {
             // "compiling" is distinguishable from "hung" — the acute failure
             // mode of the live-patch loop.
             setStatus("compiling…", isError: false)
-            try await engine.call("load_patch_graph", graph)
+            compileState = .compiling(authoredRevision: revision)
+            let adoption = try await engine.loadPatchGraph(
+                graph,
+                expectedTapNames: expectedTapNames,
+                vocabularyFingerprint: vocabulary.fingerprint
+            )
+            guard truth.adoptCompile(
+                adoption,
+                authoredRevision: revision,
+                loweringRevision: compiledLoweringRevision,
+                graph: graph
+            ) else {
+                switch adoption {
+                case .superseded, .stale:
+                    compileState = .superseded(
+                        compiledRevision: revision,
+                        currentRevision: authoredRevision
+                    )
+                    setStatus(
+                        "compile superseded · running patch unchanged",
+                        isError: false
+                    )
+                case .adopted:
+                    break
+                }
+                return
+            }
             lastPushed = graph
+            publishTruth()
+            if let realizedPatch {
+                observationSampler.adoptCompileGeneration(
+                    realizedPatch.generation
+                )
+            }
+            scopeTraces = [:]
             // A relower transfers slots by name, so a live scrub survives it —
             // except a COLD first compile, which seeds master.velocity at its
             // default (1). Re-apply a non-default scrub so the slider and the
             // running clock agree (no-op if equal).
             if velocity != 1 { params.send("master.velocity", velocity) }
-            await refreshScopeTaps()
-            setStatus(audioOn ? "playing" : "compiled", isError: false)
+            if revision == authoredRevision, let runningGeneration {
+                compileState = .running(
+                    authoredRevision: revision,
+                    generation: runningGeneration
+                )
+                setStatus(audioOn ? "playing" : "compiled", isError: false)
+            } else {
+                compileState = .superseded(
+                    compiledRevision: revision,
+                    currentRevision: authoredRevision
+                )
+                setStatus("compiled revision superseded by edits", isError: false)
+            }
         } catch {
-            lastPushed = nil
+            compileState = .failed(
+                authoredRevision: revision,
+                message: error.localizedDescription
+            )
             setStatus("compile: \(error.localizedDescription)", isError: true)
         }
     }
@@ -331,16 +539,45 @@ final class PatchModel: ObservableObject {
     // ── Live param drive ──────────────────────────────────────────────────
     lazy var params = ParamSender(model: self)
 
-    func sendKnob(_ node: PatchNode, _ knob: KnobSpec, _ value: Double) {
-        // A monitor's knobs (Scope `window`) are view state, not param slots.
-        guard !node.kind.spec.monitor else { return }
+    func setKnob(_ node: PatchNode, _ knob: KnobSpec, _ value: Double) {
+        guard value.isFinite, var current = nodes[node.id],
+              current.values[knob.name] != value
+        else { return }
+        current.values[knob.name] = value
+        nodes[node.id] = current
+
+        // A monitor's knobs (Scope `window`) are authored view state, not
+        // parameter slots and do not invalidate lowering compatibility.
+        guard !node.kind.spec.monitor else {
+            advanceAuthoredRevision(requiresCompile: false)
+            return
+        }
         let name = "\(node.id).\(knob.name)"
+        guard let realizedPatch,
+              realizedPatch.loweringRevision == loweringRevision,
+              case .live = realizedPatch.patch.parameterStatus(
+                nodeID: node.id,
+                port: knob.name
+              )
+        else {
+            // Absent live truth means the edit is structural (or belongs to a
+            // not-yet-realized lowering revision).
+            advanceAuthoredRevision()
+            schedulePush(after: .milliseconds(90))
+            return
+        }
+        advanceAuthoredRevision(requiresCompile: false)
         params.send(name, value)
     }
 
-    func setVelocity(_ v: Double) {
-        velocity = v
-        params.send("master.velocity", v)
+    func setVelocity(_ v: Double, force: Bool = false) {
+        guard v.isFinite else { return }
+        let changed = velocity != v
+        if changed {
+            velocity = v
+            advanceAuthoredRevision(requiresCompile: false)
+        }
+        if changed || force { params.send("master.velocity", v) }
     }
 
     // ── Transport ─────────────────────────────────────────────────────────
@@ -406,111 +643,100 @@ final class PatchModel: ObservableObject {
         }
     }
 
-    // ── Scope taps ────────────────────────────────────────────────────────
-    // A scope channel names a NODE; the engine names a SLOT. After each
-    // compile `list_scope_taps` rebinds node id → `__root__.tap:<id>` (a node
-    // that failed to lower simply has no tap and its trace goes dark). The
-    // final mix is the one slot that exists in every compile, so Out maps
-    // statically — no taps build required to watch the output.
-    private var scopeTapSlots: [String: String] = [:]
-
-    /// Latest triggered trace per scope channel, keyed "<scopeId>.<port>".
+    // ── Generation-pinned observations ────────────────────────────────────
+    /// Latest complete trace set, keyed "<scopeId>.<port>". The dictionary is
+    /// replaced only from one immutable ObservationFrame.
     @Published var scopeTraces: [String: [Double]] = [:]
 
+    private struct ScopeProjection: Equatable {
+        let binding: ObservationBinding
+        let displayCounts: [String: Int]
+    }
+
     func scopeSlot(for sourceId: String) -> String? {
-        if nodes[sourceId]?.kind == .out { return "__root__.out" }
-        return scopeTapSlots[sourceId]
+        guard let realizedPatch else { return nil }
+        let tapName = nodes[sourceId]?.kind == .out ? "out" : sourceId
+        return realizedPatch.patch.tap(named: tapName)?.slot
     }
 
-    private func refreshScopeTaps() async {
-        guard tapsWanted else { scopeTapSlots = [:]; return }
-        guard let r = try? await engine.call("list_scope_taps"),
-              case .array(let taps)? = r["taps"] else { return }
-        var map: [String: String] = [:]
-        for t in taps {
-            guard let name = t["name"]?.stringValue,
-                  let slot = t["slot"]?.stringValue, name != "out" else { continue }
-            map[name] = slot
-        }
-        scopeTapSlots = map
-    }
-
-    // ── Scope poll loop ───────────────────────────────────────────────────
-    // `render_window` + `playback_position` are data-plane methods: answered
-    // synchronously in C++ off the audio thread, never queued behind the Lean
-    // control thread — so the trace stays live through a compile and works
-    // with the transport stopped (the kernel is closed-form; a frozen clock
-    // just yields a still waveform). One serial loop, so a slow frame can
-    // never pile up requests.
     static let sampleRate = 44100.0
-    private var scopeTask: Task<Void, Never>?
-
     private func startScopePolling() {
-        scopeTask = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(33))
-                guard !Task.isCancelled else { return }
-                await self?.pollScopes()
-            }
+        observationDisplayLink.start { [weak self] in
+            self?.pollScopes()
         }
     }
 
-    private func pollScopes() async {
-        let scopes = order.compactMap { nodes[$0] }
-            .filter { $0.kind == .scope && !$0.allInputs.isEmpty }
-        guard !scopes.isEmpty else {
+    private func pollScopes() {
+        guard let projection = makeScopeProjection() else {
             if !scopeTraces.isEmpty { scopeTraces = [:] }
             return
         }
-        guard let pos = try? await engine.call("playback_position"),
-              let position = pos["position"]?.doubleValue else { return }
-        var fresh: [String: [Double]] = [:]
+        observationSampler.request(projection.binding)
+    }
+
+    private func makeScopeProjection() -> ScopeProjection? {
+        guard let realizedPatch else { return nil }
+        let scopes = order.compactMap { nodes[$0] }
+            .filter { $0.kind == .scope && !$0.allInputs.isEmpty }
+        guard !scopes.isEmpty else { return nil }
+
+        var channels: [ObservationChannel] = []
+        var displayCounts: [String: Int] = [:]
+        var maximumFetch = 0
         for scope in scopes {
             let window = scope.values["window"] ?? 0.02
-            let count = min(8192, max(128, Int(window * Self.sampleRate)))
-            // Fetch 2× the display span so the trigger can align a full
-            // window ending at the live head.
-            let fetch = min(16384, count * 2)
-            let start = max(0, Int(position) - fetch)
-            var slots: [String] = [], keys: [String] = []
+            let displayCount = min(
+                8_192,
+                max(128, Int(window * Self.sampleRate))
+            )
+            maximumFetch = max(maximumFetch, min(16_384, displayCount * 2))
             for port in scope.kind.spec.inlets {
                 guard let src = scope.inputs[port]?.first,
                       let slot = scopeSlot(for: src) else { continue }
-                slots.append(slot)
-                keys.append("\(scope.id).\(port)")
-            }
-            guard !slots.isEmpty,
-                  let r = try? await engine.call("render_window", .object([
-                      "start": .number(Double(start)),
-                      "count": .number(Double(fetch)),
-                      "slots": .array(slots.map(JSONValue.string)),
-                  ])),
-                  case .array(let chans)? = r["values"] else { continue }
-            for (i, key) in keys.enumerated() {
-                guard i < chans.count, case .array(let raw) = chans[i] else { continue }
-                let samples = raw.compactMap(\.doubleValue)
-                let t = Self.triggerIndex(samples, display: count)
-                fresh[key] = Array(samples[t..<min(t + count, samples.count)])
+                let key = "\(scope.id).\(port)"
+                channels.append(.init(key: key, slot: slot))
+                displayCounts[key] = displayCount
             }
         }
-        scopeTraces = fresh
+        guard maximumFetch > 0, !channels.isEmpty,
+              let binding = try? ObservationBinding(
+                expectedGeneration: realizedPatch.generation,
+                span: maximumFetch,
+                pointBudget: maximumFetch,
+                channels: channels
+              )
+        else { return nil }
+        return .init(binding: binding, displayCounts: displayCounts)
     }
 
-    /// Rising level-trigger with hysteresis (the playground scope's port of
-    /// tui/scope/trigger.ts): arm below −h, fire on the first climb past +h,
-    /// searching only far enough back that a full display window remains.
-    static func triggerIndex(_ s: [Double], display: Int) -> Int {
-        let searchEnd = s.count - display
-        guard searchEnd > 0 else { return 0 }
-        let peak = s.reduce(0) { max($0, abs($1)) }
-        let h = peak * 0.05
-        guard h > 0 else { return 0 }
-        var armed = false
-        for i in 0..<searchEnd {
-            if s[i] < -h { armed = true }
-            else if armed && s[i] >= h { return i }
+    private func adoptObservationFrame(_ frame: ObservationFrame) {
+        if truth.adoptObservation(frame.generation) {
+            publishTruth()
+            if case .running(let revision, _) = compileState,
+               let runningGeneration {
+                compileState = .running(
+                    authoredRevision: revision,
+                    generation: runningGeneration
+                )
+            }
         }
-        return 0
+
+        // The authored monitor wiring may have changed while the socket request
+        // was in flight. Never publish old channel identities into a new view.
+        guard let projection = makeScopeProjection(),
+              projection.binding == frame.binding
+        else { return }
+        var fresh: [String: [Double]] = [:]
+        for channel in frame.channels {
+            guard let displayCount = projection.displayCounts[channel.channel.key]
+            else { continue }
+            fresh[channel.channel.key] = ScopeTraceProjection.triggeredSamples(
+                channel.values,
+                displayCount: displayCount
+            )
+        }
+        guard fresh.count == frame.channels.count else { return }
+        scopeTraces = fresh
     }
 
     private func pollTelemetry() async {

--- a/reversible/Sources/Reversible/RealizedPatch.swift
+++ b/reversible/Sources/Reversible/RealizedPatch.swift
@@ -1,0 +1,425 @@
+import Foundation
+
+/// Identity of an immutable runtime program and one of its control snapshots.
+/// Program identity dominates ordering; live writes may advance only the
+/// control component of the currently adopted program.
+struct EngineGeneration: Equatable, Comparable, Sendable {
+    let programVersion: UInt64
+    let controlVersion: UInt64
+
+    static func < (lhs: EngineGeneration, rhs: EngineGeneration) -> Bool {
+        if lhs.programVersion != rhs.programVersion {
+            return lhs.programVersion < rhs.programVersion
+        }
+        return lhs.controlVersion < rhs.controlVersion
+    }
+}
+
+enum RealizedNodeStatus: String, Equatable, Sendable {
+    case active
+    case excluded
+}
+
+struct RealizedNode: Equatable, Sendable {
+    let id: String
+    let kind: NodeKindID
+    let status: RealizedNodeStatus
+}
+
+enum RealizedInletState: Equatable, Sendable {
+    case wired(sources: [String])
+    case normalled
+}
+
+struct RealizedInlet: Equatable, Sendable {
+    let nodeID: String
+    let port: String
+    let state: RealizedInletState
+}
+
+struct RealizedLiveParameter: Equatable, Sendable {
+    let name: String
+    let value: Double
+    let discipline: WriteDisciplineID
+}
+
+enum RealizedParameterStatus: Equatable, Sendable {
+    case live(discipline: WriteDisciplineID)
+    case structural
+    case inactive
+}
+
+struct ScopeTapBinding: Equatable, Sendable {
+    let name: String
+    let instance: String
+    let output: String
+    let slot: String
+}
+
+/// Complete realized truth published by one successful load_patch_graph call.
+/// Nothing in this value is inferred from the authored graph or a follow-up
+/// diagnostic request.
+struct RealizedPatch: Equatable, Sendable {
+    let vocabularyFingerprint: String
+    let generation: EngineGeneration
+    let nodes: [RealizedNode]
+    let inlets: [RealizedInlet]
+    let liveParameters: [RealizedLiveParameter]
+    let taps: [ScopeTapBinding]
+
+    func node(id: String) -> RealizedNode? {
+        nodes.first { $0.id == id }
+    }
+
+    func inlet(nodeID: String, port: String) -> RealizedInlet? {
+        inlets.first { $0.nodeID == nodeID && $0.port == port }
+    }
+
+    func liveParameter(named name: String) -> RealizedLiveParameter? {
+        liveParameters.first { $0.name == name }
+    }
+
+    func parameterStatus(nodeID: String, port: String) -> RealizedParameterStatus {
+        guard node(id: nodeID)?.status == .active else { return .inactive }
+        guard let parameter = liveParameter(named: "\(nodeID).\(port)") else {
+            return .structural
+        }
+        return .live(discipline: parameter.discipline)
+    }
+
+    func tap(named name: String) -> ScopeTapBinding? {
+        taps.first { $0.name == name }
+    }
+}
+
+enum PatchCompileResponse: Equatable, Sendable {
+    case published(RealizedPatch)
+    case superseded
+
+    /// Decode the complete handshake and, when supplied, require its tap table
+    /// to be exactly the stable projection requested in the authored graph.
+    static func decode(
+        _ value: JSONValue,
+        expectedTapNames: [String]? = nil,
+        expectedVocabularyFingerprint: String? = nil
+    ) throws -> PatchCompileResponse {
+        guard case .object(let object) = value else {
+            throw RealizedPatchDecodeError.invalidField("response")
+        }
+        if case .bool(true)? = object["superseded"] { return .superseded }
+        guard case .bool(true)? = object["ok"] else {
+            throw object["ok"] == nil
+                ? RealizedPatchDecodeError.missingField("ok")
+                : RealizedPatchDecodeError.invalidField("ok")
+        }
+
+        let fingerprint = try requiredString(
+            object, "vocabulary_fingerprint", path: "vocabulary_fingerprint"
+        )
+        if let expectedVocabularyFingerprint,
+           fingerprint != expectedVocabularyFingerprint {
+            throw RealizedPatchDecodeError.vocabularyMismatch(
+                expected: expectedVocabularyFingerprint,
+                actual: fingerprint
+            )
+        }
+        let generation = EngineGeneration(
+            programVersion: try requiredExactUInt64(object, "program_version"),
+            controlVersion: try requiredExactUInt64(object, "control_version")
+        )
+        guard generation.programVersion > 0, generation.controlVersion > 0 else {
+            throw RealizedPatchDecodeError.invalidField("generation")
+        }
+
+        let nodeValues = try requiredArray(object, "nodes")
+        var nodes: [RealizedNode] = []
+        var nodeIDs = Set<String>()
+        for (index, raw) in nodeValues.enumerated() {
+            guard case .object(let fields) = raw else {
+                throw RealizedPatchDecodeError.invalidField("nodes[\(index)]")
+            }
+            let id = try requiredString(fields, "id", path: "nodes[\(index)].id")
+            let rawKind = try requiredString(
+                fields, "kind", path: "nodes[\(index)].kind"
+            )
+            let rawStatus = try requiredString(
+                fields, "status", path: "nodes[\(index)].status"
+            )
+            guard nodeIDs.insert(id).inserted else {
+                throw RealizedPatchDecodeError.duplicate("node id '\(id)'")
+            }
+            guard let kind = NodeKindID(rawValue: rawKind),
+                  let status = RealizedNodeStatus(rawValue: rawStatus)
+            else { throw RealizedPatchDecodeError.invalidField("nodes[\(index)]") }
+            nodes.append(.init(id: id, kind: kind, status: status))
+        }
+
+        let inletValues = try requiredArray(object, "inputs")
+        var inlets: [RealizedInlet] = []
+        var inletKeys = Set<String>()
+        for (index, raw) in inletValues.enumerated() {
+            guard case .object(let fields) = raw else {
+                throw RealizedPatchDecodeError.invalidField("inputs[\(index)]")
+            }
+            let nodeID = try requiredString(
+                fields, "node", path: "inputs[\(index)].node"
+            )
+            let port = try requiredString(
+                fields, "port", path: "inputs[\(index)].port"
+            )
+            let rawState = try requiredString(
+                fields, "state", path: "inputs[\(index)].state"
+            )
+            guard nodeIDs.contains(nodeID) else {
+                throw RealizedPatchDecodeError.invalidField("inputs[\(index)].node")
+            }
+            let key = "\(nodeID)\u{0}\(port)"
+            guard inletKeys.insert(key).inserted else {
+                throw RealizedPatchDecodeError.duplicate("inlet '\(nodeID).\(port)'")
+            }
+            let state: RealizedInletState
+            switch rawState {
+            case "normalled":
+                guard fields["sources"] == nil else {
+                    throw RealizedPatchDecodeError.invalidField(
+                        "inputs[\(index)].sources"
+                    )
+                }
+                state = .normalled
+            case "wired":
+                let sourceValues = try requiredArray(fields, "sources")
+                var seenSources = Set<String>()
+                let sources = try sourceValues.enumerated().map { sourceIndex, source in
+                    guard let id = source.stringValue, nodeIDs.contains(id),
+                          seenSources.insert(id).inserted
+                    else {
+                        throw RealizedPatchDecodeError.invalidField(
+                            "inputs[\(index)].sources[\(sourceIndex)]"
+                        )
+                    }
+                    return id
+                }
+                guard !sources.isEmpty else {
+                    throw RealizedPatchDecodeError.invalidField(
+                        "inputs[\(index)].sources"
+                    )
+                }
+                state = .wired(sources: sources)
+            default:
+                throw RealizedPatchDecodeError.invalidField("inputs[\(index)].state")
+            }
+            inlets.append(.init(nodeID: nodeID, port: port, state: state))
+        }
+
+        let parameterValues = try requiredArray(object, "params")
+        var parameters: [RealizedLiveParameter] = []
+        var parameterNames = Set<String>()
+        for (index, raw) in parameterValues.enumerated() {
+            guard case .object(let fields) = raw else {
+                throw RealizedPatchDecodeError.invalidField("params[\(index)]")
+            }
+            let name = try requiredString(
+                fields, "name", path: "params[\(index)].name"
+            )
+            let rawDiscipline = try requiredString(
+                fields, "discipline", path: "params[\(index)].discipline"
+            )
+            guard parameterNames.insert(name).inserted else {
+                throw RealizedPatchDecodeError.duplicate("parameter '\(name)'")
+            }
+            guard let value = fields["value"]?.doubleValue, value.isFinite,
+                  let discipline = WriteDisciplineID(rawValue: rawDiscipline)
+            else { throw RealizedPatchDecodeError.invalidField("params[\(index)]") }
+            parameters.append(.init(name: name, value: value, discipline: discipline))
+        }
+
+        let tapValues = try requiredArray(object, "taps")
+        var taps: [ScopeTapBinding] = []
+        var tapNames = Set<String>()
+        var tapSlots = Set<String>()
+        for (index, raw) in tapValues.enumerated() {
+            guard case .object(let fields) = raw else {
+                throw RealizedPatchDecodeError.invalidField("taps[\(index)]")
+            }
+            let name = try requiredString(
+                fields, "name", path: "taps[\(index)].name"
+            )
+            let instance = try requiredString(
+                fields, "instance", path: "taps[\(index)].instance"
+            )
+            let output = try requiredString(
+                fields, "output", path: "taps[\(index)].output"
+            )
+            let slot = try requiredString(
+                fields, "slot", path: "taps[\(index)].slot"
+            )
+            guard name == "out" || nodeIDs.contains(name),
+                  slot == "\(instance).\(output)"
+            else { throw RealizedPatchDecodeError.invalidField("taps[\(index)]") }
+            guard tapNames.insert(name).inserted else {
+                throw RealizedPatchDecodeError.duplicate("tap name '\(name)'")
+            }
+            guard tapSlots.insert(slot).inserted else {
+                throw RealizedPatchDecodeError.duplicate("tap slot '\(slot)'")
+            }
+            taps.append(.init(name: name, instance: instance, output: output, slot: slot))
+        }
+        if let expectedTapNames, taps.map(\.name) != expectedTapNames {
+            throw RealizedPatchDecodeError.invalidField("taps")
+        }
+
+        return .published(.init(
+            vocabularyFingerprint: fingerprint,
+            generation: generation,
+            nodes: nodes,
+            inlets: inlets,
+            liveParameters: parameters,
+            taps: taps
+        ))
+    }
+}
+
+enum RealizedPatchDecodeError: Error, Equatable, LocalizedError, Sendable {
+    case missingField(String)
+    case invalidField(String)
+    case duplicate(String)
+    case vocabularyMismatch(expected: String, actual: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingField(let path): return "compile handshake missing '\(path)'"
+        case .invalidField(let path): return "compile handshake has invalid '\(path)'"
+        case .duplicate(let fact): return "compile handshake repeats \(fact)"
+        case .vocabularyMismatch(let expected, let actual):
+            return "compile handshake vocabulary '\(actual)' does not match adopted vocabulary '\(expected)'"
+        }
+    }
+}
+
+private func requiredString(
+    _ object: [String: JSONValue], _ key: String, path: String
+) throws -> String {
+    guard let value = object[key] else {
+        throw RealizedPatchDecodeError.missingField(path)
+    }
+    guard let string = value.stringValue,
+          !string.isEmpty,
+          string == string.trimmingCharacters(in: .whitespacesAndNewlines)
+    else { throw RealizedPatchDecodeError.invalidField(path) }
+    return string
+}
+
+private func requiredArray(
+    _ object: [String: JSONValue], _ key: String
+) throws -> [JSONValue] {
+    guard let value = object[key] else {
+        throw RealizedPatchDecodeError.missingField(key)
+    }
+    guard case .array(let array) = value else {
+        throw RealizedPatchDecodeError.invalidField(key)
+    }
+    return array
+}
+
+private func requiredExactUInt64(
+    _ object: [String: JSONValue], _ key: String
+) throws -> UInt64 {
+    guard let value = object[key] else {
+        throw RealizedPatchDecodeError.missingField(key)
+    }
+    guard let exact = JSONExact.uint64(value) else {
+        throw RealizedPatchDecodeError.invalidField(key)
+    }
+    return exact
+}
+
+enum CompileAdoption: Equatable, Sendable {
+    case adopted(RealizedPatch)
+    case superseded(activeGeneration: EngineGeneration?)
+    case stale(candidate: EngineGeneration, active: EngineGeneration)
+}
+
+/// The engine-side generation guard. Failed, superseded, and late responses
+/// never replace the last complete realized handshake.
+struct RealizedPatchStore: Sendable {
+    private(set) var current: RealizedPatch?
+
+    mutating func adopt(_ response: PatchCompileResponse) -> CompileAdoption {
+        switch response {
+        case .superseded:
+            return .superseded(activeGeneration: current?.generation)
+        case .published(let candidate):
+            if let current, candidate.generation <= current.generation {
+                return .stale(
+                    candidate: candidate.generation,
+                    active: current.generation
+                )
+            }
+            current = candidate
+            return .adopted(candidate)
+        }
+    }
+}
+
+/// One authored graph and the complete runtime truth published for it.
+struct RealizedPatchSnapshot: Equatable, Sendable {
+    let authoredRevision: Int
+    let loweringRevision: Int
+    let graph: JSONValue
+    let patch: RealizedPatch
+
+    var generation: EngineGeneration { patch.generation }
+}
+
+/// Pure state transition used by PatchModel and its tests. Compile realization
+/// is immutable; observations may only advance the control identity of that
+/// same program.
+struct PatchTruthStore: Equatable, Sendable {
+    private(set) var realized: RealizedPatchSnapshot?
+    private(set) var runningGeneration: EngineGeneration?
+
+    mutating func adoptCompile(
+        _ adoption: CompileAdoption,
+        authoredRevision: Int,
+        loweringRevision: Int,
+        graph: JSONValue
+    ) -> Bool {
+        guard case .adopted(let patch) = adoption else { return false }
+        realized = .init(
+            authoredRevision: authoredRevision,
+            loweringRevision: loweringRevision,
+            graph: graph,
+            patch: patch
+        )
+        runningGeneration = patch.generation
+        return true
+    }
+
+    mutating func retagCurrent(
+        authoredRevision: Int,
+        loweringRevision: Int
+    ) {
+        guard let realized else { return }
+        self.realized = .init(
+            authoredRevision: authoredRevision,
+            loweringRevision: loweringRevision,
+            graph: realized.graph,
+            patch: realized.patch
+        )
+    }
+
+    mutating func adoptObservation(_ generation: EngineGeneration) -> Bool {
+        guard let realized,
+              generation.programVersion == realized.generation.programVersion,
+              generation.controlVersion >= realized.generation.controlVersion,
+              runningGeneration.map({ generation >= $0 }) ?? true
+        else { return false }
+        runningGeneration = generation
+        return true
+    }
+
+    mutating func reset() {
+        realized = nil
+        runningGeneration = nil
+    }
+}

--- a/reversible/Sources/Reversible/Theme.swift
+++ b/reversible/Sources/Reversible/Theme.swift
@@ -18,6 +18,9 @@ enum Theme {
     static let transportOn = Color(hex: 0x8A3C3C)
     static let clockOn = Color(hex: 0x2C5A6E)
     static let scrubAccent = Color(hex: 0x4FD6C4)   // reversing — the moat gesture
+    static let truthActive = Color(hex: 0x55C98A)
+    static let truthExcluded = Color(hex: 0xD7A35A)
+    static let truthPending = Color(hex: 0x768195)
 
     static let mono = Font.system(size: 13, design: .monospaced)
     static let monoSmall = Font.system(size: 11, design: .monospaced)

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -51,12 +51,30 @@ struct PatchToolbar: ToolbarContent {
         }
 
         ToolbarItem {
+            Text(truthSummary)
+                .font(Theme.monoSmall)
+                .foregroundStyle(Theme.muted)
+                .monospacedDigit()
+                .help("authored revision · realized revision · latest acknowledged program/control generation")
+        }
+
+        ToolbarItem {
             Text(model.status)
                 .font(Theme.monoSmall)
                 .foregroundStyle(model.statusIsError ? Theme.err : Theme.muted)
                 .lineLimit(1)
                 .frame(minWidth: 180, alignment: .trailing)
         }
+    }
+
+    private var truthSummary: String {
+        let realizedRevision = model.realizedPatch.map {
+            String($0.authoredRevision)
+        } ?? "—"
+        guard let generation = model.runningGeneration else {
+            return "A\(model.authoredRevision) · R\(realizedRevision) · P—/C—"
+        }
+        return "A\(model.authoredRevision) · R\(realizedRevision) · P\(generation.programVersion)/C\(generation.controlVersion)"
     }
 }
 

--- a/reversible/Tests/ReversibleTests/Fixtures/observation-frame-valid.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/observation-frame-valid.json
@@ -1,0 +1,16 @@
+{
+  "anchor": "playback",
+  "playback_position": 100,
+  "start": 94,
+  "count": 3,
+  "span": 6,
+  "stride": 2,
+  "preempted": false,
+  "program_version": 41,
+  "control_version": 80,
+  "effective_sample_index": 88,
+  "values": [
+    [0.25, 0.5, 0.75],
+    [-1, 0, 1]
+  ]
+}

--- a/reversible/Tests/ReversibleTests/Fixtures/realized-patch-valid.json
+++ b/reversible/Tests/ReversibleTests/Fixtures/realized-patch-valid.json
@@ -1,0 +1,23 @@
+{
+  "ok": true,
+  "vocabulary_fingerprint": "fnv1a64:0123456789abcdef",
+  "program_version": 41,
+  "control_version": 77,
+  "nodes": [
+    {"id": "src", "kind": "future_source", "status": "active"},
+    {"id": "parked", "kind": "future_processor", "status": "excluded"},
+    {"id": "out", "kind": "out", "status": "active"}
+  ],
+  "inputs": [
+    {"node": "src", "port": "frequency", "state": "normalled"},
+    {"node": "out", "port": "in", "state": "wired", "sources": ["src"]}
+  ],
+  "params": [
+    {"name": "src.frequency", "value": 440, "discipline": "future_anchor"},
+    {"name": "master.velocity", "value": 1, "discipline": "velocity"}
+  ],
+  "taps": [
+    {"name": "out", "instance": "__root__", "output": "out", "slot": "__root__.out"},
+    {"name": "src", "instance": "__root__", "output": "tap:src", "slot": "__root__.tap:src"}
+  ]
+}

--- a/reversible/Tests/ReversibleTests/ObservationSamplerTests.swift
+++ b/reversible/Tests/ReversibleTests/ObservationSamplerTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+private actor ObservationRPCStub: ObservationRPC {
+    private var replies: [JSONValue]
+    private var calls: [(String, JSONValue)] = []
+    private let delay: Duration?
+
+    init(replies: [JSONValue], delay: Duration? = nil) {
+        self.replies = replies
+        self.delay = delay
+    }
+
+    func call(_ method: String, _ params: JSONValue) async throws -> JSONValue {
+        calls.append((method, params))
+        if let delay { try await Task.sleep(for: delay) }
+        guard method == "render_window", !replies.isEmpty else {
+            throw EngineError.rpc("unexpected observation call")
+        }
+        return replies.removeFirst()
+    }
+
+    func recordedCalls() -> [(String, JSONValue)] { calls }
+}
+
+final class ObservationSamplerTests: XCTestCase {
+    private func binding() throws -> ObservationBinding {
+        try ObservationBinding(
+            expectedGeneration: .init(programVersion: 41, controlVersion: 77),
+            span: 6,
+            pointBudget: 3,
+            channels: [
+                .init(key: "scope1.a", slot: "__root__.tap:src"),
+                .init(key: "scope1.b", slot: "__root__.out"),
+            ]
+        )
+    }
+
+    func testOneShotPlaybackRequestDecodesOneImmutableFrame() async throws {
+        let binding = try binding()
+        let stub = ObservationRPCStub(replies: [try fixtureJSON()])
+        let worker = ObservationWorker(rpc: stub)
+        let fetched = try await worker.fetch(binding)
+        let frame = try XCTUnwrap(fetched)
+
+        XCTAssertEqual(
+            frame.generation,
+            .init(programVersion: 41, controlVersion: 80)
+        )
+        XCTAssertEqual(frame.playbackPosition, 100)
+        XCTAssertEqual(frame.effectiveStart, 94)
+        XCTAssertEqual(frame.effectiveSampleIndex, 88)
+        XCTAssertEqual(frame.count, 3)
+        XCTAssertEqual(frame.stride, 2)
+        XCTAssertEqual(frame.channels.map(\.channel), binding.channels)
+        XCTAssertEqual(frame.channels[0].values, [0.25, 0.5, 0.75])
+
+        let calls = await stub.recordedCalls()
+        XCTAssertEqual(calls.map(\.0), ["render_window"])
+        XCTAssertEqual(calls[0].1["anchor"], .string("playback"))
+        XCTAssertEqual(calls[0].1["count"], .number(6))
+        XCTAssertEqual(calls[0].1["point_budget"], .number(3))
+        XCTAssertEqual(
+            calls[0].1["slots"],
+            .array(binding.channels.map { .string($0.slot) })
+        )
+    }
+
+    func testPreemptedWrongProgramAndStaleControlDropWholeFrames() async throws {
+        let binding = try binding()
+        let valid = try fixtureJSON()
+        let stub = ObservationRPCStub(replies: [
+            response(valid, replacing: ["control_version": .number(80)]),
+            response(valid, replacing: ["control_version": .number(79)]),
+            response(valid, replacing: [
+                "program_version": .number(42),
+                "control_version": .number(100),
+            ]),
+            response(valid, replacing: [
+                "count": .number(0),
+                "preempted": .bool(true),
+                "values": .array([]),
+            ]),
+            response(valid, replacing: ["control_version": .number(81)]),
+        ])
+        let worker = ObservationWorker(rpc: stub)
+
+        let first = try await worker.fetch(binding)
+        let stale = try await worker.fetch(binding)
+        let wrongProgram = try await worker.fetch(binding)
+        let preempted = try await worker.fetch(binding)
+        let newer = try await worker.fetch(binding)
+        XCTAssertNotNil(first)
+        XCTAssertNil(stale)
+        XCTAssertNil(wrongProgram)
+        XCTAssertNil(preempted)
+        XCTAssertEqual(
+            newer?.generation,
+            .init(programVersion: 41, controlVersion: 81)
+        )
+    }
+
+    func testMalformedOrPartialResponseNeverPublishes() async throws {
+        let binding = try binding()
+        let valid = try fixtureJSON()
+        guard case .object(var object) = valid,
+              case .array(var channels)? = object["values"],
+              case .array(var last)? = channels.last
+        else { return XCTFail("fixture shape") }
+        last.removeLast()
+        channels[channels.count - 1] = .array(last)
+        object["values"] = .array(channels)
+
+        let partialWorker = ObservationWorker(
+            rpc: ObservationRPCStub(replies: [.object(object)])
+        )
+        do {
+            _ = try await partialWorker.fetch(binding)
+            XCTFail("partial response must throw")
+        } catch let error as ObservationError {
+            XCTAssertEqual(error, .partialChannel(1))
+        }
+
+        let inexact = response(valid, replacing: [
+            "effective_sample_index": .number(9_007_199_254_740_992),
+        ])
+        let inexactWorker = ObservationWorker(
+            rpc: ObservationRPCStub(replies: [inexact])
+        )
+        do {
+            _ = try await inexactWorker.fetch(binding)
+            XCTFail("inexact protocol counter must throw")
+        } catch let error as ObservationError {
+            XCTAssertEqual(error, .invalidField("effective_sample_index"))
+        }
+    }
+
+    func testSessionEpochAllowsRestartToReuseProgramAndControlVersions() async throws {
+        let binding = try binding()
+        let valid = try fixtureJSON()
+        let stub = ObservationRPCStub(replies: [
+            response(valid, replacing: ["control_version": .number(80)]),
+            response(valid, replacing: ["control_version": .number(77)]),
+        ])
+        let worker = ObservationWorker(rpc: stub)
+
+        let beforeRestart = try await worker.fetch(binding, sessionEpoch: 0)
+        let afterRestart = try await worker.fetch(binding, sessionEpoch: 1)
+        XCTAssertEqual(
+            beforeRestart?.generation.controlVersion,
+            80
+        )
+        XCTAssertEqual(
+            afterRestart?.generation.controlVersion,
+            77
+        )
+    }
+
+    @MainActor
+    func testSamplerAdmitsOnlyOneRequestAtATime() async throws {
+        let binding = try binding()
+        let sampler = ObservationSampler(rpc: ObservationRPCStub(
+            replies: [try fixtureJSON()],
+            delay: .milliseconds(80)
+        ))
+        let published = expectation(description: "one complete frame published")
+        sampler.onFrame = { _ in published.fulfill() }
+        sampler.adoptCompileGeneration(binding.expectedGeneration)
+
+        sampler.request(binding)
+        sampler.request(binding)
+        XCTAssertTrue(sampler.hasRequestInFlight)
+        XCTAssertEqual(sampler.requestCount, 1)
+        XCTAssertEqual(sampler.droppedFrameCount, 1)
+
+        await fulfillment(of: [published], timeout: 2)
+        XCTAssertFalse(sampler.hasRequestInFlight)
+        XCTAssertNotNil(sampler.latestFrame)
+    }
+
+    @MainActor
+    func testClearDropsOldSessionReplyBeforeSameGenerationRestart() async throws {
+        let binding = try binding()
+        let valid = try fixtureJSON()
+        let sampler = ObservationSampler(rpc: ObservationRPCStub(
+            replies: [
+                response(valid, replacing: ["control_version": .number(80)]),
+                response(valid, replacing: ["control_version": .number(77)]),
+            ],
+            delay: .milliseconds(50)
+        ))
+        sampler.adoptCompileGeneration(binding.expectedGeneration)
+        sampler.request(binding)
+        sampler.clear()
+        sampler.adoptCompileGeneration(binding.expectedGeneration)
+
+        for _ in 0..<200 where sampler.hasRequestInFlight {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(sampler.hasRequestInFlight)
+        XCTAssertNil(sampler.latestFrame)
+
+        let restarted = expectation(description: "restarted session frame")
+        sampler.onFrame = { _ in restarted.fulfill() }
+        sampler.request(binding)
+        await fulfillment(of: [restarted], timeout: 2)
+        XCTAssertEqual(sampler.latestFrame?.generation.controlVersion, 77)
+    }
+
+    func testMixedWindowBatchPreservesEachScopesTwoTimesHorizon() {
+        let sharedBatch = [-1.0, 1.0, 5, 5, 5, 5, 10, 11, 12, 13, 14, 15]
+        XCTAssertEqual(
+            ScopeTraceProjection.triggeredSamples(sharedBatch, displayCount: 3),
+            [10, 11, 12]
+        )
+        XCTAssertEqual(
+            ScopeTraceProjection.triggeredSamples(sharedBatch, displayCount: 6),
+            [1, 5, 5, 5, 5, 10]
+        )
+    }
+
+    func testDisplayCadenceCapsOneHundredTwentyHertzAtSixty() {
+        var cadence = ObservationCadence(framesPerSecond: 60)
+        var accepted = 0
+        for tick in 0..<120 {
+            if cadence.accepts(timestamp: Double(tick) / 120) { accepted += 1 }
+        }
+        XCTAssertEqual(accepted, 60)
+    }
+
+    private func response(
+        _ base: JSONValue,
+        replacing fields: [String: JSONValue]
+    ) -> JSONValue {
+        guard case .object(var object) = base else { return base }
+        for (key, value) in fields { object[key] = value }
+        return .object(object)
+    }
+
+    private func fixtureJSON() throws -> JSONValue {
+        let url = try XCTUnwrap(Bundle.module.url(
+            forResource: "observation-frame-valid",
+            withExtension: "json"
+        ))
+        return try JSONDecoder().decode(
+            JSONValue.self,
+            from: Data(contentsOf: url)
+        )
+    }
+}

--- a/reversible/Tests/ReversibleTests/RealizedPatchTests.swift
+++ b/reversible/Tests/ReversibleTests/RealizedPatchTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+final class RealizedPatchTests: XCTestCase {
+    func testObservationTapSelectionIsStableDeduplicatedAndEngineOnly() {
+        XCTAssertEqual(
+            ObservationTapSelection.stableSourceIDs(
+                candidates: ["src2", "out", "src1", "src2", "scope", "src1"],
+                allowedEngineNodeIDs: ["src1", "src2"]
+            ),
+            ["src2", "src1"]
+        )
+        XCTAssertEqual(
+            ObservationTapSelection.expectedHandshakeNames(
+                requestedSourceIDs: []
+            ),
+            ["out"]
+        )
+    }
+
+    func testDecodesCompleteHandshakeAgainstExactSemanticExpectations() throws {
+        guard case .published(let patch) = try PatchCompileResponse.decode(
+            fixtureJSON(),
+            expectedTapNames: ["out", "src"],
+            expectedVocabularyFingerprint: "fnv1a64:0123456789abcdef"
+        ) else { return XCTFail("expected published patch") }
+
+        XCTAssertEqual(
+            patch.generation,
+            .init(programVersion: 41, controlVersion: 77)
+        )
+        XCTAssertEqual(patch.node(id: "parked")?.status, .excluded)
+        XCTAssertEqual(
+            patch.inlet(nodeID: "out", port: "in")?.state,
+            .wired(sources: ["src"])
+        )
+        let futureDiscipline = try WriteDisciplineID(
+            validating: "future_anchor"
+        )
+        XCTAssertEqual(
+            patch.parameterStatus(nodeID: "src", port: "frequency"),
+            .live(discipline: futureDiscipline)
+        )
+        XCTAssertEqual(
+            patch.parameterStatus(nodeID: "src", port: "structural_rows"),
+            .structural
+        )
+        XCTAssertEqual(
+            patch.parameterStatus(nodeID: "parked", port: "anything"),
+            .inactive
+        )
+        XCTAssertEqual(patch.tap(named: "src")?.slot, "__root__.tap:src")
+    }
+
+    func testRejectsVocabularyAndCompleteTapTableMismatch() throws {
+        XCTAssertThrowsError(try PatchCompileResponse.decode(
+            fixtureJSON(),
+            expectedTapNames: ["out", "src"],
+            expectedVocabularyFingerprint: "fnv1a64:ffffffffffffffff"
+        )) { error in
+            XCTAssertEqual(
+                error as? RealizedPatchDecodeError,
+                .vocabularyMismatch(
+                    expected: "fnv1a64:ffffffffffffffff",
+                    actual: "fnv1a64:0123456789abcdef"
+                )
+            )
+        }
+        XCTAssertThrowsError(try PatchCompileResponse.decode(
+            fixtureJSON(),
+            expectedTapNames: ["out", "different"]
+        )) { error in
+            XCTAssertEqual(
+                error as? RealizedPatchDecodeError,
+                .invalidField("taps")
+            )
+        }
+    }
+
+    func testRejectsInexactGenerationAndIncoherentReferences() throws {
+        guard case .object(var object) = try fixtureJSON() else {
+            return XCTFail("fixture shape")
+        }
+        object["program_version"] = .number(9_007_199_254_740_992)
+        XCTAssertThrowsError(try PatchCompileResponse.decode(.object(object))) {
+            XCTAssertEqual(
+                $0 as? RealizedPatchDecodeError,
+                .invalidField("program_version")
+            )
+        }
+
+        guard case .object(var valid) = try fixtureJSON(),
+              case .array(var inputs)? = valid["inputs"],
+              case .object(var wired)? = inputs.last
+        else { return XCTFail("fixture input shape") }
+        wired["sources"] = .array([.string("missing")])
+        inputs[inputs.count - 1] = .object(wired)
+        valid["inputs"] = .array(inputs)
+        XCTAssertThrowsError(try PatchCompileResponse.decode(.object(valid))) {
+            XCTAssertEqual(
+                $0 as? RealizedPatchDecodeError,
+                .invalidField("inputs[1].sources[0]")
+            )
+        }
+    }
+
+    func testCompileAndObservationTruthAdvanceAtomically() throws {
+        guard case .published(let patch) = try PatchCompileResponse.decode(
+            fixtureJSON()
+        ) else { return XCTFail("expected published patch") }
+        let graph: JSONValue = .object(["nodes": .array([])])
+        var truth = PatchTruthStore()
+        XCTAssertTrue(truth.adoptCompile(
+            .adopted(patch),
+            authoredRevision: 7,
+            loweringRevision: 3,
+            graph: graph
+        ))
+        XCTAssertEqual(truth.realized?.authoredRevision, 7)
+        XCTAssertEqual(truth.realized?.loweringRevision, 3)
+        XCTAssertEqual(truth.runningGeneration, patch.generation)
+
+        XCTAssertTrue(truth.adoptObservation(.init(
+            programVersion: 41,
+            controlVersion: 80
+        )))
+        XCTAssertFalse(truth.adoptObservation(.init(
+            programVersion: 41,
+            controlVersion: 79
+        )))
+        XCTAssertFalse(truth.adoptObservation(.init(
+            programVersion: 42,
+            controlVersion: 81
+        )))
+        XCTAssertEqual(
+            truth.runningGeneration,
+            .init(programVersion: 41, controlVersion: 80)
+        )
+
+        XCTAssertFalse(truth.adoptCompile(
+            .superseded(activeGeneration: patch.generation),
+            authoredRevision: 8,
+            loweringRevision: 4,
+            graph: .null
+        ))
+        XCTAssertEqual(truth.realized?.graph, graph)
+        truth.retagCurrent(authoredRevision: 8, loweringRevision: 3)
+        XCTAssertEqual(truth.realized?.authoredRevision, 8)
+    }
+
+    private func fixtureJSON() throws -> JSONValue {
+        let url = try XCTUnwrap(Bundle.module.url(
+            forResource: "realized-patch-valid",
+            withExtension: "json"
+        ))
+        return try JSONDecoder().decode(
+            JSONValue.self,
+            from: Data(contentsOf: url)
+        )
+    }
+}

--- a/tests/web/compile_handshake.test.ts
+++ b/tests/web/compile_handshake.test.ts
@@ -121,7 +121,9 @@ const graph = {
   ],
   out: 'out',
   // Exercise both an audible node and a disconnected observation-only node.
-  taps: ['src', 'scopeProbe'],
+  // Put the disconnected probe first: it must not replace the authored final
+  // mix's stable `out` binding in the separate observation artifact.
+  taps: ['scopeProbe', 'src'],
 }
 
 describe('load_patch_graph compile handshake', () => {
@@ -148,21 +150,33 @@ describe('load_patch_graph compile handshake', () => {
         expect(Object.keys(tap).sort()).toEqual(['instance', 'name', 'output', 'slot'])
         expect(tap.slot).toBe(`${tap.instance}.${tap.output}`)
       }
-      expect(report.taps.map((tap: any) => tap.name)).toEqual(['out', 'src', 'scopeProbe'])
+      expect(report.taps.map((tap: any) => tap.name)).toEqual(['out', 'scopeProbe', 'src'])
 
       const rendered = await client.call('render_window', {
         start: 0,
-        count: 4,
+        count: 32,
         slots: report.taps.map((tap: any) => tap.slot),
       })
       expect(rendered.program_version).toBe(report.program_version)
       expect(rendered.control_version).toBe(report.control_version)
+      expect(rendered.values[0]).not.toEqual(rendered.values[1])
 
       const listed = await client.call('list_scope_taps')
       expect(listed.taps).toEqual(report.taps)
 
+      // Removing projections selects the single audio artifact. Its authored
+      // final mix must be byte-identical to the dual artifact's `out` binding.
+      const audioOnly = await client.call('load_patch_graph', { ...graph, taps: [] })
+      expect(audioOnly.taps.map((tap: any) => tap.name)).toEqual(['out'])
+      const audioOnlyRendered = await client.call('render_window', {
+        start: 0,
+        count: 32,
+        slots: audioOnly.taps.map((tap: any) => tap.slot),
+      })
+      expect(audioOnlyRendered.values[0]).toEqual(rendered.values[0])
+
       const next = await client.call('load_patch_graph', graph)
-      expect(next.program_version).toBeGreaterThan(report.program_version)
+      expect(next.program_version).toBeGreaterThan(audioOnly.program_version)
       const nextRendered = await client.call('render_window', {
         start: 0,
         count: 1,

--- a/tests/web/compile_handshake.test.ts
+++ b/tests/web/compile_handshake.test.ts
@@ -1,0 +1,177 @@
+/** Atomic load_patch_graph handshake: one reply identifies the vocabulary,
+ * exact immutable runtime generation, realized graph facts, and complete
+ * observation bindings. list_scope_taps remains a compatibility diagnostic. */
+
+import { describe, expect, setDefaultTimeout, test } from 'bun:test'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { connect, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+setDefaultTimeout(120_000)
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const frontendBin = resolve(repoRoot, 'lean/.lake/build/bin/frontend')
+
+type Pending = { resolve: (value: any) => void; reject: (error: Error) => void }
+
+class EngineClient {
+  private readonly process: ChildProcess
+  private readonly socketPath: string
+  private socket: Socket | null = null
+  private buffer = ''
+  private readonly pending = new Map<number, Pending>()
+  private readonly queued: string[] = []
+  private nextId = 1
+  private stopped = false
+
+  constructor() {
+    this.socketPath = join(tmpdir(), `tropical-handshake-${process.pid}.sock`)
+    this.process = spawn(frontendBin, ['--serve', this.socketPath], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+    this.process.on('exit', () => this.failAll(new Error('engine exited')))
+    void this.connectLoop()
+  }
+
+  private async connectLoop() {
+    for (let attempt = 0; attempt < 300 && !this.stopped; attempt++) {
+      if (existsSync(this.socketPath)) {
+        const connected = await new Promise<boolean>((done) => {
+          const socket = connect({ path: this.socketPath })
+          socket.on('connect', () => {
+            this.socket = socket
+            for (const line of this.queued) socket.write(line)
+            this.queued.length = 0
+            done(true)
+          })
+          socket.on('data', (chunk: Buffer) => this.onData(chunk.toString()))
+          socket.on('error', () => {
+            socket.destroy()
+            done(false)
+          })
+        })
+        if (connected) return
+      }
+      await new Promise((done) => setTimeout(done, 100))
+    }
+    if (!this.stopped) this.failAll(new Error(`could not connect to ${this.socketPath}`))
+  }
+
+  private failAll(error: Error) {
+    for (const pending of this.pending.values()) pending.reject(error)
+    this.pending.clear()
+  }
+
+  private onData(text: string) {
+    this.buffer += text
+    let newline: number
+    while ((newline = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, newline).trim()
+      this.buffer = this.buffer.slice(newline + 1)
+      if (!line) continue
+      const message = JSON.parse(line)
+      const pending = this.pending.get(message.id)
+      if (!pending) continue
+      this.pending.delete(message.id)
+      if (message.error) {
+        pending.reject(new Error(JSON.stringify(message.error)))
+        continue
+      }
+      const textEnvelope = message.result?.content?.[0]?.text
+      if (typeof textEnvelope === 'string') {
+        const inner = JSON.parse(textEnvelope)
+        inner.status === 'ok'
+          ? pending.resolve(inner.data)
+          : pending.reject(new Error(`${inner.error?.code}: ${inner.error?.message}`))
+      } else {
+        pending.resolve(message.result)
+      }
+    }
+  }
+
+  call(method: string, params: any = {}): Promise<any> {
+    const id = this.nextId++
+    const line = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      if (this.socket) this.socket.write(line)
+      else this.queued.push(line)
+      setTimeout(() => {
+        if (this.pending.delete(id)) reject(new Error(`timeout: ${method}`))
+      }, 60_000)
+    })
+  }
+
+  stop() {
+    this.stopped = true
+    this.socket?.destroy()
+    this.process.kill()
+  }
+}
+
+const graph = {
+  nodes: [
+    { id: 'src', kind: 'source', params: { freq: 220, morph: 0 }, sel: {}, in: {} },
+    { id: 'scopeProbe', kind: 'string', params: { freq: 220, decay: 1, t: 0 }, sel: {}, in: {} },
+    { id: 'out', kind: 'out', params: {}, sel: {}, in: { in: ['src'] } },
+  ],
+  out: 'out',
+  // Exercise both an audible node and a disconnected observation-only node.
+  taps: ['src', 'scopeProbe'],
+}
+
+describe('load_patch_graph compile handshake', () => {
+  test('one response binds realized state and observations to its exact generation', async () => {
+    if (!existsSync(frontendBin))
+      throw new Error(`frontend binary missing: ${frontendBin} (run \`make build lean\`)`)
+
+    const client = new EngineClient()
+    try {
+      const vocabulary = await client.call('get_vocabulary')
+      const report = await client.call('load_patch_graph', graph)
+
+      expect(report.ok).toBe(true)
+      expect(report.vocabulary_fingerprint).toBe(vocabulary.fingerprint)
+      expect(report.program_version).toBeGreaterThan(0)
+      expect(report.control_version).toBeGreaterThan(0)
+
+      expect(report.nodes).toContainEqual({ id: 'src', kind: 'source', status: 'active' })
+      expect(report.nodes).toContainEqual({ id: 'scopeProbe', kind: 'string', status: 'excluded' })
+      expect(report.inputs).toContainEqual({ node: 'out', port: 'in', state: 'wired', sources: ['src'] })
+      expect(report.params).toContainEqual({ name: 'src.freq', value: 220, discipline: 'anchor' })
+
+      for (const tap of report.taps) {
+        expect(Object.keys(tap).sort()).toEqual(['instance', 'name', 'output', 'slot'])
+        expect(tap.slot).toBe(`${tap.instance}.${tap.output}`)
+      }
+      expect(report.taps.map((tap: any) => tap.name)).toEqual(['out', 'src', 'scopeProbe'])
+
+      const rendered = await client.call('render_window', {
+        start: 0,
+        count: 4,
+        slots: report.taps.map((tap: any) => tap.slot),
+      })
+      expect(rendered.program_version).toBe(report.program_version)
+      expect(rendered.control_version).toBe(report.control_version)
+
+      const listed = await client.call('list_scope_taps')
+      expect(listed.taps).toEqual(report.taps)
+
+      const next = await client.call('load_patch_graph', graph)
+      expect(next.program_version).toBeGreaterThan(report.program_version)
+      const nextRendered = await client.call('render_window', {
+        start: 0,
+        count: 1,
+        slots: next.taps.map((tap: any) => tap.slot),
+      })
+      expect(nextRendered.program_version).toBe(next.program_version)
+      expect(nextRendered.control_version).toBe(next.control_version)
+    } finally {
+      client.stop()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- isolate observation rendering from live audio storage with immutable, generation-pinned program and control images
- publish audio and optional observation artifacts atomically and return realized observable bindings from the exact compile generation
- adopt realized state and generation-coherent, latest-only observation sampling in Reversible
- preserve the authored final mix as the observation `out` projection

## Architecture

There remains one engine session, one authoritative graph/control image, and one playback clock. Observation gets a private render workspace over immutable published assets; it is not a second engine or state authority. Observation-only projections are compiled separately and do not execute in the audio kernel.

## Validation

- `make validate`: native 121/121, Bun 117 pass / 1 no-device skip / 0 fail, CTest 4/4
- `make reversible-build`: pass
- `make reversible-bundle-smoke`: pass, including relocated app and packaged runtime
- `make reversible-test`: blocked before execution because the installed host Swift SDK has no `XCTest` module; the Reversible application target builds successfully

## Scope hygiene

Product source, focused tests, and two small JSON fixtures only. No demo scenes, captures, qualification streams, sprint documents, generated objects, or benchmark output.
