### PR TITLE
fix(reversible): restore modal phaser demo wiring

### DIFF
--- a/reversible/README.md
+++ b/reversible/README.md
@@ -37,6 +37,8 @@ Engine resolution order:
 
 1. `Reversible.app/Contents/Resources/Tropical/frontend`
 2. `TROPICAL_ENGINE_BIN` (an explicit developer/test override)
+3. The owning checkout's `lean/.lake/build/bin/frontend` for a direct
+   `swift run --package-path reversible Reversible` development launch
 
 `reversible/scripts/run-dev` resolves both the package and engine from the
 script's repository location. There is no implicit home-checkout fallback and

--- a/reversible/Sources/Reversible/Engine.swift
+++ b/reversible/Sources/Reversible/Engine.swift
@@ -81,28 +81,72 @@ actor Engine {
     private var realizedPatches = RealizedPatchStore()
     private let events: @Sendable (EngineEvent) -> Void
 
-    /// Resolution order: bundled engine, then an explicit developer/test
-    /// override. Development launchers set the override from their own repo
-    /// location; production never guesses a checkout under the user's home.
+    /// Resolution order: bundled engine, an explicit developer/test override,
+    /// then the checkout that owns a directly launched SwiftPM executable.
+    /// The last candidate is anchored to the executable itself; it never scans
+    /// the user's home directory or depends on the launcher's current working
+    /// directory.
     static func resolveBinary() throws -> URL {
-        var checked: [URL] = []
-        if let resources = Bundle.main.resourceURL {
-            let bundled = resources
-                .appendingPathComponent("Tropical", isDirectory: true)
-                .appendingPathComponent("frontend", isDirectory: false)
-            checked.append(bundled)
-            if FileManager.default.isExecutableFile(atPath: bundled.path) {
-                return bundled
-            }
-        }
-        if let p = ProcessInfo.processInfo.environment["TROPICAL_ENGINE_BIN"] {
-            let explicit = URL(fileURLWithPath: p).standardizedFileURL
-            checked.append(explicit)
-            if FileManager.default.isExecutableFile(atPath: explicit.path) {
-                return explicit
-            }
+        let checked = binaryCandidates(
+            resourceURL: Bundle.main.resourceURL,
+            environment: ProcessInfo.processInfo.environment,
+            executableURL: Bundle.main.executableURL
+        )
+        if let binary = checked.first(where: {
+            FileManager.default.isExecutableFile(atPath: $0.path)
+        }) {
+            return binary
         }
         throw EngineError.binaryNotFound(checked.map(\.path))
+    }
+
+    static func binaryCandidates(
+        resourceURL: URL?,
+        environment: [String: String],
+        executableURL: URL?
+    ) -> [URL] {
+        var candidates: [URL] = []
+        if let resourceURL {
+            candidates.append(
+                resourceURL
+                    .appendingPathComponent("Tropical", isDirectory: true)
+                    .appendingPathComponent("frontend", isDirectory: false)
+            )
+        }
+        if let path = environment["TROPICAL_ENGINE_BIN"] {
+            candidates.append(URL(fileURLWithPath: path).standardizedFileURL)
+        }
+        if let development = developmentBinaryCandidate(for: executableURL) {
+            candidates.append(development)
+        }
+
+        var seen = Set<String>()
+        return candidates.compactMap { candidate in
+            let standardized = candidate.standardizedFileURL
+            return seen.insert(standardized.path).inserted ? standardized : nil
+        }
+    }
+
+    /// `swift run --package-path <repo>/reversible Reversible` places the
+    /// executable below `<repo>/reversible/.build`. Walk only that executable's
+    /// ancestors and accept the package root by its fixed directory name.
+    private static func developmentBinaryCandidate(for executableURL: URL?) -> URL? {
+        guard let executableURL,
+              executableURL.lastPathComponent == "Reversible"
+        else { return nil }
+
+        var directory = executableURL.standardizedFileURL.deletingLastPathComponent()
+        while directory.path != "/" {
+            if directory.lastPathComponent == "reversible" {
+                return directory.deletingLastPathComponent()
+                    .appendingPathComponent("lean/.lake/build/bin/frontend")
+                    .standardizedFileURL
+            }
+            let parent = directory.deletingLastPathComponent()
+            guard parent != directory else { break }
+            directory = parent
+        }
+        return nil
     }
 
     static func workingDirectory(for binary: URL) -> URL {

--- a/reversible/Sources/Reversible/PatchDocument.swift
+++ b/reversible/Sources/Reversible/PatchDocument.swift
@@ -307,24 +307,9 @@ extension PatchModel {
     }
 
     func newPhaserDemo() async {
-        resetHierarchy(to: .init(nodes: [:], order: [], pan: .zero))
         resetCounter()
-
-        let resonator = addNode(.resonator, at: CGPoint(x: 88, y: 132))
-        let roomA = addNode(.reverb, at: CGPoint(x: 330, y: 132))
-        let phaser = addNode(.phaser, at: CGPoint(x: 610, y: 132))
-        let roomB = addNode(.reverb, at: CGPoint(x: 930, y: 132))
-        let output = addNode(.out, at: CGPoint(x: 1210, y: 240))
-        let scope = addNode(.scope, at: CGPoint(x: 930, y: 430))
-
-        if let resonator, let roomA, let phaser, let roomB, let output {
-            connect(from: resonator.id, to: roomA.id, port: "in")
-            connect(from: roomA.id, to: phaser.id, port: "in")
-            connect(from: phaser.id, to: roomB.id, port: "in")
-            connect(from: roomB.id, to: output.id, port: "in")
-            if let scope { connect(from: output.id, to: scope.id, port: "ch1") }
-        }
-        snapshotActiveGraph()
+        resetHierarchy(to: FactoryPatches.modalPhaser)
+        advanceAuthoredRevision()
         documentURL = nil
         await pushGraph()
         setVelocity(velocity)
@@ -375,5 +360,69 @@ extension PatchModel {
             do { try await read(from: url) }
             catch { setStatus("open: \(error.localizedDescription)", isError: true) }
         }
+    }
+}
+
+/// Built-in scenes are complete immutable values before the model adopts
+/// them. Loading one therefore publishes its nodes and edges together instead
+/// of exposing a sequence of partially connected live edits to the UI and
+/// engine startup tasks.
+enum FactoryPatches {
+    static var modalPhaser: PatchGraphState {
+        func node(
+            _ index: Int,
+            _ kind: NodeKind,
+            at position: CGPoint,
+            inputs authoredInputs: [String: [String]] = [:]
+        ) -> PatchNode {
+            let spec = kind.spec
+            let values = Dictionary(uniqueKeysWithValues: spec.knobs.map {
+                ($0.name, $0.def)
+            })
+            var inputs = Dictionary(uniqueKeysWithValues: spec.inlets.map {
+                ($0, [String]())
+            })
+            for (port, sources) in authoredInputs where inputs[port] != nil {
+                inputs[port] = sources
+            }
+            let module: ModuleReference? = switch kind {
+            case .phaser: StandardModuleLibrary.phaser
+            case .allpass: StandardModuleLibrary.allpass
+            default: nil
+            }
+            return PatchNode(
+                id: "\(kind.rawValue)\(index)",
+                kind: kind,
+                position: Grid.snap(position),
+                values: values,
+                inputs: inputs,
+                hue: Double((index * 137) % 360),
+                module: module
+            )
+        }
+
+        let authored = [
+            node(1, .resonator, at: CGPoint(x: 88, y: 132)),
+            node(2, .reverb, at: CGPoint(x: 330, y: 132), inputs: [
+                "in": ["resonator1"],
+            ]),
+            node(3, .phaser, at: CGPoint(x: 610, y: 132), inputs: [
+                "in": ["reverb2"],
+            ]),
+            node(4, .reverb, at: CGPoint(x: 930, y: 132), inputs: [
+                "in": ["phaser3"],
+            ]),
+            node(5, .out, at: CGPoint(x: 1210, y: 240), inputs: [
+                "in": ["reverb4"],
+            ]),
+            node(6, .scope, at: CGPoint(x: 930, y: 430), inputs: [
+                "ch1": ["out5"],
+            ]),
+        ]
+        return PatchGraphState(
+            nodes: Dictionary(uniqueKeysWithValues: authored.map { ($0.id, $0) }),
+            order: authored.map(\.id),
+            pan: .zero
+        )
     }
 }

--- a/reversible/Tests/ReversibleTests/EngineRPCLaneTests.swift
+++ b/reversible/Tests/ReversibleTests/EngineRPCLaneTests.swift
@@ -1,7 +1,31 @@
+import Foundation
 import XCTest
 @testable import Reversible
 
 final class EngineRPCLaneTests: XCTestCase {
+    func testDirectSwiftPMLaunchFindsEngineInOwningCheckout() {
+        let candidates = Engine.binaryCandidates(
+            resourceURL: nil,
+            environment: [:],
+            executableURL: URL(
+                fileURLWithPath: "/work/tropical/reversible/.build/arm64-apple-macosx/debug/Reversible"
+            )
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.path),
+            ["/work/tropical/lean/.lake/build/bin/frontend"]
+        )
+    }
+
+    func testEngineLookupDoesNotInferCheckoutForUnrelatedExecutable() {
+        XCTAssertTrue(Engine.binaryCandidates(
+            resourceURL: nil,
+            environment: [:],
+            executableURL: URL(fileURLWithPath: "/Applications/Other.app/Contents/MacOS/Other")
+        ).isEmpty)
+    }
+
     func testChildDefaultsToMetalButPreservesExplicitJITOverride() {
         let product = Engine.childEnvironment(inherited: [:])
         XCTAssertEqual(product["TROPICAL_BACKEND"], "metal")

--- a/reversible/Tests/ReversibleTests/PhaserSurfaceTests.swift
+++ b/reversible/Tests/ReversibleTests/PhaserSurfaceTests.swift
@@ -3,6 +3,20 @@ import XCTest
 @testable import Reversible
 
 final class PhaserSurfaceTests: XCTestCase {
+    func testModalPhaserDemoLoadsItsCompleteConnectionChain() {
+        let graph = FactoryPatches.modalPhaser
+
+        XCTAssertEqual(graph.order, [
+            "resonator1", "reverb2", "phaser3", "reverb4", "out5", "scope6",
+        ])
+        XCTAssertEqual(graph.nodes["reverb2"]?.inputs["in"], ["resonator1"])
+        XCTAssertEqual(graph.nodes["phaser3"]?.inputs["in"], ["reverb2"])
+        XCTAssertEqual(graph.nodes["reverb4"]?.inputs["in"], ["phaser3"])
+        XCTAssertEqual(graph.nodes["out5"]?.inputs["in"], ["reverb4"])
+        XCTAssertEqual(graph.nodes["scope6"]?.inputs["ch1"], ["out5"])
+        XCTAssertTrue(graph.nodes["phaser3"]?.kind.spec.modal == true)
+    }
+
     func testNativePhaserSurfaceMatchesServedContract() {
         let spec = NodeKind.phaser.spec
 


### PR DESCRIPTION
## Summary
- load the built-in modal Phaser scene as one complete graph so all authored connections are present immediately
- resolve the Tropical frontend from the owning checkout for direct SwiftPM development launches
- cover the full Resonator → Reverb → Phaser → Reverb → Out chain and checkout-relative engine lookup

## Verification
- `swift build --package-path reversible`
- `git diff --check`
- focused XCTest compilation is blocked on this host because Command Line Tools does not provide the XCTest module