### PR TITLE
Add source-generic grouped-room reference

### DIFF
--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -1,8 +1,10 @@
 import Tropical.EmitArrow.Modal.Realize
+import Tropical.EmitArrow.Modal.GroupedRoomReference
 
 /-!
 # EmitArrow.Modal
 
 Stable aggregate import for modal residue algebra, bloom composition, live-pole
-classification, and signal realization.
+classification, signal realization, and the internal source-generic grouped-room
+reference.
 -/

--- a/lean/Tropical/EmitArrow/Modal/GroupedRoomReference.lean
+++ b/lean/Tropical/EmitArrow/Modal/GroupedRoomReference.lean
@@ -70,6 +70,7 @@ structure RoomReferenceGroup where
     produced it.  Pole coordinates/residues and generated prefixes live here,
     never in `RoomProfile`. -/
 structure RoomReferenceSpecialization where
+  private mk ::
   profileId : String
   profileVersion : Nat
   evaluatorVersion : String
@@ -87,6 +88,26 @@ private def exclusion (kind : RoomExclusionKind) (detail : String)
 
 private def jsonD (n : Lean.JsonNumber) : DyadicI := DyadicI.ofJsonNumber n
 
+/-- The evaluator emits exact, twelve-place decimal literals and refuses any
+    generated coefficient outside this fixed envelope.  The bound is part of
+    the v1 evaluator contract: prefix growth can never reach `litF`'s lossy
+    UInt64 path or hand an unbounded coefficient to the runtime. -/
+private def roomPrefixMagnitudeLimit : DyadicI := DyadicI.ofNat 1000000
+
+private def withinPrefixEnvelope (x : DyadicI) : Bool :=
+  x.ok && Dyadic.ble (DyadicI.abs x).hi roomPrefixMagnitudeLimit.lo
+
+/-- Deterministic exact-carrier emission.  The mantissa is computed in
+    unbounded `Int` arithmetic, after the fixed evaluator envelope is checked;
+    no intermediate `Float` or `UInt64` can saturate. -/
+private def emittedD? (x : DyadicI) : Option Sig :=
+  if withinPrefixEnvelope x then
+    let mantissa := Dyadic.toDecimalMantissa (DyadicI.mid x) 12
+    -- `JsonNumber`'s textual form for zero with a decimal exponent is not a
+    -- valid JSON numeral (`0.e-…`); canonical zero has no exponent.
+    some (if mantissa == 0 then lit 0 else lit mantissa 12)
+  else none
+
 private def containsI (lo hi x : DyadicI) : Bool :=
   lo.ok && hi.ok && x.ok && Dyadic.ble lo.lo x.lo && Dyadic.ble x.hi hi.hi
 
@@ -99,10 +120,21 @@ private def validDomain (d : RoomPoleDomain) : Bool :=
     !DyadicI.certLt f0 DyadicI.zero && DyadicI.certLt f0 f1 &&
     DyadicI.certGt s0 DyadicI.zero && DyadicI.certLt s0 s1
 
-private def sourcePole? (m : ModalMode) : Option (DyadicI × DyadicI) := do
-  let sigma ← sigConstD? m.sigma
-  let omega ← sigConstD? m.omega
-  if sigma.ok && omega.ok then some (sigma, omega) else none
+private inductive SourcePoleRead where
+  | nonconstant
+  | nonfinite
+  | value (sigma omega : DyadicI)
+
+private def sourcePoleRead (m : ModalMode) : SourcePoleRead :=
+  match sigConstD? m.sigma, sigConstD? m.omega with
+  | none, _ | _, none => .nonconstant
+  | some sigma, some omega =>
+    if sigma.ok && omega.ok then .value sigma omega else .nonfinite
+
+private def sourcePole? (m : ModalMode) : Option (DyadicI × DyadicI) :=
+  match sourcePoleRead m with
+  | .value sigma omega => some (sigma, omega)
+  | _ => none
 
 private def collectAdmissionExclusions (profile : RoomProfile)
     (sampleRate : Nat) (modes : Array ModalMode) : Array RoomExclusion := Id.run do
@@ -169,25 +201,28 @@ private def collectAdmissionExclusions (profile : RoomProfile)
   let fHi := jsonD profile.admission.poles.maxFrequencyHz
   let sLo := jsonD profile.admission.poles.minSigma
   let sHi := jsonD profile.admission.poles.maxSigma
-  let twoPi := Tropical.Exact.twoPiI
+  -- Admission uses the same authored decimal constant as `ModalMode.hz`.
+  -- That makes the documented inclusive Hz boundary attainable exactly.
+  let twoPi := jsonD ⟨6283185307179586, 15⟩
   for (mode, row) in modes.zipIdx do
     if mode.deg != 0 then
       out := out.push (exclusion .unsupportedDegree
         s!"degree {mode.deg} is unsupported; the reference admits degree zero"
         (some row))
-    match sourcePole? mode with
-    | none =>
+    match sourcePoleRead mode with
+    | .nonconstant =>
       out := out.push (exclusion .nonconstantPole
-        "sigma and omega must be finite build-time constants" (some row))
-    | some (sigma, omega) =>
-      if !sigma.ok || !omega.ok then
-        out := out.push (exclusion .nonfinitePole
-          "sigma and omega must be finite" (some row))
-      else
-        let frequency := DyadicI.div (DyadicI.abs omega) twoPi
-        if !containsI sLo sHi sigma || !containsI fLo fHi frequency then
-          out := out.push (exclusion .poleOutOfDomain
-            s!"source pole is outside profile '{profile.id}' admission" (some row))
+        "sigma and omega must be build-time constants" (some row))
+    | .nonfinite =>
+      out := out.push (exclusion .nonfinitePole
+        "sigma and omega must be finite" (some row))
+    | .value sigma omega =>
+      let omegaAbs := DyadicI.abs omega
+      let omegaLo := DyadicI.mul fLo twoPi
+      let omegaHi := DyadicI.mul fHi twoPi
+      if !containsI sLo sHi sigma || !containsI omegaLo omegaHi omegaAbs then
+        out := out.push (exclusion .poleOutOfDomain
+          s!"source pole is outside profile '{profile.id}' admission" (some row))
   return out
 
 private def exactPolePerSample (sigma omega : DyadicI) (sampleRate : Nat) : CplxDI :=
@@ -195,7 +230,10 @@ private def exactPolePerSample (sigma omega : DyadicI) (sampleRate : Nat) : Cplx
   CplxDI.exp ⟨DyadicI.neg (DyadicI.div sigma rate), DyadicI.div omega rate⟩
 
 private def emittedCplx? (z : CplxDI) : Option CplxE :=
-  if z.ok then some (litF z.re.toFloat, litF z.im.toFloat) else none
+  if !z.ok then none else do
+  let re ← emittedD? z.re
+  let im ← emittedD? z.im
+  pure (re, im)
 
 /-- Prefix law computed entirely in the exact bake carrier:
     `A[r] = Σ_{k=0}^r carrier[k]·(radius/pole)^k` and
@@ -245,14 +283,16 @@ def specializeGroupedRoomReference (profile : RoomProfile) (sampleRate : Nat)
   for group in profile.groups do
     let radius := jsonD group.radius
     let logRadius := DyadicI.log radius
-    if !logRadius.ok then
+    let logRadiusE := emittedD? logRadius
+    if !logRadius.ok || logRadiusE.isNone then
       throw { exclusions := #[exclusion .prefixComputation
-        "exact log(radius) failed" none (some groups.size)] }
+        "log(radius) failed or exceeded the v1 coefficient envelope"
+        none (some groups.size)] }
     groups := groups.push {
       id := group.id
       period := group.period
       prefixOffset := prefixStride
-      logRadius := litF logRadius.toFloat }
+      logRadius := logRadiusE.get! }
     prefixStride := prefixStride + group.period
 
   let mut forwardPrefix : Array CplxE := #[]
@@ -335,8 +375,8 @@ private def cselectE (c : Sig) (a b : CplxE) : CplxE :=
 /-- `exp((-sigma+i*omega)t/Fs)`, with `t` in samples.  The caller supplies a
     clock already made relative in integer Q32.32, so far absolute seeks do not
     spend phase or envelope mantissa bits. -/
-private def roomPoleExpSamples (sigma omega t : Sig) : CplxE :=
-  let sec := div t .sampleRate
+private def roomPoleExpSamples (bakedRate sigma omega t : Sig) : CplxE :=
+  let sec := div t bakedRate
   let env := roomExpSig (neg (mul sigma sec))
   let phase := mul omega sec
   (mul env (roomCosSig phase), mul env (roomSinSig phase))
@@ -350,14 +390,14 @@ private def complexTableRead (reTable imTable sourceIdx groupOffset residue
   (Sig.index reTable i, Sig.index imTable i)
 
 private def groupedRoomReferencePair (sourceIdx groupIdx : Sig)
-    (sigma omega cre cim position u : Sig)
+    (bakedRate sigma omega cre cim position u : Sig)
     (sourceStride periods logRadii offsets forwardRe forwardIm reverseRe reverseIm : Sig) : Sig :=
   let periodI := toIntE (Sig.index periods groupIdx)
   let periodF := toFloatE periodI
   let logRadius := Sig.index logRadii groupIdx
   let groupOffset := toIntE (Sig.index offsets groupIdx)
   let radiusP := radiusPow logRadius periodF
-  let ep := roomPoleExpSamples sigma omega periodF
+  let ep := roomPoleExpSamples bakedRate sigma omega periodF
   let zP := cscaleE radiusP ep
   let invEp := cdivE (lit 1, lit 0) ep
   let g := cscaleE radiusP invEp
@@ -370,10 +410,10 @@ private def groupedRoomReferencePair (sourceIdx groupIdx : Sig)
   let aR := complexTableRead forwardRe forwardIm sourceIdx groupOffset rI sourceStride
   let aLast := complexTableRead forwardRe forwardIm sourceIdx groupOffset
     (sub periodI (litI 1)) sourceStride
-  let eu := roomPoleExpSamples sigma omega u
+  let eu := roomPoleExpSamples bakedRate sigma omega u
   let pq := mul periodF q
   let gq := cscaleE (radiusPow logRadius pq)
-    (roomPoleExpSamples sigma omega (neg pq))
+    (roomPoleExpSamples bakedRate sigma omega (neg pq))
   let euGq := cmulE eu gq
   let causalDenom : CplxE := (sub (lit 1) g.1, neg g.2)
   let nearOne := ltE
@@ -394,7 +434,7 @@ private def groupedRoomReferencePair (sourceIdx groupIdx : Sig)
   let b := complexTableRead reverseRe reverseIm sourceIdx groupOffset
     (modE d periodI) sourceStride
   let reverseDenom : CplxE := (sub (lit 1) zP.1, neg zP.2)
-  let reversePhase := roomPoleExpSamples sigma omega (add u dF)
+  let reversePhase := roomPoleExpSamples bakedRate sigma omega (add u dF)
   let reverseNumerator := cscaleE (radiusPow logRadius dF)
     (cmulE reversePhase b)
   let reverseResponse := cdivE reverseNumerator reverseDenom
@@ -411,6 +451,7 @@ private def groupedRoomReferencePair (sourceIdx groupIdx : Sig)
 def groupedRoomReferenceSig (specialization : RoomReferenceSpecialization)
     (clk anchor position : Sig) : Sig :=
   if specialization.modes.isEmpty || specialization.groups.isEmpty then lit 0 else
+  let bakedRate := lit specialization.sampleRate
   let sigma := Sig.arr (specialization.modes.map (·.sigma))
   let omega := Sig.arr (specialization.modes.map (·.omega))
   let cre := Sig.arr (specialization.modes.map (·.cre))
@@ -431,12 +472,16 @@ def groupedRoomReferenceSig (specialization : RoomReferenceSpecialization)
     forwardRe, forwardIm, reverseRe, reverseIm]
   let inner := Sig.bankSum specialization.groups.size columns
     (groupedRoomReferencePair sourceIdx groupIdx
+      bakedRate
       (Sig.index sigma sourceIdx) (Sig.index omega sourceIdx)
       (Sig.index cre sourceIdx) (Sig.index cim sourceIdx)
       position u sourceStride periods logRadii offsets
       forwardRe forwardIm reverseRe reverseIm)
     none 4301
-  Sig.bankSum specialization.modes.size columns inner none 4300
+  let room := Sig.bankSum specialization.modes.size columns inner none 4300
+  -- Prefixes and pole evolution are baked against one rate.  A plan with a
+  -- different runtime rate fails closed instead of combining two time bases.
+  selectE (.binary .eq .sampleRate bakedRate) room (lit 0)
 
 /-- Arrow terminal over the caller's clock rail.  POSITION is live; room amount
     remains an external gain. -/

--- a/lean/Tropical/EmitArrow/Modal/GroupedRoomReference.lean
+++ b/lean/Tropical/EmitArrow/Modal/GroupedRoomReference.lean
@@ -1,0 +1,447 @@
+import Tropical.EmitArrow.Modal.RoomProfile
+import Tropical.EmitArrow.Modal.Residue
+
+/-!
+# Graph-specialized grouped-room reference
+
+This is the deliberately internal Plan-5 M5 reference.  It specializes one
+source-independent `RoomProfile` against one arbitrary admitted modal island,
+materializing forward and cyclic-future prefix tables as coefficient arrays.
+It is an executable semantic oracle and cost probe, not a public node, asset
+format, accepted acoustic profile, or production batching decision.
+-/
+
+namespace Tropical.EmitArrow
+
+open Tropical.Ir
+open Tropical.Exact (DyadicI CplxDI)
+
+inductive RoomExclusionKind where
+  | invalidProfileIdentity
+  | unsupportedEvaluator
+  | invalidSampleRate
+  | sampleRateMismatch
+  | invalidPoleDomain
+  | branchCapacity
+  | groupCapacity
+  | invalidCarrier
+  | sourceCapacity
+  | generatedScalarCapacity
+  | unsupportedDegree
+  | nonconstantPole
+  | nonfinitePole
+  | poleOutOfDomain
+  | prefixComputation
+deriving Repr, DecidableEq
+
+/-- One indexed reason the complete specialization request was refused. -/
+structure RoomExclusion where
+  kind : RoomExclusionKind
+  row? : Option Nat := none
+  group? : Option Nat := none
+  detail : String
+deriving Repr, DecidableEq
+
+/-- Admission is all-or-nothing.  Every independently detectable exclusion is
+    reported, and no partially generated specialization escapes. -/
+structure RoomRefusal where
+  exclusions : Array RoomExclusion
+deriving Repr, DecidableEq
+
+def RoomExclusion.summary (x : RoomExclusion) : String :=
+  let where_ := match x.row?, x.group? with
+    | some r, some g => s!"row {r}, group {g}: "
+    | some r, none => s!"row {r}: "
+    | none, some g => s!"group {g}: "
+    | none, none => ""
+  s!"{where_}{x.detail}"
+
+def RoomRefusal.summary (x : RoomRefusal) : String :=
+  String.intercalate "; " (x.exclusions.toList.map RoomExclusion.summary)
+
+/-- Runtime metadata derived from a room-only carrier group. -/
+structure RoomReferenceGroup where
+  id : String
+  period : Nat
+  prefixOffset : Nat
+  logRadius : Sig
+
+/-- Source-dependent cache material, named separately from the profile that
+    produced it.  Pole coordinates/residues and generated prefixes live here,
+    never in `RoomProfile`. -/
+structure RoomReferenceSpecialization where
+  profileId : String
+  profileVersion : Nat
+  evaluatorVersion : String
+  sampleRate : Nat
+  modes : Array ModalMode
+  groups : Array RoomReferenceGroup
+  prefixStride : Nat
+  forwardPrefix : Array CplxE
+  reversePrefix : Array CplxE
+  generatedScalarCount : Nat
+
+private def exclusion (kind : RoomExclusionKind) (detail : String)
+    (row? group? : Option Nat := none) : RoomExclusion :=
+  { kind, row?, group?, detail }
+
+private def jsonD (n : Lean.JsonNumber) : DyadicI := DyadicI.ofJsonNumber n
+
+private def containsI (lo hi x : DyadicI) : Bool :=
+  lo.ok && hi.ok && x.ok && Dyadic.ble lo.lo x.lo && Dyadic.ble x.hi hi.hi
+
+private def validDomain (d : RoomPoleDomain) : Bool :=
+  let f0 := jsonD d.minFrequencyHz
+  let f1 := jsonD d.maxFrequencyHz
+  let s0 := jsonD d.minSigma
+  let s1 := jsonD d.maxSigma
+  f0.ok && f1.ok && s0.ok && s1.ok &&
+    !DyadicI.certLt f0 DyadicI.zero && DyadicI.certLt f0 f1 &&
+    DyadicI.certGt s0 DyadicI.zero && DyadicI.certLt s0 s1
+
+private def sourcePole? (m : ModalMode) : Option (DyadicI × DyadicI) := do
+  let sigma ← sigConstD? m.sigma
+  let omega ← sigConstD? m.omega
+  if sigma.ok && omega.ok then some (sigma, omega) else none
+
+private def collectAdmissionExclusions (profile : RoomProfile)
+    (sampleRate : Nat) (modes : Array ModalMode) : Array RoomExclusion := Id.run do
+  let mut out : Array RoomExclusion := #[]
+  if profile.id.isEmpty || profile.profileVersion == 0 then
+    out := out.push (exclusion .invalidProfileIdentity
+      "profile id must be nonempty and profileVersion must be positive")
+  if profile.evaluatorVersion != groupedRoomReferenceEvaluatorVersion then
+    out := out.push (exclusion .unsupportedEvaluator
+      s!"unsupported evaluator '{profile.evaluatorVersion}'")
+  if profile.sampleRate == 0 then
+    out := out.push (exclusion .invalidSampleRate "profile sample rate must be positive")
+  if sampleRate != profile.sampleRate then
+    out := out.push (exclusion .sampleRateMismatch
+      s!"profile requires {profile.sampleRate} Hz; specialization requested {sampleRate} Hz")
+  if !validDomain profile.admission.poles then
+    out := out.push (exclusion .invalidPoleDomain
+      "pole bounds must be finite ordered ranges with sigma > 0 and frequency >= 0")
+  if profile.admission.maxBranches < 1 then
+    out := out.push (exclusion .branchCapacity
+      "the one-island reference requires maxBranches >= 1")
+  if profile.groups.isEmpty then
+    out := out.push (exclusion .invalidCarrier "profile must contain at least one carrier group")
+  if profile.groups.size > profile.admission.maxCarrierGroups then
+    out := out.push (exclusion .groupCapacity
+      s!"{profile.groups.size} groups exceed capacity {profile.admission.maxCarrierGroups}")
+
+  let mut seenIds : Array String := #[]
+  let mut prefixStride := 0
+  for (group, gi) in profile.groups.zipIdx do
+    let radius := jsonD group.radius
+    if group.id.isEmpty || seenIds.contains group.id then
+      out := out.push (exclusion .invalidCarrier
+        "carrier group ids must be nonempty and unique" none (some gi))
+    else
+      seenIds := seenIds.push group.id
+    if group.period == 0 || group.period != group.carrier.size then
+      out := out.push (exclusion .invalidCarrier
+        s!"period {group.period} does not match carrier length {group.carrier.size}"
+        none (some gi))
+    if group.period > profile.admission.maxPeriod then
+      out := out.push (exclusion .invalidCarrier
+        s!"period {group.period} exceeds capacity {profile.admission.maxPeriod}"
+        none (some gi))
+    if !radius.ok || !DyadicI.certGt radius DyadicI.zero ||
+        !DyadicI.certLt radius DyadicI.one then
+      out := out.push (exclusion .invalidCarrier
+        "radius must be finite and strictly inside (0, 1)" none (some gi))
+    for sample in group.carrier do
+      if !(jsonD sample).ok then
+        out := out.push (exclusion .invalidCarrier
+          "carrier samples must be finite decimals" none (some gi))
+    prefixStride := prefixStride + group.period
+
+  if modes.size > profile.admission.maxSourceRows then
+    out := out.push (exclusion .sourceCapacity
+      s!"{modes.size} source rows exceed capacity {profile.admission.maxSourceRows}")
+  let scalarCount := 4 * modes.size * prefixStride
+  if scalarCount > profile.admission.maxGeneratedScalars || scalarCount > 4294967295 then
+    out := out.push (exclusion .generatedScalarCapacity
+      s!"{scalarCount} generated scalars exceed the admitted/Plan-5 limit")
+
+  let fLo := jsonD profile.admission.poles.minFrequencyHz
+  let fHi := jsonD profile.admission.poles.maxFrequencyHz
+  let sLo := jsonD profile.admission.poles.minSigma
+  let sHi := jsonD profile.admission.poles.maxSigma
+  let twoPi := Tropical.Exact.twoPiI
+  for (mode, row) in modes.zipIdx do
+    if mode.deg != 0 then
+      out := out.push (exclusion .unsupportedDegree
+        s!"degree {mode.deg} is unsupported; the reference admits degree zero"
+        (some row))
+    match sourcePole? mode with
+    | none =>
+      out := out.push (exclusion .nonconstantPole
+        "sigma and omega must be finite build-time constants" (some row))
+    | some (sigma, omega) =>
+      if !sigma.ok || !omega.ok then
+        out := out.push (exclusion .nonfinitePole
+          "sigma and omega must be finite" (some row))
+      else
+        let frequency := DyadicI.div (DyadicI.abs omega) twoPi
+        if !containsI sLo sHi sigma || !containsI fLo fHi frequency then
+          out := out.push (exclusion .poleOutOfDomain
+            s!"source pole is outside profile '{profile.id}' admission" (some row))
+  return out
+
+private def exactPolePerSample (sigma omega : DyadicI) (sampleRate : Nat) : CplxDI :=
+  let rate := DyadicI.ofNat sampleRate
+  CplxDI.exp ⟨DyadicI.neg (DyadicI.div sigma rate), DyadicI.div omega rate⟩
+
+private def emittedCplx? (z : CplxDI) : Option CplxE :=
+  if z.ok then some (litF z.re.toFloat, litF z.im.toFloat) else none
+
+/-- Prefix law computed entirely in the exact bake carrier:
+    `A[r] = Σ_{k=0}^r carrier[k]·(radius/pole)^k` and
+    `B[r] = Σ_{s=0}^{P-1} carrier[(r+s)%P]·(pole·radius)^s`. -/
+private def specializePrefixPair (mode : ModalMode) (group : RoomCarrierGroup)
+    (sampleRate : Nat) : Option (Array CplxE × Array CplxE) := do
+  let (sigma, omega) ← sourcePole? mode
+  let radius := jsonD group.radius
+  let pole := exactPolePerSample sigma omega sampleRate
+  let ratio := CplxDI.div (CplxDI.ofI radius) pole
+  let futureStep := CplxDI.scale radius pole
+  if !ratio.ok || !futureStep.ok then none else
+  let forwardD : Array CplxDI := Id.run do
+    let mut out : Array CplxDI := #[]
+    let mut acc := CplxDI.zero
+    let mut power := CplxDI.one
+    for k in [0:group.period] do
+      let c := jsonD group.carrier[k]!
+      acc := CplxDI.add acc (CplxDI.scale c power)
+      out := out.push acc
+      power := CplxDI.mul power ratio
+    return out
+  let reverseD : Array CplxDI := Id.run do
+    let mut out : Array CplxDI := #[]
+    for r in [0:group.period] do
+      let mut acc := CplxDI.zero
+      let mut power := CplxDI.one
+      for s in [0:group.period] do
+        let c := jsonD group.carrier[(r + s) % group.period]!
+        acc := CplxDI.add acc (CplxDI.scale c power)
+        power := CplxDI.mul power futureStep
+      out := out.push acc
+    return out
+  let forward ← forwardD.mapM emittedCplx?
+  let reverse ← reverseD.mapM emittedCplx?
+  pure (forward, reverse)
+
+/-- Specialize one complete modal island against a source-independent profile.
+    Prefixes depend on `(sigma, omega)` only; `cre`, `cim`, and the later anchor
+    remain live graph data. -/
+def specializeGroupedRoomReference (profile : RoomProfile) (sampleRate : Nat)
+    (modes : Array ModalMode) : Except RoomRefusal RoomReferenceSpecialization := do
+  let exclusions := collectAdmissionExclusions profile sampleRate modes
+  if !exclusions.isEmpty then throw { exclusions }
+  let mut groups : Array RoomReferenceGroup := #[]
+  let mut prefixStride := 0
+  for group in profile.groups do
+    let radius := jsonD group.radius
+    let logRadius := DyadicI.log radius
+    if !logRadius.ok then
+      throw { exclusions := #[exclusion .prefixComputation
+        "exact log(radius) failed" none (some groups.size)] }
+    groups := groups.push {
+      id := group.id
+      period := group.period
+      prefixOffset := prefixStride
+      logRadius := litF logRadius.toFloat }
+    prefixStride := prefixStride + group.period
+
+  let mut forwardPrefix : Array CplxE := #[]
+  let mut reversePrefix : Array CplxE := #[]
+  for (mode, row) in modes.zipIdx do
+    for (group, gi) in profile.groups.zipIdx do
+      match specializePrefixPair mode group sampleRate with
+      | none =>
+        throw { exclusions := #[exclusion .prefixComputation
+          "exact prefix generation failed" (some row) (some gi)] }
+      | some (forward, reverse) =>
+        forwardPrefix := forwardPrefix ++ forward
+        reversePrefix := reversePrefix ++ reverse
+  let generatedScalarCount := 2 * (forwardPrefix.size + reversePrefix.size)
+  pure {
+    profileId := profile.id
+    profileVersion := profile.profileVersion
+    evaluatorVersion := profile.evaluatorVersion
+    sampleRate
+    modes
+    groups
+    prefixStride
+    forwardPrefix
+    reversePrefix
+    generatedScalarCount }
+
+private def floorE (x : Sig) : Sig := .unary .floor x
+private def ceilE (x : Sig) : Sig := .unary .ceil x
+private def sqrtE (x : Sig) : Sig := .unary .sqrt x
+private def ltE (a b : Sig) : Sig := .binary .lt a b
+private def gteE (a b : Sig) : Sig := .binary .gte a b
+private def floorDivE (a b : Sig) : Sig := .binary .floorDiv a b
+private def modE (a b : Sig) : Sig := .binary .mod a b
+
+/-- Longer local polynomials keep the executable reference close to its direct
+    analytic oracle without changing the incumbent modal-bank kernels. -/
+private def roomSinSig (x : Sig) : Sig :=
+  let n := roundE (mul x (lit 3183098861837907 16))
+  let r := sub x (mul n (lit 3141592653589793 15))
+  let sign := sub (lit 1) (mul (lit 2) (bitAnd n (lit 1)))
+  let z := mul r r
+  let p :=
+    add (lit (-166666666666666667) 18) (mul z (
+    add (lit 833333333333333333 20) (mul z (
+    add (lit (-198412698412698413) 21) (mul z (
+    add (lit 275573192239858907 23) (mul z (
+    add (lit (-250521083854417188) 25) (mul z (
+    add (lit 160590438368216146 27) (mul z (
+    add (lit (-764716373181981648) 30) (mul z
+        (lit 281145725434552076 32))))))))))))))
+  mul sign (mul r (add (lit 1) (mul z p)))
+
+private def roomCosSig (x : Sig) : Sig := roomSinSig (add x halfPiE)
+
+private def roomExpSig (x : Sig) : Sig :=
+  let clamped := clampE x (lit (-87)) (lit 88)
+  let n := roundE (mul clamped (lit 14426950408889634 16))
+  let r := sub (sub clamped (mul n (lit 693145751953125 15)))
+                            (mul n (lit 14286068203094173 22))
+  let p :=
+    add (lit 5 1) (mul r (
+    add (lit 166666666666666667 18) (mul r (
+    add (lit 416666666666666667 19) (mul r (
+    add (lit 833333333333333333 20) (mul r (
+    add (lit 138888888888888889 20) (mul r (
+    add (lit 198412698412698413 21) (mul r (
+    add (lit 248015873015873016 22) (mul r (
+    add (lit 275573192239858907 23) (mul r (
+    add (lit 275573192239858907 24) (mul r (
+    add (lit 250521083854417188 25) (mul r
+        (lit 208767569878680989 26))))))))))))))))))))
+  ldexpE (add (lit 1) (mul r (add (lit 1) (mul r p)))) n
+
+private def cscaleE (s : Sig) (z : CplxE) : CplxE :=
+  (mul s z.1, mul s z.2)
+
+private def cselectE (c : Sig) (a b : CplxE) : CplxE :=
+  (selectE c a.1 b.1, selectE c a.2 b.2)
+
+/-- `exp((-sigma+i*omega)t/Fs)`, with `t` in samples.  The caller supplies a
+    clock already made relative in integer Q32.32, so far absolute seeks do not
+    spend phase or envelope mantissa bits. -/
+private def roomPoleExpSamples (sigma omega t : Sig) : CplxE :=
+  let sec := div t .sampleRate
+  let env := roomExpSig (neg (mul sigma sec))
+  let phase := mul omega sec
+  (mul env (roomCosSig phase), mul env (roomSinSig phase))
+
+private def radiusPow (logRadius exponent : Sig) : Sig :=
+  roomExpSig (mul logRadius exponent)
+
+private def complexTableRead (reTable imTable sourceIdx groupOffset residue
+    sourceStride : Sig) : CplxE :=
+  let i := add (add (mul sourceIdx sourceStride) groupOffset) residue
+  (Sig.index reTable i, Sig.index imTable i)
+
+private def groupedRoomReferencePair (sourceIdx groupIdx : Sig)
+    (sigma omega cre cim position u : Sig)
+    (sourceStride periods logRadii offsets forwardRe forwardIm reverseRe reverseIm : Sig) : Sig :=
+  let periodI := toIntE (Sig.index periods groupIdx)
+  let periodF := toFloatE periodI
+  let logRadius := Sig.index logRadii groupIdx
+  let groupOffset := toIntE (Sig.index offsets groupIdx)
+  let radiusP := radiusPow logRadius periodF
+  let ep := roomPoleExpSamples sigma omega periodF
+  let zP := cscaleE radiusP ep
+  let invEp := cdivE (lit 1, lit 0) ep
+  let g := cscaleE radiusP invEp
+
+  let causal := gteE u (lit 0)
+  let m := toIntE (selectE causal (floorE u) (lit 0))
+  let qI := floorDivE m periodI
+  let rI := modE m periodI
+  let q := toFloatE qI
+  let aR := complexTableRead forwardRe forwardIm sourceIdx groupOffset rI sourceStride
+  let aLast := complexTableRead forwardRe forwardIm sourceIdx groupOffset
+    (sub periodI (litI 1)) sourceStride
+  let eu := roomPoleExpSamples sigma omega u
+  let pq := mul periodF q
+  let gq := cscaleE (radiusPow logRadius pq)
+    (roomPoleExpSamples sigma omega (neg pq))
+  let euGq := cmulE eu gq
+  let causalDenom : CplxE := (sub (lit 1) g.1, neg g.2)
+  let nearOne := ltE
+    (sqrtE (add (mul causalDenom.1 causalDenom.1)
+      (mul causalDenom.2 causalDenom.2)))
+    (lit 1 10)
+  let sQ := cselectE nearOne (cscaleE q eu)
+    (cdivE (csubE eu euGq) causalDenom)
+  let forwardNormal := caddE (cmulE aLast sQ) (cmulE aR euGq)
+  let forwardLimit := caddE (cmulE aLast (cscaleE q eu)) (cmulE aR eu)
+  let forwardResponse := cselectE nearOne forwardLimit forwardNormal
+  let forwardReal := selectE causal
+    (sub (mul cre forwardResponse.1) (mul cim forwardResponse.2)) (lit 0)
+
+  let d0 := ceilE (neg u)
+  let d := toIntE (selectE (gt d0 (lit 0)) d0 (lit 0))
+  let dF := toFloatE d
+  let b := complexTableRead reverseRe reverseIm sourceIdx groupOffset
+    (modE d periodI) sourceStride
+  let reverseDenom : CplxE := (sub (lit 1) zP.1, neg zP.2)
+  let reversePhase := roomPoleExpSamples sigma omega (add u dF)
+  let reverseNumerator := cscaleE (radiusPow logRadius dF)
+    (cmulE reversePhase b)
+  let reverseResponse := cdivE reverseNumerator reverseDenom
+  let reverseReal := sub (mul cre reverseResponse.1) (mul cim reverseResponse.2)
+
+  let p := clampE position (lit (-1)) (lit 1)
+  let forwardGain := sqrtE (mul (lit 5 1) (add (lit 1) p))
+  let reverseGain := sqrtE (mul (lit 5 1) (sub (lit 1) p))
+  add (mul forwardGain forwardReal) (mul reverseGain reverseReal)
+
+/-- Evaluate one graph specialization.  The room's prefix tables are Plan-5
+    coefficient arrays; source/group trip counts affect data, not expression
+    size. -/
+def groupedRoomReferenceSig (specialization : RoomReferenceSpecialization)
+    (clk anchor position : Sig) : Sig :=
+  if specialization.modes.isEmpty || specialization.groups.isEmpty then lit 0 else
+  let sigma := Sig.arr (specialization.modes.map (·.sigma))
+  let omega := Sig.arr (specialization.modes.map (·.omega))
+  let cre := Sig.arr (specialization.modes.map (·.cre))
+  let cim := Sig.arr (specialization.modes.map (·.cim))
+  let periods := Sig.arr (specialization.groups.map fun g => lit g.period)
+  let logRadii := Sig.arr (specialization.groups.map (·.logRadius))
+  let offsets := Sig.arr (specialization.groups.map fun g => lit g.prefixOffset)
+  let forwardRe := Sig.arr (specialization.forwardPrefix.map (·.1))
+  let forwardIm := Sig.arr (specialization.forwardPrefix.map (·.2))
+  let reverseRe := Sig.arr (specialization.reversePrefix.map (·.1))
+  let reverseIm := Sig.arr (specialization.reversePrefix.map (·.2))
+  let sourceStride := lit specialization.prefixStride
+  let clkRel := relClockQ clk anchor
+  let u := div (toFloatE clkRel) (lit 4294967296)
+  let sourceIdx := Sig.loopIdx 4300
+  let groupIdx := Sig.loopIdx 4301
+  let columns := #[sigma, omega, cre, cim, periods, logRadii, offsets,
+    forwardRe, forwardIm, reverseRe, reverseIm]
+  let inner := Sig.bankSum specialization.groups.size columns
+    (groupedRoomReferencePair sourceIdx groupIdx
+      (Sig.index sigma sourceIdx) (Sig.index omega sourceIdx)
+      (Sig.index cre sourceIdx) (Sig.index cim sourceIdx)
+      position u sourceStride periods logRadii offsets
+      forwardRe forwardIm reverseRe reverseIm)
+    none 4301
+  Sig.bankSum specialization.modes.size columns inner none 4300
+
+/-- Arrow terminal over the caller's clock rail.  POSITION is live; room amount
+    remains an external gain. -/
+def groupedRoomReferenceTerm (specialization : RoomReferenceSpecialization)
+    (anchor position : Sig) (clk : Clock) : ArrowTerm :=
+  .arrUn (fun c => groupedRoomReferenceSig specialization c anchor position) (.clk clk)
+
+end Tropical.EmitArrow

--- a/lean/Tropical/EmitArrow/Modal/RoomProfile.lean
+++ b/lean/Tropical/EmitArrow/Modal/RoomProfile.lean
@@ -1,0 +1,79 @@
+import Tropical.Exact.Cplx
+
+/-!
+# Source-independent grouped-room profiles
+
+This module is deliberately data-only.  A `RoomProfile` describes periodic
+room carriers and the finite source/capacity envelope in which the internal
+Plan-5 reference may specialize them.  Source poles, residues, strike anchors,
+generated prefix tables, and rendered samples do not belong here.
+
+This is not an asset ABI or a public patch node.  It is the smallest executable
+M5 contract needed to prove that one unchanged room description can accept
+arbitrary admitted modal coordinates before a packaged format is chosen.
+-/
+
+namespace Tropical.EmitArrow
+
+/-- Stable decimal carrier input.  Keeping authored room data as `JsonNumber`
+    lets admission and prefix generation enter the exact interval carrier
+    without a platform `Float` decision. -/
+structure RoomCarrierGroup where
+  id : String
+  period : Nat
+  radius : Lean.JsonNumber
+  carrier : Array Lean.JsonNumber
+deriving Repr, DecidableEq
+
+/-- Inclusive source-pole domain for a source-generic room specialization.
+    Frequency is stated in Hz at the profile boundary; modal rows continue to
+    carry their native `omega` in rad/s. -/
+structure RoomPoleDomain where
+  minFrequencyHz : Lean.JsonNumber
+  maxFrequencyHz : Lean.JsonNumber
+  minSigma : Lean.JsonNumber
+  maxSigma : Lean.JsonNumber
+deriving Repr, DecidableEq
+
+/-- Whole-request resource bounds.  M5's reference consumes one timed island,
+    but `maxBranches` is recorded now so a future forest evaluator cannot
+    silently reinterpret a one-branch profile as an unbounded batch contract. -/
+structure RoomAdmission where
+  poles : RoomPoleDomain
+  maxBranches : Nat
+  maxSourceRows : Nat
+  maxCarrierGroups : Nat
+  maxPeriod : Nat
+  maxGeneratedScalars : Nat
+deriving Repr, DecidableEq
+
+/-- The only live room control admitted by the M5 reference. -/
+inductive RoomPositionLaw where
+  | equalPowerForwardReverse
+deriving Repr, DecidableEq
+
+/-- Carrier values retain their authored scale.  Room/send amount stays an
+    external live gain rather than becoming source data in the profile. -/
+inductive RoomNormalization where
+  | preserveCarrierScale
+deriving Repr, DecidableEq
+
+/-- A source-independent room identity plus its admission/capacity contract.
+    There is intentionally no source row, anchor, timeline, prefix, wet score,
+    capture, or rendered-content field. -/
+structure RoomProfile where
+  id : String
+  profileVersion : Nat
+  evaluatorVersion : String
+  sampleRate : Nat
+  groups : Array RoomCarrierGroup
+  positionLaw : RoomPositionLaw := .equalPowerForwardReverse
+  normalization : RoomNormalization := .preserveCarrierScale
+  admission : RoomAdmission
+deriving Repr, DecidableEq
+
+/-- Evaluator identity pinned by the first graph-specialized reference. -/
+def groupedRoomReferenceEvaluatorVersion : String :=
+  "grouped-prefix-reference-v1"
+
+end Tropical.EmitArrow

--- a/lean/Tropical/Tropicaltest/GroupedRoomReference.lean
+++ b/lean/Tropical/Tropicaltest/GroupedRoomReference.lean
@@ -45,7 +45,7 @@ private def tinyProfile : RoomProfile := {
     maxBranches := 1
     maxSourceRows := 4
     maxCarrierGroups := 2
-    maxPeriod := 8
+    maxPeriod := 5
     maxGeneratedScalars := 256 } }
 
 private structure OracleMode where
@@ -94,7 +94,7 @@ private def powNatF (x : Float) (n : Nat) : Float := Id.run do
   return y
 
 /-- Direct time-domain carrier train.  Causal is a finite history sum; reverse
-    is a 512-tap future sum whose omitted tail is below 1e-100 for this profile.
+    is a 512-tap future sum whose omitted tail is below 1e-70 for this profile.
     No prefix or geometric block is shared with production. -/
 private def directPair (m : OracleMode) (g : RoomCarrierGroup)
     (position u : Float) : Float := Id.run do
@@ -156,6 +156,16 @@ private def buildRoomPlan (arena : Arena) (name : String)
   buildAndFinish (.ok (buildExprCarrier name
     (groupedRoomReferenceSig s clk anchor position) arena))
 
+private def renderRoom (arena : Arena) (name : String)
+    (s : RoomReferenceSpecialization) (clk anchor position : Sig) (count : Nat) :
+    IO (Except String (Array Float)) :=
+  match buildRoomPlan arena name s clk anchor position with
+  | .error e => pure (.error s!"build {name}: {firstLine e}")
+  | .ok p => do
+    match ← renderPlanSamples p count with
+    | .error e => pure (.error s!"render {name}: {firstLine e}")
+    | .ok got => pure (.ok got)
+
 private def renderAgainstOracle (arena : Arena) (name : String)
     (spec : RoomReferenceSpecialization) (modes : Array OracleMode)
     (position : Float) (clk anchor : Sig) (count : Nat) (uAt : Nat → Float) :
@@ -180,6 +190,12 @@ private def exclusionHas (kind : RoomExclusionKind) (row? group? : Option Nat)
 private def prefixEqual (a b : RoomReferenceSpecialization) : Bool :=
   a.forwardPrefix == b.forwardPrefix && a.reversePrefix == b.reversePrefix
 
+private def specializationOk
+    (r : Except RoomRefusal RoomReferenceSpecialization) : Bool :=
+  match r with
+  | .ok _ => true
+  | .error _ => false
+
 set_option maxRecDepth 2048 in
 def runGroupedRoomReference (arena : Arena)
     (_resolved : Array (String × ProgramIdx)) : IO Bool := do
@@ -190,7 +206,14 @@ def runGroupedRoomReference (arena : Arena)
   | _, .error e => failGate "grouped-room-reference" s!"source B admission: {e.summary}"
   | .ok specA, .ok specB =>
     let ampOnlyModes : Array ModalMode := #[
-      { sourceA[0]! with cre := lit 2, cim := lit (-3) 1 }, sourceA[1]!]
+      { sourceA[0]! with cre := lit 2 }, sourceA[1]!]
+    let frequencyModes : Array ModalMode := #[
+      { sourceA[0]! with omega := lit 801 }, sourceA[1]!]
+    let dampingModes : Array ModalMode := #[
+      { sourceA[0]! with sigma := lit 8 }, sourceA[1]!]
+    let phaseModes : Array ModalMode := #[
+      { sourceA[0]! with cre := lit (-2) 1, cim := lit 7 1 }, sourceA[1]!]
+    let zeroResidueModes := sourceA.map fun m => { m with cre := lit 0, cim := lit 0 }
     let emptyResult := specializeGroupedRoomReference profile 44100 #[]
     let ampResult := specializeGroupedRoomReference profile 44100 ampOnlyModes
     match emptyResult, ampResult with
@@ -207,34 +230,95 @@ def runGroupedRoomReference (arena : Arena)
           2 * (specA.forwardPrefix.size + specA.reversePrefix.size) &&
         prefixEqual specA ampSpec && !prefixEqual specA specB && repeatedPrefixes
 
+      let frequencyResult := specializeGroupedRoomReference profile 44100 frequencyModes
+      let dampingResult := specializeGroupedRoomReference profile 44100 dampingModes
+      let phaseResult := specializeGroupedRoomReference profile 44100 phaseModes
+      let zeroResidueResult := specializeGroupedRoomReference profile 44100 zeroResidueModes
+
       let badPeriodGroup := { profile.groups[0]! with period := 4 }
       let badPeriod := { profile with groups := #[badPeriodGroup, profile.groups[1]!] }
       let badRadiusGroup := { profile.groups[0]! with radius := jn 1 }
       let badRadius := { profile with groups := #[badRadiusGroup, profile.groups[1]!] }
+      let duplicateIdGroup := { profile.groups[1]! with id := profile.groups[0]!.id }
+      let duplicateIds := { profile with groups := #[profile.groups[0]!, duplicateIdGroup] }
       let livePole : Array ModalMode := #[
         { sourceA[0]! with sigma := .paramRef ⟨0⟩ }, sourceA[1]!]
+      let nonfinitePole : Array ModalMode := #[
+        { sourceA[0]! with sigma := div (lit 1) (lit 0) }, sourceA[1]!]
       let degreeOne : Array ModalMode := #[{ sourceA[0]! with deg := 1 }, sourceA[1]!]
       let outOfDomain : Array ModalMode := #[
         { sourceA[0]! with sigma := lit 100 }, sourceA[1]!]
+      let boundaryModes : Array ModalMode := #[
+        ModalMode.hz (lit 10) (lit 1) (lit 1),
+        ModalMode.hz (lit 5000) (lit 50) (lit 1)]
+      let belowFrequency : Array ModalMode := #[ModalMode.hz (lit 9) (lit 1) (lit 1)]
+      let aboveFrequency : Array ModalMode := #[ModalMode.hz (lit 5001) (lit 50) (lit 1)]
       let rowCap := { profile with admission := { profile.admission with maxSourceRows := 1 } }
       let scalarCap := { profile with admission := { profile.admission with maxGeneratedScalars := 63 } }
+      let identityBad := { profile with id := "", profileVersion := 0 }
+      let evaluatorBad := { profile with evaluatorVersion := "grouped-prefix-reference-v0" }
+      let zeroRate := { profile with sampleRate := 0 }
+      let domainBad := { profile with admission := { profile.admission with poles :=
+        { profile.admission.poles with maxFrequencyHz := jn 10 } } }
+      let branchCap := { profile with admission := { profile.admission with maxBranches := 0 } }
+      let groupCap := { profile with admission := { profile.admission with maxCarrierGroups := 0 } }
+      let periodCap := { profile with admission := { profile.admission with maxPeriod := 0 } }
+      let explosiveGroup : RoomCarrierGroup := {
+        id := "explosive-1", period := 1, radius := jn 9 1,
+        carrier := #[jn 1000001] }
+      let explosiveProfile : RoomProfile := {
+        profile with
+        groups := #[explosiveGroup]
+        admission := {
+          poles := profile.admission.poles
+          maxBranches := 1
+          maxSourceRows := 1
+          maxCarrierGroups := 1
+          maxPeriod := 1
+          maxGeneratedScalars := 4 } }
+      let explosiveMode : Array ModalMode := #[sourceA[0]!]
       let refusals :=
+        exclusionHas .invalidProfileIdentity none none
+          (specializeGroupedRoomReference identityBad 44100 sourceA) &&
+        exclusionHas .unsupportedEvaluator none none
+          (specializeGroupedRoomReference evaluatorBad 44100 sourceA) &&
+        exclusionHas .invalidSampleRate none none
+          (specializeGroupedRoomReference zeroRate 0 sourceA) &&
+        exclusionHas .invalidPoleDomain none none
+          (specializeGroupedRoomReference domainBad 44100 sourceA) &&
+        exclusionHas .branchCapacity none none
+          (specializeGroupedRoomReference branchCap 44100 sourceA) &&
+        exclusionHas .groupCapacity none none
+          (specializeGroupedRoomReference groupCap 44100 sourceA) &&
+        exclusionHas .invalidCarrier none (some 0)
+          (specializeGroupedRoomReference periodCap 44100 sourceA) &&
         exclusionHas .sampleRateMismatch none none
           (specializeGroupedRoomReference profile 48000 sourceA) &&
         exclusionHas .invalidCarrier none (some 0)
           (specializeGroupedRoomReference badPeriod 44100 sourceA) &&
         exclusionHas .invalidCarrier none (some 0)
           (specializeGroupedRoomReference badRadius 44100 sourceA) &&
+        exclusionHas .invalidCarrier none (some 1)
+          (specializeGroupedRoomReference duplicateIds 44100 sourceA) &&
         exclusionHas .nonconstantPole (some 0) none
           (specializeGroupedRoomReference profile 44100 livePole) &&
+        exclusionHas .nonfinitePole (some 0) none
+          (specializeGroupedRoomReference profile 44100 nonfinitePole) &&
         exclusionHas .unsupportedDegree (some 0) none
           (specializeGroupedRoomReference profile 44100 degreeOne) &&
         exclusionHas .poleOutOfDomain (some 0) none
           (specializeGroupedRoomReference profile 44100 outOfDomain) &&
+        specializationOk (specializeGroupedRoomReference profile 44100 boundaryModes) &&
+        exclusionHas .poleOutOfDomain (some 0) none
+          (specializeGroupedRoomReference profile 44100 belowFrequency) &&
+        exclusionHas .poleOutOfDomain (some 0) none
+          (specializeGroupedRoomReference profile 44100 aboveFrequency) &&
         exclusionHas .sourceCapacity none none
           (specializeGroupedRoomReference rowCap 44100 sourceA) &&
         exclusionHas .generatedScalarCapacity none none
-          (specializeGroupedRoomReference scalarCap 44100 sourceA)
+          (specializeGroupedRoomReference scalarCap 44100 sourceA) &&
+        exclusionHas .prefixComputation (some 0) (some 0)
+          (specializeGroupedRoomReference explosiveProfile 44100 explosiveMode)
 
       let n := 128
       let anchorF := 23.25
@@ -277,12 +361,38 @@ def runGroupedRoomReference (arena : Arena)
 
       let mut amplitudeChanges := false
       match ← renderAgainstOracle arena "room_ref_amp" ampSpec
-          #[{ sourceAOracle[0]! with cre := 2.0, cim := -0.3 }, sourceAOracle[1]!]
+          #[{ sourceAOracle[0]! with cre := 2.0 }, sourceAOracle[1]!]
           0.0 clockLit anchor n (fun i => i.toFloat - anchorF) with
       | .error e => if renderFailure.isNone then renderFailure := some e
       | .ok (got, err) =>
         amplitudeChanges := maxAbsDiff got baseAtZero > 1e-4
         if err > oracleWorst then oracleWorst := err
+
+      let mut isolatedMutations := false
+      let mut zeroResiduesZero := false
+      match frequencyResult, dampingResult, phaseResult, zeroResidueResult with
+      | .ok frequencySpec, .ok dampingSpec, .ok phaseSpec, .ok zeroSpec =>
+        let prefixContract := !prefixEqual specA frequencySpec &&
+          !prefixEqual specA dampingSpec && prefixEqual specA phaseSpec &&
+          prefixEqual specA zeroSpec
+        match ← renderRoom arena "room_ref_frequency" frequencySpec clockLit anchor (lit 0) n,
+              ← renderRoom arena "room_ref_damping" dampingSpec clockLit anchor (lit 0) n,
+              ← renderRoom arena "room_ref_phase" phaseSpec clockLit anchor (lit 0) n,
+              ← renderRoom arena "room_ref_anchor" specA clockLit (lit 2425 2) (lit 0) n,
+              ← renderRoom arena "room_ref_zero_residue" zeroSpec clockLit anchor (lit 0) n with
+        | .ok frequencyGot, .ok dampingGot, .ok phaseGot, .ok anchorGot, .ok zeroGot =>
+          isolatedMutations := prefixContract &&
+            maxAbsDiff frequencyGot baseAtZero > 1e-5 &&
+            maxAbsDiff dampingGot baseAtZero > 1e-5 &&
+            maxAbsDiff phaseGot baseAtZero > 1e-5 &&
+            maxAbsDiff anchorGot baseAtZero > 1e-5
+          zeroResiduesZero := zeroGot.all (· == 0.0)
+        | .error e, _, _, _, _ | _, .error e, _, _, _ |
+          _, _, .error e, _, _ | _, _, _, .error e, _ | _, _, _, _, .error e =>
+          if renderFailure.isNone then renderFailure := some e
+      | _, _, _, _ =>
+        if renderFailure.isNone then
+          renderFailure := some "isolated mutation specialization unexpectedly refused"
 
       let mut emptyZero := false
       match buildRoomPlan arena "room_ref_empty" emptySpec clockLit anchor (lit 0) with
@@ -290,6 +400,15 @@ def runGroupedRoomReference (arena : Arena)
       | .ok p => match ← renderPlanSamples p n with
         | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
         | .ok got => emptyZero := got.all (· == 0.0)
+
+      let mut runtimeRateMismatchZero := false
+      match buildRoomPlan arena "room_ref_rate_mismatch" specA clockLit anchor (lit 0) with
+      | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+      | .ok p =>
+        let mismatched := { p with sampleRate := jn 48000 }
+        match ← renderPlanSamples mismatched n with
+        | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+        | .ok got => runtimeRateMismatchZero := got.all (· == 0.0)
 
       let farSamples : Int := 1000000000
       let farQ : Int := farSamples * 4294967296
@@ -321,15 +440,17 @@ def runGroupedRoomReference (arena : Arena)
       | some e => failGate "grouped-room-reference" e
       | none =>
         let ok := structural && refusals && planShape && oracleWorst < 2e-7 &&
-          sourceBOracleOk && amplitudeChanges && emptyZero && forwardPreZero &&
-          reversePreNonzero && farTranslationExact && holdReverseOk
+          sourceBOracleOk && amplitudeChanges && isolatedMutations && zeroResiduesZero &&
+          runtimeRateMismatchZero && emptyZero && forwardPreZero && reversePreNonzero &&
+          farTranslationExact && holdReverseOk
         IO.println s!"        room-only profile: groups={profile.groups.size}, generated={specA.generatedScalarCount} scalars, source grids A/B both admitted"
         IO.println s!"        direct carrier-train oracle worst relative L2={oracleWorst}; nested Plan-5 reductions={planShape}"
-        IO.println s!"        profile/prefix separation={structural}; indexed refusals={refusals}; empty/endpoint/translation/hold/reverse={emptyZero}/{forwardPreZero}/{farTranslationExact}/{holdReverseOk}"
+        IO.println s!"        profile/prefix separation={structural}; indexed refusals={refusals}; rate/zero/mutations={runtimeRateMismatchZero}/{zeroResiduesZero}/{isolatedMutations}"
+        IO.println s!"        empty/endpoint/translation/hold/reverse={emptyZero}/{forwardPreZero}/{farTranslationExact}/{holdReverseOk}"
         if ok then
           passGate "grouped-room-reference"
             "one unchanged room profile specializes unrelated modal poles; exact prefixes and Plan-5 evaluator agree with the direct causal/reverse oracle"
         else
-          failGate "grouped-room-reference" s!"structural={structural} refusals={refusals} shape={planShape} oracle={oracleWorst} sourceB={sourceBOracleOk} amp={amplitudeChanges} empty={emptyZero} fwdPre={forwardPreZero} revPre={reversePreNonzero} far={farTranslationExact} holdRev={holdReverseOk}"
+          failGate "grouped-room-reference" s!"structural={structural} refusals={refusals} shape={planShape} oracle={oracleWorst} sourceB={sourceBOracleOk} amp={amplitudeChanges} mutations={isolatedMutations} zeroResidues={zeroResiduesZero} rateMismatch={runtimeRateMismatchZero} empty={emptyZero} fwdPre={forwardPreZero} revPre={reversePreNonzero} far={farTranslationExact} holdRev={holdReverseOk}"
 
 end Tropical.Tropicaltest.GroupedRoomReference

--- a/lean/Tropical/Tropicaltest/GroupedRoomReference.lean
+++ b/lean/Tropical/Tropicaltest/GroupedRoomReference.lean
@@ -1,0 +1,335 @@
+import Tropical.Tropicaltest.Modal
+import Tropical.EmitArrow.Modal.GroupedRoomReference
+
+/-!
+# Source-generic grouped-room reference gate
+
+The oracle below sums the causal and anti-causal carrier trains directly in
+`Float`.  It does not use the production prefix generator, geometric-block
+evaluator, or emitted expression, so agreement is a genuine differential.
+-/
+
+open Tropical
+open Tropical.Plan
+open Tropical.Ir (Arena ProgramIdx)
+
+namespace Tropical.Tropicaltest.GroupedRoomReference
+
+open Tropical.EmitArrow
+
+private def jn (m : Int) (e : Nat := 0) : Lean.JsonNumber :=
+  { mantissa := m, exponent := e }
+
+private instance : Inhabited RoomCarrierGroup :=
+  ⟨{ id := "", period := 1, radius := jn 5 1, carrier := #[jn 0] }⟩
+
+private instance : Inhabited ModalMode :=
+  ⟨{ sigma := lit 1, omega := lit 0, cre := lit 0 }⟩
+
+private def tinyProfile : RoomProfile := {
+  id := "synthetic-two-cycle-room"
+  profileVersion := 2
+  evaluatorVersion := groupedRoomReferenceEvaluatorVersion
+  sampleRate := 44100
+  groups := #[
+    { id := "early-3", period := 3, radius := jn 72 2,
+      carrier := #[jn 3 1, jn (-12) 2, jn 8 2] },
+    { id := "late-5", period := 5, radius := jn 61 2,
+      carrier := #[jn 17 2, jn 5 2, jn (-9) 2, jn 4 2, jn 2 2] }]
+  admission := {
+    poles := {
+      minFrequencyHz := jn 10
+      maxFrequencyHz := jn 5000
+      minSigma := jn 1
+      maxSigma := jn 50 }
+    maxBranches := 1
+    maxSourceRows := 4
+    maxCarrierGroups := 2
+    maxPeriod := 8
+    maxGeneratedScalars := 256 } }
+
+private structure OracleMode where
+  sigma : Float
+  omega : Float
+  cre : Float
+  cim : Float
+deriving Inhabited
+
+private def OracleMode.emit (m : OracleMode) : ModalMode := {
+  sigma := litF m.sigma
+  omega := litF m.omega
+  cre := litF m.cre
+  cim := litF m.cim }
+
+private def sourceAOracle : Array OracleMode := #[
+  { sigma := 7.0, omega := 701.0, cre := 0.7, cim := 0.2 },
+  { sigma := 13.0, omega := 1337.0, cre := -0.35, cim := 0.15 }]
+
+private def sourceBOracle : Array OracleMode := #[
+  { sigma := 9.0, omega := 947.0, cre := 0.42, cim := -0.18 },
+  { sigma := 17.0, omega := 1703.0, cre := 0.31, cim := 0.11 }]
+
+private def sourceA : Array ModalMode := sourceAOracle.map OracleMode.emit
+private def sourceB : Array ModalMode := sourceBOracle.map OracleMode.emit
+
+private structure OCplx where
+  re : Float
+  im : Float
+
+namespace OCplx
+private def zero : OCplx := ⟨0.0, 0.0⟩
+private def add (a b : OCplx) : OCplx := ⟨a.re + b.re, a.im + b.im⟩
+private def scale (s : Float) (a : OCplx) : OCplx := ⟨s * a.re, s * a.im⟩
+end OCplx
+
+private def poleAtSamples (m : OracleMode) (t : Float) : OCplx :=
+  let sec := t / 44100.0
+  let env := Float.exp (-m.sigma * sec)
+  let ph := m.omega * sec
+  ⟨env * Float.cos ph, env * Float.sin ph⟩
+
+private def powNatF (x : Float) (n : Nat) : Float := Id.run do
+  let mut y := 1.0
+  for _ in [0:n] do y := y * x
+  return y
+
+/-- Direct time-domain carrier train.  Causal is a finite history sum; reverse
+    is a 512-tap future sum whose omitted tail is below 1e-100 for this profile.
+    No prefix or geometric block is shared with production. -/
+private def directPair (m : OracleMode) (g : RoomCarrierGroup)
+    (position u : Float) : Float := Id.run do
+  let radius := g.radius.toFloat
+  let mut causal := OCplx.zero
+  if u >= 0.0 then
+    let last := Float.floor u |>.toUInt64.toNat
+    let mut radiusN := 1.0
+    for n in [0:last + 1] do
+      let c := g.carrier[n % g.period]!.toFloat
+      causal := causal.add ((poleAtSamples m (u - n.toFloat)).scale (c * radiusN))
+      radiusN := radiusN * radius
+  let dFloat := Float.ceil (-u)
+  let d := if dFloat > 0.0 then dFloat.toUInt64.toNat else 0
+  let mut reverse := OCplx.zero
+  let mut radiusN := powNatF radius d
+  for k in [0:512] do
+    let n := d + k
+    let c := g.carrier[n % g.period]!.toFloat
+    reverse := reverse.add ((poleAtSamples m (u + n.toFloat)).scale (c * radiusN))
+    radiusN := radiusN * radius
+  let forwardReal := m.cre * causal.re - m.cim * causal.im
+  let reverseReal := m.cre * reverse.re - m.cim * reverse.im
+  let p := if position < -1.0 then -1.0 else if position > 1.0 then 1.0 else position
+  let forwardGain := Float.sqrt (0.5 * (1.0 + p))
+  let reverseGain := Float.sqrt (0.5 * (1.0 - p))
+  return forwardGain * forwardReal + reverseGain * reverseReal
+
+private def directRoom (profile : RoomProfile) (modes : Array OracleMode)
+    (position u : Float) : Float :=
+  modes.foldl (fun total m =>
+    profile.groups.foldl (fun acc g => acc + directPair m g position u) total) 0.0
+
+private def sinkGain : Float := Tropical.Plan.defaultSinkGain.toFloat
+
+private def directSamples (profile : RoomProfile) (modes : Array OracleMode)
+    (position : Float) (count : Nat) (uAt : Nat → Float) : Array Float :=
+  (Array.range count).map fun i => sinkGain * directRoom profile modes position (uAt i)
+
+private def relL2 (got ref : Array Float) : Float := Id.run do
+  let mut num := 0.0
+  let mut den := 0.0
+  for i in [0:min got.size ref.size] do
+    let d := got[i]! - ref[i]!
+    num := num + d * d
+    den := den + ref[i]! * ref[i]!
+  return Float.sqrt (num / (den + 1e-300))
+
+private def maxAbsDiff (a b : Array Float) : Float := Id.run do
+  let mut mx := 0.0
+  for i in [0:min a.size b.size] do
+    let d := (a[i]! - b[i]!).abs
+    if d > mx then mx := d
+  return mx
+
+private def buildRoomPlan (arena : Arena) (name : String)
+    (s : RoomReferenceSpecialization) (clk anchor position : Sig) :
+    Except String Tropical.Plan.FlatPlan :=
+  buildAndFinish (.ok (buildExprCarrier name
+    (groupedRoomReferenceSig s clk anchor position) arena))
+
+private def renderAgainstOracle (arena : Arena) (name : String)
+    (spec : RoomReferenceSpecialization) (modes : Array OracleMode)
+    (position : Float) (clk anchor : Sig) (count : Nat) (uAt : Nat → Float) :
+    IO (Except String (Array Float × Float)) := do
+  match buildRoomPlan arena name spec clk anchor (litF position) with
+  | .error e => pure (.error s!"build {name}: {firstLine e}")
+  | .ok p =>
+    match ← renderPlanSamples p count with
+    | .error e => pure (.error s!"render {name}: {firstLine e}")
+    | .ok got =>
+      let ref := directSamples tinyProfile modes position count uAt
+      pure (.ok (got, relL2 got ref))
+
+private def exclusionHas (kind : RoomExclusionKind) (row? group? : Option Nat)
+    (r : Except RoomRefusal RoomReferenceSpecialization) : Bool :=
+  match r with
+  | .ok _ => false
+  | .error refusal => refusal.exclusions.any fun x =>
+      x.kind == kind && (row?.isNone || x.row? == row?) &&
+        (group?.isNone || x.group? == group?)
+
+private def prefixEqual (a b : RoomReferenceSpecialization) : Bool :=
+  a.forwardPrefix == b.forwardPrefix && a.reversePrefix == b.reversePrefix
+
+set_option maxRecDepth 2048 in
+def runGroupedRoomReference (arena : Arena)
+    (_resolved : Array (String × ProgramIdx)) : IO Bool := do
+  let profile := tinyProfile
+  match specializeGroupedRoomReference profile 44100 sourceA,
+        specializeGroupedRoomReference profile 44100 sourceB with
+  | .error e, _ => failGate "grouped-room-reference" s!"source A admission: {e.summary}"
+  | _, .error e => failGate "grouped-room-reference" s!"source B admission: {e.summary}"
+  | .ok specA, .ok specB =>
+    let ampOnlyModes : Array ModalMode := #[
+      { sourceA[0]! with cre := lit 2, cim := lit (-3) 1 }, sourceA[1]!]
+    let emptyResult := specializeGroupedRoomReference profile 44100 #[]
+    let ampResult := specializeGroupedRoomReference profile 44100 ampOnlyModes
+    match emptyResult, ampResult with
+    | .error e, _ => failGate "grouped-room-reference" s!"empty source admission: {e.summary}"
+    | _, .error e => failGate "grouped-room-reference" s!"amplitude-only admission: {e.summary}"
+    | .ok emptySpec, .ok ampSpec =>
+      let repeated := specializeGroupedRoomReference profile 44100 sourceA
+      let repeatedPrefixes := match repeated with
+        | .ok s => prefixEqual specA s
+        | .error _ => false
+      let structural := profile == tinyProfile && profile.groups.size == 2 &&
+        specA.profileId == profile.id && specA.generatedScalarCount == 64 &&
+        specA.generatedScalarCount ==
+          2 * (specA.forwardPrefix.size + specA.reversePrefix.size) &&
+        prefixEqual specA ampSpec && !prefixEqual specA specB && repeatedPrefixes
+
+      let badPeriodGroup := { profile.groups[0]! with period := 4 }
+      let badPeriod := { profile with groups := #[badPeriodGroup, profile.groups[1]!] }
+      let badRadiusGroup := { profile.groups[0]! with radius := jn 1 }
+      let badRadius := { profile with groups := #[badRadiusGroup, profile.groups[1]!] }
+      let livePole : Array ModalMode := #[
+        { sourceA[0]! with sigma := .paramRef ⟨0⟩ }, sourceA[1]!]
+      let degreeOne : Array ModalMode := #[{ sourceA[0]! with deg := 1 }, sourceA[1]!]
+      let outOfDomain : Array ModalMode := #[
+        { sourceA[0]! with sigma := lit 100 }, sourceA[1]!]
+      let rowCap := { profile with admission := { profile.admission with maxSourceRows := 1 } }
+      let scalarCap := { profile with admission := { profile.admission with maxGeneratedScalars := 63 } }
+      let refusals :=
+        exclusionHas .sampleRateMismatch none none
+          (specializeGroupedRoomReference profile 48000 sourceA) &&
+        exclusionHas .invalidCarrier none (some 0)
+          (specializeGroupedRoomReference badPeriod 44100 sourceA) &&
+        exclusionHas .invalidCarrier none (some 0)
+          (specializeGroupedRoomReference badRadius 44100 sourceA) &&
+        exclusionHas .nonconstantPole (some 0) none
+          (specializeGroupedRoomReference profile 44100 livePole) &&
+        exclusionHas .unsupportedDegree (some 0) none
+          (specializeGroupedRoomReference profile 44100 degreeOne) &&
+        exclusionHas .poleOutOfDomain (some 0) none
+          (specializeGroupedRoomReference profile 44100 outOfDomain) &&
+        exclusionHas .sourceCapacity none none
+          (specializeGroupedRoomReference rowCap 44100 sourceA) &&
+        exclusionHas .generatedScalarCapacity none none
+          (specializeGroupedRoomReference scalarCap 44100 sourceA)
+
+      let n := 128
+      let anchorF := 23.25
+      let anchor := lit 2325 2
+      let positions : Array Float := #[-1.0, -0.35, 0.0, 0.45, 1.0]
+      let mut oracleWorst := 0.0
+      let mut renderFailure : Option String := none
+      let mut baseAtZero : Array Float := #[]
+      let mut forwardPreZero := true
+      let mut reversePreNonzero := false
+      let mut planShape := true
+      for (position, pi) in positions.zipIdx do
+        if renderFailure.isNone then
+          let plan := buildRoomPlan arena s!"room_ref_a_{pi}" specA clockLit anchor (litF position)
+          match plan with
+          | .error e => renderFailure := some s!"build position {position}: {firstLine e}"
+          | .ok p =>
+            planShape := planShape && planTagCount "ReduceBegin" p == 2
+            match ← renderPlanSamples p n with
+            | .error e => renderFailure := some s!"render position {position}: {firstLine e}"
+            | .ok got =>
+              let ref := directSamples profile sourceAOracle position n
+                (fun i => i.toFloat - anchorF)
+              let err := relL2 got ref
+              if err > oracleWorst then oracleWorst := err
+              if position == 0.0 then baseAtZero := got
+              if position == 1.0 then
+                for i in [0:24] do
+                  if got[i]! != 0.0 then forwardPreZero := false
+              if position == -1.0 then
+                reversePreNonzero := (got.take 24).any (· != 0.0)
+
+      let mut sourceBOracleOk := false
+      match ← renderAgainstOracle arena "room_ref_b" specB sourceBOracle 0.2
+          clockLit anchor n (fun i => i.toFloat - anchorF) with
+      | .error e => if renderFailure.isNone then renderFailure := some e
+      | .ok (_, err) =>
+        sourceBOracleOk := err < 2e-7
+        if err > oracleWorst then oracleWorst := err
+
+      let mut amplitudeChanges := false
+      match ← renderAgainstOracle arena "room_ref_amp" ampSpec
+          #[{ sourceAOracle[0]! with cre := 2.0, cim := -0.3 }, sourceAOracle[1]!]
+          0.0 clockLit anchor n (fun i => i.toFloat - anchorF) with
+      | .error e => if renderFailure.isNone then renderFailure := some e
+      | .ok (got, err) =>
+        amplitudeChanges := maxAbsDiff got baseAtZero > 1e-4
+        if err > oracleWorst then oracleWorst := err
+
+      let mut emptyZero := false
+      match buildRoomPlan arena "room_ref_empty" emptySpec clockLit anchor (lit 0) with
+      | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+      | .ok p => match ← renderPlanSamples p n with
+        | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+        | .ok got => emptyZero := got.all (· == 0.0)
+
+      let farSamples : Int := 1000000000
+      let farQ : Int := farSamples * 4294967296
+      let farAnchor := lit 100000002325 2
+      let mut farTranslationExact := false
+      match buildRoomPlan arena "room_ref_far" specA
+          (add clockLit (litI farQ)) farAnchor (lit 0) with
+      | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+      | .ok p => match ← renderPlanSamples p n with
+        | .error e => if renderFailure.isNone then renderFailure := some (firstLine e)
+        | .ok got => farTranslationExact := bitDiffCount got baseAtZero == 0
+
+      let holdClock := litI (115 * 1073741824)
+      let reverseClock := sub (litI (133 * 1073741824)) clockLit
+      let mut holdReverseOk := false
+      match ← renderAgainstOracle arena "room_ref_hold" specA sourceAOracle 0.45
+          holdClock anchor n (fun _ => 5.5),
+          ← renderAgainstOracle arena "room_ref_reverse" specA sourceAOracle (-0.35)
+          reverseClock anchor n (fun i => 10.0 - i.toFloat) with
+      | .ok (hold, holdErr), .ok (_, reverseErr) =>
+        let holdExact := hold.all (· == hold[0]!)
+        holdReverseOk := holdExact && holdErr < 2e-7 && reverseErr < 2e-7
+        if holdErr > oracleWorst then oracleWorst := holdErr
+        if reverseErr > oracleWorst then oracleWorst := reverseErr
+      | .error e, _ | _, .error e =>
+        if renderFailure.isNone then renderFailure := some e
+
+      match renderFailure with
+      | some e => failGate "grouped-room-reference" e
+      | none =>
+        let ok := structural && refusals && planShape && oracleWorst < 2e-7 &&
+          sourceBOracleOk && amplitudeChanges && emptyZero && forwardPreZero &&
+          reversePreNonzero && farTranslationExact && holdReverseOk
+        IO.println s!"        room-only profile: groups={profile.groups.size}, generated={specA.generatedScalarCount} scalars, source grids A/B both admitted"
+        IO.println s!"        direct carrier-train oracle worst relative L2={oracleWorst}; nested Plan-5 reductions={planShape}"
+        IO.println s!"        profile/prefix separation={structural}; indexed refusals={refusals}; empty/endpoint/translation/hold/reverse={emptyZero}/{forwardPreZero}/{farTranslationExact}/{holdReverseOk}"
+        if ok then
+          passGate "grouped-room-reference"
+            "one unchanged room profile specializes unrelated modal poles; exact prefixes and Plan-5 evaluator agree with the direct causal/reverse oracle"
+        else
+          failGate "grouped-room-reference" s!"structural={structural} refusals={refusals} shape={planShape} oracle={oracleWorst} sourceB={sourceBOracleOk} amp={amplitudeChanges} empty={emptyZero} fwdPre={forwardPreZero} revPre={reversePreNonzero} far={farTranslationExact} holdRev={holdReverseOk}"
+
+end Tropical.Tropicaltest.GroupedRoomReference

--- a/lean/Tropicaltest.lean
+++ b/lean/Tropicaltest.lean
@@ -21,6 +21,7 @@ import Tropical.Testing.Semantics
 import Lean.Data.Json
 import Tropical.Tropicaltest.Patcher
 import Tropical.Tropicaltest.Exact
+import Tropical.Tropicaltest.GroupedRoomReference
 
 /-!
 # tropicaltest — the post-TS golden + native-equiv runner (Phase 8)
@@ -45,7 +46,7 @@ open Tropical.Ir (Arena ProgramIdx)
     reported as the total collapse it is; the `arrow-block-count` gate at the end
     of `main` checks the number against what the block actually ran, so it is
     verified rather than maintained. -/
-def arrowBlockGates : Nat := 99
+def arrowBlockGates : Nat := 100
 
 set_option maxRecDepth 1024 in
 def main (args : List String) : IO UInt32 := do
@@ -503,6 +504,9 @@ def main (args : List String) : IO UInt32 := do
       failed := failed + 1
     total := total + 1
     if !(← runModalForestTimedIslands arena resolved) then
+      failed := failed + 1
+    total := total + 1
+    if !(← Tropical.Tropicaltest.GroupedRoomReference.runGroupedRoomReference arena resolved) then
       failed := failed + 1
     total := total + 1
     if !(← runModalLive arena resolved) then


### PR DESCRIPTION
## Summary
- define a data-only, versioned room profile with explicit pole and capacity admission
- specialize one unchanged profile against arbitrary admitted modal sources using exact forward/reverse prefix generation
- evaluate the grouped law through nested Plan-5 reductions with live POSITION and fail-closed sample-rate binding
- add an independent direct carrier-train oracle plus admission, random-access, mutation, and safety gates

## Scope
This is the intentionally internal M5 semantic reference. It adds no public node, vocabulary entry, Patch route, asset ABI, Plan schema, Swift/demo surface, Clouds profile, or gong behavior change.

## Safety
- specialization is all-or-nothing and indexed
- generated exact literals use unbounded integer quantization behind a fixed coefficient envelope
- specialization construction is sealed
- a plan-rate mismatch renders exact zero rather than combining incompatible time bases

## Validation
- make validate
- Lean/native: 125/125
- Bun: 117 pass, 1 intentional capability skip, 0 fail
- CTest: 4/4 including process socket and Metal kernel
- independent landing re-review: no remaining correctness, trust, scope, or public-surface blockers