### PR TITLE
fix(scope): retire obsolete CF warmup

### DIFF
--- a/design/cf-only.md
+++ b/design/cf-only.md
@@ -228,15 +228,14 @@ save/restore round-trip for delays, state-transfer-by-name on hot-swap,
 and the MCP `feedback` tool. The session-acyclicity check stays, but
 hardens into a plain "no cycles at all" rule.
 
-One payoff closes the loop with the scope work. The scope's `WARMUP`
-lead exists only because the MCP wraps every wire in a unit delay to
-break session cycles — so "stateless" patches are secretly stateful, the
-render window starts cold, and it needs priming. CF-only pulls the wire
-delays at the root: `render_window` becomes cold-start-exact, no warmup,
-no priming, and the scope sees everything because there is nothing left
-it cannot. The strange-scope smell and the cold-start garbage are the
-same residual state, removed at the source instead of patched at two
-leaves.
+One payoff closes the loop with the scope work. The scope's former `WARMUP`
+lead existed only because the MCP wrapped every wire in a unit delay to
+break session cycles — so "stateless" patches were secretly stateful, the
+render window started cold, and it needed priming. CF-only pulls the wire
+delays at the root: `render_window` is cold-start-exact, with no warmup or
+priming, and the scope sees everything because there is nothing left it
+cannot. The strange-scope smell and the cold-start garbage were the same
+residual state, removed at the source instead of patched at two leaves.
 
 ## One-line summary
 

--- a/playground/renderer/app.js
+++ b/playground/renderer/app.js
@@ -233,7 +233,6 @@ function drawTrace(canvas, v) {
 
 // ── boot + the render loop ───────────────────────────────────────────────────
 const DISPLAY = 1024      // samples per well
-const WARMUP = 64
 const FPS = 24
 
 async function boot() {
@@ -264,12 +263,12 @@ async function loop() {
     document.getElementById('tau').textContent = `τ ${p}`
     const live = wells.filter((s) => s.slot)
     const count = DISPLAY * 2 // display + trigger search
-    const start = Math.max(0, p - count - WARMUP)
+    const start = Math.max(0, p - count)
     const res = await rpc('render_window', {
-      start, count: count + WARMUP, slots: live.map((s) => s.slot),
+      start, count, slots: live.map((s) => s.slot),
     })
     live.forEach((s, i) => {
-      const v = (res.values[i] ?? []).slice(WARMUP)
+      const v = res.values[i] ?? []
       const off = s.trig ? findTrigger(v, 0, DISPLAY) : 0
       drawTrace(s.canvas, v.slice(off, off + DISPLAY))
     })

--- a/tests/web/compile_handshake.test.ts
+++ b/tests/web/compile_handshake.test.ts
@@ -164,6 +164,20 @@ describe('load_patch_graph compile handshake', () => {
       expect(rendered.control_version).toBe(report.control_version)
       expect(rendered.values[0]).not.toEqual(rendered.values[1])
 
+      // CF-only kernels need no priming: a fresh random-access render at N is
+      // exactly the same signal as the N-offset slice of a render from zero.
+      const offset = 17
+      const coldRendered = await client.call('render_window', {
+        start: offset,
+        count: 32 - offset,
+        slots: report.taps.map((tap: any) => tap.slot),
+      })
+      expect(coldRendered.program_version).toBe(report.program_version)
+      expect(coldRendered.control_version).toBe(report.control_version)
+      expect(coldRendered.values).toEqual(
+        rendered.values.map((values: number[]) => values.slice(offset)),
+      )
+
       const listed = await client.call('list_scope_taps')
       expect(listed.taps).toEqual(report.taps)
 


### PR DESCRIPTION
## Summary

- remove the obsolete 64-sample scope warmup left behind after the CF-only migration
- request the display and trigger-search window from the exact intended coordinate
- add a cold-start random-access regression comparing a render at N with the equivalent slice from zero
- update the CF-only contract to describe the enforced behavior

## Context

The compiler and runtime already implement the handoff Option B commitment: state operations are unrepresentable, session wires are zero-latency, cycles are rejected, and hot swaps carry only the coordinate. This PR closes the remaining product-level mismatch in the Electron scope.

## Validation

- `node --check playground/renderer/app.js`
- `bun test tests/web/compile_handshake.test.ts` — 3 passed, 45 assertions
- `git diff --check`