### PR TITLE
Preserve timed modal forests and refuse unsafe bloom crossings

### DIFF
--- a/lean/Tropical/EmitArrow/Modal/Bloom.lean
+++ b/lean/Tropical/EmitArrow/Modal/Bloom.lean
@@ -475,7 +475,7 @@ deriving Inhabited
 /-- The bloom crossing's region for one composed (μ, ν) pair — a TOTAL partition
     of config space (`classifyBloomPair` is total, never `Option`). Dispatch is an
     exhaustive match, so a region without a handler is a compile error, and the
-    depth-cap drop is a NAMED outcome (`excludedDepth`) the coverage gate tallies
+    depth-cap refusal is a NAMED outcome (`excludedDepth`) the coverage gate tallies
     rather than a silent `continue`. This is the type the island's totality claim
     hangs off. The four served regions differ only in which per-pair lanes the
     realizer emits; the two axes are coincidence (`|a| < ½`, the pole on the
@@ -497,8 +497,14 @@ inductive SeamRegion where
       `selectE` is const-true) and is NOT emitted — the tightest region, series-DD
       + secular only. -/
   | coincidentSubtle
-  /-- Envelope depth over the 300 cap: a graceful drop (no lanes emitted). Counted,
-      never silent — the coverage gate reports the excluded fraction. -/
+  /-- The E1 Horner would cross to the CF while `a` lies in the measured
+      ill-conditioned disc around one of `-1, …, -300`.  At the concrete
+      `a = -0.98`, `|κ| ≈ 72.2` witness the f64 Horner is wrong by more than
+      eight orders of magnitude.  This is a numerical refusal, not a semantic
+      zero and not a depth-cap event. -/
+  | excludedConditioning
+  /-- Envelope depth over the shared cap. The checked composer treats this as an
+      explicit whole-composition refusal; the coverage gate reports its count. -/
   | excludedDepth
 deriving Inhabited, DecidableEq
 
@@ -508,16 +514,87 @@ def SeamRegion.label : SeamRegion → String
   | .crossing           => "crossing"
   | .coincidentCrossing => "coincidentCrossing"
   | .coincidentSubtle   => "coincidentSubtle"
+  | .excludedConditioning => "excludedConditioning"
   | .excludedDepth      => "excludedDepth"
+
+/-- Radius of the stop-line around the negative-integer `a` lattice.  The
+    measured failure is at distance `0.02` from `-1`; `1/32 = 0.03125` is the
+    next outward exact binary radius, giving a reproducible 1.5625× guard.
+    This is intentionally a measured admission boundary, not a claim that the
+    Horner error has an analytic bound outside it. -/
+def bloomConditioningRadius : Float := 0.03125
+
+/-- One source of truth for the emitted Horner/CF depth limit and for the
+    negative-integer lattice whose denominators those arrays can materialize. -/
+def bloomDepthCap : Nat := 300
+
+/-- The inspected conditioning lattice is exactly `-1, …, -bloomDepthCap`. -/
+def bloomConditioningLatticeDepth : Nat := bloomDepthCap
+
+/-- Point diagnostic reported by the seam gate: distance from `a` to the
+    nearest negative integer represented by the bounded Horner. -/
+def bloomConditioningMetric (a : CplxB) : Float := Id.run do
+  let mut d := Float.sqrt ((a.re + 1.0) * (a.re + 1.0) + a.im * a.im)
+  for j in [1:bloomConditioningLatticeDepth] do
+    let n := (j + 1).toFloat
+    d := min d (Float.sqrt ((a.re + n) * (a.re + n) + a.im * a.im))
+  return d
+
+/-- Evidence-carrier version of the conditioning stop-line for a baked pair.
+    A pair is refused only where the CF crossing is reached; `κ = 0` and other
+    series-only pairs retain their exact degeneration.  Failure to certify that
+    the point lies outside the disc fails toward refusal. -/
+def bloomExcludedConditioningD (a kappa : CplxDI) : Bool := Id.run do
+  let absAP1 := CplxDI.abs (CplxDI.add a CplxDI.one)
+  let absKappa := CplxDI.abs kappa
+  if absKappa.ok && absKappa.lo.isZero && absKappa.hi.isZero then return false
+  -- Equality/overlap is not a certificate that the crossing is unreachable.
+  -- Fail open only with positive evidence that `|a+1| > |κ|`; otherwise the
+  -- disc test decides and uncertainty fails toward refusal.
+  if DyadicI.certGt absAP1 absKappa then return false
+  let radius := DyadicI.ofFloat bloomConditioningRadius
+  for j in [0:bloomConditioningLatticeDepth] do
+    let n := CplxDI.ofNat (j + 1)
+    if !DyadicI.certGt (CplxDI.abs (CplxDI.add a n)) radius then
+      return true
+  return false
+
+/-- Interval-aware stop-line for live room damping. `Re a` walks the horizontal
+    segment `[reLo,reHi]`; for each negative integer the closest point is its
+    projection onto that segment. A disc intersection and CF reachability are
+    certified independently anywhere on the interval, so uncertainty can only
+    over-refuse, never miss an edge whose two witnesses occur at different points. -/
+def bloomExcludedConditioningLive (reLo reHi imA : Float) (kappa : CplxB) : Bool := Id.run do
+  let lo := DyadicI.ofFloat (min reLo reHi)
+  let hi := DyadicI.ofFloat (max reLo reHi)
+  let im := DyadicI.ofFloat imA
+  let absAt := fun (re c : DyadicI) =>
+    DyadicI.sqrt (DyadicI.add (DyadicI.square (DyadicI.add re c)) (DyadicI.square im))
+  let radius := DyadicI.ofFloat bloomConditioningRadius
+  let absKappa := CplxDI.abs kappa.toExact
+  if absKappa.ok && absKappa.lo.isZero && absKappa.hi.isZero then return false
+  -- Conservative conjunction of two interval facts.  The crossing and disc
+  -- witnesses need not be the same endpoint: coupling them at the disc-centre
+  -- projection can miss a segment whose right disc edge enters the crossing.
+  let reCross := DyadicI.max lo (DyadicI.min hi (DyadicI.neg DyadicI.one))
+  if DyadicI.certGt (absAt reCross DyadicI.one) absKappa then return false
+  for j in [0:bloomConditioningLatticeDepth] do
+    let n := DyadicI.ofNat (j + 1)
+    let re := DyadicI.max lo (DyadicI.min hi (DyadicI.neg n))
+    let discDistance := absAt re n
+    if !DyadicI.certGt discDistance radius then
+      return true
+  return false
 
 /-- The per-pair classification + baking data for one composed (μ, ν) pair — the
     executable form of the bloom atom's region partition (the sprint's epistemics
     fix: the boundary is an apparatus output, not a comment). TOTAL: `region` is
     always one of `SeamRegion`'s constructors (`excludedDepth` for a depth-cap
-    drop, never a `none`). `bloomCompose` matches on `region` exhaustively to emit
-    exactly that region's lanes; the seam-sweep harness and the coverage gate
-    consult the SAME classifier, so "which region is this pair, and does the atom
-    promise anything there" has one answer, in code. `nDepth`/`kDepth` size the
+    refusal, never a `none`). The checked composer inspects that region before
+    materialization, and supported regions emit exactly their own lanes; the
+    seam-sweep harness and the coverage gate consult the SAME classifier, so
+    "which region is this pair, and does the atom promise anything there" has
+    one answer, in code. `nDepth`/`kDepth` size the
     coefficient arrays (`kDepth = 0` where no CF is reached). -/
 structure BloomPairPlan where
   mu      : CplxB
@@ -532,10 +609,10 @@ structure BloomPairPlan where
 deriving Inhabited
 
 /-- Classify one composed (μ, ν) pair into its `SeamRegion` and size its depths —
-    TOTAL (replaces the `Option`-with-flags `bloomPairPlan?`: the depth-cap drop is
-    now the `excludedDepth` region, not a `none`). The control flow is preserved
-    byte-for-byte from the old predicate — same `zBnd`, same `nRaw`/`kRaw` depth
-    caps, same admission set — so the region label is the only new information; the
+    TOTAL (replaces the `Option`-with-flags `bloomPairPlan?`: depth and measured
+    conditioning exclusions are typed regions, not `none`). Away from the new
+    conditioning stop-line and exact `κ = 0` identity, the depth control flow is
+    preserved — same `zBnd`, same `nRaw`/`kRaw` depth caps. The
     two axes (coincidence `|a| < ½` and the CF boundary `|κ|` vs `|a+1|`) name the
     branches the old flags already encoded.
 
@@ -558,6 +635,14 @@ def classifyBloomPair (mu nu : CplxB) (B g : Float) : BloomPairPlan := Id.run do
   let kappa := mu.scale B
   let absAP1 := CplxDI.abs (CplxDI.add aD CplxDI.one)
   let absKappa := CplxDI.abs kappa.toExact
+  -- κ=0 is the exact identity M(1,a+1,0)=1 for every a, including the
+  -- negative-integer lattice where evaluating unused Horner reciprocals would
+  -- divide by zero. Emit the empty Horner explicitly.
+  if !coincident && absKappa.ok && absKappa.lo.isZero && absKappa.hi.isZero then
+    return { mu, nu, aC, kappa, region := .serOnly, nDepth := 0, kDepth := 0 }
+  if bloomExcludedConditioningD aD kappa.toExact then
+    return { mu, nu, aC, kappa, region := .excludedConditioning,
+             nDepth := 0, kDepth := 0 }
   let serOnly := !coincident && !DyadicI.certLt absAP1 absKappa
   let excluded : BloomPairPlan :=
     { mu, nu, aC, kappa, region := .excludedDepth, nDepth := 0, kDepth := 0 }
@@ -573,12 +658,12 @@ def classifyBloomPair (mu nu : CplxB) (B g : Float) : BloomPairPlan := Id.run do
                   (CplxD.abs (CplxD.add aP CplxD.one)) (CplxD.abs kP)).getD 1
   let zBnd := if serOnly then kP else CplxD.scale ratio kP
   let nRaw := bloomM1DepthD aP zBnd bloomM1TolD
-  if nRaw + 8 > 300 then return excluded
+  if nRaw + 8 > bloomDepthCap then return excluded
   if serOnly then
     return { mu, nu, aC, kappa, region := .serOnly, nDepth := nRaw + 8, kDepth := 0 }
   else
     let kRaw := bloomCFDepthD aP zBnd bloomCFTolD
-    if kRaw + 8 > 300 then return excluded
+    if kRaw + 8 > bloomDepthCap then return excluded
     -- non-coincident here is always the CF-bridged crossing; coincident splits on
     -- the CF boundary (`dSwitch` sign = sign of `|κ| − |a+1|`): `|κ| ≥ |a+1|`
     -- reaches the CF (coincidentCrossing), else the CF lane is dead (subtle).
@@ -596,7 +681,7 @@ def classifyBloomPair (mu nu : CplxB) (B g : Float) : BloomPairPlan := Id.run do
     Executable data the sweep probes at its edges, not an annotation. -/
 def bloomAdmitsPair (mu nu : CplxB) (B g : Float) : Bool :=
   match (classifyBloomPair mu nu B g).region with
-  | .excludedDepth => false
+  | .excludedConditioning | .excludedDepth => false
   | _ => true
 
 

--- a/lean/Tropical/EmitArrow/Modal/Live.lean
+++ b/lean/Tropical/EmitArrow/Modal/Live.lean
@@ -11,11 +11,65 @@ namespace Tropical.EmitArrow
 open Tropical.Ir
 open Tropical.Exact (DyadicI CplxD CplxDI)
 
+/-- Why one requested voice×room bloom crossing could not be materialized.  The
+    reason is data, not a silent `continue`: callers may inspect every refused
+    pair and the Patch lowerer turns any nonempty set into an explicit error. -/
+inductive BloomExclusionReason where
+  | voiceSigmaNotConstant
+  | voiceOmegaNotConstant
+  | roomOmegaNotConstant
+  | liveSigmaRangeMissing
+  | liveSigmaNotS0
+  | liveRegionUnsupported
+  | excludedConditioning
+  | excludedDepth
+  | coefficientMaterialization
+deriving Inhabited, DecidableEq
+
+def BloomExclusionReason.label : BloomExclusionReason → String
+  | .voiceSigmaNotConstant      => "voiceSigmaNotConstant"
+  | .voiceOmegaNotConstant      => "voiceOmegaNotConstant"
+  | .roomOmegaNotConstant       => "roomOmegaNotConstant"
+  | .liveSigmaRangeMissing      => "liveSigmaRangeMissing"
+  | .liveSigmaNotS0             => "liveSigmaNotS0"
+  | .liveRegionUnsupported      => "liveRegionUnsupported"
+  | .excludedConditioning       => "excludedConditioning"
+  | .excludedDepth              => "excludedDepth"
+  | .coefficientMaterialization => "coefficientMaterialization"
+
+structure BloomPairExclusion where
+  voiceIndex : Option Nat
+  roomIndex  : Option Nat
+  reason     : BloomExclusionReason
+deriving Inhabited
+
+structure BloomComposition where
+  expectedPairs : Nat
+  pairs          : Array BloomPair
+  exclusions     : Array BloomPairExclusion
+deriving Inhabited
+
+def BloomComposition.isComplete (c : BloomComposition) : Bool :=
+  c.exclusions.isEmpty && c.pairs.size == c.expectedPairs
+
+/-- Compatibility lens for direct atom tests. Production lowering inspects the
+    typed exclusions and reports them; this helper never turns an exclusion
+    into a partial bank. -/
+def BloomComposition.toOption (c : BloomComposition) : Option (Array BloomPair) :=
+  if c.isComplete then some c.pairs else none
+
+def BloomComposition.refusalSummary (c : BloomComposition) : String :=
+  String.intercalate ", " (c.exclusions.toList.map fun x =>
+    match x.voiceIndex, x.roomIndex with
+    | some vi, some ri => s!"voice[{vi}]×room[{ri}]:{x.reason.label}"
+    | _, _ => s!"global:{x.reason.label}")
+
 /-- The two regions the LIVE classifier can emit — a two-constructor sum, so
     `bloomCompose`'s match is exhaustive BY TYPE rather than by an
-    "unreachable" comment (the coincident regions and the depth exclusion are
-    not representable here: they return `none` and stay baked-only). The
-    baked classifier keeps the full five-region `SeamRegion`. -/
+    "unreachable" comment (the coincident regions, conditioning stop-line, and
+    depth exclusion are not representable here: the checked classifier returns
+    a typed refusal and the compatibility lens returns `none`). The baked
+    classifier keeps the full six-region `SeamRegion`. -/
 inductive LiveRegion where
   | serOnly
   | crossing
@@ -25,12 +79,10 @@ structure LiveBloomPairPlan where
   nDepth : Nat
   kDepth : Nat
 
-/-- WS-LP: classify a live-σ pair over its whole σ interval — `some plan` iff
-    the pair sits in ONE non-coincident region at EVERY
-    σ ∈ `[sigLo, sigHi]` (`serOnly` throughout, phase 1, or `crossing`
-    throughout, phase 2), else `none` (the pair drops gracefully; a pair that
-    CHANGES region across the interval is phase 3's union emit, and the
-    coincident regions are with it). Only `Re a = (σ_μ − σ_ν)/g` moves with σ_ν
+/-- WS-LP: classify a live-σ pair over its whole σ interval. A supported interval
+    is series-only throughout or uses the crossing lanes (including a safe
+    series/crossing straddle); conditioning, depth, and coincident-region cases
+    return typed refusals. Only `Re a = (σ_μ − σ_ν)/g` moves with σ_ν
     (`Im a` and `κ = μ·B` are σ_ν-independent), so the region conditions reduce
     to interval extrema of `|a + c|` along a horizontal segment — the min at
     `Re a = −c` clamped to the segment, the max at an endpoint (convexity).
@@ -38,8 +90,8 @@ structure LiveBloomPairPlan where
     approach to `−1`, where `|a+1|` bottoms out), with the baked classifier's
     `zBnd` per region (κ itself for serOnly; the branch-boundary `|z| = |a+1|`
     for crossing), same `+8` guard and `≤ 300` cap. -/
-def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
-    (B g : Float) : Option LiveBloomPairPlan := Id.run do
+def classifyBloomPairLiveChecked (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
+    (B g : Float) : Except BloomExclusionReason LiveBloomPairPlan := Id.run do
   let kappa := mu.scale B
   let imA := (nuOmega - mu.im) / g
   -- Re a = (−σ_ν − Re μ)/g, decreasing in σ_ν
@@ -49,8 +101,7 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
   -- a live-σ pair is emitted at all and with which lanes, so it may not depend
   -- on a platform's rounding. `absKappa`/`absAt`/`minAbsAt` are the same
   -- expressions, evaluated as enclosures; each threshold is taken in the
-  -- direction that DROPS a pair it cannot certify (graceful exclusion is the
-  -- house rule for a legal-but-unservable config, never a warning).
+  -- conservative direction. Failure to certify support becomes a typed refusal.
   let imAD := DyadicI.ofFloat imA
   let reLoD := DyadicI.ofFloat reLo
   let reHiD := DyadicI.ofFloat reHi
@@ -59,15 +110,20 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
     DyadicI.sqrt (DyadicI.add (DyadicI.square (DyadicI.add re c)) (DyadicI.square imAD))
   let minAbsAtD := fun (c : DyadicI) =>
     absAtD (DyadicI.max reLoD (DyadicI.min reHiD (DyadicI.neg c))) c
+  if bloomExcludedConditioningLive reLo reHi imA kappa then
+    return .error .excludedConditioning
   -- ¬coincident throughout: min |a| ≥ ½ (the τ·e coincidence stays baked-only)
-  if !DyadicI.certGt (minAbsAtD DyadicI.zero) (DyadicI.ofFloat 0.5) then return none
+  if !DyadicI.certGt (minAbsAtD DyadicI.zero) (DyadicI.ofFloat 0.5) then
+    return .error .liveRegionUnsupported
+  if absKappaD.ok && absKappaD.lo.isZero && absKappaD.hi.isZero then
+    return .ok { region := .serOnly, nDepth := 0, kDepth := 0 }
   let samples := #[reLo, reHi, max reLo (min reHi (-1.0))]
   if !DyadicI.certLt (minAbsAtD DyadicI.one) absKappaD then
     -- serOnly throughout: |a+1| never falls below |κ|
     let nRaw := samples.foldl (fun m re =>
       max m (bloomM1DepthD (CplxD.ofFloats re imA) kappa.toPoint bloomM1TolD)) 0
-    if nRaw + 8 > 300 then return none
-    return some { region := .serOnly, nDepth := nRaw + 8, kDepth := 0 }
+    if nRaw + 8 > bloomDepthCap then return .error .excludedDepth
+    return .ok { region := .serOnly, nDepth := nRaw + 8, kDepth := 0 }
   -- |a+1| dips below |κ| somewhere: crossing-throughout OR straddling (phase 3a
   -- — the union COLLAPSES onto the crossing lanes: on a serOnly-side config
   -- `dSwitch < 0`, the per-sample select sits on the series lane from d = 0,
@@ -95,8 +151,14 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
     let zBnd := CplxD.scale ratio kP
     nRaw := max nRaw (bloomM1DepthD aP (if straddles then kP else zBnd) bloomM1TolD)
     kRaw := max kRaw (bloomCFDepthD aP zBnd bloomCFTolD)
-  if nRaw + 8 > 300 || kRaw + 8 > 300 then return none
-  return some { region := .crossing, nDepth := nRaw + 8, kDepth := kRaw + 8 }
+  if nRaw + 8 > bloomDepthCap || kRaw + 8 > bloomDepthCap then return .error .excludedDepth
+  return .ok { region := .crossing, nDepth := nRaw + 8, kDepth := kRaw + 8 }
+
+/-- Compatibility lens for existing direct callers. New production lowering uses
+    `classifyBloomPairLiveChecked` so the refusal reason remains available. -/
+def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
+    (B g : Float) : Option LiveBloomPairPlan :=
+  (classifyBloomPairLiveChecked mu nuOmega sigLo sigHi B g).toOption
 
 /-- `bloomedVoice ⋙ reverb` as Γ-bridge pairs — the residue composition ACROSS a
     pitch-bloom warp (`B = β·scale/g` seconds of total clock advance, `g` the
@@ -107,14 +169,11 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
     `sigmaRange` from the authoring site: the pair's constants are then built as
     s0 `CplxE` expressions of the live pole (Stage0 hoists them; rt60 turns with
     no relower), the live σ clamped to the classified interval so the region
-    choice is sound by construction. A live pair must be `serOnly` over the
-    WHOLE interval (`classifyBloomPairLiveSer`) — a pair that crosses a region
-    boundary across the rt60 range drops gracefully (per pair, `continue`; the
-    Phase 3 region-union emit removes this limit). Amps stay live as always.
-    Admission drops (graceful exclusion, the documented v1 scope) are the
-    `classifyBloomPair` `excludedDepth` region and are now depth-only: pairs whose
-    envelope depth exceeds 300 (cockpit-measured shipped max ≈ 250 incl. the
-    coincident CF side; the cap is headroom, not a tuning). The per-pair emit is
+    choice is sound by construction. `classifyBloomPairLiveChecked` admits a
+    serOnly, crossing-throughout, or safe straddling interval; conditioning,
+    depth, coincidence, and pole-contract failures are typed reasons that make
+    the outer composition all-or-nothing. Amps stay live as always. The shared
+    `bloomDepthCap` is headroom, not a tuning. The per-pair emit is
     REGION-INDEXED (WS-CL): the exhaustive `match plan.region` bakes exactly each
     region's lanes — the coincident regions no longer carry the dead E1 (`invA`)
     lane, and `coincidentSubtle` (`dSwitch < 0`) drops the whole CF lane the
@@ -125,7 +184,7 @@ def classifyBloomPairLive (mu : CplxB) (nuOmega : Float) (sigLo sigHi : Float)
     `residueComposeEC`'s coincidence. `B = 0` (or κ→0) degenerates every pair to
     series-only with `M ≡ 1` — the WS-B2 divided-difference atom, which the
     `modal-bloom-gamma` gate pins. -/
-def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
+private def bloomComposePairs? (voice reverb : Array ModalMode) (B g : Float) :
     Option (Array BloomPair) := Id.run do
   let mut out : Array BloomPair := #[]
   for v in voice do
@@ -139,13 +198,13 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
       | none =>
         -- WS-LP Phase 1: a LIVE reverb σ (the rt60 pole). Admissible only when
         -- the pole read is s0 (a raw slot, not a glide — `settle` a glided pole
-        -- first) and the authoring site declared its interval; otherwise the
-        -- pre-WS-LP baked-pole fallback (`none` ⇒ the caller's bare bloom).
+        -- first) and the authoring site declared its interval; the checked
+        -- preflight reports either violation before this private materializer runs.
         let some (sLo, sHi) := r.sigmaRange | return none
         if !(sigIsS0 r.sigma) then return none
-        match classifyBloomPairLive mu rOm sLo sHi B g with
-        | none => continue   -- coincident / region-changing over the interval: graceful per-pair drop (Phase 3 widens)
-        | some plan =>
+        match classifyBloomPairLiveChecked mu rOm sLo sHi B g with
+        | .error _ => continue
+        | .ok plan =>
           -- the lift: every baked constant re-expressed as an s0 `CplxE` of the
           -- live pole. The clamp ENFORCES the classified interval in-kernel, so
           -- an out-of-range slot write saturates the crossing's σ instead of
@@ -198,11 +257,10 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
               dSwitch, invA, cfB, cfN }
       | some rSig =>
         let nu : CplxB := ⟨-rSig, rOm⟩
-        -- the shared classifier (WS-CL): `excludedDepth` ⇒ this pair is out of scope
-        -- (a COUNTED graceful drop — the coverage gate tallies it, not a silent
-        -- `continue`); every other region emits EXACTLY its own lanes (region-indexed
-        -- — the coincident regions no longer bake the dead E1/CF lanes). `bloomCompose`
-        -- and the seam-sweep harness consult THIS classifier, one answer in code.
+        -- The checked preflight has already rejected every excluded region for
+        -- the whole composition. This private materializer therefore emits only
+        -- supported region-indexed lanes; its defensive `continue` arms cannot
+        -- create a production partial bank.
         let plan := classifyBloomPair mu nu B g
         let aC := plan.aC
         let kappa := plan.kappa
@@ -214,11 +272,13 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
         -- dyadic), so nothing is lost crossing.
         let aD := aC.toExact
         let kD := kappa.toExact
+        let kAbs := CplxDI.abs kD
+        let kZero := kAbs.ok && kAbs.lo.isZero && kAbs.hi.isZero
         let gD := DyadicI.ofFloat g
         let invNuMuD := CplxDI.div CplxDI.one (CplxDI.sub nu.toExact mu.toExact)
         let aP1D := CplxDI.add aD CplxDI.one
         -- `ln(|κ|/|a+1|)/g` — the per-sample series↔CF bridge point
-        let dSwitchD := DyadicI.div
+        let dSwitchD := if kZero then DyadicI.zero else DyadicI.div
           (DyadicI.log (DyadicI.div (CplxDI.abs kD) (CplxDI.abs aP1D))) gD
         let invAD := (Array.range plan.nDepth).map (fun k =>
           CplxDI.div CplxDI.one (CplxDI.add aD (CplxDI.ofNat (k + 1))))
@@ -228,14 +288,15 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
           let jf := CplxDI.ofNat (j + 1)
           CplxDI.mul jf (CplxDI.sub jf aD))
         match plan.region with
+        | .excludedConditioning => continue
         | .excludedDepth => continue
         | .serOnly =>
           -- M(κ)'s own term count is a REPRODUCIBILITY question (point carrier);
           -- the sum it sizes is an ACCURACY question (enclosure). Note this count
           -- is not `plan.nDepth`: that one sizes the emitted `invA` at `zBnd`,
           -- this one converges the κ-side constant.
-          let nK := bloomM1DepthD aC.toPoint kappa.toPoint bloomM1TolD
-          let mK := bloomM1D aD kD nK
+          let nK := if kZero then 0 else bloomM1DepthD aC.toPoint kappa.toPoint bloomM1TolD
+          let mK := if kZero then CplxDI.one else bloomM1D aD kD nK
           let some k1SerE := cplxLitD? (CplxDI.mul mK invNuMuD) | return none
           let some kappaE := cplxLitD? kD | return none
           let some fSerE  := cplxLitD? (CplxDI.neg invNuMuD) | return none
@@ -333,6 +394,85 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
             secCoef := (litF (vSig - rSig), litF (rOm - vOm)) }
   return some out
 
+/-- Classify the complete requested Cartesian product before materializing any
+    coefficient arrays.  This is the stop-line inventory: every unsupported or
+    excluded pair has stable indices and a named reason. -/
+private def bloomCompositionExclusions (voice reverb : Array ModalMode) (B g : Float) :
+    Array BloomPairExclusion := Id.run do
+  let mut out : Array BloomPairExclusion := #[]
+  for vi in [0:voice.size] do
+    let some v := voice[vi]? | continue
+    let some vSig := sigConstF? v.sigma
+      | for ri in [0:reverb.size] do
+          out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .voiceSigmaNotConstant }
+        continue
+    let some vOm := sigConstF? v.omega
+      | for ri in [0:reverb.size] do
+          out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .voiceOmegaNotConstant }
+        continue
+    let mu : CplxB := ⟨-vSig, vOm⟩
+    for ri in [0:reverb.size] do
+      let some r := reverb[ri]? | continue
+      let some rOm := sigConstF? r.omega
+        | out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .roomOmegaNotConstant }
+          continue
+      match sigConstF? r.sigma with
+      | none =>
+        let some (sLo, sHi) := r.sigmaRange
+          | out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                              reason := .liveSigmaRangeMissing }
+            continue
+        if !(sigIsS0 r.sigma) then
+          out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .liveSigmaNotS0 }
+          continue
+        match classifyBloomPairLiveChecked mu rOm sLo sHi B g with
+        | .ok _ => pure ()
+        | .error reason =>
+          out := out.push { voiceIndex := some vi, roomIndex := some ri, reason }
+      | some rSig =>
+        let nu : CplxB := ⟨-rSig, rOm⟩
+        match (classifyBloomPair mu nu B g).region with
+        | .excludedConditioning =>
+          out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .excludedConditioning }
+        | .excludedDepth =>
+          out := out.push { voiceIndex := some vi, roomIndex := some ri,
+                            reason := .excludedDepth }
+        | _ => pure ()
+  return out
+
+/-- Typed, all-or-nothing bloom composition.  `pairs` is populated only when
+    every requested voice×room pair is supported; otherwise the complete
+    exclusion inventory is returned and no partial room response exists for a
+    caller to realize accidentally. -/
+def bloomComposeChecked (voice reverb : Array ModalMode) (B g : Float) : BloomComposition :=
+  let expectedPairs := voice.size * reverb.size
+  let exclusions := bloomCompositionExclusions voice reverb B g
+  if !exclusions.isEmpty then
+    { expectedPairs, pairs := #[], exclusions }
+  else
+    match bloomComposePairs? voice reverb B g with
+    | some pairs =>
+      if pairs.size == expectedPairs then
+        { expectedPairs, pairs, exclusions := #[] }
+      else
+        { expectedPairs, pairs := #[], exclusions := #[{
+            voiceIndex := none, roomIndex := none,
+            reason := .coefficientMaterialization }] }
+    | none =>
+      { expectedPairs, pairs := #[], exclusions := #[{
+          voiceIndex := none, roomIndex := none,
+          reason := .coefficientMaterialization }] }
+
+/-- Compatibility lens preserving the historical `Option (Array BloomPair)`
+    API. New production lowering uses `bloomComposeChecked` and reports reasons. -/
+def bloomCompose (voice reverb : Array ModalMode) (B g : Float) : Option (Array BloomPair) :=
+  (bloomComposeChecked voice reverb B g).toOption
+
 /-- The bloom-composed pair bank as a pure `Sig` over the clock: per pair, TWO
     Q-rotator carriers — the reverb ring `e^{νd}` on the straight relative clock
     and the bloomed voice mode `e^{μφ(d)}` on the OFFSET clock (the same Q32.32
@@ -347,42 +487,23 @@ def bloomCompose (voice reverb : Array ModalMode) (B g : Float) :
     (the `modalBankSigTableDD` skeleton). Unrolled per pair — envelope depths
     are per-pair ragged, the non-uniform route. Causal gate on `clkRel > 0`.
 
-    RANGE (WS-AA range lens). **Rail**: `|env·w| < 32` PER CARRIER, PER pair (2
-    `land` calls for non-coincident pairs, 3 with the τ·e secular). A FACTOR site:
-    each `w` carries the region-selected series-M / continued-fraction / Γ★ / τ·e
-    factor, so the sup must be taken over d≥0 on the SELECTED lane only (a naive
-    both-lane sup over-estimates by ~1e10 — the unselected series-M reaches ~5e10
-    at z=κ where the selected CF weight is ~0.2). **Reachable max at every config
-    that fires today: ≪ 32** (measured: SeamSweep gong-reverb 0.005; WS-A4
-    coincident 0.27–0.92; a baked filterPair(Q44) stress config 2.48), so this
-    site is **unprotected but not broken** at every config reachable today, and
-    option E at k=0 is a byte-identical no-op for it. **Two reasons it is NOT landed
-    in this pass, DEFERRED to the factor-site follow-on**: (a) it is UNREACHABLE from
-    the surface — `bloomgong` (its only surface producer) is a WITHHELD kind, rejected
-    by `Playground.checkServedKinds` (WS-LP made the live-rt60 CROSSING compile, but
-    the surface stays sealed until this factor site carries the per-pair `k`), so
-    only the tropicaltest gates and authored/loaded literal-pole programs emit it;
-    (b) there is a reachable-by-baked-poles case option E CANNOT absorb — filtering a
-    gong ON one of its own partials (room pole tuned to a voice partial: `Im a ≈ 0`)
-    with `a` near a negative integer `−n` (`Re a ≈ −(σ_ν−σ_μ)/g`, so a resonance
-    sweep walks `Re a` down the lattice −1,−2,…) AND large `|z|=|κ|`: there the
-    fixed-depth float64 series-M Horner catastrophically cancels (the `1/(a+k+1)`
-    factor at `k≈n−1` is near-singular — MEASURED rel error ~1e8, e.g. `|M_float|`
-    ≈ 3.7e11 vs true ≈ 971 at `a=−0.98, |κ|=76.8`), so the LANDED weight can reach
-    ~5e12–1e19, past the k≤28 ceiling of 32·2²⁸≈8.6e9. This is a CONDITIONING
-    failure of the series REALIZATION, **not** a defect in the Γ★ bridge, which is
-    EXACT there — the two lane-totals agree to 74+ digits at high precision (the
-    identity `−M(z)/(ga) − CF(z)/g = −Γ(a)z^{−a}eᶻ/g`, verified
-    `demos/bridge_verify.py`); the earlier "semantically invalid / lanes disagree by
-    ~1e8" reading conflated the float64 Horner's own cancellation error with a lane
-    disagreement. The near-integer configs are NOT incidentally depth-excluded
-    (`zBnd ≈ |a+1|` is small, so `classifyBloomPair` admits them as `crossing`). Its
-    correct remedy is a new `classifyBloomPair` admission guard rejecting a DISC
-    around each negative integer (`|a+n| ≲ ε`), NOT the half-plane `Re a ≲ −1` (which
-    excludes ~91% of the benign shipped register — measured), to a NEW `SeamRegion`
-    (not `excludedDepth`, which the coverage gate's totality assertion relies on),
-    landed ALONGSIDE the per-pair exponent — a correctness fix, not a landing-scale
-    one. -/
+    RANGE (WS-AA range lens). The selected two or three `env·w` factors still
+    land at fixed Q4.28. A per-sample exponent is not an acceptable patch: these
+    factors depend on `dPos`, and moving `floatExponent`/`ldexp` into every audio
+    sample and pair would violate the coefficient-time landing invariant, make
+    backend precision affect exponent choices, and scale badly for a 672-pair
+    room. A correct selected-lane supremum remains an explicit architecture gate.
+
+    Landing also cannot repair an ill-conditioned value. The measured
+    `a=-0.98, |κ|≈72.2` Horner witness is wrong by >1e8 and can exceed the
+    `k≤28` ceiling. `classifyBloomPair` therefore names and refuses the
+    CF-crossing intersection with the exact-binary radius-`1/32` discs around
+    `-1,…,-300`; the live classifier applies the conservative interval analogue.
+    `BloomComposition` makes any such or depth/contract exclusion explicit, and
+    Patch lowering refuses the requested room crossing rather than rendering a
+    bare bloom or partial room. The fixed factor landing is not a proof for
+    arbitrary authored tables outside this measured admission contract, which is
+    why the public `bloomgong` surface remains withheld. -/
 def bloomComposedSig (pairs : Array BloomPair) (clkInt anchorSamples : Sig) : Sig :=
   let clkRel := relClockQ clkInt anchorSamples
   let dSec := div (div (toFloatE clkRel) (lit 4294967296)) .sampleRate
@@ -559,7 +680,7 @@ def bloomFoldCompose (voice : Array ModalMode) (r1 r2 : ModalMode) (B g : Float)
     if !DyadicI.certGt (CplxDI.abs (CplxDI.add a1D CplxDI.one)) (CplxDI.abs kD) then continue
     let nRaw := bloomM1DepthD a1.toPoint kappa.toPoint bloomM1TolD
     let nDepth := nRaw + 8    -- M(a1;z) depth; the a-DD's Hₙ factor is a small (~log) tail
-    if nDepth > 300 then continue
+    if nDepth > bloomDepthCap then continue
     -- the constants, exact and then projected — `CplxB ⟨toFloat re, toFloat im⟩`
     -- emits bit-identically to `cplxLitD?`, since `cplxLitE` is `litF` of exactly
     -- those two doubles; a poisoned constant drops the mode rather than emitting
@@ -660,11 +781,11 @@ def bloomFoldComposedSig (pairs : Array BloomFoldPair) (clkInt anchorSamples : S
 def bloomFoldComposedTerm (pairs : Array BloomFoldPair) (anchor : Sig) (c : Clock) : ArrowTerm :=
   ArrowTerm.arrUn (fun clkSig => bloomFoldComposedSig pairs clkSig anchor) (ArrowTerm.clk c)
 
-/-- The pitch-bloom clock warp for a BARE bloomed source (no room to cross): the
+/-- The pitch-bloom clock warp for a BARE bloomed source (no room requested): the
     offset `B·(1−e^{−g·d⁺})` added to the untouched integer clock — `B` already
     folds the register scale (`B = β·scale/g`). The scale-1 sibling of
     `gongBloomWarp` (which lives one layer up, in `Gong.lean`), defined here so
-    `Patch.lowerInput` can realize a bloomed source's bare fallback without a
+    `Patch.lowerInput` can realize the explicitly bare source without a
     circular import. `W(0)=0`, monotone, so the bank's own causal gate is
     untouched. -/
 def bloomWarpClock (anchorSamples : Sig) (B g : Float) : Clock → Clock :=

--- a/lean/Tropical/EmitArrow/Modal/Realize.lean
+++ b/lean/Tropical/EmitArrow/Modal/Realize.lean
@@ -295,3 +295,4 @@ def modalBankTermDir (modes : Array ModalMode) (anchor : Sig) (c : Clock)
 structure ModalDir where
   dir : Sig := lit 0
   damp : Option (Sig × Sig) := none
+deriving BEq

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -391,17 +391,27 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
       -- Pole union remains the compatibility optimization for a forest whose
       -- branches have structurally identical realization metadata. Different
       -- anchors/clocks/addresses/directions remain independent branches.
-      let normalizeBranch : ModalBranch → Except String ModalBranch := fun branch =>
+      let normalizeBranch : ModalBranch → ModalBranch := fun branch =>
         match branch.bank with
-        | .plain ms rooms => .ok { branch with
+        | .plain ms rooms => { branch with
             bank := .plain (foldRoomsEC ms rooms) #[]
             modeCount? := none }
-        | .bloomed .. => .error s!"modalMix '{id}': a bloomed source has a pitch-bloom warp pole-union can't merge (v1) — cross it through a reverb before mixing"
-      let normalized ← parts.mapM normalizeBranch
+        -- A bloomed branch cannot participate in a pole union: its clock warp
+        -- is part of the branch's realization. Keep it in its authored slot and
+        -- let the Modal→Sig seam realize it independently.
+        | .bloomed .. => branch
+      let normalized := parts.map normalizeBranch
       match normalized.toList with
       | [] => .error s!"modalMix '{id}': no inputs"
       | first :: _ =>
-        if normalized.all (ModalBranch.sameRealizationMetadata first) then
+        -- Preserve the incumbent pole-union optimization only when the WHOLE
+        -- forest is plain and metadata-compatible. In a heterogeneous forest,
+        -- even compatible plain branches stay in place so no bloomed branch is
+        -- crossed, merged, or reordered as an accidental side effect.
+        let allPlain := normalized.all fun branch => match branch.bank with
+          | .plain .. => true
+          | .bloomed .. => false
+        if allPlain && normalized.all (ModalBranch.sameRealizationMetadata first) then
           let union := normalized.foldl (fun acc branch => match branch.bank with
             | .plain modes _ => acc ++ modes
             | .bloomed .. => acc) #[]

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -492,16 +492,19 @@ def lowerInput (g : PatchGraph) (rankOf : String → Option Nat)
             | some d => modalBankTermDir (foldRoomsEC ms rooms) modal.strikeAnchor
                 modal.realizationClock d.dir d.damp modal.modeCount?)
         | .bloomed voice room B gr =>
-          -- A bare bloomed branch and its graceful crossing fallback retain the
-          -- existing path, now without constraining sibling branch metadata.
+          -- A genuinely bare bloom keeps its clock-warp realization. Once a
+          -- room crossing was requested, however, composition is all-or-nothing:
+          -- an unsupported or numerically excluded pair is a named lowering
+          -- error, never a bare-bloom or partial-room substitution.
           let bare := ArrowTerm.warp (bloomWarpClock modal.strikeAnchor B gr)
             (modalBankTerm voice modal.strikeAnchor modal.realizationClock modal.modeCount?)
           if room.isEmpty then .ok bare
-          else match bloomCompose voice room B gr with
-            | some pairs =>
-              if pairs.isEmpty then .ok bare
-              else .ok (bloomComposedTerm pairs modal.strikeAnchor modal.realizationClock)
-            | none => .ok bare
+          else
+            let composed := bloomComposeChecked voice room B gr
+            if composed.isComplete then
+              .ok (bloomComposedTerm composed.pairs modal.strikeAnchor modal.realizationClock)
+            else
+              .error s!"lower: bloomed room crossing at '{id}' refused ({composed.refusalSummary})"
       match modal.addressNode? with
       | none => .ok term
       -- A patched address signal becomes only this branch's clock.

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -184,17 +184,31 @@ inductive ModalBank where
   | plain (voice : Array ModalMode) (rooms : Array (Array ModalMode))
   | bloomed (voice room : Array ModalMode) (bloomB gRate : Float)
 
-/-- The result of lowering a modal island before it crosses into the signal
-    graph. These values travel together, but are not interchangeable tuple
-    positions: the bank is the spectral payload, while the remaining fields
-    describe how and where that payload is realized. -/
-structure LoweredModal where
+/-- One independently timed branch of a lowered modal island. The bank is the
+    spectral payload; the remaining fields describe how and where only this
+    branch is realized. Keeping that metadata per branch is what prevents a
+    modal fan-in from borrowing its first input's strike anchor or clock. -/
+structure ModalBranch where
   bank : ModalBank
   strikeAnchor : Sig
   realizationClock : Clock
   addressNode? : Option String
   direction? : Option ModalDir
   modeCount? : Option Sig
+
+/-- The compiler value carried by a modal edge. Authored order is semantic:
+    effects map over it and a Modal→Sig seam realizes and sums it left-to-right. -/
+abbrev ModalForest := Array ModalBranch
+
+/-- Structural equality for the metadata that permits a legacy pole union.
+    The bank is deliberately excluded: compatible plain banks are concatenated
+    after their deferred rooms fold. -/
+def ModalBranch.sameRealizationMetadata (a b : ModalBranch) : Bool :=
+  a.strikeAnchor == b.strikeAnchor &&
+  a.realizationClock == b.realizationClock &&
+  a.addressNode? == b.addressNode? &&
+  a.direction? == b.direction? &&
+  a.modeCount? == b.modeCount?
 
 /-- The COLLECTED chain fold, arrival order — today's exact expressions (the
     byte-identity comparator, and the fallback for the surfaces that need a
@@ -247,13 +261,17 @@ def foldRoomsPartitioned (voice : Array ModalMode)
     residueComposePartitioned (foldRoomsEC voice front) last
 
 /-- The empty modal value (`__silence__`, the graceful-silence contract). -/
-private def silentModal : LoweredModal where
+private def silentModal : ModalBranch where
   bank := .plain #[] #[]
   strikeAnchor := lit 0
   realizationClock := clockLit
   addressNode? := none
   direction? := none
   modeCount? := none
+
+/-- Silence remains a singleton so terminals that historically accepted an
+    unwired modal inlet retain their exact graceful-silence path. -/
+private def silentForest : ModalForest := #[silentModal]
 
 /-- The rank-certificate breach message. Dead by invariant — `lowerAt`
     refuses cyclic graphs (with the full loop named) before any lowering
@@ -270,12 +288,12 @@ private def cycleGuardMsg (src dst : String) : String :=
     `lowerModal`. Total: recursion descends the caller-supplied topological
     rank (`rankOf`, built by `lowerAt`); `r` is this node's own rank. -/
 def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (r : Nat) :
-    Except String LoweredModal := do
+    Except String ModalForest := do
   -- An unconnected modal inlet points at `__silence__`; a modal node with no modal
   -- source is a legal, incomplete patch — it compiles to an EMPTY bank (silence),
   -- not an error. (The graceful-silence contract, same as `mix []`.)
   if id == "__silence__" then
-    return silentModal
+    return silentForest
   let some pn := g.nodes.find? (·.id == id)
     | .error s!"lowerModal: node '{id}' not found"
   -- The gated modal recursion (inlined at each site for the WF measure):
@@ -289,24 +307,24 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
     -- together under knob overdrive). In-span drives are value-identical.
     let ms := clampSigmas ms
     match bloom? with
-    | none => .ok {
+    | none => .ok #[{
         bank := .plain ms #[]
         strikeAnchor := a
         realizationClock := clk
         addressNode? := addr
         direction? := none
-        modeCount? := count }
+        modeCount? := count }]
     -- a bloomed source starts modal with an EMPTY room; reverbs fold in downstream
-    | some (B, gr) => .ok {
+    | some (B, gr) => .ok #[{
         bank := .bloomed ms #[] B gr
         strikeAnchor := a
         realizationClock := clk
         addressNode? := addr
         direction? := none
-        modeCount? := count }
+        modeCount? := count }]
   | .modalReverb inId room dir => do
     let lowered ←
-      if inId == "__silence__" then pure silentModal
+      if inId == "__silence__" then pure silentForest
       else match rankOf inId with
         | none => throw s!"lowerModal: node '{inId}' not found"
         | some ri =>
@@ -318,28 +336,26 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
     -- Room unit modes enter clamped (the uniform-bank σ clamp — see
     -- `.modalSource`); in-span drives are value-identical.
     let room := clampSigmas room
-    match lowered.bank with
-    | .plain v rooms =>
-      -- source ⋙ filter: ACCUMULATE the room; the fold (and the EC/DD
-      -- partition) happens once, at realization — where the whole chain is
-      -- visible and hot rooms can sort last. Amps stay symbolic, so live
-      -- source knobs survive the room.
-      .ok { lowered with
-        bank := .plain v (rooms.push room)
-        direction? := dir.orElse (fun _ => lowered.direction?)
-        modeCount? := none }
-    | .bloomed voice acc B gr =>
-      -- filter ∘ filter: FOLD this room into the accumulated room chain (voice
-      -- stays separate, bloom uncrossed). An empty accumulator is the fold
-      -- identity (the first reverb in a chain).
-      let folded := if acc.isEmpty then room else residueComposeEC acc room
-      .ok { lowered with
-        bank := .bloomed voice folded B gr
-        direction? := dir.orElse (fun _ => lowered.direction?)
-        modeCount? := none }
+    return lowered.map fun branch =>
+      match branch.bank with
+      | .plain v rooms =>
+        -- source ⋙ filter: ACCUMULATE the room independently on every
+        -- branch. Amps stay symbolic, so live source knobs survive the room.
+        { branch with
+          bank := .plain v (rooms.push room)
+          direction? := dir.orElse (fun _ => branch.direction?)
+          modeCount? := none }
+      | .bloomed voice acc B gr =>
+        -- filter ∘ filter: fold this room into this branch's accumulated
+        -- room chain while leaving its voice and bloom uncrossed.
+        let folded := if acc.isEmpty then room else residueComposeEC acc room
+        { branch with
+          bank := .bloomed voice folded B gr
+          direction? := dir.orElse (fun _ => branch.direction?)
+          modeCount? := none }
   | .modalGauge inId gExpr => do
     let lowered ←
-      if inId == "__silence__" then pure silentModal
+      if inId == "__silence__" then pure silentForest
       else match rankOf inId with
         | none => throw s!"lowerModal: node '{inId}' not found"
         | some ri =>
@@ -350,54 +366,48 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
     -- reverb's composition. An un-settleable input declines to identity inside
     -- `normalizePeak`. A bloomed source gauges its VOICE modes; the folded room and
     -- the uncrossed bloom are untouched.
-    match lowered.bank with
-    -- gauge is a COLLECTED surface in v1: it needs the composed bank to
-    -- self-measure, so it forces the fold here (today's exact expressions) —
-    -- and its output amps carry the norm's expSig, so downstream couplings
-    -- are unmeasurable and stay collected (status quo, documented). The fold
-    -- is SAFE against hot chains even though the collected amps carry the
-    -- huge cancelling ±c/Δ pair: the norm reads the transfer function H,
-    -- which has NO 1/Δ pole (the partial fractions recombine into the
-    -- bounded product form), so the f64 cancellation is benign — measured,
-    -- not assumed (the ecdd-gauge gate mirrors the norm independently and
-    -- pins gauged ≡ scale × collected). The residual under a gauge is the
-    -- hot pair rendering at the collected floor — which at sub-grid detune
-    -- means the pair is silent AND its ±c/Δ amps size the bank's landing
-    -- exponent, quantizing the cold modes coarsely (the LANDING POISON, the
-    -- gate's own finding) — the stated status quo of every collected
-    -- surface, one more reason the routed path is the served one.
-    | .plain v rooms =>
-      .ok { lowered with
-        bank := .plain (normalizePeak gExpr (foldRoomsEC v rooms)) #[] }
-    | .bloomed voice acc B gr =>
-      .ok { lowered with
-        bank := .bloomed (normalizePeak gExpr voice) acc B gr }
+    return lowered.map fun branch =>
+      match branch.bank with
+      -- gauge is a COLLECTED surface in v1: each branch self-measures its own
+      -- composed bank. Its output amps keep the existing collected behavior.
+      | .plain v rooms =>
+        { branch with
+          bank := .plain (normalizePeak gExpr (foldRoomsEC v rooms)) #[] }
+      | .bloomed voice acc B gr =>
+        { branch with
+          bank := .bloomed (normalizePeak gExpr voice) acc B gr }
   | .modalMix inputs => do
-    let parts ← inputs.mapM fun i =>
-      if i == "__silence__" then pure silentModal
+    let forests ← inputs.mapM fun i =>
+      if i == "__silence__" then pure silentForest
       else match rankOf i with
         | none => throw s!"lowerModal: node '{i}' not found"
         | some ri =>
           if h : ri < r then lowerModal g rankOf i ri
           else throw (cycleGuardMsg id i)
-    match parts.toList with
-    | [] => .error s!"modalMix '{id}': no inputs"
-    -- head carries the shared anchor/clock/address/direction for the union.
-    | first :: rest =>
-      -- pole union is defined on PLAIN banks; a bloomed source carries a warp
-      -- the union can't merge (v1) — reverb it before mixing.
-      -- mix is a COLLECTED surface in v1: pole union needs plain mode arrays,
-      -- so a deferred chain folds here (today's exact expressions). A hot
-      -- coupling BELOW a mix stays collected (status quo, documented); one
-      -- formed by a reverb ABOVE the mix partitions normally.
-      let modesOf : ModalBank → Except String (Array ModalMode) := fun b => match b with
-        | .plain ms rooms => .ok (foldRoomsEC ms rooms)
+    let parts := forests.foldl (fun acc forest => acc ++ forest) #[]
+    if parts.isEmpty then
+      .error s!"modalMix '{id}': no inputs"
+    else
+      -- Pole union remains the compatibility optimization for a forest whose
+      -- branches have structurally identical realization metadata. Different
+      -- anchors/clocks/addresses/directions remain independent branches.
+      let normalizeBranch : ModalBranch → Except String ModalBranch := fun branch =>
+        match branch.bank with
+        | .plain ms rooms => .ok { branch with
+            bank := .plain (foldRoomsEC ms rooms) #[]
+            modeCount? := none }
         | .bloomed .. => .error s!"modalMix '{id}': a bloomed source has a pitch-bloom warp pole-union can't merge (v1) — cross it through a reverb before mixing"
-      let ms0 ← modesOf first.bank
-      let union ← rest.foldlM (fun acc p => do
-        let modes ← modesOf p.bank
-        pure (acc ++ modes)) ms0
-      .ok { first with bank := .plain union #[], modeCount? := none }
+      let normalized ← parts.mapM normalizeBranch
+      match normalized.toList with
+      | [] => .error s!"modalMix '{id}': no inputs"
+      | first :: _ =>
+        if normalized.all (ModalBranch.sameRealizationMetadata first) then
+          let union := normalized.foldl (fun acc branch => match branch.bank with
+            | .plain modes _ => acc ++ modes
+            | .bloomed .. => acc) #[]
+          .ok #[{ first with bank := .plain union #[], modeCount? := none }]
+        else
+          .ok normalized
   | _ => .error s!"a modal inlet (reverb/modal-mix) needs a modal SOURCE — resonator or modal-mix — but '{id}' is a signal node; a Sig has no poles to compose"
 termination_by r
 decreasing_by all_goals exact h
@@ -456,48 +466,43 @@ termination_by (r, 1)
 def lowerInput (g : PatchGraph) (rankOf : String → Option Nat)
     (id : String) (r : Nat) : Except String ArrowTerm := do
   if nodeIsModal g id then
-    let modal ← lowerModal g rankOf id r
-    -- realize the lowered bank at THIS edge (the one-directional Modal→Sig seam).
-    let term ← match modal.bank with
-      | .plain ms rooms =>
-        -- a DIRECTION rotates the poles and reads them through the per-mode
-        -- `sign(σ·d)` gate (`modalBankTermDir`), else the plain forward causal
-        -- bank. `count?` (trip-count-as-data) is the bank's live mode count.
-        -- The deferred room chain folds HERE, partitioned (`couplingHot` routes
-        -- near-coincident couplings to the paired DD body; a cold chain emits
-        -- today's collected term verbatim). Direction is a collected surface
-        -- in v1 (its pole-rotation machinery has no paired form) — a hot
-        -- coupling under a direction stays collected, status quo.
-        .ok (match modal.direction? with
-          | none =>
-            let (plain, paired) := foldRoomsPartitioned ms rooms
-            modalBankTermPartitioned plain paired modal.strikeAnchor
-              modal.realizationClock modal.modeCount?
-          | some d => modalBankTermDir (foldRoomsEC ms rooms) modal.strikeAnchor
-              modal.realizationClock d.dir d.damp modal.modeCount?)
-      | .bloomed voice room B gr =>
-        -- the bare bloomed source: the bloom-warped bank (identical to a gong
-        -- register's `warpFx`-around-`modalSource`). Also the graceful fallback
-        -- when the crossing produces nothing (a live pole outside WS-LP's lift —
-        -- live voice/ω, live σ without a declared range, a glided σ — or every
-        -- pair fell outside admission) — legal, no warning. A live-rt60 room
-        -- with `sigmaRange` DOES cross (WS-LP): its serOnly pairs lift to s0
-        -- expressions of the live pole.
-        let bare := ArrowTerm.warp (bloomWarpClock modal.strikeAnchor B gr)
-          (modalBankTerm voice modal.strikeAnchor modal.realizationClock modal.modeCount?)
-        if room.isEmpty then .ok bare
-        else match bloomCompose voice room B gr with
-          | some pairs =>
-            if pairs.isEmpty then .ok bare
-            else .ok (bloomComposedTerm pairs modal.strikeAnchor modal.realizationClock)
-          | none => .ok bare
-    match modal.addressNode? with
-    | none => .ok term
-    -- a patched address signal BECOMES the bank's clock (absolute warp): the
-    -- signal is lowered as an ordinary Sig here at the seam, then `modalAddrWarp`
-    -- routes it into the bank's clock leaf. The master scrub still reaches the
-    -- bank through this modulator (it too rides the enclosing clock transform).
-    | some addrId => .ok (.swarp modalAddrWarp (← lowerInputGated g rankOf id addrId r) term)
+    let forest ← lowerModal g rankOf id r
+    let terms ← forest.mapM fun modal => do
+      -- Realize each branch independently at THIS edge. The forest order is the
+      -- authored order and therefore the signal-sum order.
+      let term ← match modal.bank with
+        | .plain ms rooms =>
+          -- A DIRECTION rotates this branch's poles and reads them through the
+          -- per-mode gate; otherwise its deferred room chain folds here.
+          .ok (match modal.direction? with
+            | none =>
+              let (plain, paired) := foldRoomsPartitioned ms rooms
+              modalBankTermPartitioned plain paired modal.strikeAnchor
+                modal.realizationClock modal.modeCount?
+            | some d => modalBankTermDir (foldRoomsEC ms rooms) modal.strikeAnchor
+                modal.realizationClock d.dir d.damp modal.modeCount?)
+        | .bloomed voice room B gr =>
+          -- A bare bloomed branch and its graceful crossing fallback retain the
+          -- existing path, now without constraining sibling branch metadata.
+          let bare := ArrowTerm.warp (bloomWarpClock modal.strikeAnchor B gr)
+            (modalBankTerm voice modal.strikeAnchor modal.realizationClock modal.modeCount?)
+          if room.isEmpty then .ok bare
+          else match bloomCompose voice room B gr with
+            | some pairs =>
+              if pairs.isEmpty then .ok bare
+              else .ok (bloomComposedTerm pairs modal.strikeAnchor modal.realizationClock)
+            | none => .ok bare
+      match modal.addressNode? with
+      | none => .ok term
+      -- A patched address signal becomes only this branch's clock.
+      | some addrId =>
+        .ok (.swarp modalAddrWarp (← lowerInputGated g rankOf id addrId r) term)
+    -- Keep every pre-forest singleton plan structurally identical. Forests with
+    -- multiple branches cross once as a stable authored-order signal sum.
+    match terms.toList with
+    | [] => .ok (.sum #[])
+    | [term] => .ok term
+    | _ => .ok (.sum terms)
   else lowerNode g rankOf id r
 termination_by (r, 2)
 end

--- a/lean/Tropical/EmitArrow/Sig.lean
+++ b/lean/Tropical/EmitArrow/Sig.lean
@@ -51,7 +51,7 @@ inductive Sig where
   -- `idxId` names the binder the body's `loopIdx id` refers to.
   | bankSum (count : Nat) (tables : Array Sig) (body : Sig)
       (dynCount? : Option Sig) (idxId : Nat)
-deriving Repr, Inhabited
+deriving Repr, Inhabited, BEq
 
 /-- A clock-as-value expression (Q32.32 fixed-point sample coordinate). -/
 abbrev Clock := Sig

--- a/lean/Tropical/Playground/Decode.lean
+++ b/lean/Tropical/Playground/Decode.lean
@@ -231,9 +231,9 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
     -- lowering folds the room chain first and crosses the bloom ONCE. Baked-pole-
     -- bloom contract (besselFuse parity): β, g, scale baked (a change relowers);
     -- amps stay live. Wired to `out` it plays the bare bloom-warped register;
-    -- wired to a reverb it crosses — including a LIVE-rt60 reverb since WS-LP
-    -- (serOnly pairs lift to s0 CplxE of the live pole; region-crossing pairs
-    -- drop gracefully per pair until the Phase 3 region-union emit).
+    -- wired to a reverb it crosses — including a supported LIVE-rt60 interval.
+    -- Any conditioning/depth/pole-contract exclusion refuses the whole requested
+    -- crossing at lowering; there is no partial-room or bare-room fallback.
     -- β, g and scale stay `Float` here: they feed `modalSource`'s
     -- `(Float × Float)` bloom pair, whose type this pass does not reach.
     let beta := jFloat params "beta" 0.05
@@ -364,7 +364,7 @@ def checkOutTarget (j : Json) (raws : Array Raw) : Except String Unit :=
 def checkServedKinds (raws : Array Raw) : Except String Unit := do
   for r in raws do
     if withheldKinds.contains r.kind then
-      throw s!"unserved kind: '{r.id}' has kind '{r.kind}', which the engine builds but WITHHOLDS from the surface vocabulary (its modal factor-site landing has no admission guard yet) — not available as a patch node"
+      throw s!"unserved kind: '{r.id}' has kind '{r.kind}', which the engine builds but WITHHOLDS from the surface vocabulary (conditioning is guarded, but arbitrary-table factor landing, profile bounds, cost, and live-beta topology are not yet a served contract) — not available as a patch node"
     unless vocabularyKinds.contains r.kind do
       throw s!"unknown kind: '{r.id}' has kind '{r.kind}', which is not a served node kind — see get_vocabulary for the {vocabularyKinds.size} kinds the surface builds"
   pure ()

--- a/lean/Tropical/Playground/Vocabulary.lean
+++ b/lean/Tropical/Playground/Vocabulary.lean
@@ -586,18 +586,19 @@ def buildNodeKinds : Array String := #[
   "reverse", "mix", "ring", "resonator", "reverb", "filter", "modalmix",
   "gauge", "gong", "bloomgong", "string"]
 
-/-- Kinds `buildNode` builds but which are WITHHELD from the served surface. Their
-    modal factor-site landing (`bloomComposedSig`) still lands `lit 268435456`
-    unconditionally — no per-region sup, no admission guard for the conditioning
-    hazard when `a` is near a negative integer (the fixed-depth float64 series-M
-    Horner catastrophically cancels; see that def's RANGE block). `checkServedKinds`
+/-- Kinds `buildNode` builds but which are WITHHELD from the served surface.
+    The measured negative-integer conditioning discs are now named refusals, but
+    `bloomComposedSig`'s admitted selected factors still use fixed Q4.28 landing,
+    and arbitrary authored mode tables are not proven total outside the measured
+    admission contract; full live β would also change topology/depth rather than
+    only coefficients. `checkServedKinds`
     rejects a withheld kind with an honest message rather than letting it die
     downstream as a MISLEADING `signal→modal` type error: `outletOf` falls through
     to `signal` for it, which DRIFTS from its modal constructed node — the exact
     drift the `modal-class-agreement` gate now sees because it drives off
-    `buildNodeKinds`. Un-withholding one is NOT a one-line `outletOf` edit: it
-    re-admits the unguarded factor site, so it waits on the per-region-sup landing
-    (`design/seam-hardening-optionE-handoff.local.md`, the factor-site follow-on). -/
+    `buildNodeKinds`. Un-withholding one is NOT a one-line `outletOf` edit: the
+    accepted structural profile, factor bound/landing strategy, refusal semantics,
+    cost, and any live-β topology contract must be bounded first. -/
 def withheldKinds : Array String := #["bloomgong"]
 
 -- Derived views — the ONLY readers of glide/anchor/knob facts from here down.

--- a/lean/Tropical/Tropicaltest/Exact.lean
+++ b/lean/Tropical/Tropicaltest/Exact.lean
@@ -436,8 +436,8 @@ private def benchBank (n : Nat) : Array Tropical.EmitArrow.ModalMode :=
     value feeds `landK`'s power-of-two read and every `certLt` in the EC/DD
     router, where an enclosure one ulp wider OR NARROWER is not a rounding
     difference but a different emitted program. Narrower is not the safe
-    direction: a tighter interval turns `overlap` into a verdict, and
-    `classifyBloomPairLive` DROPS what it cannot certify.
+    direction: a tighter interval turns `overlap` into a verdict, and the checked
+    live classifier REFUSES what it cannot certify.
 
     Exponents past the table's end are included so the division fallback is
     exercised rather than assumed. The two timings are PRINTED, never gated — a
@@ -561,9 +561,9 @@ open Tropical.EmitArrow in
     second number to read: a literal disagrees only when the true value sits
     within the float path's own error of a half-grid boundary.
 
-    `poisoned == 0` is a hard assertion. A poisoned constant makes `bloomCompose`
-    return `none` and the caller fall back to the bare bloom — silently, and
-    correctly, but the shipped register must never take that path. -/
+    `poisoned == 0` is a hard assertion. A poisoned constant becomes a typed
+    `coefficientMaterialization` refusal, and Patch lowering reports it explicitly;
+    the shipped register must never take that path. -/
 def runExactValues : IO Bool := do
   let tStart ← IO.monoMsNow
   let n := 120

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1456,6 +1456,149 @@ def runModalForestAnchors (arena : Arena)
   | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
     failGate "modal-forest-anchors" s!"build: {firstLine e}"
 
+open Tropical.EmitArrow in
+/-- THE MODAL-FOREST M2 gate. A compact, test-only score models sixteen authored
+    timed islands without importing the demo scene or its grouped-room cache.
+    Every fourth island is bloomed, so the fixture exercises a heterogeneous
+    forest: modalMix must retain all sixteen branches in authored order and the
+    Modal→Sig seam must realize each at its own anchor. An ordinary signal mix of
+    the same sixteen modal sources is the independent seam oracle.
+
+    The oracle is checked under forward, velocity-zero hold, reverse, and seek
+    clocks. Hold/reverse/seek are also compared directly with the corresponding
+    coordinates of the forward render, pinning the closed-form random-access
+    reading rather than merely comparing two compiler plans. Finally, removing
+    each island is silent until that island's anchor and audible afterwards. -/
+def runModalForestTimedIslands (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let islandCount : Nat := 16
+  let frameCount : Nat := 2048
+  let anchors := (Array.range islandCount).map fun i => 60 + 100 * i
+  let ids := (Array.range islandCount).map fun i => s!"timed-island-{i}"
+  let bloomB : Float := 0.0004
+  let bloomG : Float := 2.0
+  let modesFor := fun (i : Nat) => (#[
+    ModalMode.hz (lit (Int.ofNat (180 + 19 * i)))
+      (lit (Int.ofNat (6 + i % 5)))
+      (lit (Int.ofNat (1 + i % 3)) 1)] : Array ModalMode)
+  let sourceFor := fun (clk : Clock) (i : Nat) =>
+    let modes := modesFor i
+    let anchor := lit (Int.ofNat anchors[i]!)
+    let bloom? := if i % 4 == 0 then some (bloomB, bloomG) else none
+    ({ id := ids[i]!, node := .modalSource modes anchor clk none none bloom? } : PatchNode)
+  let sourcesFor := fun (clk : Clock) =>
+    (Array.range islandCount).map (sourceFor clk)
+  let modalGraphFor := fun (clk : Clock) (inputs : Array String) => ({
+    nodes := (sourcesFor clk).push { id := "timed-modal-mix", node := .modalMix inputs }
+    output := "timed-modal-mix" } : PatchGraph)
+  let signalGraphFor := fun (clk : Clock) => ({
+    nodes := (sourcesFor clk).push { id := "timed-signal-mix", node := .mix ids }
+    output := "timed-signal-mix" } : PatchGraph)
+
+  -- Inspect the modal value before realization: size, stable order, anchors,
+  -- and the plain/bloomed pattern are all compiler facts, not audio inferences.
+  let rankOf := fun (id : String) =>
+    if id == "timed-modal-mix" then some 1
+    else if ids.contains id then some 0
+    else none
+  let structureOk := match lowerModal (modalGraphFor clockLit ids)
+      rankOf "timed-modal-mix" 1 with
+    | .error _ => false
+    | .ok forest => forest.size == islandCount &&
+        (Array.range islandCount).all fun i => match forest[i]? with
+          | none => false
+          | some branch =>
+            let anchorOk := branch.strikeAnchor == lit (Int.ofNat anchors[i]!)
+            let bankOk := match branch.bank with
+              | .bloomed voice room B g =>
+                i % 4 == 0 && voice.size == 1 && room.isEmpty &&
+                  B == bloomB && g == bloomG
+              | .plain voice rooms =>
+                i % 4 != 0 && voice.size == 1 && rooms.isEmpty
+            anchorOk && bankOk
+
+  let carrier := fun (name : String) (graph : PatchGraph) => (do
+    let term ← lowerGraph graph
+    let (out, _) := emitTerm (normalize term) {}
+    .ok (buildExprCarrier name out arena) : Except String (Arena × ProgramIdx))
+  let renderPair : String → Clock → Nat →
+      IO (Except String (Array Float × Array Float)) := fun tag clk n => do
+    match buildAndFinish (carrier s!"timed_forest_{tag}" (modalGraphFor clk ids)),
+          buildAndFinish (carrier s!"timed_oracle_{tag}" (signalGraphFor clk)) with
+    | .error e, _ => pure (.error s!"forest {tag}: {e}")
+    | _, .error e => pure (.error s!"oracle {tag}: {e}")
+    | .ok forestPlan, .ok oraclePlan =>
+      match ← renderPlanSamples forestPlan n, ← renderPlanSamples oraclePlan n with
+      | .ok forest, .ok oracle => pure (.ok (forest, oracle))
+      | .error e, _ => pure (.error s!"forest render {tag}: {e}")
+      | _, .error e => pure (.error s!"oracle render {tag}: {e}")
+
+  let q : Int := 4294967296
+  let holdAt : Nat := 1234
+  let seekBy : Nat := 257
+  let holdClock : Clock := litI (Int.ofNat holdAt * q)
+  let reverseClock : Clock := sub (litI (Int.ofNat frameCount * q)) clockLit
+  let seekClock : Clock := add clockLit (litI (Int.ofNat seekBy * q))
+  match ← renderPair "forward" clockLit frameCount,
+        ← renderPair "hold" holdClock frameCount,
+        ← renderPair "reverse" reverseClock frameCount,
+        ← renderPair "seek" seekClock (frameCount - seekBy) with
+  | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
+    failGate "modal-forest-timed-islands" (firstLine e)
+  | .ok (forward, forwardOracle), .ok (held, heldOracle),
+      .ok (reversed, reversedOracle), .ok (sought, soughtOracle) =>
+    let forwardOracleDiff := bitDiffCount forward forwardOracle
+    let holdOracleDiff := bitDiffCount held heldOracle
+    let reverseOracleDiff := bitDiffCount reversed reversedOracle
+    let seekOracleDiff := bitDiffCount sought soughtOracle
+    let heldValue := forward[holdAt]!
+    let mut holdCoordinateDiff := 0
+    for i in [0:held.size] do
+      if held[i]! != heldValue then holdCoordinateDiff := holdCoordinateDiff + 1
+    let mut reverseCoordinateDiff := 0
+    for i in [1:min reversed.size forward.size] do
+      if reversed[i]! != forward[frameCount - i]! then
+        reverseCoordinateDiff := reverseCoordinateDiff + 1
+    let mut seekCoordinateDiff := 0
+    for i in [0:min sought.size (forward.size - seekBy)] do
+      if sought[i]! != forward[i + seekBy]! then
+        seekCoordinateDiff := seekCoordinateDiff + 1
+
+    -- Source-removal is the onset oracle. Before the removed island's anchor it
+    -- contributed exact zero; afterwards its one-mode ring must be observable.
+    let mut removalsBuilt := true
+    let mut preOnsetDiff := 0
+    let mut survivingOnsets := 0
+    for island in [0:islandCount] do
+      let kept := ids.filter (· != ids[island]!)
+      match buildAndFinish (carrier s!"timed_without_{island}"
+          (modalGraphFor clockLit kept)) with
+      | .error _ => removalsBuilt := false
+      | .ok removedPlan =>
+        match ← renderPlanSamples removedPlan frameCount with
+        | .error _ => removalsBuilt := false
+        | .ok removed =>
+          let anchor := anchors[island]!
+          for i in [0:min (anchor + 1) (min forward.size removed.size)] do
+            if forward[i]! != removed[i]! then preOnsetDiff := preOnsetDiff + 1
+          let mut deltaEnergy : Float := 0.0
+          for i in [anchor + 1:min forward.size removed.size] do
+            let d := forward[i]! - removed[i]!
+            deltaEnergy := deltaEnergy + d * d
+          if deltaEnergy > 1e-9 then survivingOnsets := survivingOnsets + 1
+
+    IO.println "        ModalForest 16-island heterogeneous timed score (4 bloom, 12 plain):"
+    IO.println s!"        structure order/anchors={structureOk} · explicit-sum bitDiff fwd/hold/rev/seek={forwardOracleDiff}/{holdOracleDiff}/{reverseOracleDiff}/{seekOracleDiff}"
+    IO.println s!"        random access hold/rev/seek coordinate bitDiff={holdCoordinateDiff}/{reverseCoordinateDiff}/{seekCoordinateDiff} · removal pre-onset diff={preOnsetDiff} · surviving onsets={survivingOnsets}/{islandCount}"
+    if structureOk && removalsBuilt && survivingOnsets == islandCount && preOnsetDiff == 0 &&
+        forwardOracleDiff == 0 && holdOracleDiff == 0 && reverseOracleDiff == 0 &&
+        seekOracleDiff == 0 && holdCoordinateDiff == 0 && reverseCoordinateDiff == 0 &&
+        seekCoordinateDiff == 0 then
+      passGate "modal-forest-timed-islands" "16 independently timed plain/bloomed branches retain authored order and onsets; forward, hold, reverse, and seek equal the explicit branch sum and its random-access coordinates byte-for-byte"
+    else
+      failGate "modal-forest-timed-islands"
+        s!"structure={structureOk} removalsBuilt={removalsBuilt} onsets={survivingOnsets} pre={preOnsetDiff} oracle={forwardOracleDiff}/{holdOracleDiff}/{reverseOracleDiff}/{seekOracleDiff} coordinates={holdCoordinateDiff}/{reverseCoordinateDiff}/{seekCoordinateDiff}"
+
 /-- THE MODAL LIVE gate (the payoff). A JSON patch `resonator(freq) → reverb → out`
     compiled through the real `compilePlanPure` — decode → lowerModal → symbolic
     residue → realize → strata → session compile → a JIT-loadable kernel — and its

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1390,6 +1390,72 @@ def runModalPatch (arena : Arena)
     | .error e, _ | _, .error e => failGate "modal-patch" s!"render: {firstLine e}"
   | .error e, _ | _, .error e => failGate "modal-patch" s!"build: {firstLine e}"
 
+open Tropical.EmitArrow in
+/-- THE MODAL-FOREST M1 gate. Same-metadata branches retain the incumbent pole
+    union byte-for-byte; branches with different anchors remain independent and
+    enter the realized sum only at their own causal onset. The second arm is the
+    regression for the old `modalMix` behavior, which copied its first input's
+    anchor onto every later bank. -/
+def runModalForestAnchors (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let aModes : Array ModalMode := #[
+    ModalMode.hz (lit 220) (lit 4) (lit 7 1),
+    ModalMode.hz (lit 440) (lit 6) (lit 3 1)]
+  let bModes : Array ModalMode := #[
+    ModalMode.hz (lit 330) (lit 5) (lit 5 1),
+    ModalMode.hz (lit 660) (lit 8) (lit 2 1)]
+  let firstAnchor := lit 200
+  let secondAnchor := lit 700
+  let source := fun (id : String) (modes : Array ModalMode) (anchor : Sig) =>
+    ({ id, node := Node.modalSource modes anchor clockLit none } : PatchNode)
+  let sameGraph : PatchGraph := {
+    nodes := #[source "a" aModes firstAnchor, source "b" bModes firstAnchor,
+      { id := "mix", node := .modalMix #["a", "b"] }]
+    output := "mix" }
+  let unionGraph : PatchGraph := {
+    nodes := #[source "union" (aModes ++ bModes) firstAnchor]
+    output := "union" }
+  let differentGraph : PatchGraph := {
+    nodes := #[source "a" aModes firstAnchor, source "b" bModes secondAnchor,
+      { id := "mix", node := .modalMix #["a", "b"] }]
+    output := "mix" }
+  let firstOnlyGraph : PatchGraph := {
+    nodes := #[source "a" aModes firstAnchor]
+    output := "a" }
+  let carrier := fun (name : String) (graph : PatchGraph) => (do
+    let term ← lowerGraph graph
+    let (out, _) := emitTerm (normalize term) {}
+    .ok (buildExprCarrier name out arena) : Except String (Arena × ProgramIdx))
+  match buildAndFinish (carrier "mf_same" sameGraph),
+        buildAndFinish (carrier "mf_union" unionGraph),
+        buildAndFinish (carrier "mf_different" differentGraph),
+        buildAndFinish (carrier "mf_first" firstOnlyGraph) with
+  | .ok samePlan, .ok unionPlan, .ok differentPlan, .ok firstPlan =>
+    match ← renderPlanSamples samePlan 2048, ← renderPlanSamples unionPlan 2048,
+          ← renderPlanSamples differentPlan 2048, ← renderPlanSamples firstPlan 2048 with
+    | .ok same, .ok union, .ok different, .ok firstOnly =>
+      let n := min (min same.size union.size) (min different.size firstOnly.size)
+      let mut sameBitDiff := 0
+      let mut beforeSecondBitDiff := 0
+      let mut afterSecondBitDiff := 0
+      for i in [0:n] do
+        if same[i]! != union[i]! then sameBitDiff := sameBitDiff + 1
+        if i ≤ 700 then
+          if different[i]! != firstOnly[i]! then
+            beforeSecondBitDiff := beforeSecondBitDiff + 1
+        else if different[i]! != firstOnly[i]! then
+          afterSecondBitDiff := afterSecondBitDiff + 1
+      IO.println "        ModalForest modal-mix, same-anchor compatibility and different-anchor causality:"
+      IO.println s!"        result   same-anchor union bitDiff={sameBitDiff}/{n} · before second anchor={beforeSecondBitDiff}/701 · after second anchor differing={afterSecondBitDiff}/{n - 701}"
+      if sameBitDiff == 0 && beforeSecondBitDiff == 0 && afterSecondBitDiff > 0 then
+        passGate "modal-forest-anchors" "same metadata keeps the incumbent union byte-exact; a later branch retains its own anchor and joins the stable signal sum only after that onset"
+      else
+        failGate "modal-forest-anchors" s!"same={sameBitDiff} beforeSecond={beforeSecondBitDiff} afterSecond={afterSecondBitDiff}"
+    | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
+      failGate "modal-forest-anchors" s!"render: {firstLine e}"
+  | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
+    failGate "modal-forest-anchors" s!"build: {firstLine e}"
+
 /-- THE MODAL LIVE gate (the payoff). A JSON patch `resonator(freq) → reverb → out`
     compiled through the real `compilePlanPure` — decode → lowerModal → symbolic
     residue → realize → strata → session compile → a JIT-loadable kernel — and its

--- a/lean/Tropical/Tropicaltest/Modal.lean
+++ b/lean/Tropical/Tropicaltest/Modal.lean
@@ -1232,7 +1232,8 @@ def runModalBloomGamma (arena : Arena)
   let anchor := lit 200
   let n : Nat := 32768
   let fabs := fun (x : Float) => if x < 0.0 then -x else x
-  match bloomCompose voice reverb B g, bloomCompose voice reverb 1e-12 g with
+  match bloomCompose voice reverb B g,
+        bloomCompose voice reverb 1e-12 g with
   | none, _ | _, none =>
     failGate "modal-bloom-gamma" "bloomCompose: a live pole reached the baked-pole contract"
   | some pairs, some pairs0 =>

--- a/lean/Tropical/Tropicaltest/SeamSweep.lean
+++ b/lean/Tropical/Tropicaltest/SeamSweep.lean
@@ -102,8 +102,8 @@ private def qOm (om : Float) : Float :=
     `y(d) = a·r·∫₀^d e^{ν(d−s)}·e^{μ·φ(s)} ds`, `Re` taken, summed, sink-gain
     applied. Generic over `φ` (id → residue atoms; bloom → Γ-bridge) — the
     unification the island never wrote down. `admits` filters to the pairs the
-    atom's realization actually includes (bloom drops non-admitted pairs; the
-    residue atoms compose all). Composite Simpson per sample-interval (`hdiv`
+    isolated config admits. Bloom composition itself is all-or-nothing; mixed
+    refusal is covered separately by `runBloomSafety`. Composite Simpson per sample-interval (`hdiv`
     EVEN subintervals) — the O(h⁴) rule, needed because `e^{iωs}` at audio ω is
     oscillatory and trapezoid (h²) would undersample it. `hdiv=4` vs `hdiv=8`
     gives the h→h/2 self-distance that certifies the oracle itself. NOT the
@@ -167,8 +167,8 @@ structure SeamAtom where
   realize : Array SeamMode → Array SeamMode → Sig
   /-- the admission region, as an executable predicate (not a comment). -/
   admitsPair : SeamMode → SeamMode → Bool
-  /-- `true`: the atom actively DROPS non-admitted pairs (excluded pairs must
-      render as graceful silence, and the oracle sums admitted pairs only).
+  /-- `true`: an isolated non-admitted probe refuses the whole atom (the harness
+      represents that isolated refusal as silence, and its oracle sums nothing).
       `false`: total/passive (composes every pair; the predicate marks only
       WHERE it is accurate, and the oracle sums all pairs). -/
   activeExclusion : Bool
@@ -179,11 +179,12 @@ structure SeamAtom where
   interior : Array (Array SeamMode × Array SeamMode)
   /-- boundary probes: candidate isolated pairs at the admission edges; the
       harness tags each LIVE via `admitsPair` (admitted → accuracy; actively
-      excluded → graceful silence; passively excluded → out of contract, skip). -/
+      excluded isolated probe → refusal represented as silence; passively excluded
+      → out of contract, skip). -/
   boundary : Array (SeamMode × SeamMode)
 
-/-- Which pairs the oracle sums for this atom: admitted-only when the atom
-    actively excludes (bloom), all pairs otherwise (residue atoms compose all). -/
+/-- Which pairs the isolated-probe oracle sums: admitted-only for an actively
+    refusing atom, all pairs otherwise. Mixed all-or-nothing is tested elsewhere. -/
 private def SeamAtom.oracleAdmits (atom : SeamAtom) : SeamMode → SeamMode → Bool :=
   if atom.activeExclusion then atom.admitsPair else (fun _ _ => true)
 
@@ -277,12 +278,12 @@ private def composeAtom : SeamAtom :=
 private def bloomBg : Float × Float := (0.05 / 1.8, 1.8)
 private def bloomWarp : Float → Float := fun s => s + bloomBg.1 * (1.0 - Float.exp (-bloomBg.2 * s))
 
-/-- `bloomCompose` — the Γ-bridge atom (`bloomed voice ⋙ reverb`), NOW TOTAL over
+/-- `bloomCompose` — the Γ-bridge atom (`bloomed voice ⋙ reverb`), total over
     the crossing after atom four (WS-A4): the `|a| < ½` coincidence hole (a room
     pole tuned to a settled partial — the τ·e resonance) is admitted and accurate,
     the coincident divided difference bridging the CF branch (large `z`) to the
-    series-DD branch (small `z`). ACTIVE exclusion still drops depth > 300 pairs and
-    live poles. Baked-pole v1 (the sweep pole set is all literal). NOTE: the 0.09 s
+    series-DD branch (small `z`). Conditioning/depth/unsupported exclusions are
+    typed whole-composition refusals. Baked-pole v1 (the sweep pole set is all literal). NOTE: the 0.09 s
     interior/boundary window only exercises the CF branch (which is accidentally
     stable at coincidence); the series-DD resonance lives in the tail, witnessed by
     the long-render checks in `runSeamSweep` — the `coincidence deep-tail` (a = 0
@@ -582,8 +583,8 @@ private def gongVerdict (voice room1 room2 : Array SeamMode)
     first; (2) the chain matches the INDEPENDENT double-convolution `oracleChain`
     (raw filter product, not EC's fold) — law 2, the reassociation is correct,
     not just self-consistent; (3) causal + decaying + nonzero — it is audible.
-    Baked room (the live-rt60 reverb gracefully drops to the bare bloom — the
-    recorded baked-pole-bloom v1 limitation). -/
+    This fixture uses a baked room; live-rt60 coverage and explicit refusal are
+    exercised by `runBloomLivePole` and `runBloomSafety`. -/
 def runGongReverb (arena : Arena)
     (_resolved : Array (String × ProgramIdx)) : IO Bool := do
   let (B, g) := bloomBg
@@ -626,7 +627,8 @@ def runGongReverb (arena : Arena)
     constant-fold (the surface shape: `6.91/rt60` with rt60 a slot read; here the
     un-foldable stand-in is the same expression over a clamped literal, so the
     carrier path can render it without a param table). Asserts:
-    (1) `bloomCompose` LIFTS the pairs instead of dropping to the bare bloom
+    (1) `bloomCompose` LIFTS every supported pair (the checked Patch route would
+        explicitly refuse, never substitute a bare bloom, on any exclusion)
         (all voice×room pairs present, and their constants are genuinely live —
         `sigConstF?` fails on them — and genuinely s0 — `sigIsS0` holds, the
         Stage0-hoist precondition);
@@ -635,8 +637,8 @@ def runGongReverb (arena : Arena)
         build-time arithmetic — identical up to last-bit float noise);
     (3) the live crossing ≈ `oracleSeam` under the bloom warp (the law, not just
         self-consistency), causal and finite;
-    (4) a pair that is NOT serOnly over the whole rt60 range (a room mode ON a
-        voice partial) drops gracefully PER PAIR — the rest of the bank lifts. -/
+    (4) a pair that is unsupported over the whole rt60 range refuses the typed
+        composition; no partial room bank is returned. -/
 def runBloomLivePole (arena : Arena)
     (_resolved : Array (String × ProgramIdx)) : IO Bool := do
   let (B, g) := bloomBg
@@ -657,7 +659,7 @@ def runBloomLivePole (arena : Arena)
   let rMBaked := room.map (·.toModal)
   -- (1) the lift engages: all 6 pairs, live and s0
   let some pairsLive := bloomCompose vM rMLive B g
-    | failGate "bloom-live-pole" "bloomCompose returned none for the live-rt60 room (dropped to bare bloom)"
+    | failGate "bloom-live-pole" "bloomCompose explicitly refused the supported live-rt60 room"
   -- NOT `k1Ser`: the lifted Horner shares subterms by REFERENCE, so its DAG is
   -- small but its TREE is exponential in depth — a structural walk (`sigConstF?`
   -- / `sigIsS0`, unmemoized) would never return. Its leaves are exactly the
@@ -668,17 +670,18 @@ def runBloomLivePole (arena : Arena)
     p.invA.foldl (fun a ik => a ++ #[ik.1, ik.2]) #[]) #[]
   let genuinelyLive := pairsLive.all (fun p => (sigConstF? p.nuSigma).isNone)
   let allS0 := liveConsts.all sigIsS0
-  -- (4) graceful per-pair drop: a room mode 0.05 Hz off the 220 Hz partial is
+  -- (4) explicit whole-composition refusal: a room mode 0.05 Hz off the 220 Hz partial is
   -- COINCIDENT-dipping (|Im a| ≈ 0.17 < ½, and the rt60 range walks Re a
-  -- through the disc) — the one remaining per-pair drop after phase 3a (the
+  -- through the disc) — the remaining unsupported interval after phase 3a (the
   -- τ·e lanes stay baked-only). The drop set shrank twice: phase 1's
   -- on-partial probe (220.5 Hz) lifted with phase 2's crossing arm, and
   -- phase 2's region-CHANGING probe (230.5 Hz) lifted with phase 3a's
   -- union collapse — it is now witness (6) below.
   let nearRoom := liveRoom #[mkMode 220.05 sigLive 0.5]
-  let dropCount := match bloomCompose vM nearRoom B g with
-    | some ps => ps.size
-    | none => 1000
+  let nearComposition := bloomComposeChecked vM nearRoom B g
+  let nearRefused := !nearComposition.isComplete && nearComposition.pairs.isEmpty &&
+    nearComposition.exclusions.any (fun x =>
+      x.reason == .liveRegionUnsupported || x.reason == .excludedConditioning)
   -- (6) phase 3a — the STRADDLING pair (region-changing over the interval):
   -- room 230.5 Hz vs voice 220 (|a+1| straddles |κ| = 38.4: serOnly at low
   -- rt60, crossing at high). Served by the crossing lanes alone (the union
@@ -750,7 +753,7 @@ def runBloomLivePole (arena : Arena)
     let eBakedX := relL2Win pLX pBX lo nX
     let eOracleX := relL2Win pLX (oracleSeam voiceX roomX bloomWarp adm 8 nX) lo nX
     IO.println s!"bloom live-pole crossing (WS-LP: serOnly + crossing + straddling, live rt60):"
-    IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · coincident-dip pair drops to {dropCount}/3"
+    IO.println s!"        lift     pairs {pairsLive.size}/6 · live consts (unfoldable) {genuinelyLive} · s0 {allS0} · coincident-dip composition explicitly refused {nearRefused}"
     IO.println s!"        serOnly  live ≡ baked crossing {eBaked * 1e9}e-9 · live ≡ oracle {eOracle} · pre-E {preE} · E {e}"
     IO.println s!"        crossing lifted (1 pair, CF lane) {crossingLifted} · live ≡ baked {eBakedX * 1e9}e-9 · live ≡ oracle {eOracleX} (window {nX}, seam inside)"
     IO.println s!"        straddle rt60=2 (seam in-window) ≡ baked {eBS2 * 1e9}e-9, ≡ oracle {eOS2} · rt60=0.25 (serOnly side) ≡ baked-SER-ARM {eBS0 * 1e9}e-9 (the bridge identity in-kernel), ≡ oracle {eOS0} · full bank 3/3 {straddleBankFull}"
@@ -758,13 +761,13 @@ def runBloomLivePole (arena : Arena)
     -- baked constants come from build-time forward summation (`bloomM1`) and
     -- `lgammaB`, the lifted ones from the emitted Horner/fraction/`lgammaE` —
     -- real reassociations, so the honest bar is ~1e-6, not bit-identity.
-    if pairsLive.size == 6 && genuinelyLive && allS0 && dropCount == 2
+    if pairsLive.size == 6 && genuinelyLive && allS0 && nearRefused
         && eBaked < 1e-6 && eOracle < 3e-4 && preE < 1e-18 && e > 1e-9 && allFinite pL
         && crossingLifted && eBakedX < 1e-6 && eOracleX < 3e-4 && allFinite pLX
         && eBS2 < 1e-6 && eOS2 < 3e-4 && eBS0 < 1e-6 && eOS0 < 3e-4 && straddleBankFull then
-      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom in every non-coincident region: serOnly 6/6 (≡ oracle {eOracle}); crossing incl. live dSwitch seam (≡ oracle {eOracleX}); STRADDLING pair served by the union collapse on both sides (crossing side ≡ oracle {eOS2}; serOnly side ≡ baked ser arm {eBS0 * 1e9}e-9 — the bridge identity in-kernel); only the coincident dip drops per-pair"
+      passGate "bloom-live-pole" s!"a live-rt60 reverb CROSSES the bloom in every supported non-coincident region: serOnly 6/6 (≡ oracle {eOracle}); crossing incl. live dSwitch seam (≡ oracle {eOracleX}); STRADDLING pair served by the union collapse on both sides (crossing side ≡ oracle {eOS2}; serOnly side ≡ baked ser arm {eBS0 * 1e9}e-9); an unsupported coincident dip explicitly refuses the whole typed composition"
     else
-      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} drop={dropCount} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL} xLift={crossingLifted} eBakedX={eBakedX * 1e9}e-9 eOracleX={eOracleX} finiteX={allFinite pLX} eBS2={eBS2 * 1e9}e-9 eOS2={eOS2} eBS0={eBS0 * 1e9}e-9 eOS0={eOS0} bank3={straddleBankFull}"
+      failGate "bloom-live-pole" s!"pairs={pairsLive.size} live={genuinelyLive} s0={allS0} nearRefused={nearRefused} eBaked={eBaked * 1e9}e-9 eOracle={eOracle} preE={preE} E={e} finite={allFinite pL} xLift={crossingLifted} eBakedX={eBakedX * 1e9}e-9 eOracleX={eOracleX} finiteX={allFinite pLX} eBS2={eBS2 * 1e9}e-9 eOS2={eOS2} eBS0={eBS0 * 1e9}e-9 eOS0={eOS0} bank3={straddleBankFull}"
   | .error e, _, _, _ | _, .error e, _, _ | _, _, .error e, _ | _, _, _, .error e =>
     failGate "bloom-live-pole" s!"build/render: {e}"
 
@@ -867,8 +870,8 @@ def runGammaCoeff (_arena : Arena)
 -- headroom (a sampled max over the Halton batch + the max-|κ| corner scan —
 -- empirical, never a typed bound; only the exhaustive match is type-proven).
 -- Per-region ACCURACY stays the seam-sweep's job (the contract's division of
--- labor: types for coverage, the sweep + SNR for the law). Depth-cap drops are
--- counted and printed — never a silent cap.
+-- labor: types for coverage, the sweep + SNR for the law). Depth-cap exclusions
+-- are counted and printed — never a silent cap.
 
 /-- Per-region tally + worst envelope depth over a Halton batch. -/
 private structure RegionTally where
@@ -876,6 +879,7 @@ private structure RegionTally where
   crossing : Nat := 0
   coincX   : Nat := 0        -- coincidentCrossing
   coincS   : Nat := 0        -- coincidentSubtle
+  cond     : Nat := 0        -- excludedConditioning
   excl     : Nat := 0        -- excludedDepth
   maxN     : Nat := 0        -- worst series depth (admitted samples; excluded carry 0)
   maxK     : Nat := 0        -- worst CF depth
@@ -908,6 +912,7 @@ private def tallyBatch (count : Nat) (B g : Float) (near : Bool) : RegionTally :
     | .crossing           => t := { t with crossing := t.crossing + 1 }
     | .coincidentCrossing => t := { t with coincX   := t.coincX   + 1 }
     | .coincidentSubtle   => t := { t with coincS   := t.coincS   + 1 }
+    | .excludedConditioning => t := { t with cond   := t.cond     + 1 }
     | .excludedDepth      => t := { t with excl     := t.excl     + 1 }
   return t
 
@@ -932,14 +937,14 @@ private def cornerMaxDepth (B g : Float) : Nat := Id.run do
 /-- THE REGION-COVERAGE GATE (WS-CL). Halton-classify the shipped bloom register
     and report totality as a number: the region histogram, the admitted fraction,
     and the worst envelope depth vs the 300 cap. Asserts (1) the SHIPPED surface
-    (β = 0.05, the default register) is depth-total — zero drops, worst SAMPLED
+    (β = 0.05, the default register) has zero exclusions, worst SAMPLED
     depth (Halton interior + the max-|κ| corner scan) < 300, so the cap is MEASURED
     headroom (empirical, not proven — a config in a sampling gap could differ, but
     would still become a counted `excludedDepth`, never a silent error); (2) all
     FOUR served regions are reachable — serOnly, crossing, coincidentCrossing,
     coincidentSubtle (the partition claims no region nothing lands in); (3)
-    `excludedDepth` IS reachable off-surface (β = 0.5, knob max) and is COUNTED, not
-    silently dropped. Accuracy per region is the seam-sweep's job (types for
+    `excludedDepth` IS reachable off-surface (β = 0.5, knob max), is COUNTED, and
+    makes the checked composer refuse the whole requested crossing. Accuracy per region is the seam-sweep's job (types for
     coverage, the sweep for the law). -/
 def runSeamCoverage (_arena : Arena)
     (_resolved : Array (String × ProgramIdx)) : IO Bool := do
@@ -953,14 +958,14 @@ def runSeamCoverage (_arena : Arena)
   let over   := tallyBatch 1000 Bover g false    -- knob-max β → the depth cap bites
   let corner    := cornerMaxDepth Bship g        -- the max-|κ| worst-corner scan
   let shipTotal := uni.total + near.total
-  let shipExcl  := uni.excl + near.excl
+  let shipExcl  := uni.excl + near.excl + uni.cond + near.cond
   let admitFrac := (shipTotal - shipExcl).toFloat / shipTotal.toFloat
   let maxDepth  := max (max (max uni.maxN uni.maxK) (max near.maxN near.maxK)) corner
   IO.println "seam region coverage (classify the shipped register — totality as a number):"
-  IO.println s!"        shipped register (β=0.05): serOnly {uni.serOnly + near.serOnly}, crossing {uni.crossing + near.crossing}, coincidentCrossing {near.coincX}, excludedDepth {shipExcl} / {shipTotal}"
+  IO.println s!"        shipped register (β=0.05): serOnly {uni.serOnly + near.serOnly}, crossing {uni.crossing + near.crossing}, coincidentCrossing {near.coincX}, excludedConditioning {uni.cond + near.cond}, excludedDepth {uni.excl + near.excl} / {shipTotal}"
   IO.println s!"        admitted fraction {admitFrac} · worst SAMPLED depth {maxDepth} of cap 300 (measured headroom {300 - maxDepth}; Halton interior + max-|κ| corner scan {corner})"
   IO.println s!"        subtle-bloom box (B={bSmall}): coincidentSubtle {subtle.coincS} / {subtle.total} reachable"
-  IO.println s!"        knob-max box (β=0.5): excludedDepth {over.excl} / {over.total} — COUNTED, a graceful drop, not a silent cap"
+  IO.println s!"        knob-max box (β=0.5): excludedDepth {over.excl} / {over.total} — counted explicit refusal, not a silent cap"
   let mut ok := true
   -- (1) the shipped register is depth-total: the ≤300 cap is measured headroom
   --     (sampled max incl. the worst corner; empirical, never a typed bound)
@@ -972,18 +977,152 @@ def runSeamCoverage (_arena : Arena)
   if uni.serOnly == 0 || uni.crossing + near.crossing == 0 || near.coincX == 0 || subtle.coincS == 0 then
     IO.println s!"        COVERAGE VIOLATION: a served region is unreachable (serOnly {uni.serOnly}, crossing {uni.crossing + near.crossing}, coincidentCrossing {near.coincX}, coincidentSubtle {subtle.coincS}) — the partition claims a region nothing lands in"
     ok := false
-  -- (3) excludedDepth is reachable off-surface AND counted (the drop is named).
-  --     Graceful SILENCE for an excluded pair is structural, not rendered here: the
-  --     `| .excludedDepth => continue` (Modal.lean) drops the pair from the bank
-  --     entirely, so a mixed bank is byte-identical to the bank without it — nothing
-  --     to render. This gate proves the region is reachable and counted, not silent.
+  -- (3) excludedDepth is reachable off-surface AND counted. `runBloomSafety`
+  --     separately proves the typed composer and Patch refuse it all-or-nothing.
   if over.excl == 0 then
     IO.println s!"        COVERAGE VIOLATION: knob-max β did not exceed the depth cap — excludedDepth is never exercised, so 'counted not silent' is untested"
     ok := false
   if ok then
-    passGate "seam-coverage" s!"the shipped register classifies TOTALLY: admitted fraction {admitFrac} (0 depth drops, worst SAMPLED depth {maxDepth} < 300 — measured headroom, Halton + corner scan), all four served regions reachable, excludedDepth counted off-surface ({over.excl}/{over.total})"
+    passGate "seam-coverage" s!"the shipped register classifies TOTALLY: admitted fraction {admitFrac} (0 exclusions, worst SAMPLED depth {maxDepth} < 300 — measured headroom, Halton + corner scan), all four served regions reachable, excludedDepth counted off-surface ({over.excl}/{over.total})"
   else
     failGate "seam-coverage" "the region partition is not total over the shipped register — see the lines above"
+
+/-- M3-A stop-line gate: the measured negative-integer witness and its exact
+    boundary, the conservative live-interval conjunction edge, the real default
+    21×32 register/room endpoint census, κ=0 identity classification, and explicit
+    Patch refusal with no partial/bare-room fallback. -/
+def runBloomSafety (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let g : Float := 1.8
+  let B : Float := 0.05 / g
+  let mu : CplxB := ⟨-0.5, tp * 413.867122763⟩
+  let planAt := fun (reA : Float) (b : Float) =>
+    let nu := mu.add ⟨g * reA, 0⟩
+    classifyBloomPair mu nu b g
+  let hazard := planAt (-0.98) B
+  let metric := bloomConditioningMetric hazard.aC
+  let boundary := planAt (-1.0 + bloomConditioningRadius) B
+  let outside := planAt (-1.0 + bloomConditioningRadius + 0.0009765625) B
+  let latticeEnd := planAt (-300.0 + bloomConditioningRadius) 1.0
+  let equalityRefused := bloomExcludedConditioningD
+    (⟨-0.984375, 0⟩ : CplxB).toExact (⟨0.015625, 0⟩ : CplxB).toExact
+  let k0 := planAt (-0.98) 0.0
+  let k0ExactPole := planAt (-1.0) 0.0
+  let k0Live := !bloomExcludedConditioningLive (-1.0) (-1.0) 0.0 ⟨0, 0⟩
+  let tunedOk := hazard.region == .excludedConditioning && metric < bloomConditioningRadius
+    && boundary.region == .excludedConditioning
+    && outside.region != .excludedConditioning
+    && latticeEnd.region == .excludedConditioning
+    && equalityRefused
+    && k0.region != .excludedConditioning
+    && k0ExactPole.region != .excludedConditioning && k0Live
+  -- The disc is witnessed at the left/centre end while the crossing is reached
+  -- only at the right edge. This is the conjunction the former coupled-point
+  -- check missed.
+  let liveEdge := bloomExcludedConditioningLive (-2.0) (-1.96875) 0.0 ⟨0.98, 0⟩
+  let liveNoCross := !bloomExcludedConditioningLive (-2.0) (-1.96875) 0.0 ⟨0.96, 0⟩
+  let liveReversed := bloomExcludedConditioningLive (-1.96875) (-2.0) 0.0 ⟨0.98, 0⟩
+  let liveIm := bloomExcludedConditioningLive (-1.0) (-1.0) 0.015625 ⟨0.1, 0⟩
+  let liveImOutside := !bloomExcludedConditioningLive (-1.0) (-1.0) 0.04 ⟨0.1, 0⟩
+
+  -- Actual default structures: 13 full + 8 half gong modes against the emitted
+  -- 32-mode ordinary room, classified at both rt60 damping endpoints.
+  let (full, half) := defaultGongModes 110.0
+  let room := Tropical.Playground.bakedReverbProbe 32
+  let sLo : Float := 6.91 / 12.0
+  let sHi : Float := 6.91 / 0.2
+  let mut endpointTotal := 0
+  let mut endpointExcluded := 0
+  let mut liveExcluded := 0
+  for vb in #[(full, B), (half, B * 0.5)] do
+    for v in vb.1 do
+      let some vs := sigConstF? v.sigma | liveExcluded := liveExcluded + room.size; continue
+      let some vo := sigConstF? v.omega | liveExcluded := liveExcluded + room.size; continue
+      let vmu : CplxB := ⟨-vs, vo⟩
+      for r in room do
+        let some ro := sigConstF? r.omega | liveExcluded := liveExcluded + 1; continue
+        match classifyBloomPairLiveChecked vmu ro sLo sHi vb.2 g with
+        | .ok _ => pure ()
+        | .error _ => liveExcluded := liveExcluded + 1
+        for rs in #[sLo, sHi] do
+          endpointTotal := endpointTotal + 1
+          match (classifyBloomPair vmu ⟨-rs, ro⟩ vb.2 g).region with
+          | .excludedConditioning | .excludedDepth =>
+            endpointExcluded := endpointExcluded + 1
+          | _ => pure ()
+  let censusOk := full.size == 13 && half.size == 8 && room.size == 32
+    && endpointTotal == 1344 && endpointExcluded == 0 && liveExcluded == 0
+
+  -- One safe and one unsafe pair: the typed result must contain no partial bank,
+  -- and Patch lowering must name the conditioning refusal. Bare bloom is intact.
+  let unsafeNu := mu.add ⟨g * (-0.98), 0⟩
+  let mkModePole := fun (p : CplxB) =>
+    ({ sigma := litF (-p.re), omega := litF p.im, cre := lit 1 } : ModalMode)
+  let voices := #[mkModePole mu, mkMode 610.0 1.0 0.5 |>.toModal]
+  let rooms := #[mkModePole unsafeNu]
+  let comp := bloomComposeChecked voices rooms B g
+  let safeMu : CplxB := ⟨-1.0, tp * 610.0⟩
+  let safePlan := classifyBloomPair safeMu unsafeNu B g
+  let mixedRefusal := !comp.isComplete && comp.pairs.isEmpty && comp.expectedPairs == 2
+    && safePlan.region != .excludedConditioning && safePlan.region != .excludedDepth
+    && comp.exclusions.size == 1 && match comp.exclusions[0]? with
+      | some x => x.voiceIndex == some 0 && x.roomIndex == some 0 && x.reason == .excludedConditioning
+      | none => false
+  let crossed : PatchGraph :=
+    { nodes := #[{ id := "src", node := .modalSource voices anchorSig clockLit none none (some (B, g)) },
+                 { id := "rev", node := .modalReverb "src" rooms none }], output := "rev" }
+  let bare : PatchGraph :=
+    { nodes := #[{ id := "src", node := .modalSource voices anchorSig clockLit none none (some (B, g)) }],
+      output := "src" }
+  let patchRefused := match lowerGraph crossed with
+    | .error e => (e.splitOn "excludedConditioning").length > 1
+    | .ok _ => false
+  let bareOk := match lowerGraph bare with | .ok _ => true | .error _ => false
+
+  -- Exact κ=0, a=-1: empty Horner identity, complete composition, finite render;
+  -- the live point classifier takes the same zero-depth route.
+  let k0Nu := mu.add ⟨-g, 0⟩
+  let k0Comp := bloomComposeChecked #[mkModePole mu] #[mkModePole k0Nu] 0.0 g
+  let k0LivePlan := classifyBloomPairLiveChecked mu mu.im (-k0Nu.re) (-k0Nu.re) 0.0 g
+  let k0Typed := k0Comp.isComplete && k0Comp.pairs.size == 1 && match k0LivePlan with
+    | .ok { region := .serOnly, nDepth, kDepth } => nDepth == 0 && kDepth == 0
+    | .ok { region := .crossing, .. } => false
+    | .error _ => false
+  let k0Render ← match k0Comp.toOption with
+    | some ps => renderConfig arena "bloom_kappa_zero" (bloomComposedSig ps clockLit anchorSig)
+    | none => pure (.error "κ=0 composition refused")
+  let k0Ref ← renderConfig arena "bloom_kappa_zero_ref"
+    (modalBankSig (residueComposeEC #[mkModePole mu] #[mkModePole k0Nu]) clockLit anchorSig)
+  let k0Error := match k0Render, k0Ref with
+    | .ok xs, .ok ys => relL2Win xs ys (anchorNat + 1) nProbe
+    | _, _ => 1.0
+  let k0RenderOk := match k0Render, k0Ref with
+    | .ok xs, .ok ys => allFinite xs && allFinite ys && k0Error < 3e-4
+    | _, _ => false
+
+  -- Depth exclusion is the same all-or-nothing contract as conditioning.
+  let depthB : Float := 0.5 / g
+  let depthMu : CplxB := ⟨-0.2, tp * 1023.0⟩
+  let depthNu : CplxB := ⟨-0.58, tp * 500.0⟩
+  let depthComp := bloomComposeChecked #[mkModePole depthMu] #[mkModePole depthNu] depthB g
+  let depthGraph : PatchGraph :=
+    { nodes := #[{ id := "src", node := .modalSource #[mkModePole depthMu] anchorSig clockLit none none (some (depthB, g)) },
+                 { id := "rev", node := .modalReverb "src" #[mkModePole depthNu] none }], output := "rev" }
+  let depthTyped := !depthComp.isComplete && depthComp.pairs.isEmpty
+    && depthComp.exclusions.size == 1 && match depthComp.exclusions[0]? with
+      | some x => x.voiceIndex == some 0 && x.roomIndex == some 0 && x.reason == .excludedDepth
+      | none => false
+  let depthPatch := match lowerGraph depthGraph with
+    | .error e => (e.splitOn "excludedDepth").length > 1
+    | .ok _ => false
+
+  IO.println s!"bloom M3-A safety: metric {metric} (radius {bloomConditioningRadius}) · live conjunction {liveEdge}/{liveNoCross}, reverse {liveReversed}, im {liveIm}/{liveImOutside} · default endpoints {endpointTotal} excluded {endpointExcluded}, live excluded {liveExcluded} · conditioning refusal {mixedRefusal}/{patchRefused}, depth {depthTyped}/{depthPatch}, κ0 {k0Typed}/{k0RenderOk} rel {k0Error}, bare {bareOk}"
+  if tunedOk && liveEdge && liveNoCross && liveReversed && liveIm && liveImOutside
+      && censusOk && mixedRefusal && patchRefused && depthTyped && depthPatch
+      && k0Typed && k0RenderOk && bareOk then
+    passGate "bloom-safety" s!"conditioning is named/refused at a≈-0.98, -300, exact disc/equality edges, reversed intervals, and nonzero-im live points; exact κ=0,a=-1 composes with an empty Horner and matches the unwarped residue atom (rel {k0Error}); the actual 21×32 default endpoint box is total; conditioning and depth refuse all-or-nothing with exact pair indices; bare bloom remains intact"
+  else
+    failGate "bloom-safety" s!"tuned={tunedOk} live={liveEdge}/{liveNoCross}/{liveReversed}/{liveIm}/{liveImOutside} census={censusOk} mixed={mixedRefusal} patch={patchRefused} depth={depthTyped}/{depthPatch} k0={k0Typed}/{k0RenderOk} bare={bareOk}"
 
 -- ── WS-CL: the lane-tidying bit-clean witness ─────────────────────────────────
 

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -45,7 +45,7 @@ open Tropical.Ir (Arena ProgramIdx)
     reported as the total collapse it is; the `arrow-block-count` gate at the end
     of `main` checks the number against what the block actually ran, so it is
     verified rather than maintained. -/
-def arrowBlockGates : Nat := 98
+def arrowBlockGates : Nat := 99
 
 set_option maxRecDepth 1024 in
 def main (args : List String) : IO UInt32 := do
@@ -485,6 +485,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runSeamCoverage arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← Tropical.Tropicaltest.SeamSweep.runBloomSafety arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← Tropical.Tropicaltest.SeamSweep.runSeamLaneClean arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -45,7 +45,7 @@ open Tropical.Ir (Arena ProgramIdx)
     reported as the total collapse it is; the `arrow-block-count` gate at the end
     of `main` checks the number against what the block actually ran, so it is
     verified rather than maintained. -/
-def arrowBlockGates : Nat := 96
+def arrowBlockGates : Nat := 97
 
 set_option maxRecDepth 1024 in
 def main (args : List String) : IO UInt32 := do
@@ -494,6 +494,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runModalPatch arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runModalForestAnchors arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runModalLive arena resolved) then

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -45,7 +45,7 @@ open Tropical.Ir (Arena ProgramIdx)
     reported as the total collapse it is; the `arrow-block-count` gate at the end
     of `main` checks the number against what the block actually ran, so it is
     verified rather than maintained. -/
-def arrowBlockGates : Nat := 97
+def arrowBlockGates : Nat := 98
 
 set_option maxRecDepth 1024 in
 def main (args : List String) : IO UInt32 := do
@@ -497,6 +497,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runModalForestAnchors arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← runModalForestTimedIslands arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runModalLive arena resolved) then


### PR DESCRIPTION
## Summary

- preserve authored order and independent strike anchors when modal branches are mixed
- retain mixed plain and bloomed branches instead of prematurely collapsing their realization metadata
- prove forward, hold, reverse, and seek behavior against the explicit branch sum for a 16-island heterogeneous score
- make bloom conditioning and depth admission typed, conservative, indexed, and all-or-nothing

## Product boundary

This PR lands the modal-forest semantics and safety foundation only. The served `gong` remains signal-valued and `bloomgong` remains withheld. It does not include the rejected timed-bloom batch terminal, live-beta planner, Metal diagnostic, generalized-room assets, or any demo material.

## Validation

- `make validate`: native modal/safety suite green, Bun 117 pass / 1 no-device skip / 0 fail, CTest 4/4
- same-anchor modal union remains byte-identical
- 16 independently timed mixed branches match their explicit sum byte-for-byte for forward, hold, reverse, and seek
- the shipped default bloom box is total; unsupported conditioning/depth cases refuse the whole typed composition with exact pair indices

## Scope hygiene

Eleven Lean source/test files only. No sprint documents, captures, qualification streams, demo scenes, generated objects, batch-terminal code, or benchmark output.
