### PR TITLE
fix(reversible): make modal phaser demo audible

### DIFF
--- a/reversible/Sources/Reversible/CanvasView.swift
+++ b/reversible/Sources/Reversible/CanvasView.swift
@@ -225,16 +225,43 @@ struct InletView: View {
 
     private var sources: [String] { node.inputs[port] ?? [] }
 
+    private func sourceTitle(_ sourceID: String) -> String {
+        guard let source = model.nodes[sourceID] else { return sourceID }
+        return "\(source.kind.spec.title) · \(sourceID)"
+    }
+
     var body: some View {
         HStack(spacing: 4) {
             Menu {
                 let legal = model.legalSources(for: node.id, port: port)
-                if legal.isEmpty {
-                    Text("no legal sources")
-                } else {
-                    ForEach(legal) { src in
-                        Button("\(src.kind.spec.title) · \(src.id)") {
-                            model.connect(from: src.id, to: node.id, port: port)
+                if !sources.isEmpty {
+                    Section("Connected to \(port)") {
+                        ForEach(sources, id: \.self) { sourceID in
+                            Button(role: .destructive) {
+                                model.deleteEdge(
+                                    to: node.id,
+                                    port: port,
+                                    from: sourceID
+                                )
+                            } label: {
+                                Label(
+                                    sourceTitle(sourceID),
+                                    systemImage: "xmark.circle"
+                                )
+                            }
+                        }
+                    }
+                }
+                Section(sources.isEmpty ? "Connect source" : "Add source") {
+                    if legal.isEmpty {
+                        Text(InletMenuCopy.noLegalSources(
+                            hasExistingConnections: !sources.isEmpty
+                        ))
+                    } else {
+                        ForEach(legal) { src in
+                            Button("\(src.kind.spec.title) · \(src.id)") {
+                                model.connect(from: src.id, to: node.id, port: port)
+                            }
                         }
                     }
                 }
@@ -246,18 +273,50 @@ struct InletView: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
-            .help("patch a source into \(port)")
+            .help(sources.isEmpty
+                  ? "patch a source into \(port)"
+                  : "view, add, or disconnect sources for \(port)")
 
-            ForEach(sources, id: \.self) { src in
-                Circle()
-                    .fill(model.nodes[src]?.color ?? Theme.jack)
-                    .frame(width: 10, height: 10)
-                    .onTapGesture { model.deleteEdge(to: node.id, port: port, from: src) }
-                    .help("\(src) → \(port) · click to disconnect")
+            ForEach(Array(sources.prefix(2)), id: \.self) { sourceID in
+                HStack(spacing: 3) {
+                    Circle()
+                        .fill(model.nodes[sourceID]?.color ?? Theme.jack)
+                        .frame(width: 10, height: 10)
+                    Text(sourceID)
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(Theme.text)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 62)
+                }
+                .padding(.horizontal, 4).padding(.vertical, 2)
+                .background(
+                    (model.nodes[sourceID]?.color ?? Theme.jack).opacity(0.13),
+                    in: Capsule()
+                )
+                .contentShape(Capsule())
+                .onTapGesture {
+                    model.deleteEdge(to: node.id, port: port, from: sourceID)
+                }
+                .help("\(sourceTitle(sourceID)) → \(port) · click to disconnect")
+            }
+            if sources.count > 2 {
+                Text("+\(sources.count - 2)")
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(Theme.muted)
+                    .help("\(sources.count - 2) more connected sources; open the menu to inspect")
             }
 
             Text(port).font(Theme.monoSmall).foregroundStyle(Theme.muted)
         }
+    }
+}
+
+enum InletMenuCopy {
+    static func noLegalSources(hasExistingConnections: Bool) -> String {
+        hasExistingConnections
+            ? "No additional legal sources"
+            : "No legal sources"
     }
 }
 

--- a/reversible/Sources/Reversible/PatchDocument.swift
+++ b/reversible/Sources/Reversible/PatchDocument.swift
@@ -373,12 +373,16 @@ enum FactoryPatches {
             _ index: Int,
             _ kind: NodeKind,
             at position: CGPoint,
+            values authoredValues: [String: Double] = [:],
             inputs authoredInputs: [String: [String]] = [:]
         ) -> PatchNode {
             let spec = kind.spec
-            let values = Dictionary(uniqueKeysWithValues: spec.knobs.map {
+            var values = Dictionary(uniqueKeysWithValues: spec.knobs.map {
                 ($0.name, $0.def)
             })
+            for (name, value) in authoredValues where values[name] != nil {
+                values[name] = value
+            }
             var inputs = Dictionary(uniqueKeysWithValues: spec.inlets.map {
                 ($0, [String]())
             })
@@ -402,7 +406,16 @@ enum FactoryPatches {
         }
 
         let authored = [
-            node(1, .resonator, at: CGPoint(x: 88, y: 132)),
+            // An unaddressed resonator strikes only at master time zero. The
+            // demo is hot-swapped after startup, so that strike may already
+            // be in the past. This qualified sub-Hz saw repeatedly crosses
+            // zero and therefore gives the scene an audible re-trigger.
+            node(7, .source, at: CGPoint(x: 88, y: 420), values: [
+                "freq": 0.63,
+            ]),
+            node(1, .resonator, at: CGPoint(x: 88, y: 132), inputs: [
+                "addr": ["source7"],
+            ]),
             node(2, .reverb, at: CGPoint(x: 330, y: 132), inputs: [
                 "in": ["resonator1"],
             ]),

--- a/reversible/Tests/ReversibleTests/PhaserSurfaceTests.swift
+++ b/reversible/Tests/ReversibleTests/PhaserSurfaceTests.swift
@@ -7,14 +7,28 @@ final class PhaserSurfaceTests: XCTestCase {
         let graph = FactoryPatches.modalPhaser
 
         XCTAssertEqual(graph.order, [
-            "resonator1", "reverb2", "phaser3", "reverb4", "out5", "scope6",
+            "source7", "resonator1", "reverb2", "phaser3",
+            "reverb4", "out5", "scope6",
         ])
+        XCTAssertEqual(graph.nodes["source7"]?.values["freq"], 0.63)
+        XCTAssertEqual(graph.nodes["resonator1"]?.inputs["addr"], ["source7"])
         XCTAssertEqual(graph.nodes["reverb2"]?.inputs["in"], ["resonator1"])
         XCTAssertEqual(graph.nodes["phaser3"]?.inputs["in"], ["reverb2"])
         XCTAssertEqual(graph.nodes["reverb4"]?.inputs["in"], ["phaser3"])
         XCTAssertEqual(graph.nodes["out5"]?.inputs["in"], ["reverb4"])
         XCTAssertEqual(graph.nodes["scope6"]?.inputs["ch1"], ["out5"])
         XCTAssertTrue(graph.nodes["phaser3"]?.kind.spec.modal == true)
+    }
+
+    func testConnectedInletMenuDoesNotClaimItHasNoSources() {
+        XCTAssertEqual(
+            InletMenuCopy.noLegalSources(hasExistingConnections: true),
+            "No additional legal sources"
+        )
+        XCTAssertEqual(
+            InletMenuCopy.noLegalSources(hasExistingConnections: false),
+            "No legal sources"
+        )
     }
 
     func testNativePhaserSurfaceMatchesServedContract() {


### PR DESCRIPTION
## Summary
- drive the factory resonator address with the qualified 0.63 Hz oscillator so a hot-loaded demo retriggers instead of missing its time-zero strike
- keep the retrigger source and all demo edges in the same atomic factory graph
- label connected inlet chips with source IDs and list existing connections in the inlet menu
- distinguish an already-connected inlet with no further candidates from an inlet with no legal sources

## Verification
- `make lean`
- `lean/.lake/build/bin/phasercheck`
- exact addressed factory graph: JIT compile/render in 1.6 s with nonzero samples after the first zero crossing
- `swift build --package-path reversible` (macOS 15.4 SDK)
- `git diff --check`

Local `swift test` is blocked by this host Command Line Tools installation lacking the XCTest module; the Reversible source and app target compile successfully, and macOS CI will run the XCTest suite.