### PR TITLE
Bound aggregate Metal coefficient columns

### DIFF
--- a/engine/runtime/FlatRuntime.cpp
+++ b/engine/runtime/FlatRuntime.cpp
@@ -629,7 +629,14 @@ FlatRuntime::load_ir_staged_with_observation_generation(
          new_state.coeff_generations[
            std::atomic_ref(new_state.control_published_gen)
              .load(std::memory_order_relaxed)])
+    {
+      if (column.size() > std::numeric_limits<uint32_t>::max()
+          || column_floats
+               > std::numeric_limits<uint32_t>::max() - column.size())
+        throw std::runtime_error(
+          "FlatRuntime: aggregate Metal coefficient columns exceed uint32");
       column_floats += column.size();
+    }
     new_state.metal = tropical_metal::create(
       audio_msl_source, metal_render_tile_frames_,
       static_cast<uint32_t>(new_state.slots.size()),


### PR DESCRIPTION
## Summary

- reject aggregate Metal coefficient-column totals that cannot be represented by the runtime's `uint32_t` ABI
- check both an individually oversized column and overflow while summing columns
- keep the rejected timed-bloom terminal and its batch-specific admission logic out of this PR

## Validation

- runtime/native build: pass
- CTest: 4/4 pass
- full repository CI required before merge

## Scope

One product source file, seven added lines. No generated objects, diagnostics, benchmark output, or terminal-specific code.
