### PR TITLE
feat(modal): add topology-derived hierarchical composition

### DIFF
--- a/design/topology-derived-modal-composition.md
+++ b/design/topology-derived-modal-composition.md
@@ -1,0 +1,746 @@
+# Topology-derived modal composition
+
+Date: 2026-08-11 (America/Los_Angeles)
+
+Status: grounded proposal for the next development phase. This document does
+not supersede [`architecture.md`](architecture.md); it proposes a bounded route
+from the implementation on `main` to a more deeply composable authoring model.
+
+## 1. Decision requested
+
+Make the authored graph, including graphs nested inside reusable modules, the
+primary language of modal construction.
+
+Do not expose `cascade`, `parallel`, or a growing catalog of effect-specific
+compiler combinators as boxes the user must understand. In the authoring
+surface:
+
+- a connection is sequential composition;
+- a fan-out is shared use of one value;
+- several wires entering an ordinary typed inlet are ordered parallel
+  composition;
+- a module boundary names and hides a subgraph; and
+- opening a module reveals the same patching interface again.
+
+The compiler still needs a small algebraic representation of these operations.
+That representation is derived from topology and remains compiler-private. It
+is what gives the graph a denotation, preserves products without expanding
+them, and permits exact structural specializations. The choice is therefore not
+“combinators or topology.” It is:
+
+> Topology is the user notation; an algebra is the compiler meaning of that
+> topology.
+
+The first landing milestone should make the shipped six-section Phaser a
+versioned library graph assembled from first-order modal sections and ordinary
+typed wiring. Expanding it must expose an editable patch; compiling the
+expanded graph must recover the same compact product and the same production
+terminal schedule as the current privileged Phaser path. The existing
+resonant low-pass filter should pass through the same generic kernel algebra as
+a second consumer, so the new representation is not merely a renamed Phaser.
+
+This phase remains feed-forward and closed-form. It does not relax Tropical's
+global cycle rule. A later filter-designer feedback graph may be useful, but it
+must be a scoped linear graph that is solved to a closed-form modal operator
+before entering the existing acyclic patch. Arbitrary signal feedback still
+belongs to the future stateful sister runtime.
+
+## 2. Why this is the next useful seam
+
+Tropical already has most of the mathematical machinery needed for a
+bottom-up modal construction environment. What it lacks is an authoring-level
+representation that retains the user's factorization.
+
+The implementation that just landed demonstrates both sides:
+
+1. A first-order continuous-time all-pass is already decomposed in
+   [`Modal.Oriented`](../lean/Tropical/EmitArrow/Modal/Oriented.lean) as an
+   identity path plus one causal exponential tail.
+2. `Bank.phaser` proves that six such sections composed in sequence have the
+   intended rational meaning.
+3. That generic construction duplicates the identity-plus-tail expression at
+   each section. It is an oracle, not a viable six-section production carrier.
+4. `decorateDegreeZeroCausalPhaser` retains one row per source pole and one per
+   section pole instead.
+5. `FactoredTwoRoomPhaserTerminal` then preserves the two-room routed images
+   rather than flattening the whole product into scalar expressions.
+
+The resulting product is not fast because “Phaser” is inherently a primitive.
+It is fast because the compiler knows the expression is a factored cascade of
+identity-plus-tail kernels and delays expansion until an appropriate terminal.
+That fact can come from topology just as well as from a `.phaser` enum case.
+
+The resonant filter is the complementary example. `filterPair` in
+[`Playground.Vocabulary`](../lean/Tropical/Playground/Vocabulary.lean) already
+constructs an exact complex-conjugate pole pair, then presents the filter as a
+two-mode room. Resonance is not evidence that a cascade secretly contains a
+loop. It is a property of the poles of the filter kernel. A feedback circuit
+is one way to *derive* those poles; an explicit pole pair is another. Once the
+kernel is known, both are the same kind of modal action.
+
+The opportunity is to let users move between these levels:
+
+```text
+Phaser
+  └─ six Allpass1 sections + dry/wet network
+       └─ direct path + causal PoleTail1
+            └─ modal pole/residue data and scalar coefficient graph
+```
+
+No level needs to be the permanent user-facing floor. A normal patch may show
+only `Phaser`. A filter-design view may show the six sections and a response
+plot. An expert may open one section and edit its pole and residue network.
+
+## 3. Concrete observations on `main`
+
+The proposal builds beside the current paths rather than replacing the trunk.
+
+| Current fact | Concrete location | Consequence for this phase |
+|---|---|---|
+| The product graph is a downstream-only DAG and lowering uses topological rank as its termination measure. | `Node.inputIds`, `lowerAt`, and `lowerModal` in [`EmitArrow.Patch`](../lean/Tropical/EmitArrow/Patch.lean) | Feed-forward topology can be elaborated directly. Global feedback cannot be admitted by weakening one check. |
+| The public modal compiler value is an authored-order `ModalForest`; a stage maps over every branch and modal mix concatenates branches. | [`Modal.Forest`](../lean/Tropical/EmitArrow/Modal/Forest.lean) and `Semantics.ModalUniverse.lowerGraph` | This preserves meaning and ordering but distributes later stages over earlier sums. A factor-preserving expression must sit before or replace that eager distribution for linear regions. |
+| Production stages are a closed enum. | `ModalStage = ordinaryRoom | gauge | phaser` in [`Modal.Forest`](../lean/Tropical/EmitArrow/Modal/Forest.lean) | Adding every effect as another stage case will recreate a curated ceiling and another terminal pattern matrix. |
+| Terminal selection pattern-matches stage count and exact case order. | `resolvePlainStages` in [`EmitArrow.Patch`](../lean/Tropical/EmitArrow/Patch.lean) | Specialization should move from effect names to normalized kernel structure. |
+| The semantic forest model is already generic over `Source` and `Stage`. | [`Semantics.ModalUniverse.Graph`](../lean/Tropical/Semantics/ModalUniverse.lean) | The whole-universe and authored-order laws can be retained while production grows a richer linear-stage meaning. |
+| The oriented algebra already supplies convolution, addition, scaling, blending, first-order all-pass tails, a generic section, and a compact Phaser decoration. | [`Modal.Oriented`](../lean/Tropical/EmitArrow/Modal/Oriented.lean) | These are the initial interpreter and oracle for a topology-derived kernel expression. |
+| A `Bank` carries future atoms, past atoms, and a point value at exactly zero. | `Oriented.Bank` | The identity/direct path must be represented separately. `Bank.atZero` is a function value at one point, not a Dirac impulse and cannot stand for feedthrough. |
+| `ModalMode` already carries live `Sig` expressions and a declared damping interval. | [`Modal.Residue`](../lean/Tropical/EmitArrow/Modal/Residue.lean) | Atomic pole nodes can remain current-universe and participate in admission without baking live controls. |
+| The executable trunk has no modal or Phaser opcode. It has ordinary scalar DAG nodes plus bounded `bankSum` and `routedSum` regions. | [`Ir.Nodes`](../lean/Tropical/Ir/Nodes.lean) | The first phase should eliminate the new modal algebra at the Modal-to-Sig seam and keep LLVM, WASM, MSL, and Plan 6 unchanged. |
+| The product vocabulary is closed in Lean and mirrored by a closed Swift `NodeKind`. | `portSpecs`/`buildNode` in [`Playground`](../lean/Tropical/Playground/) and [`NodeKind.swift`](../reversible/Sources/Reversible/NodeKind.swift) | Atomic nodes must first become registered kinds. Reusable user modules require dynamic descriptors rather than another growing Swift enum. |
+| Reversible's v2 document is one flat `nodes` array plus presentation, monitors, transport, and one output. | [`PatchDocumentV2.swift`](../reversible/Sources/Reversible/PatchDocumentV2.swift) | There is nowhere to persist a module definition or nested graph today. A versioned document change is required. |
+| Reversible and the engine now accept multiple ordered wires on ordinary `in` ports, while controls, addresses, and modulation ports remain exclusive. | `PortSpec.multi`, `buildNode` implicit fan-in, `PatchModel.connect`, and their gates | The needed visual composition gesture has landed. It should remain type-directed and implicit. |
+| Cycles are rejected in the Reversible model, v2 validation, `Patch.lowerAt`, session compilation, and direct program/export construction. | [`PatchModel.swift`](../reversible/Sources/Reversible/PatchModel.swift), [`PatchDocumentV2.swift`](../reversible/Sources/Reversible/PatchDocumentV2.swift), and [`Ir.Cycles`](../lean/Tropical/Ir/Cycles.lean) | A filter-design loop must be a separate scoped source form with a total elaboration, not a normal patch edge. |
+| `tropical_program_2` is a patch bay over registered types and rejects `programDecl`. | [`Engine.ProgramIO.Ingest`](../lean/Tropical/Engine/ProgramIO/Ingest.lean) | Hierarchical Reversible definitions must not silently revive the retired general wire program language. They should expand hygienically to served atomic graph nodes before the current patch lowering. |
+
+### 3.1 The current performance boundary is already narrow
+
+The canonical `Reson(6) -> Room(32) -> Room(32)` baseline publishes 22,320 of
+the allowed 24,576 bytes of Metal threadgroup scratch. The Phaser product
+publishes 22,688 bytes. The qualifier reports:
+
+| Shape | Non-coefficient arrays | Largest routed image | Total scratch |
+|---|---:|---:|---:|
+| two-room baseline | 13,824 B | 2,112 records x 4 B | 22,320 B |
+| two rooms plus six-section Phaser | 14,164 B | 2,112 records x 4 B | 22,688 B |
+
+Most of the 22 KiB is therefore the existing factored two-room terminal, not
+the Phaser. The Phaser adds 368 bytes, but leaves only 1,888 bytes of policy
+headroom. A new compositional authoring layer is acceptable only if it
+recovers the compact product. Eagerly lowering the visible graph to generic
+`Bank.add`/`Bank.convolveKernel` trees would spend orders of magnitude more
+than those 368 bytes and can also make compile-time exact folding pathological.
+
+This is the central implementation constraint of the proposal:
+
+> Fine-grained authored topology must not imply fine-grained expanded runtime
+> storage.
+
+## 4. User-visible type model
+
+Keep the existing three visible data domains:
+
+- `Modal`: a deferred modal value;
+- `Sig`: an ordinary closed-form signal; and
+- `Control`: a patchable scalar control source.
+
+Processing modules retain one primary data morphism: `Modal -> Modal`,
+`Sig -> Sig`, or `Modal -> Sig`. Sources, controls, monitors, and sinks are the
+expected nullary/boundary exceptions. A module may also have named coefficient
+ports, but those do not make its primary data inlet polymorphic.
+
+The connection rules remain simple:
+
+1. A modal primary inlet accepts `Modal`, never `Sig`.
+2. A signal primary inlet accepts `Sig`; a `Modal` source may realize there at
+   the established one-way seam.
+3. A signal never converts back into poles.
+4. The destination port descriptor determines the implicit fan-in operation.
+   Multiple sources into a modal inlet form an ordered modal sum; multiple
+   sources into a signal inlet form an ordered signal sum.
+5. Named coefficient, address, and modulation ports remain single-source
+   unless their own descriptor explicitly says otherwise.
+
+There is no polymorphic `Mix` operation to explain. `Mix` and `Modal union`
+may remain decodable compatibility nodes and optional explicit junctions, but
+ordinary construction should use multi-connection inlets. The port type tells
+the compiler which sum exists. A signal connected to a modal inlet is a type
+error rather than a request for a clever conversion.
+
+## 5. Compiler meaning derived from topology
+
+### 5.1 Linear kernel algebra
+
+Introduce a compiler-private, hash-consed `ModalKernelExpr` with an explicit
+distributional direct path:
+
+```text
+KernelExpr K ::=
+    identity
+  | proper(OrientedKernelAtom)
+  | scale(control, K)
+  | parallel([K])          -- authored order
+  | cascade([K])           -- authored order
+```
+
+Its denotation is a current-universe kernel `d delta + h(t)`, where `delta` is
+the convolution identity and `h` is an oriented modal expansion. The direct
+coefficient and proper tail may remain factored rather than being collected
+into one pole array.
+
+`parallel` denotes kernel addition. `cascade` denotes convolution in connection
+order. Neither constructor authorizes reordering or floating-point
+reassociation. Arrays retain authored order, singleton constructors normalize
+away, and empty cases have explicit typed identities.
+
+The modal value graph is correspondingly small:
+
+```text
+ValueExpr V ::=
+    source(ModalSource)
+  | apply(K, V)
+  | parallel([V])          -- authored order
+  | gauge(control, V)
+```
+
+`gauge` stays outside `KernelExpr` because it measures and rescales the complete
+current modal value. It is not linear and may not be distributed through a
+sum or cascade. Bloom likewise retains its existing specialized source truth
+and named crossing rules until a general carrier handles it.
+
+These are not new backend instructions and not user-visible combinator nodes.
+They are the elaborated meaning of graph topology between `lowerModal` and the
+existing Modal-to-Sig terminal.
+
+### 5.2 Topology elaboration is not effect recognition
+
+Each registered atomic node kind must declare a local semantic action:
+
+- a linear modal atom contributes one `KernelExpr` factor;
+- a modal source contributes one `ValueExpr.source`;
+- a nonlinear modal atom contributes an explicit value operation such as
+  `gauge`; and
+- a typed multi-inlet contributes ordered `parallel`.
+
+The graph elaborator composes those local meanings from edges. It does not
+search an arbitrary graph for something that “looks like a Phaser.” The
+normalized result may then be matched by optimization rules to choose a
+realizer. Such a match changes cost and representation, never denotation.
+
+This distinction prevents two failure modes:
+
+- semantic behavior does not depend on node names, positions, grouping, or a
+  fragile pattern heuristic; and
+- an optimizer can refuse an expensive shape without declaring the authored
+  graph meaningless.
+
+### 5.3 Initial identities
+
+The current implementations supply the first algebra instances:
+
+```text
+Room(h, dir)       = proper(oriented(h, dir))
+PoleTail1(a)       = proper(-2a * exp(-a t) * 1[t>0])
+Allpass1(a)        = parallel([identity, PoleTail1(a)])
+AllpassCascade(as) = cascade(as.map(Allpass1))
+Phaser(as, mix)    = parallel([
+                        scale(1 - mix, identity),
+                        scale(mix, AllpassCascade(as))
+                      ])
+Filter(fc, q)      = proper(filterPair(fc, q))
+```
+
+Applying the Phaser expression to a source is precisely the existing rational
+meaning. The expression must stay factored: distributing every
+identity-plus-tail sum through every later cascade produces the generic
+doubling that the current oracle intentionally exhibits.
+
+### 5.4 Realization policy
+
+A terminal interpreter chooses among existing and future carriers:
+
+1. Small expressions may use the generic `Oriented.Bank` interpreter. This is
+   the simple reference path.
+2. A causal degree-zero cascade of identity-plus-tail factors may use
+   `decorateDegreeZeroCausalPhaser`, generalized and renamed around its
+   structural contract rather than the effect name.
+3. A source, two compatible rooms, and such a factor may use the current
+   `FactoredTwoRoomPhaserTerminal`, likewise selected from normalized structure.
+4. Unsupported orientation, coincidence, bloom, or repeated-room crossings
+   retain named refusals until an admitted carrier exists.
+5. A later structured or lifted realization may interpret the same expression
+   without changing the authoring graph.
+
+The first phase should not add `KernelExpr` to `Ir.ENode`. Architecture on
+`main` admits backend-visible structure only when a backend needs it as data.
+The existing terminal can already eliminate this expression to `Sig`,
+`bankSum`, and `routedSum`. Keeping that waist unchanged materially reduces the
+risk and gives plan equivalence a strong qualification target.
+
+## 6. Atomic floor and reusable definitions
+
+Arbitrary levels of abstraction do not remove the need for primitives. They
+make the primitive floor explicit and allow it to move downward over time.
+
+The first served floor should be small enough to build the Phaser graph without
+giving every internal residue field equal prominence in the normal patcher:
+
+| Atom | Primary type | Meaning |
+|---|---|---|
+| `PoleTail1` | `Modal -> Modal` | Convolution with one causal first-order proper tail. Pole and residue controls remain live and carry declared ranges. |
+| `ModalScale` | `Modal -> Modal` | Scale a complete modal value by one control. |
+| `ControlAdd`, `ControlMul`, `ControlNeg`, `ControlExp2`, `ControlSin` | `Sig -> Sig` or scalar multi-input | The coefficient network needed to relate a module's exposed controls to pole/residue controls. These are ordinary closed-form signal atoms, not a second formula language. |
+| module inlet/outlet boundaries | typed boundaries | A modal outlet may accept several ordered connections and therefore supplies implicit modal fan-in. |
+
+`Allpass1` should itself be a library definition over `PoleTail1`, not an
+irreducible compiler case. The Phaser definition can then contain six
+`Allpass1` instances and a dry/wet network. The default UI does not display the
+coefficient subgraph; opening `Allpass1` does.
+
+If this atom floor proves too large for the first vertical slice, a temporary
+`SweptAllpass1 : Modal -> Modal` registered atom is an acceptable bootstrap,
+provided that:
+
+- its semantic output is still a generic `KernelExpr`, not a new Phaser stage;
+- it is stored as a versioned library dependency rather than hidden in the
+  Phaser decoder; and
+- the next slice replaces it with the lower atom graph before the hierarchy
+  schema is declared stable.
+
+This makes the compromise temporary and testable instead of establishing
+“all-pass section” as a new permanent abstraction ceiling.
+
+## 7. Hierarchical patch documents
+
+### 7.1 A separate authoring schema
+
+Reversible needs a v3 document with definitions. Conceptually:
+
+```text
+PatchDocumentV3
+  vocabulary
+  definitions : [ModuleDefinition]
+  scene       : Graph
+  monitors
+  transport
+  presentation
+
+ModuleDefinition
+  stable id + version
+  typed inlet/outlet declarations
+  exposed parameter declarations
+  graph
+  nested presentation
+```
+
+A node kind in a graph is either a served engine atom or a reference to one of
+these module definitions. Definition references must form a DAG. Each
+definition's own graph follows the ordinary typed cycle rule in the first
+phase.
+
+This is deliberately not a `tropical_program_2 programDecl` revival:
+
+- it cannot carry arbitrary `ENode`, binder, state, or backend instructions;
+- its leaves are only engine-served atomic kinds from the negotiated
+  vocabulary;
+- it is validated and hygienically expanded before `EmitArrow.PatchGraph`;
+  and
+- the existing program/session schema and refusal remain unchanged.
+
+The hierarchical elaborator should be Lean-owned so Reversible, a future web
+editor, and MCP-driven tooling cannot disagree about expansion. Reversible
+owns the lossless document and presentation, sends the definition graph to the
+frontend, and receives source-path diagnostics and the normal realized-patch
+handshake.
+
+### 7.2 Hygienic expansion
+
+Expansion needs these invariants:
+
+1. Every authored node retains a stable source path.
+2. Flat engine ids are derived hygienically from instance path plus local id;
+   user text is not concatenated without escaping.
+3. Parameter exposure creates one outer live slot and routes it to all inner
+   consumers; it must not duplicate independently writable slots.
+4. Port order and multi-wire source order survive expansion exactly.
+5. Definition and instance graphs are cycle-checked separately and errors name
+   the authored path, not only the generated id.
+6. A collapsed module and its expanded form lower to the same topology and
+   therefore the same plan.
+7. Library definitions are versioned. Opening and editing a shipped definition
+   creates a detached user definition rather than mutating the installed
+   version in place.
+
+### 7.3 Reversible migration
+
+The Swift model has already begun the useful migration: `EngineVocabulary`
+has dynamic `NodeKindID` and descriptor-derived port/type checks. The canvas
+model still stores the closed `NodeKind` enum and derives layout and behavior
+from `NodeKind.spec`.
+
+The hierarchy slice should finish that move:
+
+- store `NodeKindID` plus the negotiated descriptor in `PatchNode`;
+- move titles, port types, defaults, ranges, arity, and primary-domain truth to
+  `EngineVocabulary`;
+- keep only presentation overrides client-side;
+- introduce a module-instance descriptor synthesized from its definition;
+- add a navigation stack for the scene and nested definition graphs; and
+- retain v2 loading as an explicit one-way migration to a v3 scene with no
+  definitions.
+
+Unknown-field preservation in v2 is useful but insufficient: a v2 client can
+round-trip an unfamiliar field, yet its validator and compiler cannot give a
+definition meaning. The version bump must be explicit.
+
+## 8. UI contract
+
+The ordinary user should not be shown category-theory vocabulary or a wall of
+coefficient arithmetic.
+
+The default patch remains compact:
+
+```text
+[Resonator] -> [Phaser] -> [Reverb] -> [Out]
+```
+
+Opening `Phaser` moves into a nested canvas with a breadcrumb:
+
+```text
+Patch / Phaser
+
+Modal In -> AP1 -> AP2 -> AP3 -> AP4 -> AP5 -> AP6 -> wet
+     |                                                   |
+     +---------------- dry ------------------------------+-> blend -> Modal Out
+```
+
+Opening an all-pass section shows its direct and tail branches. Control
+routing may be collapsed by default and revealed with “Show control routing.”
+There is no `Cascade` box: the row of connections is the cascade. There is no
+required `Modal union` box at the output: two connections into the typed modal
+outlet are the ordered parallel sum. An explicit junction can still be placed
+when it improves layout or gives the sum a name.
+
+The filter-designer view is another projection of the same nested graph, not a
+second compiler language. It may add:
+
+- transfer magnitude and phase;
+- pole/zero display;
+- section list and reorder gesture;
+- current modal-row/factor count;
+- estimated compile and Metal scratch cost; and
+- a switch between compact module, section graph, and coefficient graph.
+
+Edits in any view update the same stable node ids. Returning to the main patch
+does not synthesize a different hidden definition.
+
+The sequence editor can follow the same document/view principle later, but it
+is not part of this landing. There is not yet a shared event/lane authoring IR
+in the current patch path, so claiming it here would make the modal milestone
+depend on a separate language project.
+
+## 9. Feedback is a later scoped elaboration
+
+The visual topology of a resonant filter often contains feedback. The current
+Tropical patch cannot represent that loop, and it should not be taught to do so
+by slipping one cyclic edge past `Ir.Cycles`.
+
+A credible later design is a nested `LinearCircuit` definition with different
+rules:
+
+1. Every atom in the region declares a linear continuous-time transfer or
+   generator meaning.
+2. The elaborator finds strongly connected components.
+3. Each component is solved symbolically to a rational, state-space, or sparse
+   generator representation.
+4. Stability, invertibility, parameter ranges, and cost are admitted before
+   compilation.
+5. The solved result becomes an acyclic `KernelExpr` node at the outer patch
+   boundary.
+
+This is how a user could draw the familiar integrator/feedback topology of a
+resonant filter while Tropical still emits a random-access closed-form kernel.
+The cycle exists in the *design notation* and is eliminated at compile time;
+it is not a sample-to-sample runtime recurrence.
+
+The difficult part is not graph traversal. Live coefficients make arbitrary
+high-order root finding, whole-range stability, and factor selection real
+obligations. The first feedback spike should therefore target one bounded
+second-order continuous-time circuit, compare its solved transfer with the
+existing `filterPair`, and refuse:
+
+- nonlinear atoms inside the component;
+- instantaneous algebraic loops without a certified inverse;
+- coefficient ranges that can cross instability or a singular solve;
+- arbitrary signal excitation that cannot be represented as a modal source;
+  and
+- general recursive audio feedback.
+
+A sparse state-space or matrix-exponential carrier, such as the candidate in
+[`lifted-modal-totality-spike.md`](lifted-modal-totality-spike.md), may
+eventually avoid live polynomial root finding. It is not a prerequisite for
+the feed-forward topology phase and must earn its own JIT/Metal cost witness.
+
+## 10. Landing plan
+
+The phase should land as a sequence of independently gated PRs. Later PRs must
+not be started by copying the current Phaser special case into a new enum.
+
+### PR 1: kernel semantics and factor-preserving prototype
+
+Add a new semantic module, tentatively
+`Tropical.Semantics.ModalKernel`, and a production representation,
+tentatively `Tropical.EmitArrow.Modal.Kernel`.
+
+Deliverables:
+
+- the `identity`, `proper`, `scale`, `parallel`, and `cascade` denotations;
+- explicit separation of Dirac feedthrough from `Bank.atZero`;
+- authored-order laws and whole-universe control freezing;
+- a generic interpreter into `Oriented.Bank` for bounded oracle cases;
+- a factor-preserving six-all-pass prototype whose expression size grows
+  linearly with section count; and
+- an independent rational-transfer differential.
+
+This PR has no product UI and no trunk/backend change.
+
+### PR 2: structural terminal selection
+
+Replace effect-name selection with normalized-kernel selection for the served
+linear shapes.
+
+Deliverables:
+
+- generalize `decorateDegreeZeroCausalPhaser` around “causal degree-zero
+  identity-plus-tail cascade” rather than Phaser;
+- select the compact one-stage and two-room product terminals from
+  `KernelExpr` structure;
+- retain generic `Bank` lowering as the f64 reference;
+- add a pre-emission cost witness; and
+- keep emitted Plan 6, LLVM, WASM, and MSL vocabularies unchanged.
+
+The old `.phaser` stage may coexist as a compatibility producer during this
+PR, but it must elaborate to the generic kernel expression.
+
+### PR 3: served atoms and library-graph prototype
+
+Add the minimum registered atom floor and replace the privileged Phaser stage
+producer with a programmatically constructed flat `PatchGraph` fixture. This
+proves the atom graph before the persistence format depends on it.
+
+Deliverables:
+
+- typed atom descriptors and lowering actions;
+- direct, tail, scale, and coefficient routing sufficient to express one
+  all-pass section;
+- programmatic `Allpass1` and six-section Phaser graph factories;
+- the served legacy Phaser kind expands through that graph factory; and
+- no production semantic match on the string `"phaser"` or
+  `ModalStage.phaser` remains after the compatibility window.
+
+The existing filter must also lower through `KernelExpr.proper` in this PR.
+
+### PR 4: hierarchical Lean elaboration, library definitions, and document v3
+
+Add definitions, typed boundary ports, hygienic expansion, source maps, and v2
+migration. Keep `tropical_program_2` unchanged.
+
+Deliverables:
+
+- a closed v3 schema and round-trip fixtures;
+- versioned `Allpass1` and six-section `Phaser` library definitions replacing
+  the programmatic factories as the product source of truth;
+- legacy Phaser documents migrate to an instance of the shipped definition;
+- definition-reference and inner-graph cycle refusal;
+- stable expansion ids and one-slot parameter forwarding;
+- expanded/collapsed plan equivalence; and
+- realized diagnostics mapped back to the nested authored path.
+
+### PR 5: Reversible hierarchy and filter view
+
+Move the canvas to dynamic vocabulary descriptors, add expand/collapse and
+breadcrumbs, and render the first response/pole view.
+
+Deliverables:
+
+- compact default Phaser UI;
+- editable six-section view;
+- editable all-pass internal view;
+- save/reload without changing ids, order, or definitions;
+- detach-and-edit behavior for shipped definitions; and
+- visible cost/admission feedback before a compile is attempted.
+
+### Optional PR 6: bounded linear-feedback spike
+
+This PR is not required to declare the feed-forward topology phase landed. It
+must remain a spike until one second-order feedback circuit solves to the same
+filter response and meets an explicit cost/stability contract.
+
+## 11. Cost and admission contract
+
+`KernelExpr` needs a structural cost result before it can become a served
+authoring feature. At minimum record:
+
+- source modal rows;
+- proper kernel rows by factor;
+- direct-path count;
+- generic expansion bound;
+- selected terminal realization;
+- routed item and output counts;
+- non-coefficient array floats;
+- coefficient array slots;
+- estimated Metal threadgroup scratch;
+- emitted expression/plan node bound; and
+- whether live parameter ranges preserve each specialization's admission.
+
+The estimator must run on the factor graph. It must not expand a product in
+order to discover that expansion is too large. A failure is a named compile
+refusal attached to the authored module path. The compiler must not silently
+drop sections, approximate a stable shape, switch wet to dry, or realize a
+modal intermediate as `Sig` to escape the cost.
+
+The first product gate remains 24,576 bytes of threadgroup scratch on the
+current Metal policy. Because the baseline already uses 22,320 bytes, the
+milestone target is equality with the landed compact Phaser, not merely “under
+the cap.”
+
+## 12. Qualification: what “landed” means
+
+The phase is complete only when all of the following are true.
+
+### Semantic qualification
+
+- One-, two-, and six-section topology-derived all-pass cascades agree with an
+  independent rational evaluator over mix endpoints, cancellation
+  neighborhoods, and the audible frequency grid.
+- Wet all-pass magnitude remains unity within the existing lens.
+- The topology-derived Phaser preserves the whole-universe law for live
+  center, sweep, rate, and mix.
+- Modal fan-in preserves authored source order.
+- Gauge and bloom are not crossed by a linear rewrite without a named law and
+  admission predicate.
+- The resonant low-pass still passes attenuation, ping-frequency, and live
+  cutoff gates through the generic kernel path.
+
+### Structural qualification
+
+- Expanding or collapsing a definition does not change the elaborated graph.
+- The six-section expression has linear, not exponential, retained size.
+- The factory Phaser and an independently authored equivalent graph select the
+  same terminal realization.
+- The backend plan contains ordinary routed/bank regions and no Phaser or
+  hierarchy opcode.
+- Untouched v2 documents migrate deterministically and retain connection order.
+- Signal-to-modal edges are rejected at the typed boundary in every view.
+
+### Performance qualification
+
+- The canonical `6 -> 32 -> six sections -> 32` plan publishes no more than
+  the current 22,688 bytes of Metal scratch, subject to an explicitly reviewed
+  baseline change rather than tolerance creep.
+- Largest routed image, coefficient columns, array slots, MSL size, first load,
+  and warmed block percentiles are reported beside the current Phaser row.
+- Topology elaboration and cost analysis remain bounded without invoking the
+  exponentially expanded reference.
+- JIT, WASM, and Metal retain their current numerical contracts.
+
+### Product qualification
+
+- Reversible can display Phaser as one ordinary module.
+- A user can open it, inspect all six sections, change section topology, return
+  to the parent, save, reload, and hear the changed graph.
+- A user can open one all-pass section to its direct and tail branches.
+- Connection menus offer only type-legal sources; modal main inlets never list
+  signal nodes.
+- Ordinary multi-connections remain legible without requiring a visible Mix or
+  Modal-union node.
+- Errors and cost refusals point to the nested authored module and node.
+
+The standing `make validate` suite remains mandatory. New gates should live
+beside the current Phaser, oriented-algebra, modal-filter, vocabulary,
+malformed-document, Reversible surface, compile-handshake, and Metal-vs-JIT
+tests rather than in an isolated prototype runner.
+
+## 13. Risks and explicit decisions still needed
+
+### Direct feedthrough
+
+The compiler must decide on one representation of `d delta + h`. Reusing
+`Bank.atZero` would be mathematically wrong. The recommendation is an explicit
+direct scalar on `KernelExpr`, eliminated only when the kernel is applied.
+
+### Numerical order
+
+Analytic convolution identities do not imply bit-identical floating
+evaluation. Normalization may remove identities and singletons but should not
+freely commute or reassociate parallel terms. Each optimized terminal needs an
+observable differential against an independent oracle and the current generic
+route.
+
+### Definition ownership
+
+Shipped definitions need stable ids, versions, and migration policy. Editing a
+library instance must choose explicitly between overriding parameters and
+detaching a definition. Silent mutation of a shared definition is unacceptable.
+
+### Scalar atom scope
+
+Building the complete Phaser control network from arithmetic atoms will grow
+the initial vocabulary. Those atoms should be chosen from concrete definition
+needs, not from an attempt to recreate a general source language. Each remains
+an ordinary registered closed-form node.
+
+### Compilation latency
+
+The full generic all-pass tree is not merely a runtime problem. Exact constant
+folding over duplicated `Sig` trees became a multi-minute test during the
+Phaser qualification and had to be replaced with one evaluation of the
+interned DAG plus a bounded two-section generic witness. The production
+elaborator, cost model, and tests must all operate on shared DAGs and must never
+use full expansion as a routine oracle.
+
+### Feedback carrier
+
+A solved linear circuit needs a representation for live high-order systems.
+Explicit roots, sparse state space, and structured matrix-exponential action
+have different stability and backend costs. No choice is implicit in the
+feed-forward phase.
+
+## 14. Non-goals for this phase
+
+- arbitrary cycles in `PatchGraph`, `ResolvedProgram`, `ENode`, or Plan 6;
+- a delay/register/state primitive;
+- signal-to-modal conversion;
+- nonlinear feedback or arbitrary external-signal recursive filtering;
+- a new Phaser, modal-kernel, or hierarchy backend opcode;
+- automatic approximation when a factor graph exceeds admission;
+- fully general formula/binder definitions over the wire;
+- a sequence editor implementation; or
+- exposing every residue, route, and backend array in the ordinary patch view.
+
+## 15. What this opens afterward
+
+Once topology can elaborate to a factored kernel, several effects stop needing
+privileged nodes:
+
+- static and swept notch/EQ networks from direct and proper branches;
+- resonant low-pass, band-pass, and high-pass variants from shared pole-pair
+  definitions;
+- arbitrary all-pass and dispersive cascades;
+- room networks composed in series and parallel, subject to current carrier
+  admission;
+- modal differentiation/integration and affine reclocking from the existing
+  residue operations; and
+- bounded polynomial modal distortion, whose products remain finite sums of
+  exponential-polynomial atoms but carry an explicit multiplicative mode-count
+  cost.
+
+Non-polynomial saturation does not in general remain a finite modal value, and
+polynomial distortion can grow quadratically or worse. Those facts become cost
+and representation questions in the same framework rather than reasons to add
+an opaque `Distortion` effect prematurely.
+
+The larger trajectory is a single hierarchical design environment with
+different views over one typed graph. The immediate proof is deliberately
+smaller: make one shipped effect cease to be semantically privileged, preserve
+its exact compact runtime shape, and let a user descend through its construction
+without leaving the patching language.

--- a/design/topology-derived-modal-composition.md
+++ b/design/topology-derived-modal-composition.md
@@ -2,9 +2,39 @@
 
 Date: 2026-08-11 (America/Los_Angeles)
 
-Status: grounded proposal for the next development phase. This document does
-not supersede [`architecture.md`](architecture.md); it proposes a bounded route
-from the implementation on `main` to a more deeply composable authoring model.
+Status: grounded architectural direction. The first compiler milestone in
+section 10 is implemented on this branch; hierarchy, editable definitions, and
+the Reversible views remain future work. This document does not supersede
+[`architecture.md`](architecture.md).
+
+## 0. Milestone landed on this branch
+
+This branch is no longer document-only. It lands the first compiler vertical
+slice:
+
+- `ModalKernelExpr` represents explicit identity, proper kernels, scale,
+  authored-order parallel/cascade, and dry/wet blend without adding a backend
+  opcode;
+- `ModalStage.phaser` and `Node.modalPhaser` are removed in favor of one generic
+  `ModalStage.linear`, plus ordinary `modalLinear`, `modalMix`, and `modalBlend`
+  graph nodes;
+- the served Phaser decoder expands to six explicit proper-tail transforms,
+  six `identity + tail` topology junctions, and one dry/wet blend;
+- lowering recognizes those junctions strictly from shared node identity,
+  retains six factors, and selects the compact terminal from generic kernel
+  structure rather than an effect tag;
+- the served resonant Filter is an independent producer of
+  `KernelExpr.proper`, while preserving its existing live parameter path; and
+- the qualifier proves one-, two-, and six-section retained size is linear,
+  checks the independent rational render oracle and four live Phaser controls,
+  exercises the Filter as a second producer, and retains the 22,688-byte
+  canonical product scratch row (22,320-byte baseline).
+
+What has not landed yet is equally important: the Phaser expansion is
+compiler-visible flat topology, not yet a persisted, user-expandable library
+definition. Reversible still displays the compact public Phaser node. Document
+v3, nested editing, the lower atomic/control floor, diagnostics/source maps,
+and filter-designer views remain the next phase.
 
 ## 1. Decision requested
 
@@ -31,13 +61,13 @@ them, and permits exact structural specializations. The choice is therefore not
 > Topology is the user notation; an algebra is the compiler meaning of that
 > topology.
 
-The first landing milestone should make the shipped six-section Phaser a
-versioned library graph assembled from first-order modal sections and ordinary
-typed wiring. Expanding it must expose an editable patch; compiling the
-expanded graph must recover the same compact product and the same production
-terminal schedule as the current privileged Phaser path. The existing
-resonant low-pass filter should pass through the same generic kernel algebra as
-a second consumer, so the new representation is not merely a renamed Phaser.
+The compiler milestone on this branch makes the shipped six-section Phaser an
+ordinary flat graph assembled from first-order modal sections and typed wiring,
+and recovers the same compact product and production terminal schedule. The
+existing resonant low-pass Filter passes through the same generic kernel
+algebra as a second consumer, so the representation is not merely a renamed
+Phaser. The next product milestone promotes that factory to a versioned library
+definition users can expand and edit.
 
 This phase remains feed-forward and closed-form. It does not relax Tropical's
 global cycle rule. A later filter-designer feedback graph may be useful, but it
@@ -99,8 +129,8 @@ The proposal builds beside the current paths rather than replacing the trunk.
 |---|---|---|
 | The product graph is a downstream-only DAG and lowering uses topological rank as its termination measure. | `Node.inputIds`, `lowerAt`, and `lowerModal` in [`EmitArrow.Patch`](../lean/Tropical/EmitArrow/Patch.lean) | Feed-forward topology can be elaborated directly. Global feedback cannot be admitted by weakening one check. |
 | The public modal compiler value is an authored-order `ModalForest`; a stage maps over every branch and modal mix concatenates branches. | [`Modal.Forest`](../lean/Tropical/EmitArrow/Modal/Forest.lean) and `Semantics.ModalUniverse.lowerGraph` | This preserves meaning and ordering but distributes later stages over earlier sums. A factor-preserving expression must sit before or replace that eager distribution for linear regions. |
-| Production stages are a closed enum. | `ModalStage = ordinaryRoom | gauge | phaser` in [`Modal.Forest`](../lean/Tropical/EmitArrow/Modal/Forest.lean) | Adding every effect as another stage case will recreate a curated ceiling and another terminal pattern matrix. |
-| Terminal selection pattern-matches stage count and exact case order. | `resolvePlainStages` in [`EmitArrow.Patch`](../lean/Tropical/EmitArrow/Patch.lean) | Specialization should move from effect names to normalized kernel structure. |
+| Production stages are a closed enum. | Before this branch, `ModalStage = ordinaryRoom | gauge | phaser`; this branch replaces the privileged effect case with generic `linear` in [`Modal.Forest`](../lean/Tropical/EmitArrow/Modal/Forest.lean). | Future linear effects should enter through the algebra rather than recreate a curated stage ceiling. |
+| Terminal selection pattern-matches stage count and exact case order. | `resolvePlainStages` in [`EmitArrow.Patch`](../lean/Tropical/EmitArrow/Patch.lean) still recognizes carrier order, but this branch selects the all-pass specialization from `KernelExpr` structure rather than a Phaser case. | Later work should make more carrier selection structural without weakening existing room/gauge admission. |
 | The semantic forest model is already generic over `Source` and `Stage`. | [`Semantics.ModalUniverse.Graph`](../lean/Tropical/Semantics/ModalUniverse.lean) | The whole-universe and authored-order laws can be retained while production grows a richer linear-stage meaning. |
 | The oriented algebra already supplies convolution, addition, scaling, blending, first-order all-pass tails, a generic section, and a compact Phaser decoration. | [`Modal.Oriented`](../lean/Tropical/EmitArrow/Modal/Oriented.lean) | These are the initial interpreter and oracle for a topology-derived kernel expression. |
 | A `Bank` carries future atoms, past atoms, and a point value at exactly zero. | `Oriented.Bank` | The identity/direct path must be represented separately. `Bank.atZero` is a function value at one point, not a Dirac impulse and cannot stand for feedthrough. |
@@ -482,14 +512,16 @@ the feed-forward topology phase and must earn its own JIT/Metal cost witness.
 
 ## 10. Landing plan
 
-The phase should land as a sequence of independently gated PRs. Later PRs must
-not be started by copying the current Phaser special case into a new enum.
+The larger phase can still land as independently gated slices. The current
+branch combines the useful compiler core of the first three originally
+proposed PRs so the architectural claim is backed by production code. Later
+work must not copy the retired Phaser stage into another effect-specific enum.
 
-### PR 1: kernel semantics and factor-preserving prototype
+### Milestone A: kernel semantics and factor-preserving topology — landed here
 
-Add a new semantic module, tentatively
-`Tropical.Semantics.ModalKernel`, and a production representation,
-tentatively `Tropical.EmitArrow.Modal.Kernel`.
+The production representation is
+`Tropical.EmitArrow.Modal.Kernel`. A separate theorem-oriented semantic module
+is still optional future hardening rather than a prerequisite for this slice.
 
 Deliverables:
 
@@ -501,9 +533,9 @@ Deliverables:
   linearly with section count; and
 - an independent rational-transfer differential.
 
-This PR has no product UI and no trunk/backend change.
+There is no trunk/backend change.
 
-### PR 2: structural terminal selection
+### Milestone B: structural terminal selection — landed for the served shapes
 
 Replace effect-name selection with normalized-kernel selection for the served
 linear shapes.
@@ -518,28 +550,30 @@ Deliverables:
 - add a pre-emission cost witness; and
 - keep emitted Plan 6, LLVM, WASM, and MSL vocabularies unchanged.
 
-The old `.phaser` stage may coexist as a compatibility producer during this
-PR, but it must elaborate to the generic kernel expression.
+No `.phaser` modal stage remains. Existing specialized terminal implementation
+names remain internal carrier names, but their selection reads generic
+identity-plus-tail cascade structure.
 
-### PR 3: served atoms and library-graph prototype
+### Milestone C: served topology factory and second producer — landed as bootstrap
 
-Add the minimum registered atom floor and replace the privileged Phaser stage
-producer with a programmatically constructed flat `PatchGraph` fixture. This
-proves the atom graph before the persistence format depends on it.
+The privileged Phaser stage producer is replaced with a programmatically
+constructed flat `PatchGraph` topology, and Filter enters through the same
+generic algebra. The lower public atom/control floor is intentionally deferred;
+the current bootstrap tail node owns its swept coefficient builder.
 
 Deliverables:
 
-- typed atom descriptors and lowering actions;
-- direct, tail, scale, and coefficient routing sufficient to express one
-  all-pass section;
-- programmatic `Allpass1` and six-section Phaser graph factories;
+- compiler-private typed linear-tail and blend lowering actions;
+- explicit direct-plus-tail topology sufficient to express one all-pass
+  section;
+- programmatic first-order-section and six-section Phaser graph factories;
 - the served legacy Phaser kind expands through that graph factory; and
 - no production semantic match on the string `"phaser"` or
-  `ModalStage.phaser` remains after the compatibility window.
+  `ModalStage.phaser` remains.
 
-The existing filter must also lower through `KernelExpr.proper` in this PR.
+The existing Filter lowers through `KernelExpr.proper` in this milestone.
 
-### PR 4: hierarchical Lean elaboration, library definitions, and document v3
+### Next milestone: hierarchical Lean elaboration, library definitions, and document v3
 
 Add definitions, typed boundary ports, hygienic expansion, source maps, and v2
 migration. Keep `tropical_program_2` unchanged.
@@ -555,7 +589,7 @@ Deliverables:
 - expanded/collapsed plan equivalence; and
 - realized diagnostics mapped back to the nested authored path.
 
-### PR 5: Reversible hierarchy and filter view
+### Following milestone: Reversible hierarchy and filter view
 
 Move the canvas to dynamic vocabulary descriptors, add expand/collapse and
 breadcrumbs, and render the first response/pole view.
@@ -569,16 +603,17 @@ Deliverables:
 - detach-and-edit behavior for shipped definitions; and
 - visible cost/admission feedback before a compile is attempted.
 
-### Optional PR 6: bounded linear-feedback spike
+### Optional later spike: bounded linear feedback
 
-This PR is not required to declare the feed-forward topology phase landed. It
-must remain a spike until one second-order feedback circuit solves to the same
-filter response and meets an explicit cost/stability contract.
+This is not required for the feed-forward topology phase. It must remain a
+spike until one second-order feedback circuit solves to the same filter
+response and meets an explicit cost/stability contract.
 
 ## 11. Cost and admission contract
 
-`KernelExpr` needs a structural cost result before it can become a served
-authoring feature. At minimum record:
+The focused gate already records the retained factor count and actual product
+scratch row. Before arbitrary user-authored definitions become served,
+`KernelExpr` also needs a predictive structural cost result. At minimum record:
 
 - source modal rows;
 - proper kernel rows by factor;

--- a/design/topology-derived-modal-composition.md
+++ b/design/topology-derived-modal-composition.md
@@ -2,12 +2,12 @@
 
 Date: 2026-08-11 (America/Los_Angeles)
 
-Status: grounded architectural direction. The first compiler milestone in
-section 10 is implemented on this branch; hierarchy, editable definitions, and
-the Reversible views remain future work. This document does not supersede
+Status: grounded architectural direction with the first two vertical slices in
+section 10 implemented on this branch. Lower coefficient atoms, the response /
+pole view, and predictive cost UX remain future work. This document does not supersede
 [`architecture.md`](architecture.md).
 
-## 0. Milestone landed on this branch
+## 0. Milestones landed on this branch
 
 This branch is no longer document-only. It lands the first compiler vertical
 slice:
@@ -18,8 +18,9 @@ slice:
 - `ModalStage.phaser` and `Node.modalPhaser` are removed in favor of one generic
   `ModalStage.linear`, plus ordinary `modalLinear`, `modalMix`, and `modalBlend`
   graph nodes;
-- the served Phaser decoder expands to six explicit proper-tail transforms,
-  six `identity + tail` topology junctions, and one dry/wet blend;
+- the legacy Phaser input migrates through the hierarchy boundary to six
+  explicit proper-tail transforms, six `identity + tail` topology junctions,
+  and one dry/wet blend;
 - lowering recognizes those junctions strictly from shared node identity,
   retains six factors, and selects the compact terminal from generic kernel
   structure rather than an effect tag;
@@ -30,11 +31,27 @@ slice:
   exercises the Filter as a second producer, and retains the 22,688-byte
   canonical product scratch row (22,320-byte baseline).
 
-What has not landed yet is equally important: the Phaser expansion is
-compiler-visible flat topology, not yet a persisted, user-expandable library
-definition. Reversible still displays the compact public Phaser node. Document
-v3, nested editing, the lower atomic/control floor, diagnostics/source maps,
-and filter-designer views remain the next phase.
+The second vertical slice promotes that topology into the authoring language:
+
+- a Lean-owned v3 hierarchy elaborator validates definition and inner-graph
+  cycles, protects installed definition versions, topologically orders graphs,
+  assigns length-delimited hygienic ids, forwards one public parameter slot to
+  every bound leaf, and emits nested source maps before ordinary graph checks;
+- versioned installed `Allpass1` and six-section `Phaser` definitions are now
+  the hierarchical source of truth, and an authored detached Phaser definition
+  qualifies against the legacy compact surface and installed definition;
+- the engine serves the installed module library and still emits no hierarchy,
+  Phaser, or module backend opcode;
+- Reversible writes document v3, deterministically migrates v1 Phaser nodes to
+  installed definition references, persists nested presentation/order/bindings, and lets a
+  user enter Phaser and Allpass canvases through a breadcrumb; and
+- realized reports carry the elaborator source map, allowing nested nodes to
+  show the active/excluded truth of their expanded atoms.
+
+The lower public coefficient/control floor is still intentionally deferred: the
+first-order tail remains a compiler-private bootstrap atom. The response/pole
+view, predictive cost feedback, and bounded linear-feedback spike also remain
+future work.
 
 ## 1. Decision requested
 
@@ -61,12 +78,12 @@ them, and permits exact structural specializations. The choice is therefore not
 > Topology is the user notation; an algebra is the compiler meaning of that
 > topology.
 
-The compiler milestone on this branch makes the shipped six-section Phaser an
+The first compiler milestone on this branch makes the shipped six-section Phaser an
 ordinary flat graph assembled from first-order modal sections and typed wiring,
 and recovers the same compact product and production terminal schedule. The
 existing resonant low-pass Filter passes through the same generic kernel
 algebra as a second consumer, so the representation is not merely a renamed
-Phaser. The next product milestone promotes that factory to a versioned library
+Phaser. The second milestone now promotes that factory to a versioned library
 definition users can expand and edit.
 
 This phase remains feed-forward and closed-form. It does not relax Tropical's
@@ -137,7 +154,7 @@ The proposal builds beside the current paths rather than replacing the trunk.
 | `ModalMode` already carries live `Sig` expressions and a declared damping interval. | [`Modal.Residue`](../lean/Tropical/EmitArrow/Modal/Residue.lean) | Atomic pole nodes can remain current-universe and participate in admission without baking live controls. |
 | The executable trunk has no modal or Phaser opcode. It has ordinary scalar DAG nodes plus bounded `bankSum` and `routedSum` regions. | [`Ir.Nodes`](../lean/Tropical/Ir/Nodes.lean) | The first phase should eliminate the new modal algebra at the Modal-to-Sig seam and keep LLVM, WASM, MSL, and Plan 6 unchanged. |
 | The product vocabulary is closed in Lean and mirrored by a closed Swift `NodeKind`. | `portSpecs`/`buildNode` in [`Playground`](../lean/Tropical/Playground/) and [`NodeKind.swift`](../reversible/Sources/Reversible/NodeKind.swift) | Atomic nodes must first become registered kinds. Reusable user modules require dynamic descriptors rather than another growing Swift enum. |
-| Reversible's v2 document is one flat `nodes` array plus presentation, monitors, transport, and one output. | [`PatchDocumentV2.swift`](../reversible/Sources/Reversible/PatchDocumentV2.swift) | There is nowhere to persist a module definition or nested graph today. A versioned document change is required. |
+| Reversible's active file path is the flat v1 `PatchDocument`; the richer lossless `PatchDocumentV2` exists beside it but is not wired into app open/save. | [`PatchDocument.swift`](../reversible/Sources/Reversible/PatchDocument.swift) and [`PatchDocumentV2.swift`](../reversible/Sources/Reversible/PatchDocumentV2.swift) | V3 must migrate the format users actually save, rather than accidentally extending the inactive v2 experiment. |
 | Reversible and the engine now accept multiple ordered wires on ordinary `in` ports, while controls, addresses, and modulation ports remain exclusive. | `PortSpec.multi`, `buildNode` implicit fan-in, `PatchModel.connect`, and their gates | The needed visual composition gesture has landed. It should remain type-directed and implicit. |
 | Cycles are rejected in the Reversible model, v2 validation, `Patch.lowerAt`, session compilation, and direct program/export construction. | [`PatchModel.swift`](../reversible/Sources/Reversible/PatchModel.swift), [`PatchDocumentV2.swift`](../reversible/Sources/Reversible/PatchDocumentV2.swift), and [`Ir.Cycles`](../lean/Tropical/Ir/Cycles.lean) | A filter-design loop must be a separate scoped source form with a total elaboration, not a normal patch edge. |
 | `tropical_program_2` is a patch bay over registered types and rejects `programDecl`. | [`Engine.ProgramIO.Ingest`](../lean/Tropical/Engine/ProgramIO/Ingest.lean) | Hierarchical Reversible definitions must not silently revive the retired general wire program language. They should expand hygienically to served atomic graph nodes before the current patch lowering. |
@@ -415,8 +432,8 @@ The hierarchy slice should finish that move:
 - keep only presentation overrides client-side;
 - introduce a module-instance descriptor synthesized from its definition;
 - add a navigation stack for the scene and nested definition graphs; and
-- retain v2 loading as an explicit one-way migration to a v3 scene with no
-  definitions.
+- retain v1 loading as an explicit one-way migration to a v3 scene, referencing
+  installed definitions for legacy product modules such as Phaser.
 
 Unknown-field preservation in v2 is useful but insufficient: a v2 client can
 round-trip an unfamiliar field, yet its validator and compiler cannot give a
@@ -566,33 +583,36 @@ Deliverables:
 - compiler-private typed linear-tail and blend lowering actions;
 - explicit direct-plus-tail topology sufficient to express one all-pass
   section;
-- programmatic first-order-section and six-section Phaser graph factories;
-- the served legacy Phaser kind expands through that graph factory; and
+- programmatic first-order-section and six-section Phaser oracle factories;
+- the served legacy Phaser kind migrates through the installed definition; and
 - no production semantic match on the string `"phaser"` or
   `ModalStage.phaser` remains.
 
 The existing Filter lowers through `KernelExpr.proper` in this milestone.
 
-### Next milestone: hierarchical Lean elaboration, library definitions, and document v3
+### Landed: hierarchical Lean elaboration, library definitions, and document v3
 
-Add definitions, typed boundary ports, hygienic expansion, source maps, and v2
-migration. Keep `tropical_program_2` unchanged.
+This branch adds definitions, typed boundary ports, hygienic expansion, source
+maps, and legacy-document migration while keeping `tropical_program_2`
+unchanged.
 
 Deliverables:
 
 - a closed v3 schema and round-trip fixtures;
 - versioned `Allpass1` and six-section `Phaser` library definitions replacing
   the programmatic factories as the product source of truth;
-- legacy Phaser documents migrate to an instance of the shipped definition;
+- legacy Phaser documents migrate to the installed definition and detach only
+  when its internals are opened for editing;
 - definition-reference and inner-graph cycle refusal;
 - stable expansion ids and one-slot parameter forwarding;
 - expanded/collapsed plan equivalence; and
 - realized diagnostics mapped back to the nested authored path.
 
-### Following milestone: Reversible hierarchy and filter view
+### Partially landed: Reversible hierarchy; filter view remains next
 
-Move the canvas to dynamic vocabulary descriptors, add expand/collapse and
-breadcrumbs, and render the first response/pole view.
+This branch adds expand/collapse, breadcrumbs, nested persistence, and detached
+editing. Moving the full canvas to dynamic vocabulary descriptors and rendering
+the first response/pole and cost views remain next.
 
 Deliverables:
 
@@ -664,7 +684,7 @@ The phase is complete only when all of the following are true.
   same terminal realization.
 - The backend plan contains ordinary routed/bank regions and no Phaser or
   hierarchy opcode.
-- Untouched v2 documents migrate deterministically and retain connection order.
+- Untouched v1 documents migrate deterministically and retain connection order.
 - Signal-to-modal edges are rejected at the typed boundary in every view.
 
 ### Performance qualification

--- a/lean/Tropical/EmitArrow/Modal.lean
+++ b/lean/Tropical/EmitArrow/Modal.lean
@@ -3,6 +3,7 @@ import Tropical.EmitArrow.Modal.Oriented
 import Tropical.EmitArrow.Modal.OrientedRealize
 import Tropical.EmitArrow.Modal.GroupedRoomReference
 import Tropical.EmitArrow.Modal.FactoredTerminal
+import Tropical.EmitArrow.Modal.Kernel
 import Tropical.EmitArrow.Modal.Forest
 
 /-!

--- a/lean/Tropical/EmitArrow/Modal/Forest.lean
+++ b/lean/Tropical/EmitArrow/Modal/Forest.lean
@@ -1,4 +1,4 @@
-import Tropical.EmitArrow.Modal.Realize
+import Tropical.EmitArrow.Modal.Kernel
 
 /-!
 # EmitArrow.Modal.Forest
@@ -8,19 +8,8 @@ Deferred modal compiler values and their authored-order stage spine.
 
 namespace Tropical.EmitArrow
 
-/-- A live room control keeps its authored fallback expression and, when the
-    port is patched, the signal-node id that supersedes it.  The id remains a
-    graph dependency; its `ArrowTerm` is resolved only at the terminal modal
-    seam, so a room never materializes a signal while it is still modal. -/
-structure ModalControlRef where
-  fallback : ArrowTerm
-  signalNode? : Option String := none
-
-def ModalControlRef.constant (value : Sig) : ModalControlRef :=
-  { fallback := .konst value }
-
-/-- A room kernel is either already expressed as modal modes (filters and
-    internal fixtures) or constructed from one live control after all controls
+/-- A room kernel is either already expressed as modal modes (internal
+    fixtures) or constructed from one live control after all controls
     have been frozen at the terminal observation coordinate. -/
 inductive ModalRoomKernel where
   | fixed (modes : Array ModalMode)
@@ -34,22 +23,14 @@ structure OrdinaryRoomStage where
   direction : ModalControlRef := ModalControlRef.constant (lit 0)
   sway? : Option (ModalControlRef × ModalControlRef) := none
 
-/-- A current-universe modal phaser.  The four controls remain authored terms
-    until the terminal response coordinate is known; the six positive,
-    pairwise-distinct ratios are structural topology. -/
-structure PhaserStage where
-  center : ModalControlRef
-  sweep : ModalControlRef
-  rate : ModalControlRef
-  mix : ModalControlRef
-  ratios : Array Float
-
-/-- Modal→Modal operators in authored order.  Gauges and phasers are deliberate
-    peers of rooms rather than eager lowering special cases. -/
+/-- Modal→Modal operators in authored order.  Ordinary rooms retain their
+    bloom-bridge metadata; every other linear construction enters through the
+    generic factor-preserving stage.  Gauges remain separate because they are
+    nonlinear in the complete current modal value. -/
 inductive ModalStage where
   | ordinaryRoom (room : OrdinaryRoomStage)
+  | linear (stage : ModalLinearStage)
   | gauge (control : ModalControlRef)
-  | phaser (stage : PhaserStage)
 
 /-- The deferred source representation.  Rooms and gauges live exclusively on
     `ModalBranch.stages`, so heterogeneous ordering is never encoded by mutating
@@ -85,8 +66,8 @@ def OrdinaryRoomStage.controls (room : OrdinaryRoomStage) : Array ModalControlRe
 
 def ModalStage.controls : ModalStage → Array ModalControlRef
   | .ordinaryRoom room => room.controls
+  | .linear stage => stage.controls
   | .gauge control => #[control]
-  | .phaser stage => #[stage.center, stage.sweep, stage.rate, stage.mix]
 
 def ModalBranch.controls (branch : ModalBranch) : Array ModalControlRef :=
   branch.stages.foldl (fun controls stage => controls ++ stage.controls) #[]

--- a/lean/Tropical/EmitArrow/Modal/Kernel.lean
+++ b/lean/Tropical/EmitArrow/Modal/Kernel.lean
@@ -1,0 +1,155 @@
+import Tropical.EmitArrow.Modal.Oriented
+
+/-!
+# Factor-preserving modal kernels
+
+This is the compiler meaning of feed-forward modal topology.  Direct paths are
+represented explicitly as convolution identities; they are not confused with
+`Oriented.Bank.atZero`, which is only the value of a two-sided expansion at one
+coordinate.  Parallel and cascade retain authored order and remain factored
+until a terminal chooses a realization.
+-/
+
+namespace Tropical.EmitArrow
+
+open Tropical.Ir
+
+/-- A live modal control retains its authored fallback and, when patched, the
+    signal node that supersedes it.  Binding happens once the terminal response
+    coordinate is known. -/
+structure ModalControlRef where
+  fallback : ArrowTerm
+  signalNode? : Option String := none
+
+def ModalControlRef.constant (value : Sig) : ModalControlRef :=
+  { fallback := .konst value }
+
+/-- Proper (no-Dirac) kernel atoms currently understood by the oriented bank
+    oracle.  `oriented` is the general room/filter atom.  `causalTail` records
+    the structural first-order tail needed to recover an all-pass product
+    without inspecting or comparing floating expressions. -/
+inductive ModalProperKernel where
+  | oriented (modes : Array ModalMode) (direction : Sig)
+  | causalTail (tail : ModalMode)
+
+/-- A resolved current-universe linear modal kernel.  It is compiler-private
+    authoring structure, not an executable-trunk or backend opcode. -/
+inductive ModalKernelExpr where
+  | identity
+  | proper (kernel : ModalProperKernel)
+  | scale (value : Sig) (kernel : ModalKernelExpr)
+  | parallel (kernels : Array ModalKernelExpr)
+  | cascade (kernels : Array ModalKernelExpr)
+  | blend (mix : Sig) (dry wet : ModalKernelExpr)
+
+instance : Inhabited ModalKernelExpr := ⟨.identity⟩
+
+/-- One deferred linear stage.  `build` sees one frozen terminal universe and
+    returns only generic kernel topology; effect names do not survive here. -/
+structure ModalLinearStage where
+  controls : Array ModalControlRef := #[]
+  build : Sig → Array Sig → ModalKernelExpr
+
+private def ModalProperKernel.applyGeneric (kernel : ModalProperKernel)
+    (input : Oriented.Bank) : Oriented.Bank :=
+  match kernel with
+  | .oriented modes direction =>
+      input.convolveKernel modes direction Oriented.syntacticSameSideClassifier
+  | .causalTail tail =>
+      input.convolveKernel #[tail] (lit 0) Oriented.syntacticSameSideClassifier
+
+/-- Literal reference interpretation.  This may expand parallel products and
+    is therefore reserved for small or oracle shapes; production terminals
+    inspect the retained factors first. -/
+def ModalKernelExpr.applyGeneric (input : Oriented.Bank) : ModalKernelExpr → Oriented.Bank
+  | .identity => input
+  | .proper kernel => kernel.applyGeneric input
+  | .scale value kernel =>
+      (kernel.applyGeneric input).scale (value, lit 0)
+  | .parallel kernels =>
+      kernels.attach.foldl (fun total kernel =>
+        total.add (kernel.1.applyGeneric input)) {}
+  | .cascade kernels =>
+      kernels.attach.foldl (fun value kernel =>
+        kernel.1.applyGeneric value) input
+  | .blend mix dry wet =>
+      Oriented.Bank.blend (dry.applyGeneric input) (wet.applyGeneric input) mix
+termination_by kernel => sizeOf kernel
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem kernel.2; simp_all; omega)
+
+/-- One exact first-order all-pass section: the convolution identity in
+    parallel with its causal exponential tail. -/
+def ModalKernelExpr.allpassSection (tail : ModalMode) : ModalKernelExpr :=
+  .parallel #[.identity, .proper (.causalTail tail)]
+
+/-- A retained all-pass cascade followed by one dry/wet blend. -/
+def ModalKernelExpr.dryWetAllpassCascade (tails : Array ModalMode)
+    (mix : Sig) : ModalKernelExpr :=
+  .blend mix .identity (.cascade (tails.map ModalKernelExpr.allpassSection))
+
+/-- The exact topology of one first-order identity-plus-tail section. -/
+def ModalKernelExpr.allpassTail? : ModalKernelExpr → Option ModalMode
+  | .parallel kernels => match kernels.toList with
+      | [.identity, .proper (.causalTail tail)] => some tail
+      | _ => none
+  | _ => none
+
+/-- Extract the retained section rows of an all-pass cascade. -/
+def ModalKernelExpr.allpassCascadeTails? : ModalKernelExpr → Option (Array ModalMode)
+  | .cascade kernels => kernels.mapM ModalKernelExpr.allpassTail?
+  | _ => none
+
+/-- Extract a dry/wet all-pass product by generic structure. -/
+def ModalKernelExpr.dryWetAllpassCascadeShape? :
+    ModalKernelExpr → Option (Array ModalMode × Sig)
+  | .blend mix .identity wet => do
+      let tails ← wet.allpassCascadeTails?
+      if tails.isEmpty then none else some (tails, mix)
+  | _ => none
+
+/-- Extract one ordinary oriented proper kernel.  Filters use the same case as
+    rooms; the terminal cares about structure, not the product node name. -/
+def ModalKernelExpr.orientedShape? : ModalKernelExpr → Option (Array ModalMode × Sig)
+  | .proper (.oriented modes direction) => some (modes, direction)
+  | _ => none
+
+/-- Compose several deferred linear stages into one stage without evaluating
+    any control early.  Their control bundles remain in authored stage order. -/
+def ModalLinearStage.cascade (stages : Array ModalLinearStage) : ModalLinearStage where
+  controls := stages.foldl (fun out stage => out ++ stage.controls) #[]
+  build := fun response values =>
+    let (_, kernels) := stages.foldl (fun (state : Nat × Array ModalKernelExpr) stage =>
+      let cursor := state.1
+      let next := cursor + stage.controls.size
+      (next, state.2.push (stage.build response (values.extract cursor next)))) (0, #[])
+    .cascade kernels
+
+/-- The topology `x + proper(x)` represented as one retained kernel factor. -/
+def ModalLinearStage.withDirect (stage : ModalLinearStage) : ModalLinearStage where
+  controls := stage.controls
+  build := fun response values =>
+    .parallel #[.identity, stage.build response values]
+
+/-- Scale the complete input value by one deferred control. -/
+def ModalLinearStage.scale (control : ModalControlRef)
+    (complement : Bool := false) : ModalLinearStage where
+  controls := #[control]
+  build := fun _ values =>
+    let value := (values[0]?).getD (lit 0)
+    .scale (if complement then sub (lit 1) value else value) .identity
+
+/-- Put an independently authored wet stage chain beside its untouched input. -/
+def ModalLinearStage.dryWet (stages : Array ModalLinearStage)
+    (mix : ModalControlRef) : ModalLinearStage :=
+  let wet := ModalLinearStage.cascade stages
+  { controls := wet.controls.push mix
+    build := fun response values =>
+      let wetCount := wet.controls.size
+      let wetKernel := wet.build response (values.extract 0 wetCount)
+      let mixValue := (values[wetCount]?).getD (lit 0)
+      .blend mixValue .identity wetKernel }
+
+end Tropical.EmitArrow

--- a/lean/Tropical/EmitArrow/Patch.lean
+++ b/lean/Tropical/EmitArrow/Patch.lean
@@ -118,7 +118,7 @@ inductive Node where
   | modalSource (modes : Array ModalMode) (anchor : Sig) (clk : Clock)
       (addr : Option String) (count : Option Sig := none)
       (bloom : Option (Float × Float) := none)
-  /-- A fixed modal room used by filters and internal fixtures.  Its optional
+  /-- A fixed modal room used by internal fixtures.  Its optional
       direction is still room-local; this constructor remains convenient for
       structural banks that do not own a wireable RT60 control. -/
   | modalReverb (input : String) (room : Array ModalMode) (dir : Option ModalDir)
@@ -127,10 +127,14 @@ inductive Node where
       until the terminal multi-input binding seam. -/
   | modalRoom (input : String) (build : Sig → Array ModalMode)
       (rt60 direction sway rate : ModalControlRef)
-  /-- A feed-forward current-universe analog all-pass cascade.  Its ratios are
-      structural; center/sweep/rate/mix retain live terminal control binding. -/
-  | modalPhaser (input : String) (center sweep rate mix : ModalControlRef)
-      (ratios : Array Float)
+  /-- One generic linear modal-kernel action.  The stage builds a retained
+      identity/proper/parallel/cascade expression only after its controls are
+      frozen at the terminal response coordinate. -/
+  | modalLinear (input : String) (stage : ModalLinearStage)
+  /-- A dry/wet value junction.  When `wet` is structurally a feed-forward
+      linear chain from `dry`, lowering factors the shared prefix and retains
+      one kernel blend.  Other legal inputs remain an ordered two-branch sum. -/
+  | modalBlend (dry wet : String) (mix : ModalControlRef)
   | modalMix (inputs : Array String)
   -- `modalGauge` is the excitation-gauge adapter (§5): it re-levels its modal input's
   -- residues by the self-measured `‖H‖^{−g}` (`normalizePeak`), a pure Modal ⇝ Modal
@@ -156,6 +160,45 @@ structure PatchGraph where
 def fmWarp (depthE : Sig) : Clock → Sig → Clock :=
   fun base m => sub base (toIntE (mul (mul depthE m) (lit 4294967296)))
 
+/-- The proper tail half of one swept first-order all-pass section.  This is a
+    generic linear modal stage: the all-pass direct path is supplied by an
+    ordinary topology junction, not encoded in this builder. -/
+def modalAllpassTailStage (center sweep rate : ModalControlRef)
+    (ratio : Float) : ModalLinearStage where
+  controls := #[center, sweep, rate]
+  build := fun responseClock values =>
+    let center := clampE ((values[0]?).getD (lit 700)) (lit 40) (lit 4000)
+    let sweep := clampE ((values[1]?).getD (lit 15 1)) (lit 0) (lit 3)
+    let rate := clampE ((values[2]?).getD (lit 2 1)) (lit 2 2) (lit 8)
+    let phase := phasorPhaseSig rate (lit 0) responseClock
+    let octaveOffset := mul sweep (sinSig (mul twoPiE phase))
+    let frequencyScale := expSig (mul octaveOffset (lit 6931471805599453 16))
+    let frequency := mul (mul center (litF ratio)) frequencyScale
+    let a := mul twoPiE frequency
+    let sigmaLo : Float := 6.283185307179586 * 40.0 * ratio * 0.125
+    let sigmaHi : Float := 6.283185307179586 * 4000.0 * ratio * 8.0
+    .proper (.causalTail (Oriented.allpassTail a (some (sigmaLo, sigmaHi))))
+
+/-- Expand a convenience phaser module into ordinary modal patch topology:
+    six `identity + tail` junctions in cascade, followed by a dry/wet blend.
+    The returned node is the named public module; the array contains its
+    compiler-visible internal nodes. -/
+def modalPhaserTopology (id input : String) (center sweep rate mix : ModalControlRef)
+    (ratios : Array Float) : Node × Array PatchNode := Id.run do
+  let mut nodes := #[]
+  let mut current := input
+  for (ratio, index) in ratios.zipIdx do
+    let tailId := s!"__modal_phaser_{id}_tail_{index}"
+    let sectionId := s!"__modal_phaser_{id}_section_{index}"
+    nodes := nodes.push {
+      id := tailId
+      node := .modalLinear current (modalAllpassTailStage center sweep rate ratio) }
+    nodes := nodes.push {
+      id := sectionId
+      node := .modalMix #[current, tailId] }
+    current := sectionId
+  return (.modalBlend input current mix, nodes)
+
 /-- Every input id a node's lowering recurses into — the wires of the
     graph, `modalSource`'s optional address inlet included. These are the
     edges `lowerAt` ranks (and refuses cycles over). -/
@@ -167,11 +210,13 @@ def Node.inputIds : Node → Array String
   | .sflange i m _ => #[i, m]
   | .modalSource _ _ _ addr _ _ => (addr.map (#[·])).getD #[]
   | .modalReverb i _ _ | .modalGauge i _ => #[i]
+  | .modalLinear i stage =>
+      #[i] ++ stage.controls.filterMap (fun control => control.signalNode?)
+  | .modalBlend dry wet mixControl =>
+      #[dry, wet] ++ (mixControl.signalNode?.map (#[·])).getD #[]
   | .modalGaugeControl i g => #[i] ++ (g.signalNode?.map (#[·])).getD #[]
   | .modalRoom i _ rt60 direction sway rate =>
       #[i] ++ (#[rt60, direction, sway, rate].filterMap (fun control => control.signalNode?))
-  | .modalPhaser i center sweep rate mixControl _ =>
-      #[i] ++ (#[center, sweep, rate, mixControl].filterMap (fun control => control.signalNode?))
 
 /-- Is `id` a modal-island node? Its output wire carries poles, not a `Sig`. A
     missing node reads as Sig (graceful — a half-built patch stays lowerable). -/
@@ -182,11 +227,41 @@ def nodeIsModal (g : PatchGraph) (id : String) : Bool :=
     | .modalSource .. => true
     | .modalReverb .. => true
     | .modalRoom .. => true
-    | .modalPhaser .. => true
+    | .modalLinear .. => true
+    | .modalBlend .. => true
     | .modalMix .. => true
     | .modalGauge .. => true
     | .modalGaugeControl .. => true
     | _ => false
+
+/-- Recognize the literal topology `base + linear(base)` in authored order.
+    This is an exact factoring rule over shared node identity, not an effect-name
+    heuristic. -/
+private def directLinearFactor? (g : PatchGraph) (inputs : Array String) :
+    Option (String × ModalLinearStage) := do
+  let [base, transformed] := inputs.toList | none
+  let node ← g.nodes.find? (·.id == transformed)
+  let .modalLinear input stage := node.node | none
+  if input == base then some (base, stage.withDirect) else none
+
+/-- Recover a feed-forward linear stage chain from `base` to `current`.  A
+    factored direct-plus-tail junction counts as one stage.  Fuel is bounded by
+    the patch size; the total graph entry independently rejects cycles. -/
+private def linearChainFrom? (g : PatchGraph) (base current : String) :
+    Option (Array ModalLinearStage) :=
+  let rec go : Nat → String → Option (Array ModalLinearStage)
+    | 0, _ => none
+    | fuel + 1, id =>
+      if id == base then some #[] else do
+      let node ← g.nodes.find? (·.id == id)
+      match node.node with
+      | .modalLinear input stage =>
+        return (← go fuel input).push stage
+      | .modalMix inputs =>
+        let (input, stage) ← directLinearFactor? g inputs
+        return (← go fuel input).push stage
+      | _ => none
+  go (g.nodes.size + 1) current
 
 /-- The empty modal value (`__silence__`, the graceful-silence contract). -/
 private def silentModal : ModalBranch where
@@ -284,20 +359,50 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
       sway? := some (sway, rate) }
     return lowered.map fun branch =>
       { branch with stages := branch.stages.push stage, modeCount? := none }
-  | .modalPhaser inId center sweep rate mixControl ratios => do
-    if ratios.size != 6 || !(ratios.zipIdx.all fun (ratio, index) =>
-        ratio > 0.0 && (ratios.extract 0 index).all (· != ratio)) then
-      throw s!"modal phaser '{id}': expected six distinct positive structural ratios"
+  | .modalLinear inId linear => do
     let lowered ←
       if inId == "__silence__" then pure silentForest
       else match rankOf inId with
         | none => throw s!"lowerModal: node '{inId}' not found"
         | some ri =>
-          if h : ri < r then lowerModal g rankOf inId ri
+          if _h : ri < r then lowerModal g rankOf inId ri
           else throw (cycleGuardMsg id inId)
-    let stage : ModalStage := .phaser { center, sweep, rate, mix := mixControl, ratios }
     return lowered.map fun branch =>
-      { branch with stages := branch.stages.push stage, modeCount? := none }
+      { branch with stages := branch.stages.push (.linear linear), modeCount? := none }
+  | .modalBlend dryId wetId mix => do
+    match linearChainFrom? g dryId wetId with
+    | some stages =>
+      let dry ←
+        if dryId == "__silence__" then pure silentForest
+        else match rankOf dryId with
+          | none => throw s!"lowerModal: node '{dryId}' not found"
+          | some ri =>
+            if _h : ri < r then lowerModal g rankOf dryId ri
+            else throw (cycleGuardMsg id dryId)
+      let stage : ModalStage := .linear (ModalLinearStage.dryWet stages mix)
+      return dry.map fun branch =>
+        { branch with stages := branch.stages.push stage, modeCount? := none }
+    | none =>
+      let dry ←
+        if dryId == "__silence__" then pure silentForest
+        else match rankOf dryId with
+          | none => throw s!"lowerModal: node '{dryId}' not found"
+          | some ri =>
+            if _h : ri < r then lowerModal g rankOf dryId ri
+            else throw (cycleGuardMsg id dryId)
+      let wet ←
+        if wetId == "__silence__" then pure silentForest
+        else match rankOf wetId with
+          | none => throw s!"lowerModal: node '{wetId}' not found"
+          | some ri =>
+            if _h : ri < r then lowerModal g rankOf wetId ri
+            else throw (cycleGuardMsg id wetId)
+      let dryStage : ModalStage := .linear (ModalLinearStage.scale mix true)
+      let wetStage : ModalStage := .linear (ModalLinearStage.scale mix false)
+      return (dry.map fun branch =>
+          { branch with stages := branch.stages.push dryStage, modeCount? := none }) ++
+        (wet.map fun branch =>
+          { branch with stages := branch.stages.push wetStage, modeCount? := none })
   | .modalGauge inId gExpr => do
     let lowered ←
       if inId == "__silence__" then pure silentForest
@@ -321,21 +426,33 @@ def lowerModal (g : PatchGraph) (rankOf : String → Option Nat) (id : String) (
     return lowered.map fun branch =>
       { branch with stages := branch.stages.push stage }
   | .modalMix inputs => do
-    let forests ← inputs.mapM fun i =>
-      if i == "__silence__" then pure silentForest
-      else match rankOf i with
-        | none => throw s!"lowerModal: node '{i}' not found"
-        | some ri =>
-          if _h : ri < r then lowerModal g rankOf i ri
-          else throw (cycleGuardMsg id i)
-    let parts := forests.foldl (fun acc forest => acc ++ forest) #[]
-    if parts.isEmpty then
-      .error s!"modalMix '{id}': no inputs"
-    else
-      -- A modal mix is the authored-order forest constructor.  It performs no
-      -- eager room fold or pole union: either would erase heterogeneous stage
-      -- position or make extensional equality depend on current controls.
-      .ok parts
+    match directLinearFactor? g inputs with
+    | some (baseId, linear) =>
+      let lowered ←
+        if baseId == "__silence__" then pure silentForest
+        else match rankOf baseId with
+          | none => throw s!"lowerModal: node '{baseId}' not found"
+          | some ri =>
+            if _h : ri < r then lowerModal g rankOf baseId ri
+            else throw (cycleGuardMsg id baseId)
+      return lowered.map fun branch =>
+        { branch with stages := branch.stages.push (.linear linear), modeCount? := none }
+    | none =>
+      let forests ← inputs.mapM fun i =>
+        if i == "__silence__" then pure silentForest
+        else match rankOf i with
+          | none => throw s!"lowerModal: node '{i}' not found"
+          | some ri =>
+            if _h : ri < r then lowerModal g rankOf i ri
+            else throw (cycleGuardMsg id i)
+      let parts := forests.foldl (fun acc forest => acc ++ forest) #[]
+      if parts.isEmpty then
+        .error s!"modalMix '{id}': no inputs"
+      else
+        -- A general modal mix is the authored-order forest constructor.  The
+        -- exact shared `x + linear(x)` topology above retains one factor; all
+        -- other sums preserve independent branch metadata and order.
+        .ok parts
   | _ => .error s!"a modal inlet (reverb/modal-mix) needs a modal SOURCE — resonator or modal-mix — but '{id}' is a signal node; a Sig has no poles to compose"
 termination_by r
 decreasing_by all_goals assumption
@@ -356,26 +473,10 @@ private def resolveRoomStage (room : OrdinaryRoomStage) (responseClock : Sig)
       (Oriented.swayKernel kernel sway rate responseClock, cursor + 2)
   (kernel, direction, cursor)
 
-/-- Freeze one current-universe phaser at the terminal response coordinate.
-    Public controls are clamped to their served ranges before the log-frequency
-    sweep is formed; each live section damping carries its complete declared
-    envelope for later admission checks. -/
-private def resolvePhaserStage (stage : PhaserStage) (responseClock : Sig)
-    (values : Array Sig) (cursor : Nat) : Array ModalMode × Sig × Nat :=
-  let center := clampE ((values[cursor]?).getD (lit 700)) (lit 40) (lit 4000)
-  let sweep := clampE ((values[cursor + 1]?).getD (lit 15 1)) (lit 0) (lit 3)
-  let rate := clampE ((values[cursor + 2]?).getD (lit 2 1)) (lit 2 2) (lit 8)
-  let mix := clampE ((values[cursor + 3]?).getD (lit 5 1)) (lit 0) (lit 1)
-  let phase := phasorPhaseSig rate (lit 0) responseClock
-  let octaveOffset := mul sweep (sinSig (mul twoPiE phase))
-  let frequencyScale := expSig (mul octaveOffset (lit 6931471805599453 16))
-  let tails := stage.ratios.map fun ratio =>
-    let frequency := mul (mul center (litF ratio)) frequencyScale
-    let a := mul twoPiE frequency
-    let sigmaLo : Float := 6.283185307179586 * 40.0 * ratio * 0.125
-    let sigmaHi : Float := 6.283185307179586 * 4000.0 * ratio * 8.0
-    Oriented.allpassTail a (some (sigmaLo, sigmaHi))
-  (tails, mix, cursor + 4)
+private def resolveLinearStage (stage : ModalLinearStage) (responseClock : Sig)
+    (values : Array Sig) (cursor : Nat) : ModalKernelExpr × Nat :=
+  let next := cursor + stage.controls.size
+  (stage.build responseClock (values.extract cursor next), next)
 
 private def resolvePlainStageState (initial : Nat × Oriented.Bank)
     (stages : Array ModalStage) (responseClock : Sig) (values : Array Sig) :
@@ -386,12 +487,12 @@ private def resolvePlainStageState (initial : Nat × Oriented.Bank)
     | .ordinaryRoom room =>
       let (kernel, direction, cursor) := resolveRoomStage room responseClock values cursor
       (cursor, bank.convolveKernel kernel direction Oriented.syntacticSameSideClassifier)
+    | .linear linear =>
+      let (kernel, cursor) := resolveLinearStage linear responseClock values cursor
+      (cursor, kernel.applyGeneric bank)
     | .gauge _ =>
       let g := clampE ((values[cursor]?).getD (lit 0)) (lit 0) (lit 1)
-      (cursor + 1, bank.gauge g)
-    | .phaser phaser =>
-      let (tails, mix, cursor) := resolvePhaserStage phaser responseClock values cursor
-      (cursor, bank.phaser tails mix)) initial
+      (cursor + 1, bank.gauge g)) initial
 
 private inductive PlainTerminal where
   | generic (terminal : Oriented.TerminalBank)
@@ -412,10 +513,17 @@ private def resolvePlainStages (voice : Array ModalMode) (stages : Array ModalSt
   let initial := (0, Oriented.Bank.ofFuture voice)
   if stages.size == 1 then
     match stages[0]? with
-    | some (ModalStage.phaser phaser) =>
-      let (tails, mix, _) := resolvePhaserStage phaser responseClock values 0
-      .generic <| Oriented.TerminalBank.ofBank <| Oriented.Bank.ofFuture
-        (Oriented.decorateDegreeZeroCausalPhaser voice tails mix)
+    | some (ModalStage.linear linear) =>
+      let (kernel, _) := resolveLinearStage linear responseClock values 0
+      match kernel.dryWetAllpassCascadeShape? with
+      | some (tails, mix) =>
+        .generic <| Oriented.TerminalBank.ofBank <| Oriented.Bank.ofFuture
+          (Oriented.decorateDegreeZeroCausalPhaser voice tails mix)
+      | none => match kernel.orientedShape? with
+        | some (modes, direction) =>
+          .generic ((Oriented.Bank.ofFuture voice).convolveKernelTerminal modes direction)
+        | none => .generic <| Oriented.TerminalBank.ofBank
+            (kernel.applyGeneric (Oriented.Bank.ofFuture voice))
     | some (ModalStage.ordinaryRoom room) =>
       let (kernel, direction, _) := resolveRoomStage room responseClock values 0
       .generic ((Oriented.Bank.ofFuture voice).convolveKernelTerminal kernel direction)
@@ -435,30 +543,40 @@ private def resolvePlainStages (voice : Array ModalMode) (stages : Array ModalSt
         let bank := (Oriented.Bank.ofFuture voice).convolveKernel room1 direction1
           Oriented.syntacticSameSideClassifier
         .generic (bank.convolveKernelTerminal room2 direction2)
-    | some (ModalStage.phaser phaser), some (ModalStage.ordinaryRoom room) =>
-      let (tails, mix, cursor) := resolvePhaserStage phaser responseClock values 0
-      let decorated := Oriented.decorateDegreeZeroCausalPhaser voice tails mix
-      let (kernel, direction, _) := resolveRoomStage room responseClock values cursor
-      .generic ((Oriented.Bank.ofFuture decorated).convolveKernelTerminal kernel direction)
+    | some (ModalStage.linear linear), some (ModalStage.ordinaryRoom room) =>
+      let (linearKernel, cursor) := resolveLinearStage linear responseClock values 0
+      match linearKernel.dryWetAllpassCascadeShape? with
+      | some (tails, mix) =>
+        let decorated := Oriented.decorateDegreeZeroCausalPhaser voice tails mix
+        let (kernel, direction, _) := resolveRoomStage room responseClock values cursor
+        .generic ((Oriented.Bank.ofFuture decorated).convolveKernelTerminal kernel direction)
+      | none =>
+        .generic <| Oriented.TerminalBank.ofBank
+          (resolvePlainStageState initial stages responseClock values).2
     | _, _ =>
       .generic <| Oriented.TerminalBank.ofBank
         (resolvePlainStageState initial stages responseClock values).2
   else if stages.size == 3 then
     match stages[0]?, stages[1]?, stages[2]? with
-    | some (ModalStage.ordinaryRoom first), some (ModalStage.phaser phaser),
+    | some (ModalStage.ordinaryRoom first), some (ModalStage.linear linear),
         some (ModalStage.ordinaryRoom second) =>
       let (room1, direction1, cursor) :=
         resolveRoomStage first responseClock values 0
-      let (tails, mix, cursor) := resolvePhaserStage phaser responseClock values cursor
-      let (room2, direction2, _) :=
-        resolveRoomStage second responseClock values cursor
-      match Oriented.factoredTwoRoomPhaserTerminal? voice tails room1 room2 mix
-          direction1 direction2 with
-      | some terminal => .factoredPhaser terminal
+      let (linearKernel, cursor) := resolveLinearStage linear responseClock values cursor
+      match linearKernel.dryWetAllpassCascadeShape? with
+      | some (tails, mix) =>
+        let (room2, direction2, _) :=
+          resolveRoomStage second responseClock values cursor
+        match Oriented.factoredTwoRoomPhaserTerminal? voice tails room1 room2 mix
+            direction1 direction2 with
+        | some terminal => .factoredPhaser terminal
+        | none =>
+          let bank := (Oriented.Bank.ofFuture voice).convolveKernel room1 direction1
+            Oriented.syntacticSameSideClassifier
+          .generic ((linearKernel.applyGeneric bank).convolveKernelTerminal room2 direction2)
       | none =>
-        let bank := (Oriented.Bank.ofFuture voice).convolveKernel room1 direction1
-          Oriented.syntacticSameSideClassifier
-        .generic ((bank.phaser tails mix).convolveKernelTerminal room2 direction2)
+        .generic <| Oriented.TerminalBank.ofBank
+          (resolvePlainStageState initial stages responseClock values).2
     | _, _, _ =>
       .generic <| Oriented.TerminalBank.ofBank
         (resolvePlainStageState initial stages responseClock values).2
@@ -593,9 +711,9 @@ def lowerInput (g : PatchGraph) (rankOf : String → Option Nat)
             bank.realizeSig responseClock modal.strikeAnchor modal.modeCount?)
             (#[response] ++ controlTerms))
       | .bloomed voice B gr =>
-        let hasPhaser := modal.stages.any fun stage => stage matches .phaser _
-        if hasPhaser then
-          .error s!"lower: bloomed phaser crossing at '{id}' refused (the live all-pass/Gamma crossing is not implemented)"
+        let hasLinear := modal.stages.any fun stage => stage matches .linear _
+        if hasLinear then
+          .error s!"lower: bloomed linear-kernel crossing at '{id}' refused (the live linear/Gamma crossing is not implemented)"
         else
         let term ← match fixedForwardBloomRooms? modal.stages with
           | none =>

--- a/lean/Tropical/Engine/Front.lean
+++ b/lean/Tropical/Engine/Front.lean
@@ -50,9 +50,12 @@ private def graphArtifactArgs (args : Json) (taps : Json) : Json :=
     `compileSession → buildKernelIr → loadIrStaged` tail. A compile failure
     errors BEFORE the load, so the previous kernel keeps playing. -/
 def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
-  let requestedTaps := selectedObservationTapNames args
+  let flatArgs ← match Tropical.Playground.elaboratePatchHierarchy args with
+    | .error e => internalError e
+    | .ok graph => pure graph
+  let requestedTaps := selectedObservationTapNames flatArgs
   let (compiled, publishedTaps, generation) ← if requestedTaps.isEmpty then
-      let compiled ← match ← Tropical.Playground.compilePlan args with
+      let compiled ← match ← Tropical.Playground.compilePlan flatArgs with
         | .error e => internalError e
         | .ok p => pure p
       let generation ←
@@ -64,8 +67,8 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
       -- participates in the audible path. Keep the authored final output as
       -- observation port `out`; explicit probes are additional roots, never a
       -- replacement that silently changes what the `out` binding means.
-      let audioArgs := graphArtifactArgs args (Json.bool false)
-      let observationArgs := graphArtifactArgs args
+      let audioArgs := graphArtifactArgs flatArgs (Json.bool false)
+      let observationArgs := graphArtifactArgs flatArgs
         (Json.arr (requestedTaps.map Json.str))
       let audio ← match ← Tropical.Playground.compilePlan audioArgs with
         | .error e => internalError e
@@ -83,14 +86,14 @@ def handleLoadPatchGraph (env : Env) (args : Json) : EngineM Json := do
   -- `render_window`-readable root output slot), so an attached scope discovers
   -- this graph's inspection points via `list_scope_taps` with no session wiring.
   env.state.modify (fun st => { st with
-    params := Tropical.Playground.knobParams args
+    params := Tropical.Playground.knobParams flatArgs
     scopeTaps := publishedTaps
     paramDisciplines := compiled.plan.paramDisciplines })
   -- The realized-state report: facts about what compiled (active/excluded
   -- nodes, wired/normalled inputs, live params with disciplines, taps) —
   -- never warnings. `ok` stays for callers that only ever looked at it.
-  pure <| Tropical.Playground.realizedReportForGeneration args publishedTaps
-    generation.programVersion generation.controlVersion
+  pure <| Tropical.Playground.realizedReportForGeneration flatArgs publishedTaps
+    generation.programVersion generation.controlVersion (some args)
 
 def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   wrap <| match name with
@@ -99,6 +102,7 @@ def handleTool (env : Env) (name : String) (args : Json) : IO Json :=
   -- disciplines, display metadata) — clients render it, never re-encode it.
   -- Session-independent, so it just echoes.
   | "get_vocabulary" => pure Tropical.Playground.vocabularyJson
+  | "get_module_library" => pure Tropical.Playground.hierarchyLibraryJson
   | "add_instance"    => handleAddInstance env args
   | "remove_instance" => handleRemoveInstance env args
   | "replicate"       => handleReplicate env args

--- a/lean/Tropical/Playground/Compile.lean
+++ b/lean/Tropical/Playground/Compile.lean
@@ -1,4 +1,5 @@
 import Tropical.Playground.Report
+import Tropical.Playground.Hierarchy
 
 /-!
 # Playground.Compile
@@ -22,6 +23,7 @@ open Tropical.Exact (DyadicI)
     upstream cone), so they're for the inspection build, not a lean audio path. -/
 def compilePlanPure (arena : Arena) (resolved : Array (String × ProgramIdx)) (j : Json) :
     Except String CompiledPatch := do
+  let j ← elaboratePatchHierarchy j
   let raws := rawsOf j
   checkServedKinds raws                              -- reject withheld/unknown kinds FIRST (honest msg over the misleading type error)
   checkEdgeTypes raws                                -- reject ill-typed / dangling / wire-into-knob edges pre-lowering

--- a/lean/Tropical/Playground/Decode.lean
+++ b/lean/Tropical/Playground/Decode.lean
@@ -55,7 +55,8 @@ def masterClock (pidx : String → Option Nat) : Clock :=
     `paramRef`; only structural selectors (`voice`, warp `mode`) and topology are
     baked, so only they trigger a relower. Every generator reads the live
     `masterClock` as its base, so global time-warp reaches all of them. -/
-def buildNode (pidx : String → Option Nat) (id kind : String)
+def buildNodeWithParamNames (pidx : String → Option Nat)
+    (paramName : String → String) (id kind : String)
     (_sel params inObj : Json) : Node × Array PatchNode :=
   -- Ordinary effect inlets are implicit typed fan-ins.  The inlet's served
   -- domain has already rejected signal→modal edges; here multiple signal-side
@@ -77,8 +78,8 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
   -- this node's own knob `kname` as a live value: a closed-form glide if glided,
   -- else a raw slot read; falling back to the baked literal if unallocated.
   let p := fun (kname : String) (dflt : Sig) =>
-    if isGlided kind kname then glideExpr pidx s!"{id}.{kname}" dflt
-    else pref pidx s!"{id}.{kname}" dflt
+    if isGlided kind kname then glideExpr pidx (paramName kname) dflt
+    else pref pidx (paramName kname) dflt
   -- a knob's request-or-table default: the JSON params value if given, else the
   -- table's fallback — the one place buildNode learns a default from.
   let dv := fun (kname : String) => jExpr params kname (fallbackOf kind kname)
@@ -91,15 +92,15 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
     let dflt := dv kname
     let fallback : ArrowTerm :=
       if isGlided kind kname then
-        .arrUn (fun clkQ => glideExprQAt pidx s!"{id}.{kname}" dflt clkQ)
+        .arrUn (fun clkQ => glideExprQAt pidx (paramName kname) dflt clkQ)
           (.clk clk)
       else
-        .konst (pref pidx s!"{id}.{kname}" dflt)
+        .konst (pref pidx (paramName kname) dflt)
     ({ fallback
        signalNode? := (portSources inObj kname)[0]? } : ModalControlRef)
   match kind with
   | "knob" =>
-    match pidx s!"{id}.value" with
+    match pidx (paramName "value") with
     | some i => (.knob i, #[])
     | none => (.mix #[], #[])   -- a knob missing from the table (unreachable): silence
   | "source" =>
@@ -112,7 +113,7 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
     -- the anchor: (phase slot, compile-time freq). Present only when the source's
     -- own freq is a live slot; the compile-time freq is the reference the warped
     -- copies' phase correction is measured from.
-    let anchor := (pidx s!"{id}.freq#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "freq")
+    let anchor := (pidx s!"{paramName "freq"}#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "freq")
     -- dedicated `pm` inlet: an AUDIO node wired here through-zero phase-modulates
     -- this carrier — `depth·mod` (cycles) added to the phase port, NOT the clock, so
     -- the carrier pitch stays put. `freq` is untouched, so the carrier's own freq
@@ -133,7 +134,7 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
     let pitchE := match (portSources inObj "freq")[0]? with
       | some w => pref pidx s!"{w}.value" (dv "freq")
       | none => p "freq" (dv "freq")
-    let anchor := (pidx s!"{id}.freq#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "freq")
+    let anchor := (pidx s!"{paramName "freq"}#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "freq")
     (.source (pluckedVoiceE pitchE (p "morph" (dv "morph"))
        (p "event_rate" (dv "event_rate")) anchor) clk, #[])
   | "comb" =>
@@ -156,7 +157,7 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
   | "reverse" => (.warpFx sig (fun c => neg c), sigFanIn)
   | "fm" =>
     -- `carrier` is a frequency → phase-anchored (own #phase slot); `depth` glides.
-    let carAnchor := (pidx s!"{id}.carrier#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "carrier")
+    let carAnchor := (pidx s!"{paramName "carrier"}#phase").map fun i => ((.paramRef ⟨i⟩ : Sig), dv "carrier")
     (.fm sig (sineVoiceE (p "carrier" (dv "carrier")) carAnchor)
       clk (p "depth" (dv "depth")), sigFanIn)
   | "sflange" =>
@@ -198,7 +199,7 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
       (.modalSource (resonatorBank f0 decay npart) (lit 0) clk addr?, #[])
     | some _ =>
       let cap := (jInt params "partials_max" 6).toNat
-      let countE := pref pidx s!"{id}.partials" (lit (Int.ofNat npart))
+      let countE := pref pidx (paramName "partials") (lit (Int.ofNat npart))
       (.modalSource (resonatorBank f0 decay cap) (lit 0) clk addr? (some countE), #[])
   | "reverb" =>
     let rt60 := modalControl "rt60"
@@ -241,6 +242,14 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
       (modalControl "center") (modalControl "sweep")
       (modalControl "rate") (modalControl "mix") modalPhaserRatios
     (node, modalFanIn ++ topology)
+  | "modal_allpass_tail" =>
+    (.modalLinear modal <| modalAllpassTailStage
+      (modalControl "center") (modalControl "sweep")
+      (modalControl "rate") (jFloat params "ratio" 1.0), modalFanIn)
+  | "modalblend" =>
+    let dry := ((portSources inObj "dry")[0]?).getD "__silence__"
+    let wet := ((portSources inObj "wet")[0]?).getD "__silence__"
+    (.modalBlend dry wet (modalControl "mix"), #[])
   | "modalmix" => (.modalMix (portSources inObj "in"), #[])
   | "gauge" =>
     -- §5 excitation gauge: re-level the modal input's peak. g=0 identity (unity-DC,
@@ -313,12 +322,19 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
     (.modalSource modes anchor clk addr?, #[])
   | _ => (.mix (portSources inObj "in"), #[])
 
+/-- Construct an ordinary flat node whose public parameter namespace is its id. -/
+def buildNode (pidx : String → Option Nat) (id kind : String)
+    (sel params inObj : Json) : Node × Array PatchNode :=
+  buildNodeWithParamNames pidx (fun knob => s!"{id}.{knob}")
+    id kind sel params inObj
+
 structure Raw where
   id : String
   kind : String
   sel : Json
   params : Json
   inObj : Json
+  paramAliases : Json
 
 def decodeRaw (nj : Json) : Option Raw :=
   match nj.getObjVal? "id", nj.getObjVal? "kind" with
@@ -326,13 +342,21 @@ def decodeRaw (nj : Json) : Option Raw :=
     let sel := (nj.getObjVal? "sel").toOption.getD (Json.mkObj [])
     let params := (nj.getObjVal? "params").toOption.getD (Json.mkObj [])
     let inObj := (nj.getObjVal? "in").toOption.getD (Json.mkObj [])
-    some { id, kind, sel, params, inObj }
+    let paramAliases := (nj.getObjVal? "param_aliases").toOption.getD (Json.mkObj [])
+    some { id, kind, sel, params, inObj, paramAliases }
   | _, _ => none
 
 def rawsOf (j : Json) : Array Raw :=
   match (j.getObjVal? "nodes").toOption.bind (·.getArr?.toOption) with
   | some arr => arr.filterMap decodeRaw
   | none => #[]
+
+/-- A hierarchy leaf may forward one of its local knobs to a stable parameter
+    on its containing public module. Flat v1/v2 nodes have no aliases. -/
+def paramNameOf (raw : Raw) (knob : String) : String :=
+  match raw.paramAliases.getObjVal? knob with
+  | .ok (.str name) => name
+  | _ => s!"{raw.id}.{knob}"
 
 /-- The continuous knobs each node kind carries, DERIVED from the port-spec
     table (declaration order = `ParamIdx` scan order). Structural selectors
@@ -417,7 +441,7 @@ def checkServedKinds (raws : Array Raw) : Except String Unit := do
   for r in raws do
     if withheldKinds.contains r.kind then
       throw s!"unserved kind: '{r.id}' has kind '{r.kind}', which the engine builds but WITHHOLDS from the surface vocabulary (conditioning is guarded, but arbitrary-table factor landing, profile bounds, cost, and live-beta topology are not yet a served contract) — not available as a patch node"
-    unless vocabularyKinds.contains r.kind do
+    unless (vocabularyKinds.contains r.kind) || (hierarchyAtomKinds.contains r.kind) do
       throw s!"unknown kind: '{r.id}' has kind '{r.kind}', which is not a served node kind — see get_vocabulary for the {vocabularyKinds.size} kinds the surface builds"
   pure ()
 
@@ -589,8 +613,11 @@ def collectParams (raws : Array Raw) : Array (String × JsonNumber) := Id.run do
         | some o => !(portSources r.inObj o).isEmpty
         | none => false
       if !selfWired && !ownerWired then
-        let base := s!"{r.id}.{kname}"
+        let base := paramNameOf r kname
         let dflt := (jNum? r.params kname).getD ⟨0, 0⟩
+        let alreadyRegistered := out.any fun (name, _) =>
+          name == base || name == s!"{base}#v0" || name == s!"{base}#phase"
+        if alreadyRegistered then continue
         if isGlided r.kind kname then
           -- three anchor slots for the closed-form ramp; v0=v1=current value and
           -- t0=0 means it starts flat at the knob's value (no ramp until re-anchored).
@@ -631,7 +658,8 @@ def decodeGraph (j : Json) : Except String (PatchGraph × Array (String × JsonN
   let mut pnodes : Array PatchNode := #[]
   for r in raws do
     if r.kind == "out" then continue
-    let (node, extras) := buildNode pidx r.id r.kind r.sel r.params r.inObj
+    let (node, extras) := buildNodeWithParamNames pidx (paramNameOf r)
+      r.id r.kind r.sel r.params r.inObj
     pnodes := pnodes.push { id := r.id, node }
     for e in extras do pnodes := pnodes.push e
   let outIns := match raws.find? (·.id == outId) with

--- a/lean/Tropical/Playground/Decode.lean
+++ b/lean/Tropical/Playground/Decode.lean
@@ -223,18 +223,24 @@ def buildNode (pidx : String → Option Nat) (id kind : String)
         reverbRoom boundedRt60 rtRange 32 (60, 0) (6000, 0))
       rt60 dirX sway swayRate, modalFanIn)
   | "filter" =>
-    -- the filter IS a modalReverb with a computed 2-mode room: the residue
-    -- calculus does the "filtering" at build time, knobs stay live through it.
-    (.modalReverb modal
-      (filterPair (p "cutoff" (dv "cutoff")) (p "resonance" (dv "resonance"))) none,
-      modalFanIn)
+    -- A filter is now an ordinary proper modal-kernel atom.  Its public module
+    -- remains a convenience surface, but no filter-specific stage survives
+    -- into the modal compiler algebra.
+    let stage : ModalLinearStage := {
+      controls := #[ModalControlRef.constant (lit 0)]
+      build := fun _ values =>
+        .proper (.oriented
+          (filterPair (p "cutoff" (dv "cutoff")) (p "resonance" (dv "resonance")))
+          ((values[0]?).getD (lit 0))) }
+    (.modalLinear modal stage, modalFanIn)
   | "phaser" =>
-    -- Current-universe modal phaser: controls remain deferred until the
-    -- terminal response coordinate freezes one static analog all-pass cascade.
-    -- This is not the history-dependent recurrence of a conventional pedal.
-    (.modalPhaser modal
+    -- The convenience module expands into six ordinary identity-plus-tail
+    -- junctions and one final blend.  Structural lowering, not this product
+    -- name, recovers and retains the all-pass factors.
+    let (node, topology) := modalPhaserTopology id modal
       (modalControl "center") (modalControl "sweep")
-      (modalControl "rate") (modalControl "mix") modalPhaserRatios, modalFanIn)
+      (modalControl "rate") (modalControl "mix") modalPhaserRatios
+    (node, modalFanIn ++ topology)
   | "modalmix" => (.modalMix (portSources inObj "in"), #[])
   | "gauge" =>
     -- §5 excitation gauge: re-level the modal input's peak. g=0 identity (unity-DC,

--- a/lean/Tropical/Playground/Hierarchy.lean
+++ b/lean/Tropical/Playground/Hierarchy.lean
@@ -1,0 +1,545 @@
+import Lean.Data.Json
+
+/-!
+# Version-3 patch hierarchy
+
+The persisted authoring document may contain reusable, nested definitions, but
+the production patcher continues to consume one flat downstream-only graph.
+This module is the single hygienic elaboration boundary between those worlds.
+
+V3 uses ordinary graph nodes plus three authoring-only kinds:
+
+* `module` references a definition by stable id and version;
+* `module_input` is the one primary input boundary of a definition; and
+* `module_output` is its one primary output boundary.
+
+Definitions carry typed port/parameter metadata for clients.  The elaborator
+needs only their ids, versions, ordered nodes, boundary ids, parameter defaults,
+and explicit parameter bindings.  Every leaf after expansion is an existing
+registered patch kind or one compiler-private hierarchy atom.  No hierarchy
+case reaches EmitArrow or a backend.
+-/
+
+namespace Tropical.Playground
+
+open Lean (Json JsonNumber)
+
+private def obj? : Json → Option (Std.TreeMap.Raw String Json compare)
+  | .obj fields => some fields
+  | _ => none
+
+private def arr? : Json → Option (Array Json)
+  | .arr values => some values
+  | _ => none
+
+private def str? : Json → Option String
+  | .str value => some value
+  | _ => none
+
+private def nat? : Json → Option Nat
+  | .num value =>
+      if value.exponent == 0 && value.mantissa ≥ 0 then some value.mantissa.toNat else none
+  | _ => none
+
+private def field? (json : Json) (name : String) : Option Json :=
+  (obj? json).bind (·[name]?)
+
+private def strField? (json : Json) (name : String) : Option String :=
+  (field? json name).bind str?
+
+private def arrField (json : Json) (name : String) : Array Json :=
+  (field? json name).bind arr? |>.getD #[]
+
+private def objField (json : Json) (name : String) : Std.TreeMap.Raw String Json compare :=
+  (field? json name).bind obj? |>.getD {}
+
+private def jsonSet (json : Json) (name : String) (value : Json) : Json :=
+  match json with
+  | .obj fields => .obj (fields.insert name value)
+  | _ => Json.mkObj [(name, value)]
+
+private def jsonErase (json : Json) (name : String) : Json :=
+  match json with
+  | .obj fields => .obj (fields.erase name)
+  | other => other
+
+private def inputSources (node : Json) (port : String) : Array String :=
+  match (objField node "in")[port]? with
+  | some (.arr values) => values.filterMap str?
+  | _ => #[]
+
+private def setInputs (node : Json) (ports : Array (String × Array String)) : Json :=
+  let fields := ports.foldl (fun out (name, sources) =>
+    out.insert name (.arr (sources.map Json.str))) {}
+  jsonSet node "in" (.obj fields)
+
+private structure HierarchyParameter where
+  name : String
+  defaultValue : Json
+
+private structure HierarchyDefinition where
+  id : String
+  version : Nat
+  inputNode : String
+  outputNode : String
+  inputDomain : String
+  outputDomain : String
+  parameters : Array HierarchyParameter
+  nodes : Array Json
+
+private def decodeParameter (owner : String) (json : Json) : Except String HierarchyParameter := do
+  let some name := strField? json "name"
+    | throw s!"hierarchy: definition '{owner}' has a parameter without a string name"
+  if name.isEmpty then
+    throw s!"hierarchy: definition '{owner}' has an empty parameter name"
+  let some defaultValue := field? json "default"
+    | throw s!"hierarchy: definition '{owner}' parameter '{name}' has no default"
+  pure { name, defaultValue }
+
+private def decodeDefinition (json : Json) : Except String HierarchyDefinition := do
+  let some id := strField? json "id"
+    | throw "hierarchy: definition is missing string field 'id'"
+  if id.isEmpty then throw "hierarchy: definition id cannot be empty"
+  let some version := (field? json "version").bind nat?
+    | throw s!"hierarchy: definition '{id}' is missing a nonnegative integer version"
+  let some inputNode := strField? json "input"
+    | throw s!"hierarchy: definition '{id}' is missing string field 'input'"
+  let some outputNode := strField? json "output"
+    | throw s!"hierarchy: definition '{id}' is missing string field 'output'"
+  let nodes := arrField json "nodes"
+  if nodes.isEmpty then throw s!"hierarchy: definition '{id}' has no nodes"
+  let inputDomain := strField? json "input_domain" |>.getD "modal"
+  let outputDomain := strField? json "output_domain" |>.getD "modal"
+  unless inputDomain == "modal" && outputDomain == "modal" do
+    throw s!"hierarchy: definition '{id}' v{version} must be Modal → Modal in schema v3"
+  let parameters ← (arrField json "parameters").mapM (decodeParameter id)
+  pure {
+    id, version, inputNode, outputNode, inputDomain, outputDomain
+    parameters
+    nodes }
+
+private structure BoundParameter where
+  localName : String
+  globalName : String
+  value : Json
+
+private structure ExpandedGraph where
+  nodes : Array Json := #[]
+  outputs : Array (String × Array String) := #[]
+  sourceMap : Array Json := #[]
+
+private def parameterJson (name : String) (value : Json) : Json :=
+  Json.mkObj [("name", .str name), ("default", value)]
+
+private def boundaryNode (id kind : String) (inputs : Array String := #[]) : Json :=
+  Json.mkObj <| [("id", .str id), ("kind", .str kind)] ++
+    if inputs.isEmpty then [] else
+      [("in", Json.mkObj [("in", .arr (inputs.map Json.str))])]
+
+private def allpassDefinitionJson : Json :=
+  Json.mkObj [
+    ("id", .str "tropical.modal.allpass1"), ("version", Lean.toJson 1),
+    ("input", .str "input"), ("output", .str "output"),
+    ("input_domain", .str "modal"), ("output_domain", .str "modal"),
+    ("parameters", .arr #[
+      parameterJson "center" (.num ⟨700, 0⟩),
+      parameterJson "sweep" (.num ⟨15, 1⟩),
+      parameterJson "rate" (.num ⟨2, 1⟩),
+      parameterJson "ratio" (.num ⟨1, 0⟩)]),
+    ("nodes", .arr #[
+      boundaryNode "input" "module_input",
+      Json.mkObj [
+        ("id", .str "tail"), ("kind", .str "modal_allpass_tail"),
+        ("params", Json.mkObj []),
+        ("bindings", Json.mkObj [
+          ("center", .str "center"), ("sweep", .str "sweep"),
+          ("rate", .str "rate"), ("ratio", .str "ratio")]),
+        ("in", Json.mkObj [("in", .arr #[.str "input"])])],
+      Json.mkObj [
+        ("id", .str "section"), ("kind", .str "modalmix"),
+        ("in", Json.mkObj [("in", .arr #[.str "input", .str "tail"])])],
+      boundaryNode "output" "module_output" #["section"]])]
+
+private def phaserRatioJson : Array Json := #[
+  .num ⟨42044820762685725, 17⟩,
+  .num ⟨5946035575013605, 16⟩,
+  .num ⟨8408964152537145, 16⟩,
+  .num ⟨1189207115002721, 15⟩,
+  .num ⟨1681792830507429, 15⟩,
+  .num ⟨2378414230005442, 15⟩]
+
+private def phaserStageNode (index : Nat) (ratio : Json) : Json :=
+  let input := if index == 0 then "input" else s!"stage_{index - 1}"
+  Json.mkObj [
+    ("id", .str s!"stage_{index}"), ("kind", .str "module"),
+    ("definition", .str "tropical.modal.allpass1"),
+    ("definition_version", Lean.toJson 1),
+    ("params", Json.mkObj [("ratio", ratio)]),
+    ("bindings", Json.mkObj [
+      ("center", .str "center"), ("sweep", .str "sweep"),
+      ("rate", .str "rate")]),
+    ("in", Json.mkObj [("in", .arr #[.str input])])]
+
+private def phaserDefinitionJson : Json :=
+  Json.mkObj [
+    ("id", .str "tropical.modal.phaser"), ("version", Lean.toJson 1),
+    ("input", .str "input"), ("output", .str "output"),
+    ("input_domain", .str "modal"), ("output_domain", .str "modal"),
+    ("parameters", .arr #[
+      parameterJson "center" (.num ⟨700, 0⟩),
+      parameterJson "sweep" (.num ⟨15, 1⟩),
+      parameterJson "rate" (.num ⟨2, 1⟩),
+      parameterJson "mix" (.num ⟨5, 1⟩)]),
+    ("nodes", .arr <|
+      #[boundaryNode "input" "module_input"]
+      ++ phaserRatioJson.mapIdx phaserStageNode
+      ++ #[Json.mkObj [
+          ("id", .str "blend"), ("kind", .str "modalblend"),
+          ("bindings", Json.mkObj [("mix", .str "mix")]),
+          ("in", Json.mkObj [
+            ("dry", .arr #[.str "input"]),
+            ("wet", .arr #[.str "stage_5"])])],
+        boundaryNode "output" "module_output" #["blend"]])]
+
+/-- The immutable standard definitions a client can instantiate or clone. -/
+def hierarchyLibraryJson : Json := Json.mkObj [
+  ("schema", .str "tropical_module_library"),
+  ("schema_version", Lean.toJson 1),
+  ("definitions", .arr #[allpassDefinitionJson, phaserDefinitionJson])]
+
+private def shippedDefinitionJsons : Array Json :=
+  #[allpassDefinitionJson, phaserDefinitionJson]
+
+private def orderedNodes (owner : String) (nodes : Array Json) : Except String (Array Json) := do
+  let ids ← nodes.mapM fun node => match strField? node "id" with
+    | some id => pure id
+    | none => throw s!"hierarchy: {owner} contains a node without id"
+  unless ids.all (!·.isEmpty) do
+    throw s!"hierarchy: {owner} contains an empty node id"
+  unless ids.zipIdx.all (fun (id, index) => !(ids.extract 0 index).contains id) do
+    throw s!"hierarchy: {owner} contains duplicate node ids"
+  for node in nodes do
+    let id := strField? node "id" |>.getD "?"
+    for (_, value) in (objField node "in").toList do
+      let .arr sources := value
+        | throw s!"hierarchy: {owner} node '{id}' has a non-array inlet"
+      for source in sources do
+        let .str sourceId := source
+          | throw s!"hierarchy: {owner} node '{id}' has a non-string source"
+        unless ids.contains sourceId do
+          throw s!"hierarchy: {owner} node '{id}' names missing source '{sourceId}'"
+  let mut pending := nodes
+  let mut emittedIds : Array String := #[]
+  let mut ordered : Array Json := #[]
+  for _ in [0:nodes.size] do
+    let mut next : Array Json := #[]
+    for node in pending do
+      let dependencies := (objField node "in").toList.flatMap fun (_, value) =>
+        match value with
+        | .arr sources => (sources.filterMap str?).toList
+        | _ => []
+      if dependencies.all emittedIds.contains then
+        ordered := ordered.push node
+        emittedIds := emittedIds.push (strField? node "id" |>.getD "?")
+      else
+        next := next.push node
+    pending := next
+  unless pending.isEmpty do
+    throw s!"hierarchy: cycle in {owner}"
+  pure ordered
+
+private def validateDefinitionReferences
+    (definitions : Array HierarchyDefinition) : Except String Unit := do
+  let keys := definitions.map fun definition => (definition.id, definition.version)
+  let dependencies ← definitions.mapM fun definition => do
+    let mut out := #[]
+    for node in definition.nodes do
+      if strField? node "kind" == some "module" then
+        let localId := strField? node "id" |>.getD "?"
+        let some id := strField? node "definition"
+          | throw s!"hierarchy: module '{definition.id}.{localId}' is missing definition id"
+        let some version := (field? node "definition_version").bind nat?
+          | throw s!"hierarchy: module '{definition.id}.{localId}' is missing definition version"
+        out := out.push (id, version)
+    pure out
+  for (definition, deps) in definitions.zip dependencies do
+    for dep in deps do
+      unless keys.contains dep do
+        throw s!"hierarchy: definition '{definition.id}' references unavailable definition '{dep.1}' v{dep.2}"
+  let mut resolved : Array (String × Nat) := #[]
+  for _ in [0:definitions.size] do
+    for (key, deps) in keys.zip dependencies do
+      if !resolved.contains key && deps.all resolved.contains then
+        resolved := resolved.push key
+  unless resolved.size == definitions.size do
+    throw "hierarchy: definition-reference cycle"
+
+private def lookupOutput (outputs : Array (String × Array String))
+    (id : String) : Option (Array String) :=
+  (outputs.find? (·.1 == id)).map (·.2)
+
+private def lookupBound (context : Array BoundParameter)
+    (name : String) : Option BoundParameter :=
+  context.find? (·.localName == name)
+
+/-- Length-delimited path segments make generated ids injective without
+    imposing a forbidden-character rule on authored ids. -/
+private def hygienicId (path : Array String) (localId : String) : String :=
+  (path.push localId).foldl (fun out segment =>
+    out ++ s!"{segment.length}_{segment}") "__h3_"
+
+private def definitionOf (definitions : Array HierarchyDefinition)
+    (id : String) (version : Nat) : Option HierarchyDefinition :=
+  definitions.find? fun definition =>
+    definition.id == id && definition.version == version
+
+private def outputSourceOf (definition : HierarchyDefinition) : Except String String := do
+  let some boundary := definition.nodes.find? (strField? · "id" == some definition.outputNode)
+    | throw s!"hierarchy: definition '{definition.id}' output boundary '{definition.outputNode}' is missing"
+  unless strField? boundary "kind" == some "module_output" do
+    throw s!"hierarchy: definition '{definition.id}' output id '{definition.outputNode}' is not a module_output"
+  let sources := inputSources boundary "in"
+  let [source] := sources.toList
+    | throw s!"hierarchy: definition '{definition.id}' output boundary must have exactly one source"
+  pure source
+
+private def validateDefinitionShape (definition : HierarchyDefinition) : Except String Unit := do
+  let parameterNames := definition.parameters.map (·.name)
+  unless parameterNames.zipIdx.all (fun (name, index) =>
+      !(parameterNames.extract 0 index).contains name) do
+    throw s!"hierarchy: definition '{definition.id}' repeats a parameter name"
+  let some input := definition.nodes.find? (strField? · "id" == some definition.inputNode)
+    | throw s!"hierarchy: definition '{definition.id}' input boundary '{definition.inputNode}' is missing"
+  unless strField? input "kind" == some "module_input" do
+    throw s!"hierarchy: definition '{definition.id}' input id '{definition.inputNode}' is not a module_input"
+  unless (objField input "in").isEmpty do
+    throw s!"hierarchy: definition '{definition.id}' input boundary cannot have incoming wires"
+  for node in definition.nodes do
+    let id := strField? node "id" |>.getD "?"
+    match strField? node "kind" with
+    | some "module_input" => unless id == definition.inputNode do
+        throw s!"hierarchy: definition '{definition.id}' has undeclared module_input '{id}'"
+    | some "module_output" => unless id == definition.outputNode do
+        throw s!"hierarchy: definition '{definition.id}' has undeclared module_output '{id}'"
+    | some _ => pure ()
+    | none => throw s!"hierarchy: definition '{definition.id}' node '{id}' has no kind"
+  let _ ← outputSourceOf definition
+  pure ()
+
+private def boundContext (definition : HierarchyDefinition) (inst : Json)
+    (parent : Array BoundParameter) (publicId : String) : Except String (Array BoundParameter) := do
+  let bindings := objField inst "bindings"
+  let params := objField inst "params"
+  let mut out := #[]
+  for parameter in definition.parameters do
+    match bindings[parameter.name]? with
+    | some (.str parentName) =>
+      let some inherited := lookupBound parent parentName
+        | throw s!"hierarchy: binding '{parameter.name}={parentName}' at '{publicId}' names no outer parameter"
+      out := out.push { inherited with localName := parameter.name }
+    | some _ =>
+      throw s!"hierarchy: binding '{publicId}.{parameter.name}' must name an outer parameter"
+    | none =>
+      out := out.push {
+        localName := parameter.name
+        globalName := s!"{publicId}.{parameter.name}"
+        value := (params[parameter.name]?).getD parameter.defaultValue }
+  pure out
+
+private def bindAtomicParams (node : Json) (context : Array BoundParameter) : Except String Json := do
+  let bindings := objField node "bindings"
+  let mut params := objField node "params"
+  let mut aliases : Std.TreeMap.Raw String Json compare := {}
+  for (localName, binding) in bindings.toList do
+    let .str outerName := binding
+      | throw s!"hierarchy: atomic binding '{localName}' must be a parameter name"
+    let some bound := lookupBound context outerName
+      | throw s!"hierarchy: atomic binding '{localName}={outerName}' names no module parameter"
+    params := params.insert localName bound.value
+    aliases := aliases.insert localName (.str bound.globalName)
+  pure <| jsonErase
+    (jsonSet (jsonSet node "params" (.obj params)) "param_aliases" (.obj aliases))
+    "bindings"
+
+private def translatedInputs (node : Json)
+    (outputs : Array (String × Array String)) : Except String (Array (String × Array String)) := do
+  let mut translated := #[]
+  for (port, value) in (objField node "in").toList do
+    let .arr sourcesJson := value
+      | throw s!"hierarchy: inlet '{port}' must be an ordered source array"
+    let mut sources := #[]
+    for sourceJson in sourcesJson do
+      let .str source := sourceJson
+        | throw s!"hierarchy: inlet '{port}' contains a non-string source"
+      let some resolved := lookupOutput outputs source
+        | throw s!"hierarchy: source '{source}' is not earlier in definition order"
+      sources := sources ++ resolved
+    translated := translated.push (port, sources)
+  pure translated
+
+/-- Elaborate a v3 document to the unchanged flat patch-graph envelope. Flat
+    legacy graphs pass through structurally; legacy Phaser nodes first migrate
+    to the installed hierarchy definition at this same boundary. -/
+def elaboratePatchHierarchy (document : Json) : Except String Json := do
+  let originalVersion? := (field? document "version").bind nat?
+  let legacyNodes := arrField document "nodes"
+  let document := if originalVersion? != some 3 &&
+      legacyNodes.any (strField? · "kind" == some "phaser") then
+    let migratedNodes := legacyNodes.map fun node =>
+      if strField? node "kind" == some "phaser" then
+        jsonSet
+          (jsonSet
+            (jsonSet node "kind" (.str "module"))
+            "definition" (.str "tropical.modal.phaser"))
+          "definition_version" (Lean.toJson 1)
+      else node
+    let migrated := Json.mkObj [
+      ("version", Lean.toJson 3),
+      ("definitions", .arr #[]),
+      ("scene", Json.mkObj [
+        ("nodes", .arr migratedNodes),
+        ("out", (field? document "out").getD (.str ""))]),
+      ("taps", (field? document "taps").getD (.arr #[]))]
+    migrated
+  else document
+  let version? := (field? document "version").bind nat?
+  if version? != some 3 then return document
+  let authored ← (arrField document "definitions").mapM decodeDefinition
+  let authoredKeys := authored.map fun definition => (definition.id, definition.version)
+  unless authoredKeys.zipIdx.all (fun (key, index) =>
+      !(authoredKeys.extract 0 index).contains key) do
+    throw "hierarchy: duplicate definition id/version"
+  let shipped ← shippedDefinitionJsons.mapM decodeDefinition
+  let shippedKeys := shipped.map fun definition => (definition.id, definition.version)
+  for key in authoredKeys do
+    if shippedKeys.contains key then
+      throw s!"hierarchy: document cannot replace installed definition '{key.1}' v{key.2}; detach it under a new stable id"
+  let definitions ← (shipped ++ authored).mapM fun definition => do
+    let nodes ← orderedNodes s!"definition '{definition.id}' v{definition.version}"
+      definition.nodes
+    let definition := { definition with nodes }
+    validateDefinitionShape definition
+    pure definition
+  validateDefinitionReferences definitions
+  let definitionKeys := definitions.map fun definition => (definition.id, definition.version)
+  unless definitionKeys.zipIdx.all (fun (key, index) =>
+      !(definitionKeys.extract 0 index).contains key) do
+    throw "hierarchy: duplicate definition id/version"
+  let some scene := field? document "scene"
+    | throw "hierarchy: v3 document is missing object field 'scene'"
+  let some unorderedSceneNodes := (field? scene "nodes").bind arr?
+    | throw "hierarchy: v3 scene is missing array field 'nodes'"
+  let sceneNodes ← orderedNodes "scene" unorderedSceneNodes
+
+  let rec expandModule : Nat → Json → Array String → Array BoundParameter →
+      Array String → String → Except String ExpandedGraph
+    | 0, _, _, _, _, publicId =>
+      throw s!"hierarchy: definition-reference cycle at '{publicId}'"
+    | fuel + 1, inst, outerInputs, parentContext, path, publicId => do
+      let some definitionId := strField? inst "definition"
+        | throw s!"hierarchy: module '{publicId}' is missing definition id"
+      let some definitionVersion := (field? inst "definition_version").bind nat?
+        | throw s!"hierarchy: module '{publicId}' is missing definition version"
+      let some definition := definitionOf definitions definitionId definitionVersion
+        | throw s!"hierarchy: module '{publicId}' references unavailable definition '{definitionId}' v{definitionVersion}"
+      let context ← boundContext definition inst parentContext publicId
+      let outputSource ← outputSourceOf definition
+      let mut expanded : ExpandedGraph := if outerInputs.size > 1 then
+        let fanInId := hygienicId path "__module_input_fanin__"
+        let fanIn := Json.mkObj [
+          ("id", .str fanInId), ("kind", .str "modalmix"),
+          ("params", Json.mkObj []),
+          ("in", Json.mkObj [("in", .arr (outerInputs.map Json.str))])]
+        {
+          nodes := #[fanIn]
+          outputs := #[(definition.inputNode, #[fanInId])]
+          sourceMap := #[Json.mkObj [
+            ("expanded", .str fanInId),
+            ("definition", .str definition.id),
+            ("definition_version", Lean.toJson definition.version),
+            ("local", .str definition.inputNode),
+            ("path", .arr (path.map Json.str))]] }
+      else {
+        outputs := #[(definition.inputNode, outerInputs)] }
+      for node in definition.nodes do
+        let some localId := strField? node "id"
+          | throw s!"hierarchy: definition '{definition.id}' contains a node without id"
+        let some kind := strField? node "kind"
+          | throw s!"hierarchy: definition '{definition.id}' node '{localId}' has no kind"
+        if kind == "module_input" then
+          unless localId == definition.inputNode do
+            throw s!"hierarchy: definition '{definition.id}' has an undeclared module_input '{localId}'"
+        else if kind == "module_output" then
+          unless localId == definition.outputNode do
+            throw s!"hierarchy: definition '{definition.id}' has an undeclared module_output '{localId}'"
+        else
+          let inputs ← translatedInputs node expanded.outputs
+          let nodePublicId := if localId == outputSource then publicId
+            else hygienicId path localId
+          if kind == "module" then
+            let child ← expandModule fuel (setInputs node inputs)
+              (inputs.find? (·.1 == "in") |>.map (·.2) |>.getD #[])
+              context (path.push localId) nodePublicId
+            expanded := {
+              nodes := expanded.nodes ++ child.nodes
+              sourceMap := expanded.sourceMap ++ child.sourceMap
+              outputs := expanded.outputs.push (localId,
+                (lookupOutput child.outputs "__module_output__").getD #[nodePublicId]) }
+          else
+            let bound ← bindAtomicParams (setInputs node inputs) context
+            let flat := jsonSet bound "id" (.str nodePublicId)
+            expanded := {
+              nodes := expanded.nodes.push flat
+              sourceMap := expanded.sourceMap.push <| Json.mkObj [
+                ("expanded", .str nodePublicId),
+                ("definition", .str definition.id),
+                ("definition_version", Lean.toJson definition.version),
+                ("local", .str localId),
+                ("path", .arr (path.map Json.str))]
+              outputs := expanded.outputs.push (localId, #[nodePublicId]) }
+      let some result := lookupOutput expanded.outputs outputSource
+        | throw s!"hierarchy: definition '{definition.id}' output source '{outputSource}' did not elaborate"
+      pure { expanded with outputs := expanded.outputs.push ("__module_output__", result) }
+
+  let mut flatNodes := #[]
+  let mut sourceMap := #[]
+  let mut outputs : Array (String × Array String) := #[]
+  for node in sceneNodes do
+    let some id := strField? node "id"
+      | throw "hierarchy: scene contains a node without id"
+    let some kind := strField? node "kind"
+      | throw s!"hierarchy: scene node '{id}' has no kind"
+    let inputs ← translatedInputs node outputs
+    if kind == "module" then
+      let module ← expandModule (definitions.size + 1) (setInputs node inputs)
+        (inputs.find? (·.1 == "in") |>.map (·.2) |>.getD #[])
+        #[] #[id] id
+      flatNodes := flatNodes ++ module.nodes
+      sourceMap := sourceMap ++ module.sourceMap
+      outputs := outputs.push (id,
+        (lookupOutput module.outputs "__module_output__").getD #[id])
+    else
+      flatNodes := flatNodes.push (setInputs node inputs)
+      outputs := outputs.push (id, #[id])
+
+  let sceneOut := strField? scene "out" |>.getD ""
+  let flatIds := flatNodes.filterMap (strField? · "id")
+  unless flatIds.zipIdx.all (fun (id, index) =>
+      !(flatIds.extract 0 index).contains id) do
+    throw "hierarchy: hygienic expansion id collides with an authored node id"
+  let flatOut := (lookupOutput outputs sceneOut).bind (·[0]?) |>.getD sceneOut
+  let taps := match field? document "taps" with
+    | some (.arr requested) => .arr <| requested.filterMap fun value => do
+        let source ← str? value
+        let resolved ← lookupOutput outputs source
+        let id ← resolved[0]?
+        some (.str id)
+    | some other => other
+    | none => .arr #[]
+  pure <| Json.mkObj [
+    ("nodes", .arr flatNodes),
+    ("out", .str flatOut),
+    ("taps", taps),
+    ("source_map", .arr sourceMap)]
+
+end Tropical.Playground

--- a/lean/Tropical/Playground/Report.lean
+++ b/lean/Tropical/Playground/Report.lean
@@ -35,7 +35,7 @@ def paramDisciplinesOf (raws : Array Raw) :
         | some o => !(portSources r.inObj o).isEmpty
         | none => false
       if !selfWired && !ownerWired then
-        let base := s!"{r.id}.{spec.name}"
+        let base := paramNameOf r spec.name
         let d : Tropical.Plan.ParamDiscipline := match spec.discipline with
           | .glide =>
             -- 0.02 s: the engine's glide window
@@ -47,7 +47,8 @@ def paramDisciplinesOf (raws : Array Raw) :
             { name := base, discipline := "anchor", companions := #[s!"{base}#phase"] }
           | .raw =>
             { name := base, discipline := "raw" }
-        out := out.push d
+        unless out.any (fun existing => existing.name == base) do
+          out := out.push d
     -- Trip-count-as-data: the live `partials` slot (present only with the
     -- STATIC `partials_max` capacity) is a plain raw write — same walk and
     -- skip rules as `collectParams`.
@@ -66,7 +67,7 @@ def paramDisciplinesOf (raws : Array Raw) :
     not surface. Plus the taps. The silence-with-`{ok:true}` class dies here:
     a patch that gracefully compiled to nothing now SAYS so, as facts. -/
 def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
-    (programVersion controlVersion : UInt64) : Json := Id.run do
+    (programVersion controlVersion : UInt64) (authored? : Option Json := none) : Json := Id.run do
   let raws := rawsOf args
   let outId := match (args.getObjVal? "out").toOption with
     | some (.str s) => s
@@ -79,9 +80,33 @@ def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
         for spec in portSpecs r.kind do
           for src in portSources r.inObj spec.name do
             if !reach.contains src then reach := reach.push src
+  let authoredNodes := match authored? with
+    | some authored => match authored.getObjVal? "scene" with
+      | .ok scene => match scene.getObjVal? "nodes" with
+        | .ok (.arr nodes) => nodes
+        | _ => #[]
+      | _ => match authored.getObjVal? "nodes" with
+        | .ok (.arr nodes) => nodes
+        | _ => #[]
+    | none => #[]
+  let moduleSurfaces := authoredNodes.filterMap fun node => do
+    let id ← match node.getObjVal? "id" with | .ok (.str id) => some id | _ => none
+    let kind ← match node.getObjVal? "kind" with | .ok (.str kind) => some kind | _ => none
+    if kind != "module" && kind != "phaser" then none else
+      let displayKind := if kind == "phaser" then "phaser" else
+        match node.getObjVal? "definition" with
+        | .ok (.str "tropical.modal.phaser") => "phaser"
+        | .ok (.str "tropical.modal.allpass1") => "allpass"
+        | _ => "module"
+      let sources := match node.getObjVal? "in" with
+        | .ok inObj => portSources inObj "in"
+        | _ => #[]
+      some (id, displayKind, sources)
   let nodesJ := raws.map fun r =>
+    let reportedKind := (moduleSurfaces.find? (·.1 == r.id)).map (·.2.1) |>.getD r.kind
     Json.mkObj [("id", Json.str r.id), ("kind", Json.str r.kind),
       ("status", Json.str (if reach.contains r.id then "active" else "excluded"))]
+      |>.setObjVal! "kind" (Json.str reportedKind)
   let inputsJ := raws.foldl (init := #[]) fun acc r =>
     (portSpecs r.kind).foldl (init := acc) fun acc spec =>
       if spec.accepts.isEmpty then acc else
@@ -91,6 +116,12 @@ def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
         (if srcs.isEmpty then [("state", Json.str "normalled")]
          else [("state", Json.str "wired"),
                ("sources", Json.arr (srcs.map Json.str))])))
+  let inputsJ := moduleSurfaces.foldl (init := inputsJ) fun acc surface =>
+    acc.push <| Json.mkObj <|
+      [("node", Json.str surface.1), ("port", Json.str "in")] ++
+      (if surface.2.2.isEmpty then [("state", Json.str "normalled")]
+       else [("state", Json.str "wired"),
+             ("sources", Json.arr (surface.2.2.map Json.str))])
   let kindOf : String → Option String := fun id => (raws.find? (·.id == id)).map (·.kind)
   let paramsJ := (collectParams raws).filterMap fun (nm, v) =>
     if nm.endsWith "#v1" || nm.endsWith "#t0" || nm.endsWith "#phase"
@@ -111,6 +142,9 @@ def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
       ("instance", Json.str tap.sourceInstance),
       ("output", Json.str tap.sourceOutput),
       ("slot", Json.str tap.slot)]
+  let sourceMap := match args.getObjVal? "source_map" with
+    | .ok (.arr entries) => entries
+    | _ => #[]
   return Json.mkObj [("ok", Json.bool true),
     ("vocabulary_fingerprint", Json.str vocabularyFingerprint),
     -- Keep this handshake's versions as JSON integers, matching render_window.
@@ -118,7 +152,8 @@ def realizedReportForGeneration (args : Json) (taps : Array Tropical.ScopeTap)
     ("control_version", Lean.toJson controlVersion.toNat),
     ("nodes", Json.arr nodesJ),
     ("inputs", Json.arr inputsJ), ("params", Json.arr paramsJ),
-    ("taps", Json.arr tapsJ)]
+    ("taps", Json.arr tapsJ),
+    ("source_map", Json.arr sourceMap)]
 
 /-- Pure-report compatibility seam for tests and non-publishing consumers.
     Production loads always supply the exact runtime publication identity. -/

--- a/lean/Tropical/Playground/Vocabulary.lean
+++ b/lean/Tropical/Playground/Vocabulary.lean
@@ -563,6 +563,17 @@ def portSpecs : String → Array PortSpec
         display := some { min := 0.02, max := 8, log := true, unit := "Hz" } },
       { name := "mix", knob := some (5, 1), discipline := .glide,
         display := some { min := 0, max := 1 } }]
+  -- Compiler-private atoms used only after a v3 definition has been expanded.
+  -- They share the public phaser parameter schema through explicit aliases.
+  | "modal_allpass_tail" => #[
+      { name := "in", accepts := modalIn, multi := true },
+      { name := "center", knob := some (700, 0), discipline := .glide },
+      { name := "sweep", knob := some (15, 1), discipline := .glide },
+      { name := "rate", knob := some (2, 1), discipline := .glide }]
+  | "modalblend" => #[
+      { name := "dry", accepts := modalIn },
+      { name := "wet", accepts := modalIn },
+      { name := "mix", knob := some (5, 1), discipline := .glide }]
   | "modalmix" => #[{ name := "in", accepts := modalIn, multi := true }]
   -- gauge: the §5 excitation-gauge adapter — re-levels its modal input's peak by the
   -- self-measured ‖H‖^{−g}. `g` is the gauge: 0 = unity-DC (strike, the identity),
@@ -586,7 +597,8 @@ def portSpecs : String → Array PortSpec
 /-- Each kind's outlet color (`none` = no outlet, the dac sink). -/
 def outletOf : String → Option PortDomain
   | "knob" => some .control
-  | "resonator" | "reverb" | "filter" | "phaser" | "modalmix" | "string" | "gauge" => some .modal
+  | "resonator" | "reverb" | "filter" | "phaser" | "modalmix" | "string" | "gauge"
+  | "modal_allpass_tail" | "modalblend" => some .modal
   | "out" => none
   | _ => some .signal
 
@@ -598,6 +610,9 @@ def vocabularyKinds : Array String := #[
   "mix", "ring", "gong", "string", "resonator", "reverb", "filter", "phaser",
   "modalmix", "gauge", "knob", "out"]
 
+/-- Non-public atoms admitted only after hygienic v3 definition expansion. -/
+def hierarchyAtomKinds : Array String := #["modal_allpass_tail", "modalblend"]
+
 /-- Every kind `buildNode` actually constructs (its match arms — the AUTHORITATIVE
     list, read straight off the arms below). The classification-drift gate and
     `checkServedKinds` both derive from THIS, so `buildNode` cannot grow a kind the
@@ -608,7 +623,7 @@ def vocabularyKinds : Array String := #[
 def buildNodeKinds : Array String := #[
   "knob", "source", "pluck", "comb", "flange", "sflange", "fm", "delay",
   "reverse", "mix", "ring", "resonator", "reverb", "filter", "phaser", "modalmix",
-  "gauge", "gong", "bloomgong", "string"]
+  "modal_allpass_tail", "modalblend", "gauge", "gong", "bloomgong", "string"]
 
 /-- Kinds `buildNode` builds but which are WITHHELD from the served surface.
     The measured negative-integer conditioning discs are now named refusals, but

--- a/lean/Tropical/Tropicaltest/BanksStaging.lean
+++ b/lean/Tropical/Tropicaltest/BanksStaging.lean
@@ -463,8 +463,8 @@ private def tailEnergy (xs : Array Float) (lo : Nat) : Float := Id.run do
     acc := acc + xs[i]! * xs[i]!
   pure acc
 
-/-- THE MODAL FILTER gate (the VCFQ). A `filter` node is a `modalReverb`
-    whose room is one EXACT conjugate pole pair (`filterPair`), so three
+/-- THE MODAL FILTER gate (the VCFQ). A `filter` node contributes one generic
+    proper kernel containing an EXACT conjugate pole pair (`filterPair`), so three
     behaviors must hold, all through the ordinary graph surface:
     (A) LOWPASS: the same struck resonator through cutoff=4000 vs cutoff=60
         loses most of its energy (the composition's forced modes carry

--- a/lean/Tropical/Tropicaltest/Phaser.lean
+++ b/lean/Tropical/Tropicaltest/Phaser.lean
@@ -48,8 +48,8 @@ private def cscale (scale : Float) (a : CplxF) : CplxF :=
 private def constantControl (value : Sig) : ModalControlRef :=
   ModalControlRef.constant value
 
-private def testPhaser (input : String) : Node :=
-  .modalPhaser input
+private def testPhaser (id input : String) : Node × Array PatchNode :=
+  modalPhaserTopology id input
     (constantControl (lit 700)) (constantControl (lit 15 1))
     (constantControl (lit 2 1)) (constantControl (lit 5 1))
     modalPhaserRatios
@@ -58,10 +58,11 @@ private def sourceMode (sigma : Int := 3) : ModalMode :=
   ModalMode.hz (lit 220) (lit sigma) (lit 1)
 
 private def phaserGraph : PatchGraph :=
+  let (phaser, topology) := testPhaser "phaser" "source"
   { nodes := #[
       { id := "source", node := .modalSource #[sourceMode] (lit (Int.ofNat anchor))
           clockLit none },
-      { id := "phaser", node := testPhaser "source" }]
+      { id := "phaser", node := phaser }] ++ topology
     output := "phaser" }
 
 private def graphPlan (arena : Arena) (name : String) (graph : PatchGraph) :
@@ -167,33 +168,86 @@ private def controlValue (control : ModalControlRef) : Option Float := do
   let .konst expression := control.fallback | none
   sigConstF? expression
 
-private def deferredStructureCheck : Bool :=
-  let rankOf := fun id => if id == "source" then some 0 else
-    if id == "phaser" then some 1 else none
-  match lowerModal phaserGraph rankOf "phaser" 1 with
-  | .ok #[branch] =>
-      nodeIsModal phaserGraph "phaser" && match branch.stages.toList with
-      | [.phaser stage] =>
-          stage.ratios == modalPhaserRatios &&
-            controlValue stage.center == some 700.0 &&
-            controlValue stage.sweep == some 1.5 &&
-            controlValue stage.rate == some 0.2 &&
-            controlValue stage.mix == some 0.5 &&
-            branch.controls.size == 4
+private def lowerModalRoot (graph : PatchGraph) (id : String) : Except String ModalForest := do
+  let ids := graph.nodes.map (·.id)
+  let deps := graph.nodes.map fun node => node.node.inputIds.filterMap ids.idxOf?
+  let some ranks := Tropical.Ir.topoRanks? deps | throw "fixture cycle"
+  let some index := ids.idxOf? id | throw s!"fixture node '{id}' not found"
+  let some rank := ranks[index]? | throw s!"fixture node '{id}' has no rank"
+  lowerModal graph (fun name => (ids.idxOf? name).bind (ranks[·]?)) id rank
+
+/-- Visible topology and retained compiler structure both grow by one factor
+    per authored section; no parallel product is distributed here. -/
+private def retainedSizeCheck (ratios : Array Float) : Bool :=
+  let (phaser, topology) := modalPhaserTopology "phaser" "source"
+    (constantControl (lit 700)) (constantControl (lit 15 1))
+    (constantControl (lit 2 1)) (constantControl (lit 5 1)) ratios
+  let graph : PatchGraph := {
+    nodes := #[
+      { id := "source", node := .modalSource #[sourceMode] (lit 0) clockLit none },
+      { id := "phaser", node := phaser }] ++ topology
+    output := "phaser" }
+  let tailNodes := topology.countP fun node => node.node matches .modalLinear _ _
+  let junctions := topology.countP fun node => node.node matches .modalMix _
+  match lowerModalRoot graph "phaser" with
+  | .ok #[branch] => match branch.stages.toList with
+      | [.linear stage] =>
+          let values := branch.controls.filterMap controlValue |>.map litF
+          match (stage.build clockLit values).dryWetAllpassCascadeShape? with
+          | some (tails, _) =>
+              topology.size == 2 * ratios.size && tailNodes == ratios.size &&
+                junctions == ratios.size && tails.size == ratios.size &&
+                branch.controls.size == 3 * ratios.size + 1
+          | none => false
       | _ => false
   | _ => false
 
+private def deferredStructureCheck : Bool :=
+  let explicitTails := phaserGraph.nodes.countP fun node =>
+    node.node matches .modalLinear _ _
+  let explicitJunctions := phaserGraph.nodes.countP fun node =>
+    node.node matches .modalMix _
+  retainedSizeCheck (modalPhaserRatios.extract 0 1) &&
+    retainedSizeCheck (modalPhaserRatios.extract 0 2) &&
+    retainedSizeCheck modalPhaserRatios &&
+  match lowerModalRoot phaserGraph "phaser" with
+  | .ok #[branch] =>
+      explicitTails == 6 && explicitJunctions == 6 &&
+        nodeIsModal phaserGraph "phaser" && match branch.stages.toList with
+      | [.linear stage] =>
+          let values := branch.controls.filterMap controlValue |>.map litF
+          match (stage.build clockLit values).dryWetAllpassCascadeShape? with
+          | some (tails, mix) =>
+              tails.size == 6 && sigConstF? mix == some 0.5 &&
+                branch.controls.size == 19 &&
+                branch.controls[0]?.bind controlValue == some 700.0 &&
+                branch.controls[1]?.bind controlValue == some 1.5 &&
+                branch.controls[2]?.bind controlValue == some 0.2
+          | none => false
+      | _ => false
+  | _ => false
+
+/-- Filter is the independent second producer proving the retained algebra is
+    not merely a renamed phaser stage. -/
+private def filterUsesGenericKernelCheck : Bool :=
+  let empty := Lean.Json.mkObj []
+  let (node, _) := buildNode (fun _ => none) "filter" "filter" empty empty empty
+  match node with
+  | .modalLinear _ stage =>
+      let values := stage.controls.filterMap controlValue |>.map litF
+      (stage.build clockLit values).orientedShape?.isSome
+  | _ => false
+
 private def modalMixOrderCheck : Bool :=
+  let (phaser, topology) := testPhaser "phaser" "mix"
   let graph : PatchGraph :=
     { nodes := #[
         { id := "a", node := .modalSource #[sourceMode 3] (lit 0) clockLit none },
         { id := "b", node := .modalSource #[sourceMode 7] (lit 0) clockLit none },
         { id := "mix", node := .modalMix #["b", "a"] },
-        { id := "phaser", node := testPhaser "mix" }]
+        { id := "phaser", node := phaser }] ++ topology
       output := "phaser" }
-  let rankOf := fun id => if id == "a" then some 0 else if id == "b" then some 1
-    else if id == "mix" then some 2 else if id == "phaser" then some 3 else none
-  match lowerModal graph rankOf "phaser" 3 with
+  match lowerModalRoot graph "phaser" with
   | .ok #[first, second] =>
       let sigmaOf := fun branch => match branch.source with
         | .plain modes => modes[0]?.bind (sigConstF? ·.sigma)
@@ -203,28 +257,17 @@ private def modalMixOrderCheck : Bool :=
   | _ => false
 
 private def refusalChecks : Bool :=
+  let (phaser, topology) := testPhaser "phaser" "bloom"
   let bloomed : PatchGraph :=
     { nodes := #[
         { id := "bloom", node := .modalSource #[sourceMode] (lit 0) clockLit none
             none (some (0.1, 1.8)) },
-        { id := "phaser", node := testPhaser "bloom" }]
-      output := "phaser" }
-  let badRatios : PatchGraph :=
-    { nodes := #[
-        { id := "source", node := .modalSource #[sourceMode] (lit 0) clockLit none },
-        { id := "phaser", node := .modalPhaser "source"
-            (constantControl (lit 700)) (constantControl (lit 1))
-            (constantControl (lit 1)) (constantControl (lit 5 1))
-            #[1.0, 1.0, 2.0, 3.0, 4.0, 5.0] }]
+        { id := "phaser", node := phaser }] ++ topology
       output := "phaser" }
   let bloomOk := match lowerGraph bloomed with
-    | .error error => error == "lower: bloomed phaser crossing at 'phaser' refused (the live all-pass/Gamma crossing is not implemented)"
+    | .error error => error == "lower: bloomed linear-kernel crossing at 'phaser' refused (the live linear/Gamma crossing is not implemented)"
     | .ok _ => false
-  let ranks := fun id => if id == "source" then some 0 else if id == "phaser" then some 1 else none
-  let ratiosOk := match lowerModal badRatios ranks "phaser" 1 with
-    | .error error => error == "modal phaser 'phaser': expected six distinct positive structural ratios"
-    | .ok _ => false
-  bloomOk && ratiosOk
+  bloomOk
 
 private def phaserPatchJson : String :=
   "{\"nodes\":[" ++
@@ -326,6 +369,7 @@ private def productScratchCheck (arena : Arena)
 def runPhaser (arena : Arena) (resolved : Array (String × ProgramIdx)) : IO Bool := do
   IO.eprintln "current-universe modal phaser: structural gates"
   let structural := deferredStructureCheck
+  let genericFilter := filterUsesGenericKernelCheck
   let forestOrder := modalMixOrderCheck
   let refusals := refusalChecks
   IO.eprintln "        rendering independent-oracle fixture"
@@ -338,12 +382,12 @@ def runPhaser (arena : Arena) (resolved : Array (String × ProgramIdx)) : IO Boo
   match numeric, fused, live, product with
   | .ok samples, .ok fusedError, .ok controlsLive, .ok (scratch, baseline) =>
       let oracleError := maximumOracleError samples
-      IO.println s!"        deferred={structural} forest-order={forestOrder} refusals={refusals} oracle max abs={oracleError}"
+      IO.println s!"        topology-derived={structural} generic-filter={genericFilter} forest-order={forestOrder} refusals={refusals} oracle max abs={oracleError}"
       IO.println s!"        fused two-room JIT vs generic max abs={fusedError} ({fusedError * 1.0e9}e-9)"
       IO.println s!"        four served controls live without relower={controlsLive}; canonical 6→32→6-section→32 Metal scratch={scratch.total}/24576 (arrays={scratch.arrays}, max-routes={scratch.maxRoutedRecords}×4, slots={scratch.arraySlots}/{scratch.coeffArraySlots} coeff)"
       IO.println s!"        two-room baseline scratch={baseline.total} (arrays={baseline.arrays}, max-routes={baseline.maxRoutedRecords}×4, slots={baseline.arraySlots}/{baseline.coeffArraySlots} coeff)"
       IO.println s!"        product non-coeff array floats={repr scratch.nonCoeffSizes}; baseline={repr baseline.nonCoeffSizes}"
-      if structural && forestOrder && refusals && oracleError < 2.0e-5 &&
+      if structural && genericFilter && forestOrder && refusals && oracleError < 2.0e-5 &&
           -- The two exact schedules sum the same analytic rows in different
           -- routed orders.  This absolute lens is below two accumulated
           -- Q4.28 quanta per participating row and remains meaningful at
@@ -351,7 +395,7 @@ def runPhaser (arena : Arena) (resolved : Array (String × ProgramIdx)) : IO Boo
           fusedError < 2.0e-7 &&
           controlsLive && scratch.total ≤ 24576 then
         passGate "modal-phaser"
-          "deferred current-universe stage; independent rational render oracle; authored modalMix order; live center/sweep/rate/mix; named bloom/collision refusals; exact two-room product stays inside Metal scratch policy"
+          "topology-derived generic kernel; Filter is a second producer; independent rational render oracle; authored modalMix order; live controls; named bloom crossing refusal; exact two-room product stays inside Metal scratch policy"
       else
         failGate "modal-phaser" "structural, numerical, live-control, or product scratch contract failed"
   | .error error, _, _, _ => failGate "modal-phaser" s!"render: {firstLine error}"

--- a/lean/Tropical/Tropicaltest/Phaser.lean
+++ b/lean/Tropical/Tropicaltest/Phaser.lean
@@ -275,6 +275,18 @@ private def phaserPatchJson : String :=
     "{\"id\":\"ph\",\"kind\":\"phaser\",\"params\":{\"center\":700,\"sweep\":1.5,\"rate\":0.2,\"mix\":0.5},\"in\":{\"in\":[\"res\"]}}," ++
     "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"ph\"]}}],\"out\":\"out\"}"
 
+private def hierarchicalPhaserPatchJson : String :=
+  "{\"version\":3,\"scene\":{\"nodes\":[" ++
+    "{\"id\":\"res\",\"kind\":\"resonator\",\"params\":{\"freq\":220,\"decay\":4}}," ++
+    "{\"id\":\"ph\",\"kind\":\"module\",\"definition\":\"tropical.modal.phaser\",\"definition_version\":1,\"params\":{\"center\":700,\"sweep\":1.5,\"rate\":0.2,\"mix\":0.5},\"in\":{\"in\":[\"res\"]}}," ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"ph\"]}}],\"out\":\"out\"}}"
+
+private def illegalSignalToModalModuleJson : String :=
+  "{\"version\":3,\"scene\":{\"nodes\":[" ++
+    "{\"id\":\"osc\",\"kind\":\"source\",\"params\":{\"freq\":220}}," ++
+    "{\"id\":\"ph\",\"kind\":\"module\",\"definition\":\"tropical.modal.phaser\",\"definition_version\":1,\"in\":{\"in\":[\"osc\"]}}," ++
+    "{\"id\":\"out\",\"kind\":\"out\",\"in\":{\"in\":[\"ph\"]}}],\"out\":\"out\"}}"
+
 private def blockDifference (left right : Array Float) : Float := Id.run do
   let mut energy := 0.0
   for i in [0:min left.size right.size] do
@@ -313,6 +325,99 @@ private def surfaceAndLiveCheck (arena : Arena)
   let rate ← oneControlLive compiled "rate" 3.0
   let mix ← oneControlLive compiled "mix" 0.1
   pure (.ok (center && sweep && rate && mix))
+
+private def hierarchyEquivalenceCheck (arena : Arena)
+    (resolved : Array (String × ProgramIdx)) : IO (Except String Bool) := do
+  let prepared : Except String
+      (Lean.Json × CompiledPatch × CompiledPatch × CompiledPatch × Bool) := do
+    let legacy ← Lean.Json.parse phaserPatchJson
+    let hierarchical ← Lean.Json.parse hierarchicalPhaserPatchJson
+    let flat ← elaboratePatchHierarchy hierarchical
+    let libraryDefinitions ← (hierarchyLibraryJson.getObjVal? "definitions")
+      |>.bind (fun value => value.getArr?)
+    let some installedPhaser := libraryDefinitions[1]?
+      | throw "module library has no Phaser definition"
+    let customPhaser := match installedPhaser with
+      | .obj fields => .obj (fields.insert "id" (.str "user.ph.definition"))
+      | _ => installedPhaser
+    let authored := match hierarchical with
+      | .obj fields =>
+        let scene := match fields["scene"]? with
+          | some (.obj sceneFields) => .obj <| sceneFields.insert "nodes" (.arr #[
+              Lean.Json.mkObj [
+                ("id", .str "res"), ("kind", .str "resonator"),
+                ("params", Lean.Json.mkObj [("freq", .num ⟨220, 0⟩), ("decay", .num ⟨4, 0⟩)])],
+              Lean.Json.mkObj [
+                ("id", .str "ph"), ("kind", .str "module"),
+                ("definition", .str "user.ph.definition"),
+                ("definition_version", Lean.toJson 1),
+                ("params", Lean.Json.mkObj [("center", .num ⟨700, 0⟩),
+                  ("sweep", .num ⟨15, 1⟩), ("rate", .num ⟨2, 1⟩),
+                  ("mix", .num ⟨5, 1⟩)]),
+                ("in", Lean.Json.mkObj [("in", .arr #[.str "res"])])],
+              Lean.Json.mkObj [
+                ("id", .str "out"), ("kind", .str "out"),
+                ("in", Lean.Json.mkObj [("in", .arr #[.str "ph"])])]])
+          | other => other.getD (.obj {})
+        .obj <| fields.insert "definitions" (.arr #[customPhaser])
+          |>.insert "scene" scene
+      | _ => hierarchical
+    let legacyCompiled ← compilePlanPure arena resolved legacy
+    let hierarchicalCompiled ← compilePlanPure arena resolved hierarchical
+    let authoredCompiled ← compilePlanPure arena resolved authored
+    let illegal ← Lean.Json.parse illegalSignalToModalModuleJson
+    let typedBoundaryRefusal := match compilePlanPure arena resolved illegal with
+      | .error error => (error.splitOn "signal→modal").length > 1
+      | .ok _ => false
+    pure (flat, legacyCompiled, hierarchicalCompiled, authoredCompiled,
+      typedBoundaryRefusal)
+  match prepared with
+  | .error error => pure (.error error)
+  | .ok (flat, legacyCompiled, hierarchicalCompiled, authoredCompiled,
+      typedBoundaryRefusal) =>
+    let flatRaws := rawsOf flat
+    let sourceMapSize := match flat.getObjVal? "source_map" with
+      | .ok (.arr entries) => entries.size
+      | _ => 0
+    match ← renderPlanSamples legacyCompiled.plan frameCount,
+        ← renderPlanSamples hierarchicalCompiled.plan frameCount,
+        ← renderPlanSamples authoredCompiled.plan frameCount with
+    | .error error, _, _ | _, .error error, _ | _, _, .error error => pure (.error error)
+    | .ok legacySamples, .ok hierarchicalSamples, .ok authoredSamples =>
+      let maxDifference := (Array.range (min legacySamples.size hierarchicalSamples.size)).foldl
+        (fun worst index => max worst (legacySamples[index]! - hierarchicalSamples[index]!).abs) 0.0
+      let authoredDifference := (Array.range (min legacySamples.size authoredSamples.size)).foldl
+        (fun worst index => max worst (legacySamples[index]! - authoredSamples[index]!).abs) 0.0
+      let aliases := #["center", "sweep", "rate", "mix"].all fun knob =>
+        hierarchicalCompiled.plan.paramDisciplines.any (·.name == s!"ph.{knob}")
+      let noLeakedInternals := !hierarchicalCompiled.plan.paramDisciplines.any fun discipline =>
+        "__h3_".isPrefixOf discipline.name
+      IO.eprintln s!"        hierarchy flat={flatRaws.size}/15 source-map={sourceMapSize}/13 aliases={aliases} leaked-internals={!noLeakedInternals} typed-boundary={typedBoundaryRefusal} shipped-diff={maxDifference} authored-diff={authoredDifference}"
+      pure <| Except.ok <| flatRaws.size == 15 && sourceMapSize == 13 &&
+        flatRaws.any (fun raw => raw.id == "ph" && raw.kind == "modalblend") &&
+        aliases && noLeakedInternals && typedBoundaryRefusal &&
+        maxDifference < 2.0e-5 && authoredDifference < 2.0e-5
+
+private def hierarchyValidationCheck : Bool :=
+  let selfReference :=
+    "{\"version\":3,\"definitions\":[{\"id\":\"user.loop\",\"version\":1,\"input\":\"input\",\"output\":\"output\",\"input_domain\":\"modal\",\"output_domain\":\"modal\",\"parameters\":[],\"nodes\":[{\"id\":\"input\",\"kind\":\"module_input\"},{\"id\":\"again\",\"kind\":\"module\",\"definition\":\"user.loop\",\"definition_version\":1,\"in\":{\"in\":[\"input\"]}},{\"id\":\"output\",\"kind\":\"module_output\",\"in\":{\"in\":[\"again\"]}}]}],\"scene\":{\"nodes\":[],\"out\":\"\"}}"
+  let innerCycle :=
+    "{\"version\":3,\"definitions\":[{\"id\":\"user.cycle\",\"version\":1,\"input\":\"input\",\"output\":\"output\",\"input_domain\":\"modal\",\"output_domain\":\"modal\",\"parameters\":[],\"nodes\":[{\"id\":\"input\",\"kind\":\"module_input\"},{\"id\":\"a\",\"kind\":\"modalmix\",\"in\":{\"in\":[\"b\"]}},{\"id\":\"b\",\"kind\":\"modalmix\",\"in\":{\"in\":[\"a\"]}},{\"id\":\"output\",\"kind\":\"module_output\",\"in\":{\"in\":[\"a\"]}}]}],\"scene\":{\"nodes\":[],\"out\":\"\"}}"
+  let installedOverride :=
+    "{\"version\":3,\"definitions\":[{\"id\":\"tropical.modal.allpass1\",\"version\":1,\"input\":\"input\",\"output\":\"output\",\"parameters\":[],\"nodes\":[{\"id\":\"input\",\"kind\":\"module_input\"},{\"id\":\"output\",\"kind\":\"module_output\",\"in\":{\"in\":[\"input\"]}}]}],\"scene\":{\"nodes\":[],\"out\":\"\"}}"
+  let errorsAsExpected := fun source needle => match Lean.Json.parse source with
+    | .error _ => false
+    | .ok json => match elaboratePatchHierarchy json with
+      | .error error => (error.splitOn needle).length > 1
+      | .ok _ => false
+  let stable := match Lean.Json.parse hierarchicalPhaserPatchJson with
+    | .error _ => false
+    | .ok json => match elaboratePatchHierarchy json, elaboratePatchHierarchy json with
+      | .ok left, .ok right => left.compress == right.compress
+      | _, _ => false
+  errorsAsExpected selfReference "definition-reference cycle" &&
+    errorsAsExpected innerCycle "cycle in definition 'user.cycle'" &&
+    errorsAsExpected installedOverride "cannot replace installed definition" && stable
 
 /-- Compile the product shape through the exact two-room terminal and report its
     actual Metal scratch publication.  The hard support gate remains 24,576 B. -/
@@ -372,35 +477,41 @@ def runPhaser (arena : Arena) (resolved : Array (String × ProgramIdx)) : IO Boo
   let genericFilter := filterUsesGenericKernelCheck
   let forestOrder := modalMixOrderCheck
   let refusals := refusalChecks
+  let hierarchyValidation := hierarchyValidationCheck
   IO.eprintln "        rendering independent-oracle fixture"
   let numeric ← renderGraph arena "modal_phaser_oracle" phaserGraph
   let fused ← fusedProductError arena
   IO.eprintln "        compiling and driving four live controls"
   let live ← surfaceAndLiveCheck arena resolved
+  IO.eprintln "        expanding nested v3 Phaser/Allpass definitions"
+  let hierarchy ← hierarchyEquivalenceCheck arena resolved
   IO.eprintln "        compiling canonical two-room product scratch fixture"
   let product := productScratchCheck arena resolved
-  match numeric, fused, live, product with
-  | .ok samples, .ok fusedError, .ok controlsLive, .ok (scratch, baseline) =>
+  match numeric, fused, live, hierarchy, product with
+  | .ok samples, .ok fusedError, .ok controlsLive, .ok hierarchyEquivalent,
+      .ok (scratch, baseline) =>
       let oracleError := maximumOracleError samples
-      IO.println s!"        topology-derived={structural} generic-filter={genericFilter} forest-order={forestOrder} refusals={refusals} oracle max abs={oracleError}"
+      IO.println s!"        topology-derived={structural} generic-filter={genericFilter} forest-order={forestOrder} refusals={refusals} hierarchy-validation={hierarchyValidation} oracle max abs={oracleError}"
       IO.println s!"        fused two-room JIT vs generic max abs={fusedError} ({fusedError * 1.0e9}e-9)"
       IO.println s!"        four served controls live without relower={controlsLive}; canonical 6→32→6-section→32 Metal scratch={scratch.total}/24576 (arrays={scratch.arrays}, max-routes={scratch.maxRoutedRecords}×4, slots={scratch.arraySlots}/{scratch.coeffArraySlots} coeff)"
+      IO.println s!"        nested v3 Phaser→Allpass expansion equivalent={hierarchyEquivalent}; public ph.* aliases retained"
       IO.println s!"        two-room baseline scratch={baseline.total} (arrays={baseline.arrays}, max-routes={baseline.maxRoutedRecords}×4, slots={baseline.arraySlots}/{baseline.coeffArraySlots} coeff)"
       IO.println s!"        product non-coeff array floats={repr scratch.nonCoeffSizes}; baseline={repr baseline.nonCoeffSizes}"
-      if structural && genericFilter && forestOrder && refusals && oracleError < 2.0e-5 &&
+      if structural && genericFilter && forestOrder && refusals && hierarchyValidation && oracleError < 2.0e-5 &&
           -- The two exact schedules sum the same analytic rows in different
           -- routed orders.  This absolute lens is below two accumulated
           -- Q4.28 quanta per participating row and remains meaningful at
           -- dry/wet cancellation zeros where relative error is not.
           fusedError < 2.0e-7 &&
-          controlsLive && scratch.total ≤ 24576 then
+          controlsLive && hierarchyEquivalent && scratch.total ≤ 24576 then
         passGate "modal-phaser"
           "topology-derived generic kernel; Filter is a second producer; independent rational render oracle; authored modalMix order; live controls; named bloom crossing refusal; exact two-room product stays inside Metal scratch policy"
       else
         failGate "modal-phaser" "structural, numerical, live-control, or product scratch contract failed"
-  | .error error, _, _, _ => failGate "modal-phaser" s!"render: {firstLine error}"
-  | _, .error error, _, _ => failGate "modal-phaser" s!"fused: {firstLine error}"
-  | _, _, .error error, _ => failGate "modal-phaser" s!"surface/live: {firstLine error}"
-  | _, _, _, .error error => failGate "modal-phaser" s!"product: {firstLine error}"
+  | .error error, _, _, _, _ => failGate "modal-phaser" s!"render: {firstLine error}"
+  | _, .error error, _, _, _ => failGate "modal-phaser" s!"fused: {firstLine error}"
+  | _, _, .error error, _, _ => failGate "modal-phaser" s!"surface/live: {firstLine error}"
+  | _, _, _, .error error, _ => failGate "modal-phaser" s!"hierarchy: {firstLine error}"
+  | _, _, _, _, .error error => failGate "modal-phaser" s!"product: {firstLine error}"
 
 end Tropical.Tropicaltest.Phaser

--- a/lean/Tropical/Tropicaltest/Vocabulary.lean
+++ b/lean/Tropical/Tropicaltest/Vocabulary.lean
@@ -233,7 +233,7 @@ def runImplicitFanIn : IO Bool := do
     buildNode noParams "phaserN" "phaser" empty empty pair
   let modalHelperId := "__fanin_modal_phaserN_in"
   let modalNodeOk := match phaserNode with
-    | .modalPhaser input _ _ _ _ _ => input == modalHelperId
+    | .modalBlend dry _ _ => dry == modalHelperId
     | _ => false
   let modalHelperOk := match phaserExtras[0]? with
     | some helper => helper.id == modalHelperId && match helper.node with

--- a/lean/Tropical/Tropicaltest/Vocabulary.lean
+++ b/lean/Tropical/Tropicaltest/Vocabulary.lean
@@ -187,20 +187,24 @@ def runModalClassAgreement : IO Bool := do
   let vocab    := Tropical.Playground.vocabularyKinds
   let built    := Tropical.Playground.buildNodeKinds
   let withheld := Tropical.Playground.withheldKinds
+  let hierarchyAtoms := Tropical.Playground.hierarchyAtomKinds
   let drift    := Tropical.Playground.modalClassificationDrift          -- over `built`
   let servedDrift   := drift.filter (fun k => !withheld.contains k)
   let withheldDrift := drift.filter (fun k => withheld.contains k)
   -- list-consistency: served/withheld ⊆ built, built ⊆ served ∪ withheld
   let servedNotBuilt   := (vocab.filter (· != "out")).filter (fun k => !built.contains k)
   let withheldNotBuilt := withheld.filter (fun k => !built.contains k)
-  let builtUnaccounted := built.filter (fun k => !vocab.contains k && !withheld.contains k)
+  let hierarchyNotBuilt := hierarchyAtoms.filter (fun k => !built.contains k)
+  let builtUnaccounted := built.filter (fun k =>
+    !vocab.contains k && !withheld.contains k && !hierarchyAtoms.contains k)
   let setIssues := servedNotBuilt.map (s!"served-not-built {·}")
     ++ withheldNotBuilt.map (s!"withheld-not-built {·}")
+    ++ hierarchyNotBuilt.map (s!"hierarchy-atom-not-built {·}")
     ++ builtUnaccounted.map (s!"built-unaccounted {·}")
   IO.println s!"        {built.size} built kinds: nodeIsModal(node) ⟺ outletOf == modal (served drift asserted empty)"
   IO.println s!"        served drift {servedDrift} · withheld drift (contained, rejected pre-lowering) {withheldDrift} · list-consistency {if setIssues.isEmpty then "ok" else toString setIssues}"
   if servedDrift.isEmpty && setIssues.isEmpty then
-    passGate "modal-class-agreement" s!"outletOf and nodeIsModal agree for every SERVED kind, and buildNodeKinds ⊆ served∪withheld (the {withheldDrift.size} withheld kind(s) may drift — rejected pre-lowering, so the drift cannot mis-type an edge)"
+    passGate "modal-class-agreement" s!"outletOf and nodeIsModal agree for every served/internal hierarchy kind, and buildNodeKinds ⊆ served∪withheld∪hierarchy-atoms (the {withheldDrift.size} withheld kind(s) may drift — rejected pre-lowering, so the drift cannot mis-type an edge)"
   else
     failGate "modal-class-agreement" s!"servedDrift {servedDrift} · setIssues {setIssues}"
 

--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -117,6 +117,16 @@ struct NodeView: View {
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
                 Spacer(minLength: 4)
+                if node.kind.isModule {
+                    Button {
+                        model.openModule(node.id)
+                    } label: {
+                        Image(systemName: "square.grid.3x3.square")
+                            .foregroundStyle(Theme.muted)
+                    }
+                    .buttonStyle(.plain)
+                    .help("open module")
+                }
                 if !spec.fixed {
                     Button {
                         model.deleteNode(node.id)
@@ -172,7 +182,9 @@ struct NodeView: View {
     private var knobRow: some View {
         // A knob whose name matches a wired inlet is overridden by the patch
         // (e.g. `freq` driven by a Knob node), so hide it.
-        let shown = spec.knobs.filter { (node.inputs[$0.name] ?? []).isEmpty }
+        let shown = spec.knobs.filter {
+            (node.inputs[$0.name] ?? []).isEmpty && node.bindings[$0.name] == nil
+        }
         if !shown.isEmpty {
             HStack(alignment: .top, spacing: 8) {
                 ForEach(shown, id: \.name) { k in

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -314,6 +314,10 @@ actor Engine {
         return try EngineVocabulary.decode(from: data)
     }
 
+    func loadModuleLibrary() async throws -> [ModuleReference: ModuleDefinitionState] {
+        try EngineModuleLibrary.decode(try await callRaw("get_module_library"))
+    }
+
     /// Typed compiler lane. The expected vocabulary and ordered tap names come
     /// from the model's already-adopted authored semantics; a mismatch is
     /// rejected before the engine-side realized store advances.

--- a/reversible/Sources/Reversible/NodeKind.swift
+++ b/reversible/Sources/Reversible/NodeKind.swift
@@ -17,6 +17,11 @@ struct KnobSpec {
 enum NodeKind: String, CaseIterable, Codable {
     case source, knob, flange, sflange, fm, delay, reverse, mix, ring
     case resonator, reverb, phaser, modalmix
+    case allpass
+    case modalTail = "modal_allpass_tail"
+    case modalBlend = "modalblend"
+    case moduleInput = "module_input"
+    case moduleOutput = "module_output"
     case scope
     case out
 }
@@ -70,7 +75,9 @@ extension NodeKind {
     /// Plumbing-only reducers remain decodable for old documents, but ordinary
     /// module inlets now provide the same fan-in without canvas machinery.
     var appearsInAddMenu: Bool {
-        !spec.fixed && self != .mix && self != .modalmix
+        !spec.fixed && self != .mix && self != .modalmix &&
+            self != .allpass && self != .modalTail && self != .modalBlend &&
+            self != .moduleInput && self != .moduleOutput
     }
 
     var spec: NodeSpec {
@@ -218,6 +225,40 @@ extension NodeKind {
                     KnobSpec(name: "mix", min: 0, max: 1, def: 0.5),
                 ],
                 modal: true)
+        case .allpass:
+            return NodeSpec(
+                title: "Allpass 1", accent: Color(hex: 0x68B8F2),
+                inlets: ["in"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "center", min: 40, max: 4000, def: 700, log: true, unit: "Hz"),
+                    KnobSpec(name: "sweep", min: 0, max: 3, def: 1.5, unit: "oct"),
+                    KnobSpec(name: "rate", min: 0.02, max: 8, def: 0.2, log: true, unit: "Hz"),
+                    KnobSpec(name: "ratio", min: 0.125, max: 8, def: 1, log: true),
+                ], modal: true)
+        case .modalTail:
+            return NodeSpec(
+                title: "Pole Tail 1", accent: Color(hex: 0x4B9ED3),
+                inlets: ["in"], outlets: ["out"],
+                knobs: [
+                    KnobSpec(name: "center", min: 40, max: 4000, def: 700, log: true, unit: "Hz"),
+                    KnobSpec(name: "sweep", min: 0, max: 3, def: 1.5, unit: "oct"),
+                    KnobSpec(name: "rate", min: 0.02, max: 8, def: 0.2, log: true, unit: "Hz"),
+                    KnobSpec(name: "ratio", min: 0.125, max: 8, def: 1, log: true),
+                ], modal: true)
+        case .modalBlend:
+            return NodeSpec(
+                title: "Modal Blend", accent: Color(hex: 0x79D6C9),
+                inlets: ["dry", "wet"], outlets: ["out"],
+                knobs: [KnobSpec(name: "mix", min: 0, max: 1, def: 0.5)],
+                modal: true)
+        case .moduleInput:
+            return NodeSpec(
+                title: "Modal In", accent: Color(hex: 0x55CABB),
+                inlets: [], outlets: ["out"], knobs: [], modal: true, fixed: true)
+        case .moduleOutput:
+            return NodeSpec(
+                title: "Modal Out", accent: Color(hex: 0x55CABB),
+                inlets: ["in"], outlets: [], knobs: [], modal: true, fixed: true)
         case .modalmix:
             // Pole UNION (∪) of its modal inputs — the modal twin of Mix's
             // sum. Many modal in → one modal out; no knobs (structural).
@@ -256,7 +297,13 @@ extension NodeKind {
     /// a Sig source there would throw at compile. A Sig inlet, by contrast,
     /// accepts either: a modal source realizes to a Sig at the seam
     /// (`lowerInput`), but never the reverse.
-    static let modalInlets: Set<String> = ["reverb:in", "phaser:in", "modalmix:in"]
+    static let modalInlets: Set<String> = [
+        "reverb:in", "phaser:in", "modalmix:in", "allpass:in",
+        "modal_allpass_tail:in", "modalblend:dry", "modalblend:wet",
+        "module_output:in",
+    ]
+
+    var isModule: Bool { self == .phaser || self == .allpass }
 
     func wantsModal(inlet: String) -> Bool {
         Self.modalInlets.contains("\(rawValue):\(inlet)")

--- a/reversible/Sources/Reversible/PatchDocument.swift
+++ b/reversible/Sources/Reversible/PatchDocument.swift
@@ -2,14 +2,9 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// The patch as a FILE. `PatchModel.serialize()` targets the engine — it drops
-/// monitors, positions, and hues because the kernel has no use for them. A
-/// document is the SURFACE: everything you'd lose by quitting, including the
-/// scope you left watching the mix and where you put it.
-///
-/// Deliberately a flat, hand-readable JSON term (same shape family as the
-/// engine graph) rather than an opaque archive: a patch is small, diffable,
-/// and worth being able to hand-edit.
+/// Complete authoring document. V3 separates the root scene from reusable
+/// definition graphs; the engine receives a presentation-free projection and
+/// owns its hygienic expansion. The decoder retains a deterministic v1 migration.
 struct PatchDocument: Codable {
     struct Node: Codable {
         let id: String
@@ -18,28 +13,146 @@ struct PatchDocument: Codable {
         let y: Double
         let hue: Double
         let values: [String: Double]
-        /// inlet port → ordered source node ids
         let inputs: [String: [String]]
+        var module: ModuleReference?
+        var bindings: [String: String]
+
+        init(
+            id: String,
+            kind: NodeKind,
+            x: Double,
+            y: Double,
+            hue: Double,
+            values: [String: Double],
+            inputs: [String: [String]],
+            module: ModuleReference? = nil,
+            bindings: [String: String] = [:]
+        ) {
+            self.id = id
+            self.kind = kind
+            self.x = x
+            self.y = y
+            self.hue = hue
+            self.values = values
+            self.inputs = inputs
+            self.module = module
+            self.bindings = bindings
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id, kind, x, y, hue, values, inputs, module, bindings
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            id = try c.decode(String.self, forKey: .id)
+            kind = try c.decode(NodeKind.self, forKey: .kind)
+            x = try c.decode(Double.self, forKey: .x)
+            y = try c.decode(Double.self, forKey: .y)
+            hue = try c.decode(Double.self, forKey: .hue)
+            values = try c.decodeIfPresent([String: Double].self, forKey: .values) ?? [:]
+            inputs = try c.decodeIfPresent([String: [String]].self, forKey: .inputs) ?? [:]
+            module = try c.decodeIfPresent(ModuleReference.self, forKey: .module)
+            bindings = try c.decodeIfPresent([String: String].self, forKey: .bindings) ?? [:]
+        }
     }
 
-    /// Bumped only on a breaking shape change; a reader refuses a version it
-    /// doesn't know rather than silently loading half a patch.
-    static let currentVersion = 1
+    struct Graph: Codable {
+        var nodes: [Node]
+        var order: [String]
+        var panX: Double
+        var panY: Double
+    }
 
-    var version = PatchDocument.currentVersion
-    var nodes: [Node]
-    /// stable z/render order (also the order inlet menus list sources in)
-    var order: [String]
+    struct Definition: Codable {
+        var id: String
+        var version: Int
+        var title: String
+        var input: String
+        var output: String
+        var parameters: [ModuleParameter]
+        var graph: Graph
+    }
+
+    static let currentVersion = 3
+
+    var version: Int
+    var scene: Graph
+    var definitions: [Definition]
     var velocity: Double
-    var panX: Double
-    var panY: Double
     var autoArrange: Bool
+
+    // Compatibility projections keep existing callers source-compatible while
+    // every newly encoded file uses the explicit v3 scene envelope.
+    var nodes: [Node] { scene.nodes }
+    var order: [String] { scene.order }
+    var panX: Double { scene.panX }
+    var panY: Double { scene.panY }
+
+    init(
+        nodes: [Node],
+        order: [String],
+        velocity: Double,
+        panX: Double,
+        panY: Double,
+        autoArrange: Bool,
+        definitions: [Definition] = []
+    ) {
+        version = Self.currentVersion
+        scene = .init(nodes: nodes, order: order, panX: panX, panY: panY)
+        self.definitions = definitions
+        self.velocity = velocity
+        self.autoArrange = autoArrange
+        migrateLegacyPhasers()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version, scene, definitions
+        case nodes, order, velocity, panX, panY, autoArrange
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        guard version <= Self.currentVersion else {
+            throw PatchDocumentError.unsupportedVersion(version)
+        }
+        velocity = try c.decodeIfPresent(Double.self, forKey: .velocity) ?? 1
+        autoArrange = try c.decodeIfPresent(Bool.self, forKey: .autoArrange) ?? false
+        if version >= 3 {
+            scene = try c.decode(Graph.self, forKey: .scene)
+            definitions = try c.decodeIfPresent([Definition].self, forKey: .definitions) ?? []
+        } else {
+            scene = .init(
+                nodes: try c.decode([Node].self, forKey: .nodes),
+                order: try c.decode([String].self, forKey: .order),
+                panX: try c.decodeIfPresent(Double.self, forKey: .panX) ?? 0,
+                panY: try c.decodeIfPresent(Double.self, forKey: .panY) ?? 0
+            )
+            definitions = []
+            migrateLegacyPhasers()
+            version = Self.currentVersion
+        }
+    }
+
+    private mutating func migrateLegacyPhasers() {
+        for index in scene.nodes.indices where scene.nodes[index].kind == .phaser {
+            guard scene.nodes[index].module == nil else { continue }
+            scene.nodes[index].module = StandardModuleLibrary.phaser
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(Self.currentVersion, forKey: .version)
+        try c.encode(scene, forKey: .scene)
+        try c.encode(definitions, forKey: .definitions)
+        try c.encode(velocity, forKey: .velocity)
+        try c.encode(autoArrange, forKey: .autoArrange)
+    }
 
     static let fileExtension = "rvpatch"
 
-    /// A dynamic UTI is fine here — the panels only need it to filter and to
-    /// stamp the extension, and a bare SwiftPM binary has no Info.plist to
-    /// declare an exported type in.
     static var contentType: UTType {
         UTType(filenameExtension: fileExtension) ?? .json
     }
@@ -50,93 +163,151 @@ enum PatchDocumentError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .unsupportedVersion(let v):
-            return "patch version \(v) is newer than this build (\(PatchDocument.currentVersion))"
+        case .unsupportedVersion(let version):
+            "patch version \(version) is newer than this build (\(PatchDocument.currentVersion))"
         }
     }
 }
 
-// ── Model ↔ document ──────────────────────────────────────────────────────
 extension PatchModel {
-    func makeDocument() -> PatchDocument {
-        PatchDocument(
-            nodes: order.compactMap { nodes[$0] }.map { n in
-                PatchDocument.Node(
-                    id: n.id, kind: n.kind,
-                    x: n.position.x, y: n.position.y, hue: n.hue,
-                    values: n.values, inputs: n.inputs)
-            },
-            order: order,
-            velocity: velocity,
-            panX: pan.width, panY: pan.height,
-            autoArrange: autoArrange)
+    private func documentNode(_ node: PatchNode) -> PatchDocument.Node {
+        .init(
+            id: node.id,
+            kind: node.kind,
+            x: node.position.x,
+            y: node.position.y,
+            hue: node.hue,
+            values: node.values,
+            inputs: node.inputs,
+            module: node.module,
+            bindings: node.bindings
+        )
     }
 
-    /// Adopt a document as the live patch. Everything is rebuilt through the
-    /// same invariants `addNode` maintains — a knob absent from the file takes
-    /// its spec default, an inlet the spec no longer has is dropped, and an
-    /// edge to a node that isn't in the file is dropped — so a patch written by
-    /// an older build (or hand-edited) loads as the nearest VALID patch rather
-    /// than a half-wired one.
-    func apply(_ doc: PatchDocument) async throws {
-        guard doc.version <= PatchDocument.currentVersion else {
-            throw PatchDocumentError.unsupportedVersion(doc.version)
+    private func documentGraph(_ graph: PatchGraphState) -> PatchDocument.Graph {
+        .init(
+            nodes: graph.order.compactMap { graph.nodes[$0] }.map(documentNode),
+            order: graph.order,
+            panX: graph.pan.width,
+            panY: graph.pan.height
+        )
+    }
+
+    func makeDocument() -> PatchDocument {
+        snapshotActiveGraph()
+        let encodedDefinitions = definitions.values.sorted {
+            ($0.reference.id, $0.reference.version) <
+                ($1.reference.id, $1.reference.version)
+        }.map { definition in
+            PatchDocument.Definition(
+                id: definition.reference.id,
+                version: definition.reference.version,
+                title: definition.title,
+                input: definition.inputNodeID,
+                output: definition.outputNodeID,
+                parameters: definition.parameters,
+                graph: documentGraph(definition.graph)
+            )
         }
-        let known = Set(doc.nodes.map(\.id))
+        return PatchDocument(
+            nodes: documentGraph(sceneGraph).nodes,
+            order: sceneGraph.order,
+            velocity: velocity,
+            panX: sceneGraph.pan.width,
+            panY: sceneGraph.pan.height,
+            autoArrange: autoArrange,
+            definitions: encodedDefinitions
+        )
+    }
+
+    private func modelGraph(_ graph: PatchDocument.Graph) -> PatchGraphState {
+        let known = Set(graph.nodes.map(\.id))
         var fresh: [String: PatchNode] = [:]
-        for d in doc.nodes {
-            let spec = d.kind.spec
+        for stored in graph.nodes {
+            let spec = stored.kind.spec
             var values: [String: Double] = [:]
-            for k in spec.knobs { values[k.name] = d.values[k.name] ?? k.def }
-            var inputs: [String: [String]] = [:]
-            for p in spec.inlets {
-                inputs[p] = (d.inputs[p] ?? []).filter { known.contains($0) && $0 != d.id }
+            for knob in spec.knobs {
+                values[knob.name] = stored.values[knob.name] ?? knob.def
             }
-            fresh[d.id] = PatchNode(
-                id: d.id, kind: d.kind,
-                position: CGPoint(x: d.x, y: d.y),
-                values: values, inputs: inputs, hue: d.hue)
+            var inputs: [String: [String]] = [:]
+            for port in spec.inlets {
+                inputs[port] = (stored.inputs[port] ?? []).filter {
+                    known.contains($0) && $0 != stored.id
+                }
+            }
+            fresh[stored.id] = PatchNode(
+                id: stored.id,
+                kind: stored.kind,
+                position: CGPoint(x: stored.x, y: stored.y),
+                values: values,
+                inputs: inputs,
+                hue: stored.hue,
+                module: stored.module,
+                bindings: stored.bindings
+            )
         }
-        nodes = fresh
-        // The file's order is authoritative, but never let it lose or invent a
-        // node (a hand-edit that forgets an id would make it unrenderable).
         var seen = Set<String>()
-        order = doc.order.filter { known.contains($0) && seen.insert($0).inserted }
-            + doc.nodes.map(\.id).filter { !seen.contains($0) }
-        pan = CGSize(width: doc.panX, height: doc.panY)
-        autoArrange = doc.autoArrange
-        velocity = doc.velocity
+        let stableOrder = graph.order.filter {
+            known.contains($0) && seen.insert($0).inserted
+        } + graph.nodes.map(\.id).filter { seen.insert($0).inserted }
+        return .init(
+            nodes: fresh,
+            order: stableOrder,
+            pan: CGSize(width: graph.panX, height: graph.panY)
+        )
+    }
+
+    func apply(_ document: PatchDocument) async throws {
+        guard document.version <= PatchDocument.currentVersion else {
+            throw PatchDocumentError.unsupportedVersion(document.version)
+        }
+
+        var loadedDefinitions: [ModuleReference: ModuleDefinitionState] = [:]
+        for stored in document.definitions {
+            let reference = ModuleReference(id: stored.id, version: stored.version)
+            loadedDefinitions[reference] = .init(
+                reference: reference,
+                title: stored.title,
+                inputNodeID: stored.input,
+                outputNodeID: stored.output,
+                parameters: stored.parameters,
+                graph: modelGraph(stored.graph)
+            )
+        }
+
+        var root = modelGraph(document.scene)
+        // Defensive compatibility for programmatic documents that bypassed
+        // PatchDocument's decoder migration.
+        for id in root.order {
+            guard var node = root.nodes[id], node.kind == .phaser,
+                  node.module == nil else { continue }
+            node.module = StandardModuleLibrary.phaser
+            root.nodes[id] = node
+        }
+
+        resetHierarchy(to: root)
+        definitions = loadedDefinitions
+        autoArrange = document.autoArrange
+        velocity = document.velocity
         advanceAuthoredRevision()
-        // New nodes must not collide with loaded ids: resume the counter past
-        // the highest numeric suffix in the file.
-        adoptCounter(from: known)
+        adoptCounter(from: root.nodes.keys)
 
         await pushGraph()
-        // pushGraph re-applies a non-default velocity after a COLD compile, but
-        // a load whose graph happens to match what's already running skips the
-        // compile entirely — so drive the clock here regardless.
-        setVelocity(doc.velocity, force: true)
+        setVelocity(document.velocity, force: true)
     }
 
-    /// Reset to the boot patch (Out + one Osc), forgetting the file.
     func newPatch() async {
-        nodes = [:]
-        order = []
-        pan = .zero
+        resetHierarchy(to: .init(nodes: [:], order: [], pan: .zero))
         resetCounter()
         seedBootPatch()
+        snapshotActiveGraph()
         documentURL = nil
         await pushGraph()
         setVelocity(velocity)
     }
 
-    /// Factory patch for the supported modal-phaser product path.  The Scope
-    /// observes only Out, so its recipe stays presentation-only and does not
-    /// request duplicate intermediate modal realizations.
     func newPhaserDemo() async {
-        nodes = [:]
-        order = []
-        pan = .zero
+        resetHierarchy(to: .init(nodes: [:], order: [], pan: .zero))
         resetCounter()
 
         let resonator = addNode(.resonator, at: CGPoint(x: 88, y: 132))
@@ -151,37 +322,36 @@ extension PatchModel {
             connect(from: roomA.id, to: phaser.id, port: "in")
             connect(from: phaser.id, to: roomB.id, port: "in")
             connect(from: roomB.id, to: output.id, port: "in")
-            if let scope {
-                connect(from: output.id, to: scope.id, port: "ch1")
-            }
+            if let scope { connect(from: output.id, to: scope.id, port: "ch1") }
         }
+        snapshotActiveGraph()
         documentURL = nil
         await pushGraph()
         setVelocity(velocity)
     }
 
-    // ── File I/O ──────────────────────────────────────────────────────────
     func write(to url: URL) throws {
-        let enc = JSONEncoder()
-        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
-        try enc.encode(makeDocument()).write(to: url, options: .atomic)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(makeDocument()).write(to: url, options: .atomic)
         documentURL = url
         setStatus("saved · \(url.lastPathComponent)", isError: false)
     }
 
     func read(from url: URL) async throws {
-        let doc = try JSONDecoder().decode(PatchDocument.self, from: Data(contentsOf: url))
-        try await apply(doc)
+        let document = try JSONDecoder().decode(
+            PatchDocument.self,
+            from: Data(contentsOf: url)
+        )
+        try await apply(document)
         documentURL = url
         setStatus("loaded · \(url.lastPathComponent)", isError: false)
     }
 
-    /// Save to the open file, or ask where if there isn't one yet.
     func save() {
         guard let url = documentURL else { return saveAs() }
-        do { try write(to: url) } catch {
-            setStatus("save: \(error.localizedDescription)", isError: true)
-        }
+        do { try write(to: url) }
+        catch { setStatus("save: \(error.localizedDescription)", isError: true) }
     }
 
     func saveAs() {
@@ -191,12 +361,9 @@ extension PatchModel {
             documentURL?.lastPathComponent ?? "patch.\(PatchDocument.fileExtension)"
         panel.canCreateDirectories = true
         guard panel.runModal() == .OK, var url = panel.url else { return }
-        if url.pathExtension.isEmpty {
-            url.appendPathExtension(PatchDocument.fileExtension)
-        }
-        do { try write(to: url) } catch {
-            setStatus("save: \(error.localizedDescription)", isError: true)
-        }
+        if url.pathExtension.isEmpty { url.appendPathExtension(PatchDocument.fileExtension) }
+        do { try write(to: url) }
+        catch { setStatus("save: \(error.localizedDescription)", isError: true) }
     }
 
     func open() {
@@ -205,9 +372,8 @@ extension PatchModel {
         panel.allowsMultipleSelection = false
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task {
-            do { try await read(from: url) } catch {
-                setStatus("open: \(error.localizedDescription)", isError: true)
-            }
+            do { try await read(from: url) }
+            catch { setStatus("open: \(error.localizedDescription)", isError: true) }
         }
     }
 }

--- a/reversible/Sources/Reversible/PatchHierarchy.swift
+++ b/reversible/Sources/Reversible/PatchHierarchy.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+struct ModuleReference: Codable, Equatable, Hashable, Sendable {
+    var id: String
+    var version: Int
+}
+
+struct ModuleParameter: Codable, Equatable, Sendable {
+    var name: String
+    var defaultValue: Double
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case defaultValue = "default"
+    }
+}
+
+struct PatchGraphState {
+    var nodes: [String: PatchNode]
+    var order: [String]
+    var pan: CGSize
+}
+
+struct ModuleDefinitionState {
+    var reference: ModuleReference
+    var title: String
+    var inputNodeID: String
+    var outputNodeID: String
+    var parameters: [ModuleParameter]
+    var graph: PatchGraphState
+}
+
+enum HierarchyLocation: Equatable {
+    case scene
+    case definition(ModuleReference)
+}
+
+struct HierarchyFrame: Equatable, Identifiable {
+    let location: HierarchyLocation
+    let title: String
+    let instanceID: String?
+
+    var id: String {
+        switch location {
+        case .scene: "scene"
+        case .definition(let reference):
+            "\(reference.id)@\(reference.version):\(instanceID ?? "")"
+        }
+    }
+}
+
+@MainActor
+extension PatchModel {
+    var hierarchyTitle: String {
+        hierarchyPath.map(\.title).joined(separator: " / ")
+    }
+
+    var isAtScene: Bool { currentHierarchyLocation == .scene }
+
+    var addableKinds: [NodeKind] {
+        if isAtScene {
+            return NodeKind.allCases.filter(\.appearsInAddMenu)
+        }
+        return [.allpass, .modalTail, .modalBlend, .modalmix]
+    }
+
+    func snapshotActiveGraph() {
+        let graph = PatchGraphState(nodes: nodes, order: order, pan: pan)
+        switch currentHierarchyLocation {
+        case .scene:
+            sceneGraph = graph
+        case .definition(let reference):
+            definitions[reference]?.graph = graph
+        }
+    }
+
+    func activate(_ graph: PatchGraphState) {
+        nodes = graph.nodes
+        order = graph.order
+        pan = graph.pan
+        adoptCounter(from: graph.nodes.keys)
+    }
+
+    func openModule(_ nodeID: String) {
+        guard var instance = nodes[nodeID], instance.kind.isModule,
+              var reference = instance.module
+        else { return }
+
+        // Installed definitions are immutable. Entering one through an
+        // editable canvas detaches exactly this instance first.
+        if definitions[reference] == nil {
+            guard let installed = moduleTemplate(for: reference) else {
+                setStatus("module library unavailable · try again", isError: true)
+                return
+            }
+            let detached = StandardModuleLibrary.detached(
+                installed,
+                instancePath: hierarchyPath.compactMap(\.instanceID) + [nodeID]
+            )
+            definitions[detached.reference] = detached
+            reference = detached.reference
+            instance.module = reference
+            nodes[nodeID] = instance
+            advanceAuthoredRevision()
+            schedulePush()
+        }
+
+        snapshotActiveGraph()
+        guard let definition = definitions[reference] else { return }
+        hierarchyPath.append(.init(
+            location: .definition(reference),
+            title: "\(definition.title) · \(nodeID)",
+            instanceID: nodeID
+        ))
+        currentHierarchyLocation = .definition(reference)
+        activate(definition.graph)
+    }
+
+    func exitModule() {
+        guard hierarchyPath.count > 1 else { return }
+        snapshotActiveGraph()
+        hierarchyPath.removeLast()
+        let destination = hierarchyPath.last?.location ?? .scene
+        currentHierarchyLocation = destination
+        switch destination {
+        case .scene:
+            activate(sceneGraph)
+        case .definition(let reference):
+            if let definition = definitions[reference] {
+                activate(definition.graph)
+            }
+        }
+    }
+
+    func resetHierarchy(to graph: PatchGraphState) {
+        sceneGraph = graph
+        definitions = [:]
+        hierarchyPath = [.init(location: .scene, title: "Patch", instanceID: nil)]
+        currentHierarchyLocation = .scene
+        activate(graph)
+    }
+}
+
+enum StandardModuleLibrary {
+    static let phaser = ModuleReference(id: "tropical.modal.phaser", version: 1)
+    static let allpass = ModuleReference(id: "tropical.modal.allpass1", version: 1)
+
+    /// Clone an engine-served installed definition under an author-owned id.
+    /// Swift supplies identity and presentation only; it never reconstructs
+    /// the definition's DSP topology.
+    static func detached(
+        _ installed: ModuleDefinitionState,
+        instancePath: [String]
+    ) -> ModuleDefinitionState {
+        let encoded = instancePath.map { "\($0.count)_\($0)" }.joined(separator: ".")
+        let leaf = installed.reference.id.split(separator: ".").last.map(String.init)
+            ?? "module"
+        var definition = installed
+        definition.reference = ModuleReference(
+            id: "user.\(encoded).\(leaf)",
+            version: 1
+        )
+        return definition
+    }
+}
+
+enum ModuleLibraryDecodeError: Error, LocalizedError {
+    case invalid(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalid(let path): "module library has invalid '\(path)'"
+        }
+    }
+}
+
+enum EngineModuleLibrary {
+    static func decode(_ value: JSONValue) throws -> [ModuleReference: ModuleDefinitionState] {
+        guard case .object(let root) = value,
+              root["schema"]?.stringValue == "tropical_module_library",
+              exactInt(root["schema_version"]) == 1,
+              case .array(let rawDefinitions)? = root["definitions"]
+        else { throw ModuleLibraryDecodeError.invalid("root") }
+
+        var result: [ModuleReference: ModuleDefinitionState] = [:]
+        for (definitionIndex, rawDefinition) in rawDefinitions.enumerated() {
+            let path = "definitions[\(definitionIndex)]"
+            guard case .object(let fields) = rawDefinition,
+                  let id = fields["id"]?.stringValue,
+                  let version = exactInt(fields["version"]),
+                  let input = fields["input"]?.stringValue,
+                  let output = fields["output"]?.stringValue,
+                  case .array(let rawParameters)? = fields["parameters"],
+                  case .array(let rawNodes)? = fields["nodes"]
+            else { throw ModuleLibraryDecodeError.invalid(path) }
+            let reference = ModuleReference(id: id, version: version)
+            guard result[reference] == nil else {
+                throw ModuleLibraryDecodeError.invalid("\(path).id/version")
+            }
+            let parameters = try rawParameters.enumerated().map { index, raw in
+                guard case .object(let parameter) = raw,
+                      let name = parameter["name"]?.stringValue,
+                      let defaultValue = parameter["default"]?.doubleValue,
+                      defaultValue.isFinite
+                else {
+                    throw ModuleLibraryDecodeError.invalid("\(path).parameters[\(index)]")
+                }
+                return ModuleParameter(name: name, defaultValue: defaultValue)
+            }
+
+            var nodes: [String: PatchNode] = [:]
+            var order: [String] = []
+            for (index, raw) in rawNodes.enumerated() {
+                guard case .object(let nodeFields) = raw,
+                      let nodeID = nodeFields["id"]?.stringValue,
+                      let rawKind = nodeFields["kind"]?.stringValue
+                else { throw ModuleLibraryDecodeError.invalid("\(path).nodes[\(index)]") }
+                let module: ModuleReference?
+                let kind: NodeKind
+                if rawKind == "module" {
+                    guard let definitionID = nodeFields["definition"]?.stringValue,
+                          let definitionVersion = exactInt(nodeFields["definition_version"])
+                    else {
+                        throw ModuleLibraryDecodeError.invalid("\(path).nodes[\(index)].definition")
+                    }
+                    module = .init(id: definitionID, version: definitionVersion)
+                    if definitionID == StandardModuleLibrary.allpass.id {
+                        kind = .allpass
+                    } else if definitionID == StandardModuleLibrary.phaser.id {
+                        kind = .phaser
+                    } else {
+                        throw ModuleLibraryDecodeError.invalid(
+                            "\(path).nodes[\(index)].definition"
+                        )
+                    }
+                } else {
+                    guard let decoded = NodeKind(rawValue: rawKind) else {
+                        throw ModuleLibraryDecodeError.invalid("\(path).nodes[\(index)].kind")
+                    }
+                    module = nil
+                    kind = decoded
+                }
+                let params = stringDoubleObject(nodeFields["params"])
+                let inputs = try stringArrayObject(
+                    nodeFields["in"],
+                    path: "\(path).nodes[\(index)].in"
+                )
+                let bindings = stringStringObject(nodeFields["bindings"])
+                var values: [String: Double] = [:]
+                for knob in kind.spec.knobs {
+                    values[knob.name] = params[knob.name] ?? knob.def
+                }
+                let column = Double(index)
+                let node = PatchNode(
+                    id: nodeID,
+                    kind: kind,
+                    position: CGPoint(
+                        x: 44 + column * 184,
+                        y: 116 + Double(index % 2) * 124
+                    ),
+                    values: values,
+                    inputs: inputs,
+                    hue: Double((index * 29 + 170) % 360),
+                    module: module,
+                    bindings: bindings
+                )
+                nodes[nodeID] = node
+                order.append(nodeID)
+            }
+            guard nodes[input]?.kind == .moduleInput,
+                  nodes[output]?.kind == .moduleOutput
+            else { throw ModuleLibraryDecodeError.invalid("\(path).boundaries") }
+            let title = reference == StandardModuleLibrary.phaser ? "Phaser" : "Allpass 1"
+            result[reference] = .init(
+                reference: reference,
+                title: title,
+                inputNodeID: input,
+                outputNodeID: output,
+                parameters: parameters,
+                graph: .init(nodes: nodes, order: order, pan: .zero)
+            )
+        }
+        return result
+    }
+
+    private static func exactInt(_ value: JSONValue?) -> Int? {
+        guard let number = value?.doubleValue,
+              number.isFinite,
+              number.rounded(.towardZero) == number,
+              number >= 0,
+              number <= Double(Int.max)
+        else { return nil }
+        return Int(number)
+    }
+
+    private static func stringDoubleObject(_ value: JSONValue?) -> [String: Double] {
+        guard case .object(let fields)? = value else { return [:] }
+        return fields.reduce(into: [:]) { result, entry in
+            if let number = entry.value.doubleValue, number.isFinite {
+                result[entry.key] = number
+            }
+        }
+    }
+
+    private static func stringStringObject(_ value: JSONValue?) -> [String: String] {
+        guard case .object(let fields)? = value else { return [:] }
+        return fields.reduce(into: [:]) { result, entry in
+            if let string = entry.value.stringValue { result[entry.key] = string }
+        }
+    }
+
+    private static func stringArrayObject(
+        _ value: JSONValue?,
+        path: String
+    ) throws -> [String: [String]] {
+        guard case .object(let fields)? = value else { return [:] }
+        var result: [String: [String]] = [:]
+        for (port, rawSources) in fields {
+            guard case .array(let sources) = rawSources else {
+                throw ModuleLibraryDecodeError.invalid("\(path).\(port)")
+            }
+            result[port] = try sources.enumerated().map { index, source in
+                guard let id = source.stringValue else {
+                    throw ModuleLibraryDecodeError.invalid("\(path).\(port)[\(index)]")
+                }
+                return id
+            }
+        }
+        return result
+    }
+}

--- a/reversible/Sources/Reversible/PatchModel.swift
+++ b/reversible/Sources/Reversible/PatchModel.swift
@@ -11,6 +11,9 @@ struct PatchNode: Identifiable {
     /// inlet wears the hues of its sources, so fan-out is the same color
     /// appearing at many inlets. Golden-angle spacing keeps neighbors apart.
     let hue: Double
+    var module: ModuleReference? = nil
+    /// local knob name → containing module parameter name
+    var bindings: [String: String] = [:]
 
     var allInputs: [String] { inputs.values.flatMap { $0 } }
 
@@ -86,6 +89,12 @@ enum NodePresentationStatus: Equatable, Sendable {
 final class PatchModel: ObservableObject {
     @Published var nodes: [String: PatchNode] = [:]
     @Published var order: [String] = []   // stable z/render order
+    @Published var definitions: [ModuleReference: ModuleDefinitionState] = [:]
+    @Published var hierarchyPath: [HierarchyFrame] = [
+        .init(location: .scene, title: "Patch", instanceID: nil)
+    ]
+    var currentHierarchyLocation: HierarchyLocation = .scene
+    var sceneGraph = PatchGraphState(nodes: [:], order: [], pan: .zero)
     @Published var status = "booting engine…"
     @Published var statusIsError = false
     private var telemetryOwnsStatus = false
@@ -100,6 +109,9 @@ final class PatchModel: ObservableObject {
     /// the window title and whether ⌘S needs to ask.
     @Published var documentURL: URL?
     @Published private(set) var vocabulary: EngineVocabulary?
+    @Published private(set) var installedDefinitions: [
+        ModuleReference: ModuleDefinitionState
+    ] = [:]
     @Published private(set) var authoredRevision = 0
     @Published private(set) var realizedPatch: RealizedPatchSnapshot?
     @Published private(set) var runningGeneration: EngineGeneration?
@@ -116,9 +128,28 @@ final class PatchModel: ObservableObject {
     func presentationStatus(for node: PatchNode) -> NodePresentationStatus? {
         guard !node.kind.spec.monitor else { return nil }
         guard let realizedPatch,
-              realizedPatch.loweringRevision == loweringRevision,
-              let realizedNode = realizedPatch.patch.node(id: node.id)
+              realizedPatch.loweringRevision == loweringRevision
         else { return .pending }
+        let realizedNode: RealizedNode?
+        if isAtScene {
+            realizedNode = realizedPatch.patch.node(id: node.id)
+        } else {
+            let path = hierarchyPath.compactMap(\.instanceID)
+            let candidates: [RealizedNode]
+            if node.kind.isModule {
+                candidates = realizedPatch.patch.nodes(
+                    atInstancePath: path + [node.id],
+                    localID: nil
+                )
+            } else {
+                candidates = realizedPatch.patch.nodes(
+                    atInstancePath: path,
+                    localID: node.id
+                )
+            }
+            realizedNode = candidates.first { $0.status == .active } ?? candidates.first
+        }
+        guard let realizedNode else { return nil }
         return realizedNode.status == .active ? .active : .excluded
     }
 
@@ -222,6 +253,7 @@ final class PatchModel: ObservableObject {
 
         startEngine()
         seedBootPatch()
+        snapshotActiveGraph()
         setStatus("engine up · patch something", isError: false)
         startScopePolling()
     }
@@ -242,6 +274,7 @@ final class PatchModel: ObservableObject {
             Task { await synchronizeEngineState() }
         case .exit(let code):
             vocabulary = nil
+            installedDefinitions = [:]
             lastPushed = nil
             truth.reset()
             publishTruth()
@@ -258,11 +291,16 @@ final class PatchModel: ObservableObject {
     private func synchronizeEngineState() async {
         do {
             vocabulary = try await engine.loadVocabulary()
+            installedDefinitions = try await engine.loadModuleLibrary()
             await syncAudioState()
             schedulePush()
         } catch {
             setStatus("engine vocabulary: \(error.localizedDescription)", isError: true)
         }
+    }
+
+    func moduleTemplate(for reference: ModuleReference) -> ModuleDefinitionState? {
+        installedDefinitions[reference]
     }
 
     private func publishTruth() {
@@ -307,9 +345,15 @@ final class PatchModel: ObservableObject {
         for k in spec.knobs { values[k.name] = k.def }
         var inputs: [String: [String]] = [:]
         for p in spec.inlets { inputs[p] = [] }
+        var module: ModuleReference?
+        if kind == .phaser {
+            module = StandardModuleLibrary.phaser
+        } else if kind == .allpass {
+            module = StandardModuleLibrary.allpass
+        }
         let n = PatchNode(
             id: id, kind: kind, position: pos, values: values, inputs: inputs,
-            hue: Double((counter * 137) % 360))
+            hue: Double((counter * 137) % 360), module: module)
         nodes[id] = n
         order.append(id)
         autoArrangeIfOn()
@@ -399,14 +443,15 @@ final class PatchModel: ObservableObject {
     /// define the request; repeated sources are kept once, and Out is omitted
     /// because its final-mix binding is always published as `out`.
     var requestedTapNodeIDs: [String] {
+        snapshotActiveGraph()
         var candidates: [String] = []
-        for id in order {
-            guard let monitor = nodes[id], monitor.kind.spec.monitor else { continue }
+        for id in sceneGraph.order {
+            guard let monitor = sceneGraph.nodes[id], monitor.kind.spec.monitor else { continue }
             for port in monitor.kind.spec.inlets {
                 candidates.append(contentsOf: monitor.inputs[port] ?? [])
             }
         }
-        let allowed = Set(nodes.values.compactMap { node in
+        let allowed = Set(sceneGraph.nodes.values.compactMap { node in
             node.kind != .out && !node.kind.spec.monitor ? node.id : nil
         })
         return ObservationTapSelection.stableSourceIDs(
@@ -422,26 +467,72 @@ final class PatchModel: ObservableObject {
     }
 
     func serialize() -> JSONValue {
-        var out: [JSONValue] = []
-        for id in order {
-            guard let n = nodes[id], !n.kind.spec.monitor else { continue }
-            let spec = n.kind.spec
-            var params: [String: JSONValue] = [:]
-            for k in spec.knobs { params[k.name] = .number(n.values[k.name] ?? k.def) }
-            var inputs: [String: JSONValue] = [:]
-            for p in spec.inlets { inputs[p] = .array((n.inputs[p] ?? []).map(JSONValue.string)) }
-            out.append(.object([
-                "id": .string(n.id),
-                "kind": .string(n.kind.rawValue),
-                "params": .object(params),
-                "sel": .object([:]),
-                "in": .object(inputs),
-            ]))
+        snapshotActiveGraph()
+
+        func engineNodes(_ graph: PatchGraphState) -> [JSONValue] {
+            var result: [JSONValue] = []
+            for id in graph.order {
+                guard let node = graph.nodes[id], !node.kind.spec.monitor else { continue }
+                let spec = node.kind.spec
+                var params: [String: JSONValue] = [:]
+                for knob in spec.knobs {
+                    params[knob.name] = .number(node.values[knob.name] ?? knob.def)
+                }
+                var inputs: [String: JSONValue] = [:]
+                for port in spec.inlets {
+                    inputs[port] = .array((node.inputs[port] ?? []).map(JSONValue.string))
+                }
+                var encoded: [String: JSONValue] = [
+                    "id": .string(node.id),
+                    "kind": .string(node.module == nil ? node.kind.rawValue : "module"),
+                    "params": .object(params),
+                    "sel": .object([:]),
+                    "in": .object(inputs),
+                ]
+                if let module = node.module {
+                    encoded["definition"] = .string(module.id)
+                    encoded["definition_version"] = .number(Double(module.version))
+                }
+                if !node.bindings.isEmpty {
+                    encoded["bindings"] = .object(
+                        node.bindings.mapValues(JSONValue.string)
+                    )
+                }
+                result.append(.object(encoded))
+            }
+            return result
         }
-        let outNode = nodes.values.first { $0.kind == .out }
+
+        let definitionValues: [JSONValue] = definitions.values
+            .sorted {
+                ($0.reference.id, $0.reference.version) <
+                    ($1.reference.id, $1.reference.version)
+            }
+            .map { definition in
+                .object([
+                    "id": .string(definition.reference.id),
+                    "version": .number(Double(definition.reference.version)),
+                    "input": .string(definition.inputNodeID),
+                    "output": .string(definition.outputNodeID),
+                    "input_domain": .string("modal"),
+                    "output_domain": .string("modal"),
+                    "parameters": .array(definition.parameters.map { parameter in
+                        .object([
+                            "name": .string(parameter.name),
+                            "default": .number(parameter.defaultValue),
+                        ])
+                    }),
+                    "nodes": .array(engineNodes(definition.graph)),
+                ])
+            }
+        let outNode = sceneGraph.nodes.values.first { $0.kind == .out }
         return .object([
-            "nodes": .array(out),
-            "out": outNode.map { .string($0.id) } ?? .null,
+            "version": .number(3),
+            "definitions": .array(definitionValues),
+            "scene": .object([
+                "nodes": .array(engineNodes(sceneGraph)),
+                "out": outNode.map { .string($0.id) } ?? .null,
+            ]),
             "taps": .array(requestedTapNodeIDs.map(JSONValue.string)),
         ])
     }

--- a/reversible/Sources/Reversible/RealizedPatch.swift
+++ b/reversible/Sources/Reversible/RealizedPatch.swift
@@ -56,6 +56,14 @@ struct ScopeTapBinding: Equatable, Sendable {
     let slot: String
 }
 
+struct RealizedSourceLocation: Equatable, Sendable {
+    let expandedID: String
+    let definitionID: String
+    let definitionVersion: Int
+    let localID: String
+    let instancePath: [String]
+}
+
 /// Complete realized truth published by one successful load_patch_graph call.
 /// Nothing in this value is inferred from the authored graph or a follow-up
 /// diagnostic request.
@@ -66,6 +74,7 @@ struct RealizedPatch: Equatable, Sendable {
     let inlets: [RealizedInlet]
     let liveParameters: [RealizedLiveParameter]
     let taps: [ScopeTapBinding]
+    var sourceMap: [RealizedSourceLocation] = []
 
     func node(id: String) -> RealizedNode? {
         nodes.first { $0.id == id }
@@ -89,6 +98,15 @@ struct RealizedPatch: Equatable, Sendable {
 
     func tap(named name: String) -> ScopeTapBinding? {
         taps.first { $0.name == name }
+    }
+
+    func nodes(atInstancePath path: [String], localID: String?) -> [RealizedNode] {
+        sourceMap.compactMap { location in
+            guard location.instancePath == path,
+                  localID.map({ location.localID == $0 }) ?? true
+            else { return nil }
+            return node(id: location.expandedID)
+        }
     }
 }
 
@@ -268,13 +286,55 @@ enum PatchCompileResponse: Equatable, Sendable {
             throw RealizedPatchDecodeError.invalidField("taps")
         }
 
+
+        var sourceMap: [RealizedSourceLocation] = []
+        if case .array(let entries)? = object["source_map"] {
+            for (index, raw) in entries.enumerated() {
+                guard case .object(let fields) = raw else {
+                    throw RealizedPatchDecodeError.invalidField("source_map[\(index)]")
+                }
+                let expanded = try requiredString(
+                    fields, "expanded", path: "source_map[\(index)].expanded"
+                )
+                let definition = try requiredString(
+                    fields, "definition", path: "source_map[\(index)].definition"
+                )
+                let local = try requiredString(
+                    fields, "local", path: "source_map[\(index)].local"
+                )
+                guard let versionValue = fields["definition_version"],
+                      let version64 = JSONExact.uint64(versionValue),
+                      let version = Int(exactly: version64),
+                      case .array(let pathValues)? = fields["path"]
+                else {
+                    throw RealizedPatchDecodeError.invalidField("source_map[\(index)]")
+                }
+                let path = try pathValues.enumerated().map { pathIndex, value in
+                    guard let segment = value.stringValue, !segment.isEmpty else {
+                        throw RealizedPatchDecodeError.invalidField(
+                            "source_map[\(index)].path[\(pathIndex)]"
+                        )
+                    }
+                    return segment
+                }
+                sourceMap.append(.init(
+                    expandedID: expanded,
+                    definitionID: definition,
+                    definitionVersion: version,
+                    localID: local,
+                    instancePath: path
+                ))
+            }
+        }
+
         return .published(.init(
             vocabularyFingerprint: fingerprint,
             generation: generation,
             nodes: nodes,
             inlets: inlets,
             liveParameters: parameters,
-            taps: taps
+            taps: taps,
+            sourceMap: sourceMap
         ))
     }
 }

--- a/reversible/Sources/Reversible/ToolbarView.swift
+++ b/reversible/Sources/Reversible/ToolbarView.swift
@@ -9,13 +9,28 @@ struct PatchToolbar: ToolbarContent {
     var body: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
             Menu {
-                ForEach(NodeKind.allCases.filter(\.appearsInAddMenu), id: \.self) { kind in
+                ForEach(model.addableKinds, id: \.self) { kind in
                     Button(kind.spec.title) { model.addNode(kind) }
                 }
             } label: {
                 Label("Add Module", systemImage: "plus")
             }
             .help("add a module to the patch")
+        }
+
+        ToolbarItem(placement: .navigation) {
+            HStack(spacing: 6) {
+                Button {
+                    model.exitModule()
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .disabled(model.isAtScene)
+                .help("return to containing graph")
+                Text(model.hierarchyTitle)
+                    .font(Theme.monoSmall)
+                    .lineLimit(1)
+            }
         }
 
         // Rank layout: one row per topological rank, sources at the top,

--- a/reversible/Tests/ReversibleTests/PatchHierarchyTests.swift
+++ b/reversible/Tests/ReversibleTests/PatchHierarchyTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import XCTest
+@testable import Reversible
+
+final class PatchHierarchyTests: XCTestCase {
+    private let engineLibraryFixture = """
+    {"schema":"tropical_module_library","schema_version":1,"definitions":[
+      {
+        "id":"tropical.modal.allpass1","version":1,
+        "input":"input","output":"output","input_domain":"modal","output_domain":"modal",
+        "parameters":[{"name":"ratio","default":1}],
+        "nodes":[
+          {"id":"input","kind":"module_input"},
+          {"id":"tail","kind":"modal_allpass_tail","params":{"ratio":1},
+           "bindings":{"ratio":"ratio"},"in":{"in":["input"]}},
+          {"id":"section","kind":"modalmix","in":{"in":["input","tail"]}},
+          {"id":"output","kind":"module_output","in":{"in":["section"]}}
+        ]
+      },
+      {
+        "id":"tropical.modal.phaser","version":1,
+        "input":"input","output":"output","input_domain":"modal","output_domain":"modal",
+        "parameters":[
+          {"name":"center","default":700},{"name":"sweep","default":1.5},
+          {"name":"rate","default":0.2},{"name":"mix","default":0.5}
+        ],
+        "nodes":[
+          {"id":"input","kind":"module_input"},
+          {"id":"stage_0","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":0.42044820762685725},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["input"]}},
+          {"id":"stage_1","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":0.5946035575013605},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["stage_0"]}},
+          {"id":"stage_2","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":0.8408964152537145},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["stage_1"]}},
+          {"id":"stage_3","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":1.189207115002721},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["stage_2"]}},
+          {"id":"stage_4","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":1.681792830507429},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["stage_3"]}},
+          {"id":"stage_5","kind":"module","definition":"tropical.modal.allpass1","definition_version":1,"params":{"ratio":2.378414230005442},"bindings":{"center":"center","sweep":"sweep","rate":"rate"},"in":{"in":["stage_4"]}},
+          {"id":"blend","kind":"modalblend","bindings":{"mix":"mix"},"in":{"dry":["input"],"wet":["stage_5"]}},
+          {"id":"output","kind":"module_output","in":{"in":["blend"]}}
+        ]
+      }
+    ]}
+    """
+
+    private func engineLibrary() throws -> [ModuleReference: ModuleDefinitionState] {
+        let raw = try JSONDecoder().decode(
+            JSONValue.self,
+            from: Data(engineLibraryFixture.utf8)
+        )
+        return try EngineModuleLibrary.decode(raw)
+    }
+
+    func testEngineOwnedModuleLibraryDecodesWithoutASecondSemanticTable() throws {
+        let library = try engineLibrary()
+        let allpass = try XCTUnwrap(library[StandardModuleLibrary.allpass])
+
+        XCTAssertEqual(allpass.parameters, [.init(name: "ratio", defaultValue: 1)])
+        XCTAssertEqual(allpass.graph.order, ["input", "tail", "section", "output"])
+        XCTAssertEqual(allpass.graph.nodes["tail"]?.kind, .modalTail)
+        XCTAssertEqual(allpass.graph.nodes["tail"]?.bindings, ["ratio": "ratio"])
+    }
+
+    func testStandardPhaserDecomposesIntoSixEditableAllpassInstances() throws {
+        let definition = try XCTUnwrap(try engineLibrary()[StandardModuleLibrary.phaser])
+        let stages = definition.graph.order.compactMap { definition.graph.nodes[$0] }
+            .filter { $0.kind == .allpass }
+
+        XCTAssertEqual(stages.count, 6)
+        XCTAssertEqual(
+            stages.compactMap(\.module),
+            Array(repeating: StandardModuleLibrary.allpass, count: 6)
+        )
+        XCTAssertEqual(
+            stages.compactMap { $0.bindings["center"] },
+            Array(repeating: "center", count: 6)
+        )
+        XCTAssertEqual(stages.compactMap { $0.values["ratio"] }, [
+            0.42044820762685725, 0.5946035575013605, 0.8408964152537145,
+            1.189207115002721, 1.681792830507429, 2.378414230005442,
+        ])
+        XCTAssertEqual(
+            definition.graph.nodes["blend"]?.inputs,
+            ["dry": ["input"], "wet": ["stage_5"]]
+        )
+    }
+
+    func testStandardAllpassExposesDirectPlusTailTopology() throws {
+        let definition = try XCTUnwrap(try engineLibrary()[StandardModuleLibrary.allpass])
+        XCTAssertEqual(definition.graph.nodes["tail"]?.kind, .modalTail)
+        XCTAssertEqual(definition.graph.nodes["tail"]?.inputs["in"], ["input"])
+        XCTAssertEqual(definition.graph.nodes["section"]?.kind, .modalmix)
+        XCTAssertEqual(
+            definition.graph.nodes["section"]?.inputs["in"],
+            ["input", "tail"]
+        )
+        XCTAssertEqual(definition.graph.nodes["output"]?.inputs["in"], ["section"])
+    }
+
+    func testV1PhaserMigratesDeterministicallyToInstalledV3Definition() throws {
+        let source = """
+        {
+          "version": 1,
+          "nodes": [
+            {"id":"res1","kind":"resonator","x":20,"y":30,"hue":30,
+             "values":{"freq":220,"decay":4},"inputs":{"addr":[]}},
+            {"id":"ph2","kind":"phaser","x":120,"y":30,"hue":167,
+             "values":{"center":810,"sweep":1.75,"rate":0.31,"mix":0.42},
+             "inputs":{"in":["res1"]}}
+          ],
+          "order":["res1","ph2"],"velocity":-1,
+          "panX":11,"panY":-7,"autoArrange":true
+        }
+        """
+        let first = try JSONDecoder().decode(PatchDocument.self, from: Data(source.utf8))
+        let second = try JSONDecoder().decode(PatchDocument.self, from: Data(source.utf8))
+
+        XCTAssertEqual(first.version, 3)
+        XCTAssertEqual(first.nodes.first { $0.id == "ph2" }?.module, StandardModuleLibrary.phaser)
+        XCTAssertTrue(first.definitions.isEmpty)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        XCTAssertEqual(
+            try encoder.encode(first),
+            try encoder.encode(second)
+        )
+    }
+
+    func testV3RoundTripPreservesDefinitionOrderBindingsAndPresentation() throws {
+        let installed = try XCTUnwrap(try engineLibrary()[StandardModuleLibrary.phaser])
+        let phaser = StandardModuleLibrary.detached(installed, instancePath: ["ph2"])
+        let definition = PatchDocument.Definition(
+            id: phaser.reference.id,
+            version: phaser.reference.version,
+            title: phaser.title,
+            input: phaser.inputNodeID,
+            output: phaser.outputNodeID,
+            parameters: phaser.parameters,
+            graph: .init(
+                nodes: phaser.graph.order.compactMap { phaser.graph.nodes[$0] }.map { node in
+                    .init(
+                        id: node.id, kind: node.kind,
+                        x: node.position.x, y: node.position.y, hue: node.hue,
+                        values: node.values, inputs: node.inputs,
+                        module: node.module, bindings: node.bindings
+                    )
+                },
+                order: phaser.graph.order,
+                panX: 91,
+                panY: -24
+            )
+        )
+        let document = PatchDocument(
+            nodes: [
+                .init(
+                    id: "ph2", kind: .phaser, x: 120, y: 30, hue: 167,
+                    values: ["center": 810, "sweep": 1.75, "rate": 0.31, "mix": 0.42],
+                    inputs: ["in": []], module: phaser.reference
+                ),
+            ],
+            order: ["ph2"], velocity: -1,
+            panX: 11, panY: -7, autoArrange: true,
+            definitions: [definition]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            PatchDocument.self,
+            from: JSONEncoder().encode(document)
+        )
+        XCTAssertEqual(decoded.version, 3)
+        XCTAssertEqual(decoded.definitions.first?.graph.order, phaser.graph.order)
+        XCTAssertEqual(
+            decoded.definitions.first?.graph.nodes.first { $0.id == "stage_0" }?.bindings,
+            ["center": "center", "sweep": "sweep", "rate": "rate"]
+        )
+        XCTAssertEqual(decoded.definitions.first?.graph.panX, 91)
+        XCTAssertEqual(decoded.nodes.first?.module, phaser.reference)
+    }
+}

--- a/tests/web/compile_handshake.test.ts
+++ b/tests/web/compile_handshake.test.ts
@@ -282,4 +282,59 @@ describe('load_patch_graph compile handshake', () => {
       client.stop()
     }
   })
+
+  test('serves and elaborates the versioned modal module library', async () => {
+    if (!existsSync(frontendBin))
+      throw new Error(`frontend binary missing: ${frontendBin} (run \`make build lean\`)`)
+
+    const client = new EngineClient()
+    try {
+      const library = await client.call('get_module_library')
+      expect(library).toMatchObject({
+        schema: 'tropical_module_library',
+        schema_version: 1,
+      })
+      const allpass = library.definitions.find(
+        (definition: any) => definition.id === 'tropical.modal.allpass1',
+      )
+      const phaser = library.definitions.find(
+        (definition: any) => definition.id === 'tropical.modal.phaser',
+      )
+      expect(allpass.nodes.map((node: any) => node.kind)).toEqual([
+        'module_input', 'modal_allpass_tail', 'modalmix', 'module_output',
+      ])
+      expect(phaser.nodes.filter((node: any) => node.kind === 'module')).toHaveLength(6)
+
+      const report = await client.call('load_patch_graph', {
+        version: 3,
+        definitions: [],
+        scene: {
+          nodes: [
+            {
+              id: 'ph', kind: 'module',
+              definition: 'tropical.modal.phaser', definition_version: 1,
+              params: { center: 700, sweep: 1.5, rate: 0.2, mix: 0.5 },
+              in: { in: [] },
+            },
+            { id: 'out', kind: 'out', params: {}, in: { in: ['ph'] } },
+          ],
+          out: 'out',
+        },
+        taps: [],
+      })
+      expect(report.source_map).toHaveLength(13)
+      expect(report.source_map).toContainEqual(expect.objectContaining({
+        expanded: 'ph', definition: 'tropical.modal.phaser', local: 'blend',
+        path: ['ph'],
+      }))
+      for (const name of ['center', 'sweep', 'rate', 'mix']) {
+        expect(report.params.some((parameter: any) => parameter.name === `ph.${name}`))
+          .toBe(true)
+      }
+      expect(report.params.some((parameter: any) => parameter.name.startsWith('__h3_')))
+        .toBe(false)
+    } finally {
+      client.stop()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- derive modal linear kernels from ordinary graph topology instead of a privileged Phaser stage or backend opcode
- add a closed v3 hierarchy elaborator with versioned definitions, typed Modal boundaries, cycle/ref validation, hygienic expansion, parameter forwarding, and source maps
- make engine-served Allpass 1 and six-section Phaser definitions the product source of truth
- migrate legacy Phaser patches deterministically to the installed definition and detach an instance only when it is opened for editing
- add Reversible nested canvases, breadcrumbs, v3 persistence, and realized-state projection for expanded nodes

## What landed

The first slice replaces privileged Phaser compiler meaning with generic identity/proper/parallel/cascade/blend kernel structure. The resonant Filter is a second producer of that algebra, and the compact product terminal is selected from retained topology.

The second slice promotes the decomposition into the authoring language. Lean validates and expands reusable definitions before the unchanged flat patch compiler. Reversible fetches the installed library from the engine, keeps no duplicate DSP topology table, opens Phaser as six editable Allpass instances, and opens each Allpass as direct plus proper tail plus Modal union. Saved files use document v3 and preserve nested graph order, pan, values, bindings, and presentation.

Installed definitions are immutable. Opening one clones exactly that engine-served definition under a stable user id. Public parameter aliases remain at the containing module namespace, while compiler-generated ids do not leak into the control surface. Signal to Modal edges remain illegal at both UI and compiler boundaries.

## Deliberate limits

- the first-order proper tail and modal blend are compiler-private bootstrap atoms, not yet general public coefficient nodes
- the full canvas still uses the closed Swift node presentation enum; dynamic vocabulary-derived presentation remains future work
- response/pole views, predictive cost feedback, and bounded linear feedback remain later milestones

## Qualification

- `lake build frontend phasercheck` — pass
- `lean/.lake/build/bin/tropicaltest --phaser-only` — pass
- installed hierarchy and detached authored hierarchy both match the legacy/independent oracle with zero observed sample difference
- canonical `6 -> 32 -> six sections -> 32` scratch: `22,688 / 24,576` bytes; two-room baseline: `22,320` bytes
- `TROPICAL_BACKEND=jit bun test tests/web/compile_handshake.test.ts` — 3/3 pass, 42 expectations
- `bun run tsc --noEmit` — pass
- `swift build --disable-sandbox` — pass
- `python3 tools/audit_trust_sites.py` — pass
- `git diff --check` — pass
- required PR CI — all green, including Reversible Swift tests and the full Lean/native/web/C++ gate

No user-owned local artifacts were added.